### PR TITLE
Set "shutdownAtServerSave" to false.

### DIFF
--- a/data/globalevents/scripts/serversave.lua
+++ b/data/globalevents/scripts/serversave.lua
@@ -1,4 +1,4 @@
-local shutdownAtServerSave = true
+local shutdownAtServerSave = false
 local cleanMapAtServerSave = false
 
 local function serverSave()


### PR DESCRIPTION
To avoid more threads like these:

http://otland.net/threads/shutting-automatically-tfs-1-0.210877/
http://otland.net/threads/my-server-keeps-closing.205784/#post-1975780
http://otland.net/threads/how-to-make-1-0-not-serversave.205493/

I think it would be best to have set to `false` as the default option.
