### PR TITLE
Update tiles.lua

### DIFF
--- a/data/movements/scripts/tiles.lua
+++ b/data/movements/scripts/tiles.lua
@@ -20,13 +20,6 @@ function onStepIn(cid, item, position, fromPosition)
 		return true
 	end
 
-	if item.actionid ~= 0 and player:getStorageValue(item.actionid) <= 0 then
-		player:teleportTo(fromPosition, false)
-		position:sendMagicEffect(CONST_ME_MAGIC_BLUE)
-		player:sendTextMessage(MESSAGE_INFO_DESCR, "The tile seems to be protected against unwanted intruders.")
-		return true
-	end
-
 	if position:getTile():hasFlag(TILESTATE_PROTECTIONZONE) then
 		local lookPos = player:getPosition()
 		lookPos:getNextPosition(player:getDirection())
@@ -36,6 +29,13 @@ function onStepIn(cid, item, position, fromPosition)
 			player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "Your depot contains " .. depotItems .. " item" .. (depotItems > 1 and "s." or "."))
 			return true
 		end
+	end
+
+	if item.actionid ~= 0 and player:getStorageValue(item.actionid) <= 0 then
+		player:teleportTo(fromPosition, false)
+		position:sendMagicEffect(CONST_ME_MAGIC_BLUE)
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "The tile seems to be protected against unwanted intruders.")
+		return true
 	end
 
 	return true


### PR DESCRIPTION
Check if its a depot first, since some maps uses aids for depot counts (achivments etc) and this would create the "The tile seems to be protected against unwanted intruders." message to popup.
