### PR TITLE
doTeleportThing fix

### DIFF
--- a/data/compat.lua
+++ b/data/compat.lua
@@ -675,11 +675,8 @@ end
 function queryTileAddThing(thing, position, ...) local t = Tile(position) return t ~= nil and t:queryAdd(thing, ...) or false end
 
 function doTeleportThing(uid, dest, pushMovement)
-	if uid >= 0x10000000 then
-		local creature = Creature(uid)
-		if creature ~= nil then
-			return creature:teleportTo(dest, pushMovement or false)
-		end
+	if isCreature(uid) then
+		return Creature(uid):teleportTo(dest, pushMovement or false)
 	else
 		local item = Item(uid)
 		if item ~= nil then


### PR DESCRIPTION
I have no idea what went wrong. After compiling newest source all scripts which use doTeleportThing drop something like this:

```
Lua Script Error: [Spell Interface]
data/spells/scripts/support/magic rope.lua:onCastSpell
data/compat.lua:678: attempt to compare number with userdata
stack traceback:
        [C]: in function '__le'
        data/compat.lua:678: in function 'doTeleportThing'
        data/spells/scripts/support/magic rope.lua:16: in function <data/spells/
scripts/support/magic rope.lua:1>
```

This commit fixes this error.
