### PR TITLE
WIP changed int32_t to uint32_t for creatures

### DIFF
--- a/data/migrations/18.lua
+++ b/data/migrations/18.lua
@@ -1,3 +1,6 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 19 (optimize health/healthmax to unsigned int)")
+	db.query("ALTER TABLE `players` CHANGE `health` `health` INT(11) UNSIGNED NOT NULL DEFAULT '150'")
+	db.query("ALTER TABLE `players` CHANGE `healthmax` `healthmax` INT(11) UNSIGNED NOT NULL DEFAULT '150'")
+	return true
 end

--- a/data/migrations/19.lua
+++ b/data/migrations/19.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -18,8 +18,8 @@ CREATE TABLE IF NOT EXISTS `players` (
   `account_id` int(11) NOT NULL DEFAULT '0',
   `level` int(11) NOT NULL DEFAULT '1',
   `vocation` int(11) NOT NULL DEFAULT '0',
-  `health` int(11) NOT NULL DEFAULT '150',
-  `healthmax` int(11) NOT NULL DEFAULT '150',
+  `health` int(11) unsigned NOT NULL DEFAULT '150',
+  `healthmax` int(11) unsigned NOT NULL DEFAULT '150',
   `experience` bigint(20) NOT NULL DEFAULT '0',
   `lookbody` int(11) NOT NULL DEFAULT '0',
   `lookfeet` int(11) NOT NULL DEFAULT '0',
@@ -321,7 +321,7 @@ CREATE TABLE IF NOT EXISTS `server_config` (
   PRIMARY KEY `config` (`config`)
 ) ENGINE=InnoDB;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '18'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '19'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 CREATE TABLE IF NOT EXISTS `tile_store` (
   `house_id` int(11) NOT NULL,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -784,7 +784,7 @@ Item* Creature::getCorpse(Creature*, Creature*)
 
 void Creature::changeHealth(int32_t healthChange, bool sendHealthChange/* = true*/)
 {
-	int32_t oldHealth = health;
+	uint32_t oldHealth = health;
 
 	if (healthChange > 0) {
 		health += std::min<int32_t>(healthChange, getMaxHealth() - health);

--- a/src/creature.h
+++ b/src/creature.h
@@ -219,10 +219,10 @@ class Creature : virtual public Thing
 			return baseSpeed;
 		}
 
-		int32_t getHealth() const {
+		uint32_t getHealth() const {
 			return health;
 		}
-		virtual int32_t getMaxHealth() const {
+		virtual uint32_t getMaxHealth() const {
 			return healthMax;
 		}
 		uint32_t getMana() const {
@@ -504,10 +504,10 @@ class Creature : virtual public Thing
 		uint32_t blockTicks;
 		uint32_t lastStepCost;
 		uint32_t baseSpeed;
+		uint32_t health;
+		uint32_t healthMax;
 		uint32_t mana;
 		int32_t varSpeed;
-		int32_t health;
-		int32_t healthMax;
 
 		Outfit_t currentOutfit;
 		Outfit_t defaultOutfit;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -586,10 +586,6 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 
 bool IOLoginData::savePlayer(Player* player)
 {
-	if (player->getHealth() <= 0) {
-		player->changeHealth(1);
-	}
-
 	Database* db = Database::getInstance();
 
 	std::ostringstream query;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7461,15 +7461,20 @@ int32_t LuaScriptInterface::luaCreatureSetMaxHealth(lua_State* L)
 		return 1;
 	}
 
-	creature->healthMax = getNumber<uint32_t>(L, 2);
-	creature->health = std::min<int32_t>(creature->health, creature->healthMax);
-	g_game.addCreatureHealth(creature);
+	if (getNumber<int32_t>(L, 2) > 0) {
+		creature->healthMax = getNumber<int32_t>(L, 2);
+		creature->health = std::min<uint32_t>(creature->health, creature->healthMax);
+		g_game.addCreatureHealth(creature);
 
-	Player* player = creature->getPlayer();
-	if (player) {
-		player->sendStats();
+		Player* player = creature->getPlayer();
+		if (player) {
+			player->sendStats();
+		}
+		pushBoolean(L, true);
+	} else {
+		pushBoolean(L, false);
 	}
-	pushBoolean(L, true);
+
 	return 1;
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1088,7 +1088,7 @@ void Monster::pushCreatures(Tile* tile)
 					continue;
 				}
 
-				monster->changeHealth(-monster->getHealth());
+				monster->changeHealth(-((int32_t)monster->getHealth()));
 				monster->setDropLoot(false);
 				removeCount++;
 			}
@@ -1799,7 +1799,7 @@ void Monster::death(Creature*)
 	setAttackedCreature(nullptr);
 
 	for (Creature* summon : summons) {
-		summon->changeHealth(-summon->getHealth());
+		summon->changeHealth(-((int32_t)summon->getHealth()));
 		summon->setMaster(nullptr);
 		summon->releaseThing2();
 	}
@@ -1992,7 +1992,7 @@ bool Monster::convinceCreature(Creature* creature)
 
 			//destroy summons
 			for (Creature* summon : summons) {
-				summon->changeHealth(-summon->getHealth());
+				summon->changeHealth(-((int32_t)summon->getHealth()));
 				summon->setMaster(nullptr);
 				summon->releaseThing2();
 			}
@@ -2024,7 +2024,7 @@ bool Monster::convinceCreature(Creature* creature)
 		setAttackedCreature(nullptr);
 
 		for (Creature* summon : summons) {
-			summon->changeHealth(-summon->getHealth());
+			summon->changeHealth(-((int32_t)summon->getHealth()));
 			summon->setMaster(nullptr);
 			summon->releaseThing2();
 		}

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -871,7 +871,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monster_n
 			} else if (strcasecmp(attrName, "targetdistance") == 0) {
 				mType->targetDistance = std::max<int32_t>(1, pugi::cast<int32_t>(attr.value()));
 			} else if (strcasecmp(attrName, "runonhealth") == 0) {
-				mType->runAwayHealth = pugi::cast<int32_t>(attr.value());
+				mType->runAwayHealth = pugi::cast<uint32_t>(attr.value());
 			} else if (strcasecmp(attrName, "hidehealth") == 0) {
 				mType->hiddenHealth = attr.as_bool();
 			} else {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -108,8 +108,8 @@ class MonsterType
 		uint32_t yellSpeedTicks;
 		uint32_t staticAttackChance;
 		uint32_t maxSummons;
+		uint32_t runAwayHealth;
 		int32_t targetDistance;
-		int32_t runAwayHealth;
 		int32_t baseSpeed;
 		int32_t health;
 		int32_t healthMax;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -592,7 +592,7 @@ int32_t Player::getPlayerInfo(playerinfo_t playerinfo) const
 		case PLAYERINFO_MAGICLEVEL: return std::max<int32_t>(0, magLevel + varStats[STAT_MAGICPOINTS]);
 		case PLAYERINFO_MAGICLEVELPERCENT: return magLevelPercent;
 		case PLAYERINFO_HEALTH: return health;
-		case PLAYERINFO_MAXHEALTH: return std::max<int32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS]);
+		case PLAYERINFO_MAXHEALTH: return std::max<uint32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS]);
 		case PLAYERINFO_MANA: return mana;
 		case PLAYERINFO_MAXMANA: return std::max<int32_t>(0, manaMax + varStats[STAT_MAXMANAPOINTS]);
 		case PLAYERINFO_SOUL: return getSoul();
@@ -1932,7 +1932,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 
 	while (level > 1 && experience < currLevelExp) {
 		--level;
-		healthMax = std::max<int32_t>(0, healthMax - vocation->getHPGain());
+		healthMax = std::max<uint32_t>(0, healthMax - vocation->getHPGain());
 		manaMax = std::max<int32_t>(0, manaMax - vocation->getManaGain());
 		capacity = std::max<double>(0.00, capacity - vocation->getCapGain());
 		currLevelExp = Player::getExpForLevel(level);
@@ -2211,7 +2211,7 @@ void Player::death(Creature* _lastHitCreature)
 
 			while (level > 1 && experience < Player::getExpForLevel(level)) {
 				--level;
-				healthMax = std::max<int32_t>(0, healthMax - vocation->getHPGain());
+				healthMax = std::max<uint32_t>(0, healthMax - vocation->getHPGain());
 				manaMax = std::max<int32_t>(0, manaMax - vocation->getManaGain());
 				capacity = std::max<double>(0.00, capacity - vocation->getCapGain());
 			}

--- a/src/player.h
+++ b/src/player.h
@@ -492,7 +492,7 @@ class Player : public Creature, public Cylinder
 			}
 		}
 
-		virtual int32_t getMaxHealth() const {
+		virtual uint32_t getMaxHealth() const {
 			return getPlayerInfo(PLAYERINFO_MAXHEALTH);
 		}
 		uint32_t getMaxMana() const {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2957,8 +2957,8 @@ void ProtocolGame::AddPlayerStats(NetworkMessage& msg)
 {
 	msg.AddByte(0xA0);
 
-	msg.add<uint16_t>(std::min<int32_t>(0xFFFF, player->getHealth()));
-	msg.add<uint16_t>(std::min<int32_t>(0xFFFF, player->getPlayerInfo(PLAYERINFO_MAXHEALTH)));
+	msg.add<uint16_t>(std::min<uint32_t>(0xFFFF, player->getHealth()));
+	msg.add<uint16_t>(std::min<uint32_t>(0xFFFF, player->getPlayerInfo(PLAYERINFO_MAXHEALTH)));
 
 	msg.add<uint32_t>(uint32_t(player->getFreeCapacity() * 100));
 	msg.add<uint32_t>(uint32_t(player->getCapacity() * 100));


### PR DESCRIPTION
I've started working on converting health and healthmax to uint32_t

Tested on:
Players [x]
Monsters [x]
Summons []
Npcs []

I've applied a change so you cannot set with setMaxHealth(..) a lower value then 1 to avoid that the player ends up having the max range health number from uint32_t or if you set it to 0 that he dies constantly at login.

So far combat which gone under the zero point of health worked normaly, however I'm not 100% sure if it's bulletproof yet, as I couldn't test every possibility yet.

I'm not sure if I'm still missing something so this is addressed as WIP, feel free to to give suggestions or tell me if I might be missing something.
