### PR TITLE
Added support for float values for experience stages and skill/magic rates.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -74,10 +74,10 @@ emoteSpells = "no"
 
 -- Rates
 -- NOTE: rateExp is not used if you have enabled stages in data/XML/stages.xml
-rateExp = 5
-rateSkill = 3
+rateExp = 5.0
+rateSkill = 3.0
 rateLoot = 2
-rateMagic = 3
+rateMagic = 3.0
 rateSpawn = 1
 
 -- Monsters

--- a/data/XML/stages.xml
+++ b/data/XML/stages.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <stages>
 	<config enabled="0"/>
-	<stage minlevel="1" maxlevel="8" multiplier="7"/>
-	<stage minlevel="9" maxlevel="20" multiplier="6"/>
-	<stage minlevel="21" maxlevel="50" multiplier="5"/>
-	<stage minlevel="51" maxlevel="100" multiplier="4"/>
+	<stage minlevel="1" maxlevel="8" multiplier="7.0"/>
+	<stage minlevel="9" maxlevel="20" multiplier="6.0"/>
+	<stage minlevel="21" maxlevel="50" multiplier="5.0"/>
+	<stage minlevel="51" maxlevel="100" multiplier="4.0"/>
 	<stage minlevel="101" multiplier="5"/>
 </stages>

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -108,10 +108,7 @@ bool ConfigManager::load()
 	m_confInteger[PZ_LOCKED] = getGlobalNumber(L, "pzLocked", 60000);
 	m_confInteger[DEFAULT_DESPAWNRANGE] = getGlobalNumber(L, "deSpawnRange", 2);
 	m_confInteger[DEFAULT_DESPAWNRADIUS] = getGlobalNumber(L, "deSpawnRadius", 50);
-	m_confInteger[RATE_EXPERIENCE] = getGlobalNumber(L, "rateExp", 5);
-	m_confInteger[RATE_SKILL] = getGlobalNumber(L, "rateSkill", 3);
 	m_confInteger[RATE_LOOT] = getGlobalNumber(L, "rateLoot", 2);
-	m_confInteger[RATE_MAGIC] = getGlobalNumber(L, "rateMagic", 3);
 	m_confInteger[RATE_SPAWN] = getGlobalNumber(L, "rateSpawn", 1);
 	m_confInteger[HOUSE_PRICE] = getGlobalNumber(L, "housePriceEachSQM", 1000);
 	m_confInteger[KILLS_TO_RED] = getGlobalNumber(L, "killsToRedSkull", 3);
@@ -131,6 +128,9 @@ bool ConfigManager::load()
 	m_confInteger[MAX_MARKET_OFFERS_AT_A_TIME_PER_PLAYER] = getGlobalNumber(L, "maxMarketOffersAtATimePerPlayer", 100);
 	m_confInteger[MAX_PACKETS_PER_SECOND] = getGlobalNumber(L, "maxPacketsPerSecond", 25);
 
+	m_confFloat[RATE_EXPERIENCE] = getGlobalFloat(L, "rateExp", 5.0);
+	m_confFloat[RATE_SKILL] = getGlobalFloat(L, "rateSkill", 3.0);
+	m_confFloat[RATE_MAGIC] = getGlobalFloat(L, "rateMagic", 3.0);
 	m_isLoaded = true;
 	lua_close(L);
 	return true;
@@ -169,6 +169,16 @@ int32_t ConfigManager::getNumber(integer_config_t _what) const
 	}
 }
 
+float ConfigManager::getFloat(float_config_t _what) const
+{
+	if (m_isLoaded && _what < LAST_FLOAT_CONFIG) {
+		return m_confFloat[_what];
+	} else {
+		std::cout << "[Warning - ConfigManager::getFloat] " << _what << std::endl;
+		return 0;
+	}
+}
+
 bool ConfigManager::getBoolean(boolean_config_t _what) const
 {
 	if (m_isLoaded && _what < LAST_BOOLEAN_CONFIG) {
@@ -194,6 +204,19 @@ std::string ConfigManager::getGlobalString(lua_State* _L, const std::string& _id
 }
 
 int32_t ConfigManager::getGlobalNumber(lua_State* _L, const std::string& _identifier, const int32_t _default)
+{
+	lua_getglobal(_L, _identifier.c_str());
+
+	if (!lua_isnumber(_L, -1)) {
+		return _default;
+	}
+
+	int32_t val = lua_tointeger(_L, -1);
+	lua_pop(_L, 1);
+	return val;
+}
+
+float ConfigManager::getGlobalFloat(lua_State* _L, const std::string& _identifier, const float _default)
 {
 	lua_getglobal(_L, _identifier.c_str());
 

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -77,33 +77,36 @@ class ConfigManager
 			PZ_LOCKED = 2,
 			DEFAULT_DESPAWNRANGE = 3,
 			DEFAULT_DESPAWNRADIUS = 4,
-			RATE_EXPERIENCE = 5,
-			RATE_SKILL = 6,
-			RATE_LOOT = 7,
-			RATE_MAGIC = 8,
-			RATE_SPAWN = 9,
-			HOUSE_PRICE = 10,
-			KILLS_TO_RED = 11,
-			KILLS_TO_BLACK = 12,
-			MAX_MESSAGEBUFFER = 13,
-			ACTIONS_DELAY_INTERVAL = 14,
-			EX_ACTIONS_DELAY_INTERVAL = 15,
-			KICK_AFTER_MINUTES = 16,
-			PROTECTION_LEVEL = 17,
-			DEATH_LOSE_PERCENT = 18,
-			STATUSQUERY_TIMEOUT = 19,
-			FRAG_TIME = 20,
-			WHITE_SKULL_TIME = 21,
-			GAME_PORT = 22,
-			LOGIN_PORT = 23,
-			STATUS_PORT = 24,
-			STAIRHOP_DELAY = 25,
-			MARKET_OFFER_DURATION = 26,
-			CHECK_EXPIRED_MARKET_OFFERS_EACH_MINUTES = 27,
-			MAX_MARKET_OFFERS_AT_A_TIME_PER_PLAYER = 28,
-			EXP_FROM_PLAYERS_LEVEL_RANGE = 29,
-			MAX_PACKETS_PER_SECOND = 30,
+			RATE_LOOT = 5,
+			RATE_SPAWN = 6,
+			HOUSE_PRICE = 7,
+			KILLS_TO_RED = 8,
+			KILLS_TO_BLACK = 9,
+			MAX_MESSAGEBUFFER = 10,
+			ACTIONS_DELAY_INTERVAL = 11,
+			EX_ACTIONS_DELAY_INTERVAL = 12,
+			KICK_AFTER_MINUTES = 13,
+			PROTECTION_LEVEL = 14,
+			DEATH_LOSE_PERCENT = 15,
+			STATUSQUERY_TIMEOUT = 16,
+			FRAG_TIME = 17,
+			WHITE_SKULL_TIME = 18,
+			GAME_PORT = 19,
+			LOGIN_PORT = 20,
+			STATUS_PORT = 21,
+			STAIRHOP_DELAY = 22,
+			MARKET_OFFER_DURATION = 23,
+			CHECK_EXPIRED_MARKET_OFFERS_EACH_MINUTES = 24,
+			MAX_MARKET_OFFERS_AT_A_TIME_PER_PLAYER = 25,
+			EXP_FROM_PLAYERS_LEVEL_RANGE = 26,
+			MAX_PACKETS_PER_SECOND = 27,
 			LAST_INTEGER_CONFIG /* this must be the last one */
+		};
+		enum float_config_t{
+			RATE_EXPERIENCE = 0,
+			RATE_SKILL = 1,
+			RATE_MAGIC = 2,
+			LAST_FLOAT_CONFIG /* this must be the last one */
 		};
 
 		bool load();
@@ -111,15 +114,17 @@ class ConfigManager
 
 		const std::string& getString(string_config_t _what) const;
 		int32_t getNumber(integer_config_t _what) const;
+		float getFloat(float_config_t _what) const;
 		bool getBoolean(boolean_config_t _what) const;
 
 	private:
 		static std::string getGlobalString(lua_State* _L, const std::string& _identifier, const std::string& _default = "");
 		static int32_t getGlobalNumber(lua_State* _L, const std::string& _identifier, const int32_t _default = 0);
-
+		static float getGlobalFloat(lua_State* _L, const std::string& _identifier, const float _default = 0);
 		bool m_isLoaded;
 		std::string m_confString[LAST_STRING_CONFIG];
 		int32_t m_confInteger[LAST_INTEGER_CONFIG];
+		float m_confFloat[LAST_FLOAT_CONFIG];
 		bool m_confBoolean[LAST_BOOLEAN_CONFIG];
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2683,7 +2683,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 		player->sendTextMessage(MESSAGE_INFO_DESCR, "You can not trade more than 100 items.");
 		return;
 	}
-	
+
 	if (!g_events->eventPlayerOnTradeRequest(player, tradePartner, tradeItem)) {
 		return;
 	}
@@ -4007,7 +4007,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		if (realHealthChange > 0 && !target->isInGhostMode()) {
 			std::string damageString = std::to_string(realHealthChange);
 			std::string pluralString = (realHealthChange != 1 ? "s." : ".");
-			
+
 			std::string spectatorMessage;
 			if (!attacker) {
 				spectatorMessage += ucfirst(target->getNameDescription());
@@ -4826,10 +4826,10 @@ void Game::loadPlayersRecord()
 	}
 }
 
-uint64_t Game::getExperienceStage(uint32_t level)
+float Game::getExperienceStage(uint32_t level)
 {
 	if (!stagesEnabled) {
-		return g_config.getNumber(ConfigManager::RATE_EXPERIENCE);
+		return g_config.getFloat(ConfigManager::RATE_EXPERIENCE);
 	}
 
 	if (useLastStageLevel && level >= lastStageLevel) {
@@ -4852,8 +4852,8 @@ bool Game::loadExperienceStages()
 		if (strcasecmp(stageNode.name(), "config") == 0) {
 			stagesEnabled = stageNode.attribute("enabled").as_bool();
 		} else {
-			uint32_t minLevel, maxLevel, multiplier;
-
+			uint32_t minLevel, maxLevel;
+			float multiplier;
 			pugi::xml_attribute minLevelAttribute = stageNode.attribute("minlevel");
 			if (minLevelAttribute) {
 				minLevel = pugi::cast<uint32_t>(minLevelAttribute.value());
@@ -4872,9 +4872,10 @@ bool Game::loadExperienceStages()
 
 			pugi::xml_attribute multiplierAttribute = stageNode.attribute("multiplier");
 			if (multiplierAttribute) {
-				multiplier = pugi::cast<uint32_t>(multiplierAttribute.value());
+				multiplier = pugi::cast<float>(multiplierAttribute.value());
+
 			} else {
-				multiplier = 1;
+				multiplier = 1.0;
 			}
 
 			if (useLastStageLevel) {

--- a/src/game.h
+++ b/src/game.h
@@ -493,7 +493,7 @@ class Game
 		}
 
 		bool loadExperienceStages();
-		uint64_t getExperienceStage(uint32_t level);
+		float getExperienceStage(uint32_t level);
 
 		void loadMotdNum();
 		void saveMotdNum() const;
@@ -546,7 +546,7 @@ class Game
 		std::unordered_map<uint32_t, Player*> players;
 		std::unordered_map<std::string, Player*> mappedPlayerNames;
 		std::unordered_map<uint32_t, Guild*> guilds;
-		std::map<uint32_t, uint32_t> stages;
+		std::map<uint32_t, float> stages;
 
 		std::list<Item*> decayItems[EVENT_DECAY_BUCKETS];
 		std::list<Creature*> checkCreatureLists[EVENT_CREATURECOUNT];

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1987,7 +1987,7 @@ void Player::onBlockHit()
 		--shieldBlockCount;
 
 		if (hasShield()) {
-			addSkillAdvance(SKILL_SHIELD, g_config.getNumber(ConfigManager::RATE_SKILL));
+			addSkillAdvance(SKILL_SHIELD, g_config.getFloat(ConfigManager::RATE_SKILL));
 		}
 	}
 }
@@ -4512,7 +4512,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, int32_t tries)
 		oldSkillValue = magLevel;
 		oldPercentToNextLevel = (long double)(manaSpent * 100) / nextReqMana;
 
-		tries *= g_config.getNumber(ConfigManager::RATE_MAGIC);
+		tries *= g_config.getFloat(ConfigManager::RATE_MAGIC);
 		uint32_t currMagLevel = magLevel;
 
 		while ((manaSpent + tries) >= nextReqMana) {
@@ -4568,7 +4568,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, int32_t tries)
 		oldSkillValue = skills[skill][SKILLVALUE_LEVEL];
 		oldPercentToNextLevel = (long double)(skills[skill][SKILLVALUE_TRIES] * 100) / nextReqTries;
 
-		tries *= g_config.getNumber(ConfigManager::RATE_SKILL);
+		tries *= std::round(g_config.getFloat(ConfigManager::RATE_SKILL));
 		uint32_t currSkillLevel = skills[skill][SKILLVALUE_LEVEL];
 
 		while ((skills[skill][SKILLVALUE_TRIES] + tries) >= nextReqTries) {

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -136,10 +136,11 @@ void ProtocolStatus::sendStatusString()
 	npcs.append_attribute("total") = std::to_string(g_game.getNpcsOnline()).c_str();
 
 	pugi::xml_node rates = tsqp.append_child("rates");
-	rates.append_attribute("experience") = std::to_string(g_config.getNumber(ConfigManager::RATE_EXPERIENCE)).c_str();
-	rates.append_attribute("skill") = std::to_string(g_config.getNumber(ConfigManager::RATE_SKILL)).c_str();
+	//Casting the float values to int32_t to avoid conversion problems
+	rates.append_attribute("experience") = std::to_string((int32_t)g_config.getFloat(ConfigManager::RATE_EXPERIENCE)).c_str();
+	rates.append_attribute("skill") = std::to_string((int32_t)g_config.getFloat(ConfigManager::RATE_SKILL)).c_str();
 	rates.append_attribute("loot") = std::to_string(g_config.getNumber(ConfigManager::RATE_LOOT)).c_str();
-	rates.append_attribute("magic") = std::to_string(g_config.getNumber(ConfigManager::RATE_MAGIC)).c_str();
+	rates.append_attribute("magic") = std::to_string((int32_t)g_config.getFloat(ConfigManager::RATE_MAGIC)).c_str();
 	rates.append_attribute("spawn") = std::to_string(g_config.getNumber(ConfigManager::RATE_SPAWN)).c_str();
 
 	pugi::xml_node map = tsqp.append_child("map");

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -835,7 +835,7 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 void Spell::postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost) const
 {
 	if (manaCost > 0) {
-		player->addManaSpent(manaCost * g_config.getNumber(ConfigManager::RATE_MAGIC));
+		player->addManaSpent(manaCost * g_config.getFloat(ConfigManager::RATE_MAGIC));
 		player->changeMana(-(int32_t)manaCost);
 	}
 

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -394,7 +394,7 @@ bool Weapon::useFist(Player* player, Creature* target)
 
 	Combat::doCombatHealth(player, target, damage, params);
 	if (!player->hasFlag(PlayerFlag_NotGainSkill) && player->getAddAttackSkill()) {
-		player->addSkillAdvance(SKILL_FIST, g_config.getNumber(ConfigManager::RATE_SKILL));
+		player->addSkillAdvance(SKILL_FIST, g_config.getFloat(ConfigManager::RATE_SKILL));
 	}
 
 	return true;
@@ -445,13 +445,13 @@ void Weapon::onUsedWeapon(Player* player, Item* item) const
 		skills_t skillType;
 		uint32_t skillPoint;
 		if (getSkillType(player, item, skillType, skillPoint)) {
-			player->addSkillAdvance(skillType, skillPoint * g_config.getNumber(ConfigManager::RATE_SKILL));
+			player->addSkillAdvance(skillType, skillPoint * g_config.getFloat(ConfigManager::RATE_SKILL));
 		}
 	}
 
 	uint32_t manaCost = getManaCost(player);
 	if (manaCost != 0) {
-		player->addManaSpent(manaCost * g_config.getNumber(ConfigManager::RATE_MAGIC));
+		player->addManaSpent(manaCost * g_config.getFloat(ConfigManager::RATE_MAGIC));
 		player->changeMana(-(int32_t)manaCost);
 	}
 


### PR DESCRIPTION
Closes #605
Added support for float values for experience stages and skill/magic rates. Adding new float-valued configuration variables should be quite easy now.
New functions:
ConfigManager::getGlobalFloat(...)
ConfigManager::getFloat(...)

I'm wondering if the ConfigManager::getGlobalNumber(...) and ConfigManager::getNumber(...) should be renamed to ConfigManager::getGlobalInteger(...) and ConfigManager::getInteger(...) respectively for better naming consistency.
