### PR TITLE
addSkillsInPvPZone

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -111,6 +111,9 @@ deSpawnRadius = 50
 -- Stamina
 staminaSystem = "yes"
 
+-- PvP Zone Skills
+addSkillsInPvPZone = "yes"
+
 -- Startup
 -- NOTE: defaultPriority only works on Windows and sets process priority.
 defaultPriority = "high"

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -101,6 +101,7 @@ bool ConfigManager::loadFile(const std::string& _filename)
 	m_confBoolean[ALLOW_CLONES] = booleanString(getGlobalString(L, "allowClones", "no"));
 	m_confBoolean[MARKET_ENABLED] = booleanString(getGlobalString(L, "marketEnabled", "yes"));
 	m_confBoolean[MARKET_PREMIUM] = booleanString(getGlobalString(L, "premiumToCreateMarketOffer", "yes"));
+	m_confBoolean[PVPZONE_ADDMANASPENT] = booleanString(getGlobalString(L, "addSkillsInPvPZone", "yes"));
 	m_confBoolean[STAMINA_SYSTEM] = booleanString(getGlobalString(L, "staminaSystem", "yes"));
 
 	m_confString[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -61,6 +61,7 @@ class ConfigManager
 			MARKET_ENABLED,
 			MARKET_PREMIUM,
 			STAMINA_SYSTEM,
+			PVPZONE_ADDMANASPENT,
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -938,8 +938,9 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 void Spell::postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost) const
 {
 	if (manaCost > 0) {
-		player->addManaSpent(manaCost);
 		player->changeMana(-(int32_t)manaCost);
+		if(player->getZone() != ZONE_PVP || g_config.getBoolean(ConfigManager::PVPZONE_ADDSKILLS))
+			player->addManaSpent(manaCost);	
 	}
 
 	if (!player->hasFlag(PlayerFlag_HasInfiniteSoul)) {

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -497,7 +497,8 @@ void Weapon::onUsedWeapon(Player* player, Item* item, Tile* destTile) const
 		skills_t skillType;
 		uint32_t skillPoint = 0;
 
-		if (getSkillType(player, item, skillType, skillPoint)) {
+		if (getSkillType(player, item, skillType, skillPoint) && player->getZone() != ZONE_PVP 
+			|| g_config.getBoolean(ConfigManager::PVPZONE_ADDSKILLS)) {
 			player->addSkillAdvance(skillType, skillPoint);
 		}
 	}
@@ -509,8 +510,9 @@ void Weapon::onUsedWeapon(Player* player, Item* item, Tile* destTile) const
 	int32_t manaCost = getManaCost(player);
 
 	if (manaCost > 0) {
-		player->addManaSpent(manaCost);
-		player->changeMana(-manaCost);
+		player->changeMana(-(int32_t)manaCost);
+		if(player->getZone() != ZONE_PVP || g_config.getBoolean(ConfigManager::PVPZONE_ADDSKILLS))
+			player->addManaSpent(manaCost);	
 	}
 
 	if (!player->hasFlag(PlayerFlag_HasInfiniteSoul) && soul > 0) {


### PR DESCRIPTION
Option to have no skill/ml increase while in a pvp zone, default is turned off.
