### PR TITLE
update magic rope spell

### DIFF
--- a/data/spells/scripts/support/magic rope.lua
+++ b/data/spells/scripts/support/magic rope.lua
@@ -4,7 +4,7 @@ function onCastSpell(creature, var)
 	local tile = pos:getTile()
 	if tile then
 		local thing = tile:getGround()
-		if thing and thing:isItem() and not isInArray(ropeSpots, thing:getType():getId()) then
+		if thing and not isInArray(ropeSpots, thing:getId()) then
 			creature:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 			pos:sendMagicEffect(CONST_ME_POFF)
 			return false


### PR DESCRIPTION
fixes this error:

Lua Script Error: [Spell Interface]
data/spells/scripts/support/magic rope.lua:onCastSpell
attempt to index a number value
stack traceback:
[C]: at 0x0015dbd0
[C]: in function 'getThingfromPos'
data/spells/scripts/support/magic rope.lua:4: in function cripts/support/magic rope.lua:1>
