### PR TITLE
Adding compile.sh a little script to make compiling and package retrieving easier.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -45,7 +45,7 @@ debianDeps() {
 
 fedoraDeps() {
 	yum -y install cmake gcc-c++ boost-devel \
-		gmp-devel community-mysql-devel lua-devel
+		gmp-devel mysql-devel lua-devel
 	libInstall
 }
 


### PR DESCRIPTION
Usage is as follows:
- apt-get/yum install git
- git clone https://github.com/otland/forgottenserver.git
- Then either use ./compile.sh or "bash compile.sh"

There is muilticore building but I would like to test that some more to make sure it works properly(tested only on Debian). Also I left CentOS and SL6 compiling in there but added warnings because of the conversation over here (#391). FreeBSD compiling is still not tested, I'll get to that in the coming days, Debian works so Ubuntu should to. Fedora also works. I would like to add Mac OSX as well but I have no way of testing that.

If you wish to add operating systems or edits try to keep the structures and conventions.

Also, we could replace all the ifs with cases like is mentioned here(https://stackoverflow.com/questions/21011010/). Using cases may be easier to maintain should we wish to expand it.

Also, since CentOS compiling will not be supported, I am not adding the other script I mentioned here (#391), and Fedora's MySQL rpm could be replaced by MariaDB.

Fallen(@decltype) helped me out with a few things so credits to him as well.

A wiki page about using this script would be a nice addition if this gets accepted(which I hope it does).

Leave suggestions or comments for improvements on the pull request.
