### PR TITLE
NetworkMessage: avoid strcpy

### DIFF
--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -91,7 +91,7 @@ void NetworkMessage::AddString(const char* value)
 	}
 
 	AddU16(stringlen);
-	strcpy((char*)m_MsgBuf + m_ReadPos, value);
+	memcpy((char*)m_MsgBuf + m_ReadPos, value, stringlen);
 	m_ReadPos += stringlen;
 	m_MsgSize += stringlen;
 }


### PR DESCRIPTION
Inspired by edubart's TFS extended opcode patch.
Uses memcpy instead since it's faster; all credits go to edubart.
