### PR TITLE
Casting system

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -28,6 +28,8 @@ serverName = "Forgotten"
 statusTimeout = 5000
 replaceKickOnLogin = true
 maxPacketsPerSecond = 25
+enableLiveCasting = false
+liveCastPort = 7173
 
 -- Deaths
 -- NOTE: Leave deathLosePercent as -1 if you want to use the default

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -75,7 +75,7 @@ function Player.sendExtendedOpcode(self, opcode, buffer)
 	networkMessage:addByte(0x32)
 	networkMessage:addByte(opcode)
 	networkMessage:addString(buffer)
-	networkMessage:sendToPlayer(self)
+	networkMessage:sendToPlayer(self, false)
 	networkMessage:delete()
 	return true
 end

--- a/data/talkactions/scripts/start_cast.lua
+++ b/data/talkactions/scripts/start_cast.lua
@@ -1,0 +1,8 @@
+function onSay(player, words, param)
+	if player:startLiveCast(param) then
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "You have started casting your gameplay.")
+	else
+		player:sendCancelMessage("You're already casting your gameplay.")
+	end
+	return false
+end

--- a/data/talkactions/scripts/stop_cast.lua
+++ b/data/talkactions/scripts/stop_cast.lua
@@ -1,0 +1,8 @@
+function onSay(player, words, param)
+	if player:stopLiveCast(param) then
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "You have stopped casting your gameplay.")
+	else
+		player:sendCancelMessage("You're not casting your gameplay.")
+	end
+	return false
+end

--- a/data/talkactions/talkactions.xml
+++ b/data/talkactions/talkactions.xml
@@ -43,6 +43,8 @@
 	<talkaction words="!kills" script="kills.lua" />
 	<talkaction words="!online" script="online.lua" />
 	<talkaction words="!serverinfo" script="serverinfo.lua" />
+	<talkaction words="!cast" separator=" " script="start_cast.lua" />
+	<talkaction words="!stopcast" script="stop_cast.lua" />
 
 	<!-- test talkactions -->
 	<talkaction words="!z" separator=" " script="magiceffect.lua" />

--- a/schema.sql
+++ b/schema.sql
@@ -321,6 +321,16 @@ CREATE TABLE IF NOT EXISTS `server_config` (
   PRIMARY KEY `config` (`config`)
 ) ENGINE=InnoDB;
 
+CREATE TABLE IF NOT EXISTS `live_casts` (
+  `player_id` int(11) NOT NULL,
+  `cast_name` varchar(255) NOT NULL,
+  `password` boolean NOT NULL DEFAULT false,
+  `description` varchar(255),
+  `spectators` smallint(5) DEFAULT 0,
+  UNIQUE KEY `player_id_2` (`player_id`),
+  FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
 INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '18'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 CREATE TABLE IF NOT EXISTS `tile_store` (

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,8 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/player.cpp
 	${CMAKE_CURRENT_LIST_DIR}/position.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocol.cpp
+	${CMAKE_CURRENT_LIST_DIR}/protocolspectator.cpp
+	${CMAKE_CURRENT_LIST_DIR}/protocolgamebase.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocollogin.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocolold.cpp

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -87,6 +87,7 @@ bool ConfigManager::load()
 	boolean[WARN_UNSAFE_SCRIPTS] = getGlobalBoolean(L, "warnUnsafeScripts", true);
 	boolean[CONVERT_UNSAFE_SCRIPTS] = getGlobalBoolean(L, "convertUnsafeScripts", true);
 	boolean[CLASSIC_EQUIPMENT_SLOTS] = getGlobalBoolean(L, "classicEquipmentSlots", false);
+	boolean[ENABLE_LIVE_CASTING] = getGlobalBoolean(L, "enableLiveCasting", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");
@@ -123,8 +124,10 @@ bool ConfigManager::load()
 	integer[CHECK_EXPIRED_MARKET_OFFERS_EACH_MINUTES] = getGlobalNumber(L, "checkExpiredMarketOffersEachMinutes", 60);
 	integer[MAX_MARKET_OFFERS_AT_A_TIME_PER_PLAYER] = getGlobalNumber(L, "maxMarketOffersAtATimePerPlayer", 100);
 	integer[MAX_PACKETS_PER_SECOND] = getGlobalNumber(L, "maxPacketsPerSecond", 25);
+	integer[LIVE_CAST_PORT] = getGlobalNumber(L, "liveCastPort", 7173);
 
 	loaded = true;
+
 	lua_close(L);
 	return true;
 }

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -44,6 +44,7 @@ class ConfigManager
 			WARN_UNSAFE_SCRIPTS,
 			CONVERT_UNSAFE_SCRIPTS,
 			CLASSIC_EQUIPMENT_SLOTS,
+			ENABLE_LIVE_CASTING,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};
@@ -103,6 +104,7 @@ class ConfigManager
 			MAX_MARKET_OFFERS_AT_A_TIME_PER_PLAYER,
 			EXP_FROM_PLAYERS_LEVEL_RANGE,
 			MAX_PACKETS_PER_SECOND,
+			LIVE_CAST_PORT,
 
 			LAST_INTEGER_CONFIG /* this must be the last one */
 		};

--- a/src/connection.h
+++ b/src/connection.h
@@ -114,6 +114,8 @@ class Connection : public std::enable_shared_from_this<Connection>
 		friend class ServicePort;
 
 		NetworkMessage msg;
+		void broadcastMessage(OutputMessage_ptr msg);
+		void dispatchBroadcastMessage(const OutputMessage_ptr& msg);
 
 		boost::asio::deadline_timer readTimer;
 		boost::asio::deadline_timer writeTimer;

--- a/src/const.h
+++ b/src/const.h
@@ -519,7 +519,12 @@ enum PlayerFlags : uint64_t {
 
 #define CHANNEL_GUILD 0x00
 #define CHANNEL_PARTY 0x01
+
+#define CHANNEL_CAST 0xFFFE
+
 #define CHANNEL_PRIVATE 0xFFFF
+
+const std::string LIVE_CAST_CHAT_NAME = "Live Cast Chat";
 
 //Reserved player storage key ranges
 //[10000000 - 20000000]

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3253,6 +3253,10 @@ void Game::playerSay(uint32_t playerId, uint16_t channelId, SpeakClasses type,
 		player->removeMessageBuffer();
 	}
 
+	if (channelId == CHANNEL_CAST) {
+		player->sendChannelMessage(player->getName(), text, TALKTYPE_CHANNEL_R1, channelId);
+	}
+
 	switch (type) {
 		case TALKTYPE_SAY:
 			internalCreatureSay(player, TALKTYPE_SAY, text, false);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2241,6 +2241,10 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Player", "getContainerById", LuaScriptInterface::luaPlayerGetContainerById);
 	registerMethod("Player", "getContainerIndex", LuaScriptInterface::luaPlayerGetContainerIndex);
 
+	registerMethod("Player", "startLiveCast", LuaScriptInterface::luaPlayerStartLiveCast);
+	registerMethod("Player", "stopLiveCast", LuaScriptInterface::luaPlayerStopLiveCast);
+	registerMethod("Player", "isLiveCaster", LuaScriptInterface::luaPlayerIsLiveCaster);
+
 	// Monster
 	registerClass("Monster", "Creature", LuaScriptInterface::luaMonsterCreate);
 	registerMetaMethod("Monster", "__eq", LuaScriptInterface::luaUserdataCompare);
@@ -5482,7 +5486,7 @@ int LuaScriptInterface::luaNetworkMessageSkipBytes(lua_State* L)
 
 int LuaScriptInterface::luaNetworkMessageSendToPlayer(lua_State* L)
 {
-	// networkMessage:sendToPlayer(player)
+	// networkMessage:sendToPlayer(player[, broadcast])
 	NetworkMessage* message = getUserdata<NetworkMessage>(L, 1);
 	if (!message) {
 		lua_pushnil(L);
@@ -5491,7 +5495,8 @@ int LuaScriptInterface::luaNetworkMessageSendToPlayer(lua_State* L)
 
 	Player* player = getPlayer(L, 2);
 	if (player) {
-		player->sendNetworkMessage(*message);
+		bool broadcast = getBoolean(L, 3, true);
+		player->sendNetworkMessage(*message, broadcast);
 		pushBoolean(L, true);
 	} else {
 		reportErrorFunc(getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
@@ -9257,6 +9262,47 @@ int LuaScriptInterface::luaPlayerGetContainerIndex(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+int32_t LuaScriptInterface::luaPlayerStartLiveCast(lua_State* L)
+{
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	std::string password;
+	if (lua_gettop(L) == 2) {
+		password = getString(L, 2);
+	}
+
+	lua_pushboolean(L, player->startLiveCast(password));
+	return 1;
+}
+
+int32_t LuaScriptInterface::luaPlayerStopLiveCast(lua_State* L)
+{
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	lua_pushboolean(L, player->stopLiveCast());
+	return 1;
+}
+
+int32_t LuaScriptInterface::luaPlayerIsLiveCaster(lua_State* L)
+{
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	lua_pushboolean(L, player->isLiveCaster());
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -962,6 +962,10 @@ class LuaScriptInterface
 		static int luaPlayerGetContainerById(lua_State* L);
 		static int luaPlayerGetContainerIndex(lua_State* L);
 
+		static int32_t luaPlayerStartLiveCast(lua_State* L);
+		static int32_t luaPlayerStopLiveCast(lua_State* L);
+		static int32_t luaPlayerIsLiveCaster(lua_State* L);
+
 		// Monster
 		static int luaMonsterCreate(lua_State* L);
 

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -32,6 +32,7 @@
 #include "configmanager.h"
 #include "scriptmanager.h"
 #include "rsa.h"
+#include "protocolspectator.h"
 #include "protocolold.h"
 #include "protocollogin.h"
 #include "protocolstatus.h"
@@ -262,6 +263,10 @@ void mainLoader(int, char*[], ServiceManager* services)
 
 	// Game client protocols
 	services->add<ProtocolGame>(g_config.getNumber(ConfigManager::GAME_PORT));
+	if (g_config.getBoolean(ConfigManager::ENABLE_LIVE_CASTING)) {
+		ProtocolGame::clearLiveCastInfo();
+		services->add<ProtocolSpectator>(g_config.getNumber(ConfigManager::LIVE_CAST_PORT));
+	}
 	services->add<ProtocolLogin>(g_config.getNumber(ConfigManager::LOGIN_PORT));
 
 	// OT protocols

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -66,6 +66,12 @@ class OutputMessage : public NetworkMessage
 			position += msgLen;
 		}
 
+		bool isBroadcastMsg() const {
+			return isBroadcastMesssage;
+		}
+		void setBroadcastMsg(bool isBroadcastMesssage) {
+			this->isBroadcastMesssage = isBroadcastMesssage;
+		}
 	protected:
 		template <typename T>
 		inline void add_header(T add) {
@@ -77,6 +83,7 @@ class OutputMessage : public NetworkMessage
 		}
 
 		MsgSize_t outputBufferStart;
+		bool isBroadcastMesssage {false};
 };
 
 class OutputMessagePool

--- a/src/player.h
+++ b/src/player.h
@@ -1101,9 +1101,9 @@ class Player final : public Creature, public Cylinder
 				client->sendFightModes();
 			}
 		}
-		void sendNetworkMessage(const NetworkMessage& message) {
+		void sendNetworkMessage(const NetworkMessage& message, bool broadcast = true) {
 			if (client) {
-				client->writeToOutputBuffer(message);
+				client->writeToOutputBuffer(message, broadcast);
 			}
 		}
 
@@ -1135,6 +1135,22 @@ class Player final : public Creature, public Cylinder
 		void learnInstantSpell(const std::string& spellName);
 		void forgetInstantSpell(const std::string& spellName);
 		bool hasLearnedInstantSpell(const std::string& spellName) const;
+
+		bool startLiveCast(const std::string& password) {
+			return client && client->startLiveCast(password);
+		}
+
+		bool stopLiveCast() {
+			return client && client->stopLiveCast();
+		}
+
+		bool isLiveCaster() const {
+			return client && client->isLiveCaster();
+		}
+
+		const std::map<uint8_t, OpenContainer>& getOpenContainers() const {
+			return openContainers;
+		}
 
 	protected:
 		std::forward_list<Condition*> getMuteConditions() const;
@@ -1341,6 +1357,7 @@ class Player final : public Creature, public Cylinder
 		friend class Map;
 		friend class Actions;
 		friend class IOLoginData;
+		friend class ProtocolGameBase;
 		friend class ProtocolGame;
 };
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -35,28 +35,20 @@
 #include "waitlist.h"
 #include "ban.h"
 #include "scheduler.h"
+#include "databasetasks.h"
 
+extern Game g_game;
 extern ConfigManager g_config;
 extern Actions actions;
 extern CreatureEvents* g_creatureEvents;
 extern Chat* g_chat;
 
-ProtocolGame::ProtocolGame(Connection_ptr connection) :
-	Protocol(connection),
-	player(nullptr),
-	eventConnect(0),
-	challengeTimestamp(0),
-	version(CLIENT_VERSION_MIN),
-	challengeRandom(0),
-	debugAssertSent(false),
-	acceptPackets(false)
-{
-	//
-}
+ProtocolGame::LiveCastsMap ProtocolGame::liveCasts;
 
 void ProtocolGame::release()
 {
 	//dispatcher thread
+	stopLiveCast();
 	if (player && player->client == shared_from_this()) {
 		player->client.reset();
 		player->decrementReferenceCounter();
@@ -242,9 +234,112 @@ void ProtocolGame::logout(bool displayEffect, bool forced)
 		}
 	}
 
+	stopLiveCast();
 	disconnect();
 
 	g_game.removeCreature(player);
+}
+
+bool ProtocolGame::startLiveCast(const std::string& password /*= ""*/)
+{
+	auto connection = getConnection();
+	if (!g_config.getBoolean(ConfigManager::ENABLE_LIVE_CASTING) || isLiveCaster() || !player || player->isRemoved() || !connection || liveCasts.size() >= getMaxLiveCastCount()) {
+		return false;
+	}
+
+	{
+		std::lock_guard<decltype(liveCastLock)> lock {liveCastLock};
+		//DO NOT do any send operations here
+		liveCastName = player->getName();
+		liveCastPassword = password;
+		isCaster.store(true, std::memory_order_relaxed);
+	}
+
+	liveCasts.insert(std::make_pair(player, getThis()));
+
+	registerLiveCast();
+	//Send a "dummy" channel
+	sendChannel(CHANNEL_CAST, LIVE_CAST_CHAT_NAME, nullptr, nullptr);
+	return true;
+}
+
+bool ProtocolGame::stopLiveCast()
+{
+	//dispatcher
+	if (!isLiveCaster()) {
+		return false;
+	}
+
+	CastSpectatorVec spectators;
+
+	{
+		std::lock_guard<decltype(liveCastLock)> lock {liveCastLock};
+		//DO NOT do any send operations here
+		std::swap(this->spectators, spectators);
+		isCaster.store(false, std::memory_order_relaxed);
+	}
+
+	liveCasts.erase(player);
+	for (auto& spectator : spectators) {
+		spectator->onLiveCastStop();
+	}
+	unregisterLiveCast();
+
+	return true;
+}
+
+void ProtocolGame::clearLiveCastInfo()
+{
+	static std::once_flag flag;
+	std::call_once(flag, []() {
+			assert(g_game.getGameState() == GAME_STATE_INIT);
+			std::ostringstream query;
+			query << "TRUNCATE TABLE `live_casts`;";
+			g_databaseTasks.addTask(query.str());
+		});
+}
+
+void ProtocolGame::registerLiveCast()
+{
+	std::ostringstream query;
+	query << "INSERT into `live_casts` (`player_id`, `cast_name`, `password`) VALUES (" << player->getGUID() << ", '"
+		<< getLiveCastName() << "', " << isPasswordProtected() << ");";
+	g_databaseTasks.addTask(query.str());
+}
+
+void ProtocolGame::unregisterLiveCast()
+{
+	std::ostringstream query;
+	query << "DELETE FROM `live_casts` WHERE `player_id`=" << player->getGUID() << ";";
+	g_databaseTasks.addTask(query.str());
+}
+
+void ProtocolGame::updateLiveCastInfo()
+{
+	std::ostringstream query;
+	query << "UPDATE `live_casts` SET `cast_name`='" << getLiveCastName() << "', `password`="
+		<< isPasswordProtected() << ", `spectators`=" << getSpectatorCount()
+		<< " WHERE `player_id`=" << player->getGUID() << ";";
+	g_databaseTasks.addTask(query.str());
+}
+
+void ProtocolGame::addSpectator(ProtocolSpectator_ptr spectatorClient)
+{
+	std::lock_guard<decltype(liveCastLock)> lock(liveCastLock);
+	//DO NOT do any send operations here
+	spectators.emplace_back(spectatorClient);
+	updateLiveCastInfo();
+}
+
+void ProtocolGame::removeSpectator(ProtocolSpectator_ptr spectatorClient)
+{
+	std::lock_guard<decltype(liveCastLock)> lock(liveCastLock);
+	//DO NOT do any send operations here
+	auto it = std::find(spectators.begin(), spectators.end(), spectatorClient);
+	if (it != spectators.end()) {
+		spectators.erase(it);
+		updateLiveCastInfo();
+	}
 }
 
 void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
@@ -342,34 +437,6 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	g_dispatcher.addTask(createTask(std::bind(&ProtocolGame::login, getThis(), characterName, accountId, operatingSystem)));
 }
 
-void ProtocolGame::onConnect()
-{
-	auto output = OutputMessagePool::getOutputMessage();
-	static std::random_device rd;
-	static std::ranlux24 generator(rd());
-	static std::uniform_int_distribution<uint16_t> randNumber(0x00, 0xFF);
-
-	// Skip checksum
-	output->skipBytes(sizeof(uint32_t));
-
-	// Packet length & type
-	output->add<uint16_t>(0x0006);
-	output->addByte(0x1F);
-
-	// Add timestamp & random number
-	challengeTimestamp = static_cast<uint32_t>(time(nullptr));
-	output->add<uint32_t>(challengeTimestamp);
-
-	challengeRandom = randNumber(generator);
-	output->addByte(challengeRandom);
-
-	// Go back and write checksum
-	output->skipBytes(-12);
-	output->add<uint32_t>(adlerChecksum(output->getOutputBuffer() + sizeof(uint32_t), 8));
-
-	send(output);
-}
-
 void ProtocolGame::disconnectClient(const std::string& message) const
 {
 	auto output = OutputMessagePool::getOutputMessage();
@@ -379,10 +446,22 @@ void ProtocolGame::disconnectClient(const std::string& message) const
 	disconnect();
 }
 
-void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg)
+
+void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg, bool broadcast /*= true*/)
 {
-	auto out = getOutputBuffer(msg.getLength());
-	out->append(msg);
+	if (!broadcast && isLiveCaster()) {
+		//We're casting and we need to send a packet that's not supposed to be broadcast so we need a new messasge.
+		//This shouldn't impact performance by a huge amount as most packets can be broadcast.
+		auto out = OutputMessagePool::getOutputMessage();
+		out->append(msg);
+		send(std::move(out));
+	} else {
+		auto out = getOutputBuffer(msg.getLength());
+		if (isLiveCaster()) {
+			out->setBroadcastMsg(true);
+		}
+		out->append(msg);
+	}
 }
 
 void ProtocolGame::parsePacket(NetworkMessage& msg)
@@ -393,16 +472,12 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 
 	uint8_t recvbyte = msg.getByte();
 
-	if (!player) {
-		if (recvbyte == 0x0F) {
-			disconnect();
-		}
-
-		return;
-	}
-
-	//a dead player can not performs actions
-	if (player->isRemoved() || player->getHealth() <= 0) {
+	//a dead player can not perform actions
+	if (!player || player->isRemoved() || player->getHealth() <= 0) {
+		auto this_ptr = getThis();
+		g_dispatcher.addTask(createTask([this_ptr]() {
+			this_ptr->stopLiveCast();
+		}));
 		if (recvbyte == 0x0F) {
 			disconnect();
 			return;
@@ -503,190 +578,6 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 	if (msg.isOverrun()) {
 		disconnect();
 	}
-}
-
-void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
-{
-	msg.add<uint16_t>(0x00); //environmental effects
-
-	int32_t count;
-	Item* ground = tile->getGround();
-	if (ground) {
-		msg.addItem(ground);
-		count = 1;
-	} else {
-		count = 0;
-	}
-
-	const TileItemVector* items = tile->getItemList();
-	if (items) {
-		for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
-			msg.addItem(*it);
-
-			if (++count == 10) {
-				return;
-			}
-		}
-	}
-
-	const CreatureVector* creatures = tile->getCreatures();
-	if (creatures) {
-		for (const Creature* creature : boost::adaptors::reverse(*creatures)) {
-			if (!player->canSeeCreature(creature)) {
-				continue;
-			}
-
-			bool known;
-			uint32_t removedKnown;
-			checkCreatureAsKnown(creature->getID(), known, removedKnown);
-			AddCreature(msg, creature, known, removedKnown);
-
-			if (++count == 10) {
-				return;
-			}
-		}
-	}
-
-	if (items) {
-		for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
-			msg.addItem(*it);
-
-			if (++count == 10) {
-				return;
-			}
-		}
-	}
-}
-
-void ProtocolGame::GetMapDescription(int32_t x, int32_t y, int32_t z, int32_t width, int32_t height, NetworkMessage& msg)
-{
-	int32_t skip = -1;
-	int32_t startz, endz, zstep;
-
-	if (z > 7) {
-		startz = z - 2;
-		endz = std::min<int32_t>(MAP_MAX_LAYERS - 1, z + 2);
-		zstep = 1;
-	} else {
-		startz = 7;
-		endz = 0;
-		zstep = -1;
-	}
-
-	for (int32_t nz = startz; nz != endz + zstep; nz += zstep) {
-		GetFloorDescription(msg, x, y, nz, width, height, z - nz, skip);
-	}
-
-	if (skip >= 0) {
-		msg.addByte(skip);
-		msg.addByte(0xFF);
-	}
-}
-
-void ProtocolGame::GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y, int32_t z, int32_t width, int32_t height, int32_t offset, int32_t& skip)
-{
-	for (int32_t nx = 0; nx < width; nx++) {
-		for (int32_t ny = 0; ny < height; ny++) {
-			Tile* tile = g_game.map.getTile(x + nx + offset, y + ny + offset, z);
-			if (tile) {
-				if (skip >= 0) {
-					msg.addByte(skip);
-					msg.addByte(0xFF);
-				}
-
-				skip = 0;
-				GetTileDescription(tile, msg);
-			} else if (skip == 0xFE) {
-				msg.addByte(0xFF);
-				msg.addByte(0xFF);
-				skip = -1;
-			} else {
-				++skip;
-			}
-		}
-	}
-}
-
-void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown)
-{
-	auto result = knownCreatureSet.insert(id);
-	if (!result.second) {
-		known = true;
-		return;
-	}
-
-	known = false;
-
-	if (knownCreatureSet.size() > 1300) {
-		// Look for a creature to remove
-		for (std::unordered_set<uint32_t>::iterator it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
-			Creature* creature = g_game.getCreatureByID(*it);
-			if (!canSee(creature)) {
-				removedKnown = *it;
-				knownCreatureSet.erase(it);
-				return;
-			}
-		}
-
-		// Bad situation. Let's just remove anyone.
-		std::unordered_set<uint32_t>::iterator it = knownCreatureSet.begin();
-		if (*it == id) {
-			++it;
-		}
-
-		removedKnown = *it;
-		knownCreatureSet.erase(it);
-	} else {
-		removedKnown = 0;
-	}
-}
-
-bool ProtocolGame::canSee(const Creature* c) const
-{
-	if (!c || !player || c->isRemoved()) {
-		return false;
-	}
-
-	if (!player->canSeeCreature(c)) {
-		return false;
-	}
-
-	return canSee(c->getPosition());
-}
-
-bool ProtocolGame::canSee(const Position& pos) const
-{
-	return canSee(pos.x, pos.y, pos.z);
-}
-
-bool ProtocolGame::canSee(int32_t x, int32_t y, int32_t z) const
-{
-	if (!player) {
-		return false;
-	}
-
-	const Position& myPos = player->getPosition();
-	if (myPos.z <= 7) {
-		//we are on ground level or above (7 -> 0)
-		//view is from 7 -> 0
-		if (z > 7) {
-			return false;
-		}
-	} else if (myPos.z >= 8) {
-		//we are underground (8 -> 15)
-		//view is +/- 2 from the floor we stand on
-		if (std::abs(myPos.getZ() - z) > 2) {
-			return false;
-		}
-	}
-
-	//negative offset means that the action taken place is on a lower floor than ourself
-	int32_t offsetz = myPos.getZ() - z;
-	if ((x >= myPos.getX() - 8 + offsetz) && (x <= myPos.getX() + 9 + offsetz) &&
-	        (y >= myPos.getY() - 6 + offsetz) && (y <= myPos.getY() + 7 + offsetz)) {
-		return true;
-	}
-	return false;
 }
 
 // Parse methods
@@ -1162,24 +1053,6 @@ void ProtocolGame::sendCreatureOutfit(const Creature* creature, const Outfit_t& 
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureLight(const Creature* creature)
-{
-	if (!canSee(creature)) {
-		return;
-	}
-
-	NetworkMessage msg;
-	AddCreatureLight(msg, creature);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendWorldLight(const LightInfo& lightInfo)
-{
-	NetworkMessage msg;
-	AddWorldLight(msg, lightInfo);
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendCreatureWalkthrough(const Creature* creature, bool walkthrough)
 {
 	if (!canSee(creature)) {
@@ -1279,24 +1152,7 @@ void ProtocolGame::sendReLoginWindow(uint8_t unfairFightReduction)
 	msg.addByte(0x28);
 	msg.addByte(0x00);
 	msg.addByte(unfairFightReduction);
-	writeToOutputBuffer(msg);
-}
 
-void ProtocolGame::sendStats()
-{
-	NetworkMessage msg;
-	AddPlayerStats(msg);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendBasicData()
-{
-	NetworkMessage msg;
-	msg.addByte(0x9F);
-	msg.addByte(player->isPremium() ? 0x01 : 0x00);
-	msg.add<uint32_t>(std::numeric_limits<uint32_t>::max());
-	msg.addByte(player->getVocation()->getClientId());
-	msg.add<uint16_t>(0x00);
 	writeToOutputBuffer(msg);
 }
 
@@ -1368,34 +1224,6 @@ void ProtocolGame::sendChannelsDialog()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendChannel(uint16_t channelId, const std::string& channelName, const UsersMap* channelUsers, const InvitedMap* invitedUsers)
-{
-	NetworkMessage msg;
-	msg.addByte(0xAC);
-
-	msg.add<uint16_t>(channelId);
-	msg.addString(channelName);
-
-	if (channelUsers) {
-		msg.add<uint16_t>(channelUsers->size());
-		for (const auto& it : *channelUsers) {
-			msg.addString(it.second->getName());
-		}
-	} else {
-		msg.add<uint16_t>(0x00);
-	}
-
-	if (invitedUsers) {
-		msg.add<uint16_t>(invitedUsers->size());
-		for (const auto& it : *invitedUsers) {
-			msg.addString(it.second->getName());
-		}
-	} else {
-		msg.add<uint16_t>(0x00);
-	}
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendChannelMessage(const std::string& author, const std::string& text, SpeakClasses type, uint16_t channel)
 {
 	NetworkMessage msg;
@@ -1414,44 +1242,6 @@ void ProtocolGame::sendIcons(uint16_t icons)
 	NetworkMessage msg;
 	msg.addByte(0xA2);
 	msg.add<uint16_t>(icons);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool hasParent, uint16_t firstIndex)
-{
-	NetworkMessage msg;
-	msg.addByte(0x6E);
-
-	msg.addByte(cid);
-
-	if (container->getID() == ITEM_BROWSEFIELD) {
-		msg.addItem(1987, 1);
-		msg.addString("Browse Field");
-	} else {
-		msg.addItem(container);
-		msg.addString(container->getName());
-	}
-
-	msg.addByte(container->capacity());
-
-	msg.addByte(hasParent ? 0x01 : 0x00);
-
-	msg.addByte(container->isUnlocked() ? 0x01 : 0x00); // Drag and drop
-	msg.addByte(container->hasPagination() ? 0x01 : 0x00); // Pagination
-
-	uint32_t containerSize = container->size();
-	msg.add<uint16_t>(containerSize);
-	msg.add<uint16_t>(firstIndex);
-	if (firstIndex < containerSize) {
-		uint8_t itemsToSend = std::min<uint32_t>(std::min<uint32_t>(container->capacity(), containerSize - firstIndex), std::numeric_limits<uint8_t>::max());
-
-		msg.addByte(itemsToSend);
-		for (ItemDeque::const_iterator it = container->getItemList().begin() + firstIndex, end = it + itemsToSend; it != end; ++it) {
-			msg.addItem(*it);
-		}
-	} else {
-		msg.addByte(0x00);
-	}
 	writeToOutputBuffer(msg);
 }
 
@@ -2174,54 +1964,12 @@ void ProtocolGame::sendChangeSpeed(const Creature* creature, uint32_t speed)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCancelWalk()
-{
-	NetworkMessage msg;
-	msg.addByte(0xB5);
-	msg.addByte(player->getDirection());
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendSkills()
-{
-	NetworkMessage msg;
-	AddPlayerSkills(msg);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendPing()
-{
-	NetworkMessage msg;
-	msg.addByte(0x1D);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendPingBack()
-{
-	NetworkMessage msg;
-	msg.addByte(0x1E);
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendDistanceShoot(const Position& from, const Position& to, uint8_t type)
 {
 	NetworkMessage msg;
 	msg.addByte(0x85);
 	msg.addPosition(from);
 	msg.addPosition(to);
-	msg.addByte(type);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendMagicEffect(const Position& pos, uint8_t type)
-{
-	if (!canSee(pos)) {
-		return;
-	}
-
-	NetworkMessage msg;
-	msg.addByte(0x83);
-	msg.addPosition(pos);
 	msg.addByte(type);
 	writeToOutputBuffer(msg);
 }
@@ -2249,14 +1997,6 @@ void ProtocolGame::sendFYIBox(const std::string& message)
 }
 
 //tile
-void ProtocolGame::sendMapDescription(const Position& pos)
-{
-	NetworkMessage msg;
-	msg.addByte(0x64);
-	msg.addPosition(player->getPosition());
-	GetMapDescription(pos.x - 8, pos.y - 6, pos.z, 18, 14, msg);
-	writeToOutputBuffer(msg);
-}
 
 void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const Item* item)
 {
@@ -2297,42 +2037,6 @@ void ProtocolGame::sendRemoveTileThing(const Position& pos, uint32_t stackpos)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendUpdateTile(const Tile* tile, const Position& pos)
-{
-	if (!canSee(pos)) {
-		return;
-	}
-
-	NetworkMessage msg;
-	msg.addByte(0x69);
-	msg.addPosition(pos);
-
-	if (tile) {
-		GetTileDescription(tile, msg);
-		msg.addByte(0x00);
-		msg.addByte(0xFF);
-	} else {
-		msg.addByte(0x01);
-		msg.addByte(0xFF);
-	}
-
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendPendingStateEntered()
-{
-	NetworkMessage msg;
-	msg.addByte(0x0A);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendEnterWorld()
-{
-	NetworkMessage msg;
-	msg.addByte(0x0F);
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendFightModes()
 {
 	NetworkMessage msg;
@@ -2344,117 +2048,6 @@ void ProtocolGame::sendFightModes()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin)
-{
-	if (!canSee(pos)) {
-		return;
-	}
-
-	if (creature != player) {
-		if (stackpos != -1) {
-			NetworkMessage msg;
-			msg.addByte(0x6A);
-			msg.addPosition(pos);
-			msg.addByte(stackpos);
-
-			bool known;
-			uint32_t removedKnown;
-			checkCreatureAsKnown(creature->getID(), known, removedKnown);
-			AddCreature(msg, creature, known, removedKnown);
-			writeToOutputBuffer(msg);
-		}
-
-		if (isLogin) {
-			sendMagicEffect(pos, CONST_ME_TELEPORT);
-		}
-		return;
-	}
-
-	NetworkMessage msg;
-	msg.addByte(0x17);
-
-	msg.add<uint32_t>(player->getID());
-	msg.add<uint16_t>(0x32); // beat duration (50)
-
-	msg.addDouble(Creature::speedA, 3);
-	msg.addDouble(Creature::speedB, 3);
-	msg.addDouble(Creature::speedC, 3);
-
-	// can report bugs?
-	if (player->getAccountType() >= ACCOUNT_TYPE_TUTOR) {
-		msg.addByte(0x01);
-	} else {
-		msg.addByte(0x00);
-	}
-
-	msg.addByte(0x00); // can change pvp framing option
-	msg.addByte(0x00); // expert mode button enabled
-
-	writeToOutputBuffer(msg);
-
-	sendPendingStateEntered();
-	sendEnterWorld();
-	sendMapDescription(pos);
-
-	if (isLogin) {
-		sendMagicEffect(pos, CONST_ME_TELEPORT);
-	}
-
-	sendInventoryItem(CONST_SLOT_HEAD, player->getInventoryItem(CONST_SLOT_HEAD));
-	sendInventoryItem(CONST_SLOT_NECKLACE, player->getInventoryItem(CONST_SLOT_NECKLACE));
-	sendInventoryItem(CONST_SLOT_BACKPACK, player->getInventoryItem(CONST_SLOT_BACKPACK));
-	sendInventoryItem(CONST_SLOT_ARMOR, player->getInventoryItem(CONST_SLOT_ARMOR));
-	sendInventoryItem(CONST_SLOT_RIGHT, player->getInventoryItem(CONST_SLOT_RIGHT));
-	sendInventoryItem(CONST_SLOT_LEFT, player->getInventoryItem(CONST_SLOT_LEFT));
-	sendInventoryItem(CONST_SLOT_LEGS, player->getInventoryItem(CONST_SLOT_LEGS));
-	sendInventoryItem(CONST_SLOT_FEET, player->getInventoryItem(CONST_SLOT_FEET));
-	sendInventoryItem(CONST_SLOT_RING, player->getInventoryItem(CONST_SLOT_RING));
-	sendInventoryItem(CONST_SLOT_AMMO, player->getInventoryItem(CONST_SLOT_AMMO));
-
-	sendStats();
-	sendSkills();
-
-	//gameworld light-settings
-	LightInfo lightInfo;
-	g_game.getWorldLightInfo(lightInfo);
-	sendWorldLight(lightInfo);
-
-	//player light level
-	sendCreatureLight(creature);
-
-	const std::forward_list<VIPEntry>& vipEntries = IOLoginData::getVIPEntries(player->getAccount());
-
-	if (player->isAccessPlayer()) {
-		for (const VIPEntry& entry : vipEntries) {
-			VipStatus_t vipStatus;
-
-			Player* vipPlayer = g_game.getPlayerByGUID(entry.guid);
-			if (!vipPlayer) {
-				vipStatus = VIPSTATUS_OFFLINE;
-			} else {
-				vipStatus = VIPSTATUS_ONLINE;
-			}
-
-			sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);
-		}
-	} else {
-		for (const VIPEntry& entry : vipEntries) {
-			VipStatus_t vipStatus;
-
-			Player* vipPlayer = g_game.getPlayerByGUID(entry.guid);
-			if (!vipPlayer || vipPlayer->isInGhostMode()) {
-				vipStatus = VIPSTATUS_OFFLINE;
-			} else {
-				vipStatus = VIPSTATUS_ONLINE;
-			}
-
-			sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);
-		}
-	}
-
-	sendBasicData();
-	player->sendIcons();
-}
 
 void ProtocolGame::sendMoveCreature(const Creature* creature, const Position& newPos, int32_t newStackPos, const Position& oldPos, int32_t oldStackPos, bool teleport)
 {
@@ -2517,20 +2110,6 @@ void ProtocolGame::sendMoveCreature(const Creature* creature, const Position& ne
 	} else if (canSee(creature->getPosition())) {
 		sendAddCreature(creature, newPos, newStackPos, false);
 	}
-}
-
-void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
-{
-	NetworkMessage msg;
-	if (item) {
-		msg.addByte(0x78);
-		msg.addByte(slot);
-		msg.addItem(item);
-	} else {
-		msg.addByte(0x79);
-		msg.addByte(slot);
-	}
-	writeToOutputBuffer(msg);
 }
 
 void ProtocolGame::sendAddContainerItem(uint8_t cid, uint16_t slot, const Item* item)
@@ -2696,19 +2275,6 @@ void ProtocolGame::sendUpdatedVIPStatus(uint32_t guid, VipStatus_t newStatus)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendVIP(uint32_t guid, const std::string& name, const std::string& description, uint32_t icon, bool notify, VipStatus_t status)
-{
-	NetworkMessage msg;
-	msg.addByte(0xD2);
-	msg.add<uint32_t>(guid);
-	msg.addString(name);
-	msg.addString(description);
-	msg.add<uint32_t>(std::min<uint32_t>(10, icon));
-	msg.addByte(notify ? 0x01 : 0x00);
-	msg.addByte(status);
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendSpellCooldown(uint8_t spellId, uint32_t time)
 {
 	NetworkMessage msg;
@@ -2756,171 +2322,6 @@ void ProtocolGame::sendModalWindow(const ModalWindow& modalWindow)
 }
 
 ////////////// Add common messages
-void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove)
-{
-	CreatureType_t creatureType = creature->getType();
-
-	const Player* otherPlayer = creature->getPlayer();
-
-	if (known) {
-		msg.add<uint16_t>(0x62);
-		msg.add<uint32_t>(creature->getID());
-	} else {
-		msg.add<uint16_t>(0x61);
-		msg.add<uint32_t>(remove);
-		msg.add<uint32_t>(creature->getID());
-		msg.addByte(creatureType);
-		msg.addString(creature->getName());
-	}
-
-	if (creature->isHealthHidden()) {
-		msg.addByte(0x00);
-	} else {
-		msg.addByte(std::ceil((static_cast<double>(creature->getHealth()) / std::max<int32_t>(creature->getMaxHealth(), 1)) * 100));
-	}
-
-	msg.addByte(creature->getDirection());
-
-	if (!creature->isInGhostMode() && !creature->isInvisible()) {
-		AddOutfit(msg, creature->getCurrentOutfit());
-	} else {
-		static Outfit_t outfit;
-		AddOutfit(msg, outfit);
-	}
-
-	LightInfo lightInfo;
-	creature->getCreatureLight(lightInfo);
-	msg.addByte(player->isAccessPlayer() ? 0xFF : lightInfo.level);
-	msg.addByte(lightInfo.color);
-
-	msg.add<uint16_t>(creature->getStepSpeed() / 2);
-
-	msg.addByte(player->getSkullClient(creature));
-	msg.addByte(player->getPartyShield(otherPlayer));
-
-	if (!known) {
-		msg.addByte(player->getGuildEmblem(otherPlayer));
-	}
-
-	if (creatureType == CREATURETYPE_MONSTER) {
-		const Creature* master = creature->getMaster();
-		if (master) {
-			const Player* masterPlayer = master->getPlayer();
-			if (masterPlayer) {
-				if (masterPlayer == player) {
-					creatureType = CREATURETYPE_SUMMON_OWN;
-				} else {
-					creatureType = CREATURETYPE_SUMMON_OTHERS;
-				}
-			}
-		}
-	}
-
-	msg.addByte(creatureType); // Type (for summons)
-	msg.addByte(creature->getSpeechBubble());
-	msg.addByte(0xFF); // MARK_UNMARKED
-
-	if (otherPlayer) {
-		msg.add<uint16_t>(otherPlayer->getHelpers());
-	} else {
-		msg.add<uint16_t>(0x00);
-	}
-
-	msg.addByte(player->canWalkthroughEx(creature) ? 0x00 : 0x01);
-}
-
-void ProtocolGame::AddPlayerStats(NetworkMessage& msg)
-{
-	msg.addByte(0xA0);
-
-	msg.add<uint16_t>(std::min<int32_t>(player->getHealth(), std::numeric_limits<uint16_t>::max()));
-	msg.add<uint16_t>(std::min<int32_t>(player->getPlayerInfo(PLAYERINFO_MAXHEALTH), std::numeric_limits<uint16_t>::max()));
-
-	msg.add<uint32_t>(player->getFreeCapacity());
-	msg.add<uint32_t>(player->getCapacity());
-
-	msg.add<uint64_t>(player->getExperience());
-
-	msg.add<uint16_t>(player->getLevel());
-	msg.addByte(player->getPlayerInfo(PLAYERINFO_LEVELPERCENT));
-	msg.addDouble(0, 3); // experience bonus
-
-	msg.add<uint16_t>(std::min<int32_t>(player->getMana(), std::numeric_limits<uint16_t>::max()));
-	msg.add<uint16_t>(std::min<int32_t>(player->getPlayerInfo(PLAYERINFO_MAXMANA), std::numeric_limits<uint16_t>::max()));
-
-	msg.addByte(std::min<uint32_t>(player->getMagicLevel(), std::numeric_limits<uint8_t>::max()));
-	msg.addByte(std::min<uint32_t>(player->getBaseMagicLevel(), std::numeric_limits<uint8_t>::max()));
-	msg.addByte(player->getPlayerInfo(PLAYERINFO_MAGICLEVELPERCENT));
-
-	msg.addByte(player->getSoul());
-
-	msg.add<uint16_t>(player->getStaminaMinutes());
-
-	msg.add<uint16_t>(player->getBaseSpeed() / 2);
-
-	Condition* condition = player->getCondition(CONDITION_REGENERATION);
-	msg.add<uint16_t>(condition ? condition->getTicks() / 1000 : 0x00);
-
-	msg.add<uint16_t>(player->getOfflineTrainingTime() / 60 / 1000);
-}
-
-void ProtocolGame::AddPlayerSkills(NetworkMessage& msg)
-{
-	msg.addByte(0xA1);
-
-	for (uint8_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
-		msg.add<uint16_t>(std::min<int32_t>(player->getSkillLevel(i), std::numeric_limits<uint16_t>::max()));
-		msg.add<uint16_t>(player->getBaseSkill(i));
-		msg.addByte(player->getSkillPercent(i));
-	}
-}
-
-void ProtocolGame::AddOutfit(NetworkMessage& msg, const Outfit_t& outfit)
-{
-	msg.add<uint16_t>(outfit.lookType);
-
-	if (outfit.lookType != 0) {
-		msg.addByte(outfit.lookHead);
-		msg.addByte(outfit.lookBody);
-		msg.addByte(outfit.lookLegs);
-		msg.addByte(outfit.lookFeet);
-		msg.addByte(outfit.lookAddons);
-	} else {
-		msg.addItemId(outfit.lookTypeEx);
-	}
-
-	msg.add<uint16_t>(outfit.lookMount);
-}
-
-void ProtocolGame::AddWorldLight(NetworkMessage& msg, const LightInfo& lightInfo)
-{
-	msg.addByte(0x82);
-	msg.addByte((player->isAccessPlayer() ? 0xFF : lightInfo.level));
-	msg.addByte(lightInfo.color);
-}
-
-void ProtocolGame::AddCreatureLight(NetworkMessage& msg, const Creature* creature)
-{
-	LightInfo lightInfo;
-	creature->getCreatureLight(lightInfo);
-
-	msg.addByte(0x8D);
-	msg.add<uint32_t>(creature->getID());
-	msg.addByte((player->isAccessPlayer() ? 0xFF : lightInfo.level));
-	msg.addByte(lightInfo.color);
-}
-
-//tile
-void ProtocolGame::RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos)
-{
-	if (stackpos >= 10) {
-		return;
-	}
-
-	msg.addByte(0x6C);
-	msg.addPosition(pos);
-	msg.addByte(stackpos);
-}
 
 void ProtocolGame::MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos)
 {

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -24,6 +24,8 @@
 #include "chat.h"
 #include "creature.h"
 #include "tasks.h"
+#include "protocolgamebase.h"
+#include "protocolspectator.h"
 
 class NetworkMessage;
 class Player;
@@ -34,6 +36,7 @@ class Tile;
 class Connection;
 class Quest;
 class ProtocolGame;
+class ProtocolSpectator;
 typedef std::shared_ptr<ProtocolGame> ProtocolGame_ptr;
 
 extern Game g_game;
@@ -59,18 +62,14 @@ struct TextMessage
 	}
 };
 
-class ProtocolGame final : public Protocol
+class ProtocolGame final : public ProtocolGameBase
 {
 	public:
-		// static protocol information
-		enum {server_sends_first = true};
-		enum {protocol_identifier = 0}; // Not required as we send first
-		enum {use_checksum = true};
 		static const char* protocol_name() {
 			return "gameworld protocol";
 		}
-
-		explicit ProtocolGame(Connection_ptr connection);
+		explicit ProtocolGame(Connection_ptr connection):
+			ProtocolGameBase(connection) {}
 
 		void login(const std::string& name, uint32_t accnumber, OperatingSystem_t operatingSystem);
 		void logout(bool displayEffect, bool forced);
@@ -79,26 +78,121 @@ class ProtocolGame final : public Protocol
 			return version;
 		}
 
+		const std::unordered_set<uint32_t>& getKnownCreatures() const {
+			return knownCreatureSet;
+		}
+
+		typedef std::unordered_map<Player*, ProtocolGame_ptr> LiveCastsMap;
+		typedef std::vector<ProtocolSpectator_ptr> CastSpectatorVec;
+
+		/** \brief Adds a spectator from the spectators vector.
+		 *  \param spectatorClient pointer to the \ref ProtocolSpectator object representing the spectator
+		 */
+		void addSpectator(ProtocolSpectator_ptr spectatorClient);
+
+		/** \brief Removes a spectator from the spectators vector.
+		 *  \param spectatorClient pointer to the \ref ProtocolSpectator object representing the spectator
+		 */
+		void removeSpectator(ProtocolSpectator_ptr spectatorClient);
+
+		/** \brief Starts the live cast.
+		 *  \param password live cast password(optional)
+		 *  \returns bool type indicating whether starting the cast was successful
+		*/
+		bool startLiveCast(const std::string& password = "");
+
+		/** \brief Stops the live cast and disconnects all spectators.
+		 *  \returns bool type indicating whether stopping the cast was successful
+		*/
+		bool stopLiveCast();
+
+		const CastSpectatorVec& getLiveCastSpectators() const {
+			return spectators;
+		}
+
+		size_t getSpectatorCount() const {
+			return spectators.size();
+		}
+
+		bool isLiveCaster() const {
+			return isCaster.load(std::memory_order_relaxed);
+		}
+
+		std::mutex liveCastLock;
+
+		/** \brief Adds a new live cast to the list of available casts
+		 */
+		void registerLiveCast();
+
+		/** \brief Removes a live cast from the list of available casts
+		 */
+		void unregisterLiveCast();
+
+		/** \brief Update live cast info in the database.
+		 *  \param player pointer to the casting \ref Player object
+		 *  \param client pointer to the caster's \ref ProtocolGame object
+		 */
+		void updateLiveCastInfo();
+
+		/** \brief Clears all live casts. Used to make sure there aro no live cast db rows left should a crash occur.
+		 *  \warning Only supposed to be called once.
+		 */
+		static void clearLiveCastInfo();
+
+		/** \brief Finds the caster's \ref ProtocolGame object
+		 *  \param player pointer to the casting \ref Player object
+		 *  \returns A pointer to the \ref ProtocolGame of the caster
+		 */
+		static ProtocolGame_ptr getLiveCast(Player* player) {
+			const auto it = liveCasts.find(player);
+			return it != liveCasts.end() ? it->second : nullptr;
+		}
+
+		const std::string& getLiveCastName() const {
+			return liveCastName;
+		}
+
+		const std::string& getLiveCastPassword() const {
+			return liveCastPassword;
+		}
+
+		bool isPasswordProtected() const {
+			return !liveCastPassword.empty();
+		}
+
+		static const LiveCastsMap& getLiveCasts() {
+			return liveCasts;
+		}
+
+		/** \brief Allows spectators to send text messages to the caster
+		 *   and then get broadcast to the rest of the spectators
+		 *  \param text string containing the text message
+		 */
+		void broadcastSpectatorMessage(const std::string& text) {
+			if (player) {
+				sendChannelMessage("Spectator", text, TALKTYPE_CHANNEL_Y, CHANNEL_CAST);
+			}
+		}
+
+		static uint8_t getMaxLiveCastCount() {
+			return std::numeric_limits<int8_t>::max();
+		}
+
 	private:
 		ProtocolGame_ptr getThis() {
 			return std::static_pointer_cast<ProtocolGame>(shared_from_this());
 		}
 		void connect(uint32_t playerId, OperatingSystem_t operatingSystem);
 		void disconnectClient(const std::string& message) const;
-		void writeToOutputBuffer(const NetworkMessage& msg);
+		void writeToOutputBuffer(const NetworkMessage& msg, bool broadcast = true) final;
 
 		void release() final;
 
 		void checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown);
 
-		bool canSee(int32_t x, int32_t y, int32_t z) const;
-		bool canSee(const Creature*) const;
-		bool canSee(const Position& pos) const;
-
 		// we have all the parse methods
 		void parsePacket(NetworkMessage& msg) final;
 		void onRecvFirstMessage(NetworkMessage& msg) final;
-		void onConnect() final;
 
 		//Parse methods
 		void parseAutoWalk(NetworkMessage& msg);
@@ -173,7 +267,6 @@ class ProtocolGame final : public Protocol
 		void sendClosePrivate(uint16_t channelId);
 		void sendCreatePrivateChannel(uint16_t channelId, const std::string& channelName);
 		void sendChannelsDialog();
-		void sendChannel(uint16_t channelId, const std::string& channelName, const UsersMap* channelUsers, const InvitedMap* invitedUsers);
 		void sendOpenPrivateChannel(const std::string& receiver);
 		void sendToChannel(const Creature* creature, SpeakClasses type, const std::string& text, uint16_t channelId);
 		void sendPrivateMessage(const Player* speaker, SpeakClasses type, const std::string& text);
@@ -181,24 +274,17 @@ class ProtocolGame final : public Protocol
 		void sendFYIBox(const std::string& message);
 
 		void sendDistanceShoot(const Position& from, const Position& to, uint8_t type);
-		void sendMagicEffect(const Position& pos, uint8_t type);
 		void sendCreatureHealth(const Creature* creature);
-		void sendSkills();
-		void sendPing();
-		void sendPingBack();
 		void sendCreatureTurn(const Creature* creature, uint32_t stackpos);
 		void sendCreatureSay(const Creature* creature, SpeakClasses type, const std::string& text, const Position* pos = nullptr);
 
 		void sendQuestLog();
 		void sendQuestLine(const Quest* quest);
 
-		void sendCancelWalk();
 		void sendChangeSpeed(const Creature* creature, uint32_t speed);
 		void sendCancelTarget();
 		void sendCreatureVisible(const Creature* creature, bool visible);
 		void sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit);
-		void sendStats();
-		void sendBasicData();
 		void sendTextMessage(const TextMessage& message);
 		void sendReLoginWindow(uint8_t unfairFightReduction);
 
@@ -231,15 +317,8 @@ class ProtocolGame final : public Protocol
 		void sendOutfitWindow();
 
 		void sendUpdatedVIPStatus(uint32_t guid, VipStatus_t newStatus);
-		void sendVIP(uint32_t guid, const std::string& name, const std::string& description, uint32_t icon, bool notify, VipStatus_t status);
-
-		void sendPendingStateEntered();
-		void sendEnterWorld();
 
 		void sendFightModes();
-
-		void sendCreatureLight(const Creature* creature);
-		void sendWorldLight(const LightInfo& lightInfo);
 
 		void sendCreatureSquare(const Creature* creature, SquareColor_t color);
 
@@ -247,14 +326,11 @@ class ProtocolGame final : public Protocol
 		void sendSpellGroupCooldown(SpellGroup_t groupId, uint32_t time);
 
 		//tiles
-		void sendMapDescription(const Position& pos);
 
 		void sendAddTileItem(const Position& pos, uint32_t stackpos, const Item* item);
 		void sendUpdateTileItem(const Position& pos, uint32_t stackpos, const Item* item);
 		void sendRemoveTileThing(const Position& pos, uint32_t stackpos);
-		void sendUpdateTile(const Tile* tile, const Position& pos);
 
-		void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin);
 		void sendMoveCreature(const Creature* creature, const Position& newPos, int32_t newStackPos,
 		                      const Position& oldPos, int32_t oldStackPos, bool teleport);
 
@@ -263,37 +339,12 @@ class ProtocolGame final : public Protocol
 		void sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Item* item);
 		void sendRemoveContainerItem(uint8_t cid, uint16_t slot, const Item* lastItem);
 
-		void sendContainer(uint8_t cid, const Container* container, bool hasParent, uint16_t firstIndex);
 		void sendCloseContainer(uint8_t cid);
-
-		//inventory
-		void sendInventoryItem(slots_t slot, const Item* item);
 
 		//messages
 		void sendModalWindow(const ModalWindow& modalWindow);
 
 		//Help functions
-
-		// translate a tile to clientreadable format
-		void GetTileDescription(const Tile* tile, NetworkMessage& msg);
-
-		// translate a floor to clientreadable format
-		void GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y, int32_t z,
-		                         int32_t width, int32_t height, int32_t offset, int32_t& skip);
-
-		// translate a map area to clientreadable format
-		void GetMapDescription(int32_t x, int32_t y, int32_t z,
-		                       int32_t width, int32_t height, NetworkMessage& msg);
-
-		void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove);
-		void AddPlayerStats(NetworkMessage& msg);
-		void AddOutfit(NetworkMessage& msg, const Outfit_t& outfit);
-		void AddPlayerSkills(NetworkMessage& msg);
-		void AddWorldLight(NetworkMessage& msg, const LightInfo& lightInfo);
-		void AddCreatureLight(NetworkMessage& msg, const Creature* creature);
-
-		//tiles
-		static void RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos);
 
 		void MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
 		void MoveDownCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
@@ -325,17 +376,18 @@ class ProtocolGame final : public Protocol
 			g_dispatcher.addTask(createTask(delay, std::bind(function, &g_game, std::forward<Args>(args)...)));
 		}
 
-		std::unordered_set<uint32_t> knownCreatureSet;
-		Player* player;
+		static LiveCastsMap liveCasts; ///< Stores all available casts.
 
-		uint32_t eventConnect;
-		uint32_t challengeTimestamp;
-		uint16_t version;
+		std::atomic<bool> isCaster {false}; ///< Determines if this \ref ProtocolGame object is casting
 
-		uint8_t challengeRandom;
+		/// list of spectators \warning This variable should only be accessed after locking \ref liveCastLock
+		CastSpectatorVec spectators;
 
-		bool debugAssertSent;
-		bool acceptPackets;
+		/// Live cast name that is also used as login
+		std::string liveCastName;
+
+		/// Password used to access the live cast
+		std::string liveCastPassword;
 };
 
 #endif

--- a/src/protocolgamebase.cpp
+++ b/src/protocolgamebase.cpp
@@ -1,0 +1,734 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2015  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "otpch.h"
+#include <boost/range/adaptor/reversed.hpp>
+#include "protocolgamebase.h"
+#include "game.h"
+#include "iologindata.h"
+#include "tile.h"
+#include "outputmessage.h"
+
+extern Game g_game;
+
+void ProtocolGameBase::onConnect()
+{
+	auto output = OutputMessagePool::getOutputMessage();
+	static std::random_device rd;
+	static std::ranlux24 generator(rd());
+	static std::uniform_int_distribution<uint16_t> randNumber(0x00, 0xFF);
+
+	// Skip checksum
+	output->skipBytes(sizeof(uint32_t));
+
+	// Packet length & type
+	output->add<uint16_t>(0x0006);
+	output->addByte(0x1F);
+
+	// Add timestamp & random number
+	challengeTimestamp = static_cast<uint32_t>(time(nullptr));
+	output->add<uint32_t>(challengeTimestamp);
+
+	challengeRandom = randNumber(generator);
+	output->addByte(challengeRandom);
+
+	// Go back and write checksum
+	output->skipBytes(-12);
+	output->add<uint32_t>(adlerChecksum(output->getOutputBuffer() + sizeof(uint32_t), 8));
+
+	send(std::move(output));
+}
+
+void ProtocolGameBase::AddOutfit(NetworkMessage& msg, const Outfit_t& outfit)
+{
+	msg.add<uint16_t>(outfit.lookType);
+
+	if (outfit.lookType != 0) {
+		msg.addByte(outfit.lookHead);
+		msg.addByte(outfit.lookBody);
+		msg.addByte(outfit.lookLegs);
+		msg.addByte(outfit.lookFeet);
+		msg.addByte(outfit.lookAddons);
+	} else {
+		msg.addItemId(outfit.lookTypeEx);
+	}
+
+	msg.add<uint16_t>(outfit.lookMount);
+}
+
+void ProtocolGameBase::checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown)
+{
+	auto result = knownCreatureSet.insert(id);
+	if (!result.second) {
+		known = true;
+		return;
+	}
+
+	known = false;
+
+	if (knownCreatureSet.size() > 1300) {
+		// Look for a creature to remove
+		for (std::unordered_set<uint32_t>::iterator it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
+			Creature* creature = g_game.getCreatureByID(*it);
+			if (!canSee(creature)) {
+				removedKnown = *it;
+				knownCreatureSet.erase(it);
+				return;
+			}
+		}
+
+		// Bad situation. Let's just remove anyone.
+		std::unordered_set<uint32_t>::iterator it = knownCreatureSet.begin();
+		if (*it == id) {
+			++it;
+		}
+
+		removedKnown = *it;
+		knownCreatureSet.erase(it);
+	} else {
+		removedKnown = 0;
+	}
+}
+
+void ProtocolGameBase::AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove)
+{
+	CreatureType_t creatureType = creature->getType();
+
+	const Player* otherPlayer = creature->getPlayer();
+
+	if (known) {
+		msg.add<uint16_t>(0x62);
+		msg.add<uint32_t>(creature->getID());
+	} else {
+		msg.add<uint16_t>(0x61);
+		msg.add<uint32_t>(remove);
+		msg.add<uint32_t>(creature->getID());
+		msg.addByte(creatureType);
+		msg.addString(creature->getName());
+	}
+
+	if (creature->isHealthHidden()) {
+		msg.addByte(0x00);
+	} else {
+		msg.addByte(std::ceil((static_cast<double>(creature->getHealth()) / std::max<int32_t>(creature->getMaxHealth(), 1)) * 100));
+	}
+
+	msg.addByte(creature->getDirection());
+
+	if (!creature->isInGhostMode() && !creature->isInvisible()) {
+		AddOutfit(msg, creature->getCurrentOutfit());
+	} else {
+		static Outfit_t outfit;
+		AddOutfit(msg, outfit);
+	}
+
+	LightInfo lightInfo;
+	creature->getCreatureLight(lightInfo);
+	msg.addByte(player->isAccessPlayer() ? 0xFF : lightInfo.level);
+	msg.addByte(lightInfo.color);
+
+	msg.add<uint16_t>(creature->getStepSpeed() / 2);
+
+	msg.addByte(player->getSkullClient(creature));
+	msg.addByte(player->getPartyShield(otherPlayer));
+
+	if (!known) {
+		msg.addByte(player->getGuildEmblem(otherPlayer));
+	}
+
+	if (creatureType == CREATURETYPE_MONSTER) {
+		const Creature* master = creature->getMaster();
+		if (master) {
+			const Player* masterPlayer = master->getPlayer();
+			if (masterPlayer) {
+				if (masterPlayer == player) {
+					creatureType = CREATURETYPE_SUMMON_OWN;
+				} else {
+					creatureType = CREATURETYPE_SUMMON_OTHERS;
+				}
+			}
+		}
+	}
+
+	msg.addByte(creatureType); // Type (for summons)
+	msg.addByte(creature->getSpeechBubble());
+	msg.addByte(0xFF); // MARK_UNMARKED
+
+	if (otherPlayer) {
+		msg.add<uint16_t>(otherPlayer->getHelpers());
+	} else {
+		msg.add<uint16_t>(0x00);
+	}
+
+	msg.addByte(player->canWalkthroughEx(creature) ? 0x00 : 0x01);
+}
+
+void ProtocolGameBase::AddPlayerStats(NetworkMessage& msg)
+{
+	msg.addByte(0xA0);
+
+	msg.add<uint16_t>(std::min<int32_t>(player->getHealth(), std::numeric_limits<uint16_t>::max()));
+	msg.add<uint16_t>(std::min<int32_t>(player->getPlayerInfo(PLAYERINFO_MAXHEALTH), std::numeric_limits<uint16_t>::max()));
+
+	msg.add<uint32_t>(player->getFreeCapacity());
+	msg.add<uint32_t>(player->getCapacity());
+
+	msg.add<uint64_t>(player->getExperience());
+
+	msg.add<uint16_t>(player->getLevel());
+	msg.addByte(player->getPlayerInfo(PLAYERINFO_LEVELPERCENT));
+	msg.addDouble(0, 3); // experience bonus
+
+	msg.add<uint16_t>(std::min<int32_t>(player->getMana(), std::numeric_limits<uint16_t>::max()));
+	msg.add<uint16_t>(std::min<int32_t>(player->getPlayerInfo(PLAYERINFO_MAXMANA), std::numeric_limits<uint16_t>::max()));
+
+	msg.addByte(std::min<uint32_t>(player->getMagicLevel(), std::numeric_limits<uint8_t>::max()));
+	msg.addByte(std::min<uint32_t>(player->getBaseMagicLevel(), std::numeric_limits<uint8_t>::max()));
+	msg.addByte(player->getPlayerInfo(PLAYERINFO_MAGICLEVELPERCENT));
+
+	msg.addByte(player->getSoul());
+
+	msg.add<uint16_t>(player->getStaminaMinutes());
+
+	msg.add<uint16_t>(player->getBaseSpeed() / 2);
+
+	Condition* condition = player->getCondition(CONDITION_REGENERATION);
+	msg.add<uint16_t>(condition ? condition->getTicks() / 1000 : 0x00);
+
+	msg.add<uint16_t>(player->getOfflineTrainingTime() / 60 / 1000);
+}
+
+void ProtocolGameBase::AddPlayerSkills(NetworkMessage& msg)
+{
+	msg.addByte(0xA1);
+
+	for (uint8_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
+		msg.add<uint16_t>(std::min<int32_t>(player->getSkillLevel(i), std::numeric_limits<uint16_t>::max()));
+		msg.add<uint16_t>(player->getBaseSkill(i));
+		msg.addByte(player->getSkillPercent(i));
+	}
+}
+
+void ProtocolGameBase::AddWorldLight(NetworkMessage& msg, const LightInfo& lightInfo)
+{
+	msg.addByte(0x82);
+	msg.addByte((player->isAccessPlayer() ? 0xFF : lightInfo.level));
+	msg.addByte(lightInfo.color);
+}
+
+void ProtocolGameBase::AddCreatureLight(NetworkMessage& msg, const Creature* creature)
+{
+	LightInfo lightInfo;
+	creature->getCreatureLight(lightInfo);
+
+	msg.addByte(0x8D);
+	msg.add<uint32_t>(creature->getID());
+	msg.addByte((player->isAccessPlayer() ? 0xFF : lightInfo.level));
+	msg.addByte(lightInfo.color);
+}
+
+bool ProtocolGameBase::canSee(const Creature* c) const
+{
+	if (!c || !player || c->isRemoved()) {
+		return false;
+	}
+
+	if (!player->canSeeCreature(c)) {
+		return false;
+	}
+
+	return canSee(c->getPosition());
+}
+
+bool ProtocolGameBase::canSee(const Position& pos) const
+{
+	return canSee(pos.x, pos.y, pos.z);
+}
+
+bool ProtocolGameBase::canSee(int32_t x, int32_t y, int32_t z) const
+{
+	if (!player) {
+		return false;
+	}
+
+	const Position& myPos = player->getPosition();
+	if (myPos.z <= 7) {
+		//we are on ground level or above (7 -> 0)
+		//view is from 7 -> 0
+		if (z > 7) {
+			return false;
+		}
+	} else if (myPos.z >= 8) {
+		//we are underground (8 -> 15)
+		//view is +/- 2 from the floor we stand on
+		if (std::abs(myPos.getZ() - z) > 2) {
+			return false;
+		}
+	}
+
+	//negative offset means that the action taken place is on a lower floor than ourself
+	int32_t offsetz = myPos.getZ() - z;
+	if ((x >= myPos.getX() - 8 + offsetz) && (x <= myPos.getX() + 9 + offsetz) &&
+	        (y >= myPos.getY() - 6 + offsetz) && (y <= myPos.getY() + 7 + offsetz)) {
+		return true;
+	}
+	return false;
+}
+
+//tile
+void ProtocolGameBase::RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos)
+{
+	if (stackpos >= 10) {
+		return;
+	}
+
+	msg.addByte(0x6C);
+	msg.addPosition(pos);
+	msg.addByte(stackpos);
+}
+
+void ProtocolGameBase::sendUpdateTile(const Tile* tile, const Position& pos)
+{
+	if (!canSee(pos)) {
+		return;
+	}
+
+	NetworkMessage msg;
+	msg.addByte(0x69);
+	msg.addPosition(pos);
+
+	if (tile) {
+		GetTileDescription(tile, msg);
+		msg.addByte(0x00);
+		msg.addByte(0xFF);
+	} else {
+		msg.addByte(0x01);
+		msg.addByte(0xFF);
+	}
+
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::GetTileDescription(const Tile* tile, NetworkMessage& msg)
+{
+	msg.add<uint16_t>(0x00); //environmental effects
+
+	int32_t count;
+	Item* ground = tile->getGround();
+	if (ground) {
+		msg.addItem(ground);
+		count = 1;
+	} else {
+		count = 0;
+	}
+
+	const TileItemVector* items = tile->getItemList();
+	if (items) {
+		for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
+			msg.addItem(*it);
+
+			if (++count == 10) {
+				return;
+			}
+		}
+	}
+
+	const CreatureVector* creatures = tile->getCreatures();
+	if (creatures) {
+		for (const Creature* creature : boost::adaptors::reverse(*creatures)) {
+			if (!player->canSeeCreature(creature)) {
+				continue;
+			}
+
+			bool known;
+			uint32_t removedKnown;
+			checkCreatureAsKnown(creature->getID(), known, removedKnown);
+			AddCreature(msg, creature, known, removedKnown);
+
+			if (++count == 10) {
+				return;
+			}
+		}
+	}
+
+	if (items) {
+		for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
+			msg.addItem(*it);
+
+			if (++count == 10) {
+				return;
+			}
+		}
+	}
+}
+
+void ProtocolGameBase::GetMapDescription(int32_t x, int32_t y, int32_t z, int32_t width, int32_t height, NetworkMessage& msg)
+{
+	int32_t skip = -1;
+	int32_t startz, endz, zstep;
+
+	if (z > 7) {
+		startz = z - 2;
+		endz = std::min<int32_t>(MAP_MAX_LAYERS - 1, z + 2);
+		zstep = 1;
+	} else {
+		startz = 7;
+		endz = 0;
+		zstep = -1;
+	}
+
+	for (int32_t nz = startz; nz != endz + zstep; nz += zstep) {
+		GetFloorDescription(msg, x, y, nz, width, height, z - nz, skip);
+	}
+
+	if (skip >= 0) {
+		msg.addByte(skip);
+		msg.addByte(0xFF);
+	}
+}
+
+void ProtocolGameBase::GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y, int32_t z, int32_t width, int32_t height, int32_t offset, int32_t& skip)
+{
+	for (int32_t nx = 0; nx < width; nx++) {
+		for (int32_t ny = 0; ny < height; ny++) {
+			Tile* tile = g_game.map.getTile(x + nx + offset, y + ny + offset, z);
+			if (tile) {
+				if (skip >= 0) {
+					msg.addByte(skip);
+					msg.addByte(0xFF);
+				}
+
+				skip = 0;
+				GetTileDescription(tile, msg);
+			} else if (skip == 0xFE) {
+				msg.addByte(0xFF);
+				msg.addByte(0xFF);
+				skip = -1;
+			} else {
+				++skip;
+			}
+		}
+	}
+}
+
+void ProtocolGameBase::sendContainer(uint8_t cid, const Container* container, bool hasParent, uint16_t firstIndex)
+{
+	NetworkMessage msg;
+	msg.addByte(0x6E);
+
+	msg.addByte(cid);
+
+	if (container->getID() == ITEM_BROWSEFIELD) {
+		msg.addItem(1987, 1);
+		msg.addString("Browse Field");
+	} else {
+		msg.addItem(container);
+		msg.addString(container->getName());
+	}
+
+	msg.addByte(container->capacity());
+
+	msg.addByte(hasParent ? 0x01 : 0x00);
+
+	msg.addByte(container->isUnlocked() ? 0x01 : 0x00); // Drag and drop
+	msg.addByte(container->hasPagination() ? 0x01 : 0x00); // Pagination
+
+	uint32_t containerSize = container->size();
+	msg.add<uint16_t>(containerSize);
+	msg.add<uint16_t>(firstIndex);
+	if (firstIndex < containerSize) {
+		uint8_t itemsToSend = std::min<uint32_t>(std::min<uint32_t>(container->capacity(), containerSize - firstIndex), std::numeric_limits<uint8_t>::max());
+
+		msg.addByte(itemsToSend);
+		for (ItemDeque::const_iterator it = container->getItemList().begin() + firstIndex, end = it + itemsToSend; it != end; ++it) {
+			msg.addItem(*it);
+		}
+	} else {
+		msg.addByte(0x00);
+	}
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendChannel(uint16_t channelId, const std::string& channelName, const UsersMap* channelUsers, const InvitedMap* invitedUsers)
+{
+	NetworkMessage msg;
+	msg.addByte(0xAC);
+
+	msg.add<uint16_t>(channelId);
+	msg.addString(channelName);
+
+	if (channelUsers) {
+		msg.add<uint16_t>(channelUsers->size());
+		for (const auto& it : *channelUsers) {
+			msg.addString(it.second->getName());
+		}
+	} else {
+		msg.add<uint16_t>(0x00);
+	}
+
+	if (invitedUsers) {
+		msg.add<uint16_t>(invitedUsers->size());
+		for (const auto& it : *invitedUsers) {
+			msg.addString(it.second->getName());
+		}
+	} else {
+		msg.add<uint16_t>(0x00);
+	}
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendMagicEffect(const Position& pos, uint8_t type)
+{
+	if (!canSee(pos)) {
+		return;
+	}
+
+	NetworkMessage msg;
+	msg.addByte(0x83);
+	msg.addPosition(pos);
+	msg.addByte(type);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin)
+{
+	if (!canSee(pos)) {
+		return;
+	}
+
+	if (creature != player) {
+		if (stackpos != -1) {
+			NetworkMessage msg;
+			msg.addByte(0x6A);
+			msg.addPosition(pos);
+			msg.addByte(stackpos);
+
+			bool known;
+			uint32_t removedKnown;
+			checkCreatureAsKnown(creature->getID(), known, removedKnown);
+			AddCreature(msg, creature, known, removedKnown);
+			writeToOutputBuffer(msg);
+		}
+
+		if (isLogin) {
+			sendMagicEffect(pos, CONST_ME_TELEPORT);
+		}
+		return;
+	}
+
+	NetworkMessage msg;
+	msg.addByte(0x17);
+
+	msg.add<uint32_t>(player->getID());
+	msg.add<uint16_t>(0x32); // beat duration (50)
+
+	msg.addDouble(Creature::speedA, 3);
+	msg.addDouble(Creature::speedB, 3);
+	msg.addDouble(Creature::speedC, 3);
+
+	// can report bugs?
+	if (player->getAccountType() >= ACCOUNT_TYPE_TUTOR) {
+		msg.addByte(0x01);
+	} else {
+		msg.addByte(0x00);
+	}
+
+	msg.addByte(0x00); // can change pvp framing option
+	msg.addByte(0x00); // expert mode button enabled
+
+	writeToOutputBuffer(msg);
+
+	sendPendingStateEntered();
+	sendEnterWorld();
+	sendMapDescription(pos);
+
+	if (isLogin) {
+		sendMagicEffect(pos, CONST_ME_TELEPORT);
+	}
+
+	sendInventoryItem(CONST_SLOT_HEAD, player->getInventoryItem(CONST_SLOT_HEAD));
+	sendInventoryItem(CONST_SLOT_NECKLACE, player->getInventoryItem(CONST_SLOT_NECKLACE));
+	sendInventoryItem(CONST_SLOT_BACKPACK, player->getInventoryItem(CONST_SLOT_BACKPACK));
+	sendInventoryItem(CONST_SLOT_ARMOR, player->getInventoryItem(CONST_SLOT_ARMOR));
+	sendInventoryItem(CONST_SLOT_RIGHT, player->getInventoryItem(CONST_SLOT_RIGHT));
+	sendInventoryItem(CONST_SLOT_LEFT, player->getInventoryItem(CONST_SLOT_LEFT));
+	sendInventoryItem(CONST_SLOT_LEGS, player->getInventoryItem(CONST_SLOT_LEGS));
+	sendInventoryItem(CONST_SLOT_FEET, player->getInventoryItem(CONST_SLOT_FEET));
+	sendInventoryItem(CONST_SLOT_RING, player->getInventoryItem(CONST_SLOT_RING));
+	sendInventoryItem(CONST_SLOT_AMMO, player->getInventoryItem(CONST_SLOT_AMMO));
+
+	sendStats();
+	sendSkills();
+
+	//gameworld light-settings
+	LightInfo lightInfo;
+	g_game.getWorldLightInfo(lightInfo);
+	sendWorldLight(lightInfo);
+
+	//player light level
+	sendCreatureLight(creature);
+
+	const std::forward_list<VIPEntry>& vipEntries = IOLoginData::getVIPEntries(player->getAccount());
+
+	if (player->isAccessPlayer()) {
+		for (const VIPEntry& entry : vipEntries) {
+			VipStatus_t vipStatus;
+
+			Player* vipPlayer = g_game.getPlayerByGUID(entry.guid);
+			if (!vipPlayer) {
+				vipStatus = VIPSTATUS_OFFLINE;
+			} else {
+				vipStatus = VIPSTATUS_ONLINE;
+			}
+
+			sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);
+		}
+	} else {
+		for (const VIPEntry& entry : vipEntries) {
+			VipStatus_t vipStatus;
+
+			Player* vipPlayer = g_game.getPlayerByGUID(entry.guid);
+			if (!vipPlayer || vipPlayer->isInGhostMode()) {
+				vipStatus = VIPSTATUS_OFFLINE;
+			} else {
+				vipStatus = VIPSTATUS_ONLINE;
+			}
+
+			sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);
+		}
+	}
+
+	sendBasicData();
+	player->sendIcons();
+}
+
+void ProtocolGameBase::sendStats()
+{
+	NetworkMessage msg;
+	AddPlayerStats(msg);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendBasicData()
+{
+	NetworkMessage msg;
+	msg.addByte(0x9F);
+	msg.addByte(player->isPremium() ? 0x01 : 0x00);
+	msg.add<uint32_t>(std::numeric_limits<uint32_t>::max());
+	msg.addByte(player->getVocation()->getClientId());
+	msg.add<uint16_t>(0x00);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendPendingStateEntered()
+{
+	NetworkMessage msg;
+	msg.addByte(0x0A);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendEnterWorld()
+{
+	NetworkMessage msg;
+	msg.addByte(0x0F);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendInventoryItem(slots_t slot, const Item* item)
+{
+	NetworkMessage msg;
+	if (item) {
+		msg.addByte(0x78);
+		msg.addByte(slot);
+		msg.addItem(item);
+	} else {
+		msg.addByte(0x79);
+		msg.addByte(slot);
+	}
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendSkills()
+{
+	NetworkMessage msg;
+	AddPlayerSkills(msg);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendCreatureLight(const Creature* creature)
+{
+	if (!canSee(creature)) {
+		return;
+	}
+
+	NetworkMessage msg;
+	AddCreatureLight(msg, creature);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendWorldLight(const LightInfo& lightInfo)
+{
+	NetworkMessage msg;
+	AddWorldLight(msg, lightInfo);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendMapDescription(const Position& pos)
+{
+	NetworkMessage msg;
+	msg.addByte(0x64);
+	msg.addPosition(player->getPosition());
+	GetMapDescription(pos.x - 8, pos.y - 6, pos.z, 18, 14, msg);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendVIP(uint32_t guid, const std::string& name, const std::string& description, uint32_t icon, bool notify, VipStatus_t status)
+{
+	NetworkMessage msg;
+	msg.addByte(0xD2);
+	msg.add<uint32_t>(guid);
+	msg.addString(name);
+	msg.addString(description);
+	msg.add<uint32_t>(std::min<uint32_t>(10, icon));
+	msg.addByte(notify ? 0x01 : 0x00);
+	msg.addByte(status);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendCancelWalk()
+{
+	NetworkMessage msg;
+	msg.addByte(0xB5);
+	msg.addByte(player->getDirection());
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGameBase::sendPing()
+{
+	NetworkMessage msg;
+	msg.addByte(0x1D);
+	writeToOutputBuffer(msg, false);
+}
+
+void ProtocolGameBase::sendPingBack()
+{
+	NetworkMessage msg;
+	msg.addByte(0x1E);
+	writeToOutputBuffer(msg, false);
+}

--- a/src/protocolgamebase.h
+++ b/src/protocolgamebase.h
@@ -1,0 +1,119 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2015  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FS_PROTOCOLGAMEBASE_H_A28CB86652D0AF6760E43DCD9ACED40D
+#define FS_PROTOCOLGAMEBASE_H_A28CB86652D0AF6760E43DCD9ACED40D
+
+#include "protocol.h"
+#include "creature.h"
+#include "outfit.h"
+#include "chat.h"
+
+class NetworkMessage;
+class Player;
+class Game;
+class House;
+class Container;
+class Tile;
+class Connection;
+class Quest;
+
+/** \brief Contains methods and member variables common to both the game and spectator protocols
+ */
+class ProtocolGameBase : public Protocol {
+	public:
+		// static protocol information
+		enum {server_sends_first = true};
+		enum {protocol_identifier = 0}; // Not required as we send first
+		enum {use_checksum = true};
+
+	protected:
+		explicit ProtocolGameBase(Connection_ptr connection):
+			Protocol(connection),
+			player(nullptr),
+			eventConnect(0),
+			version(CLIENT_VERSION_MIN),
+			challengeTimestamp(0),
+			challengeRandom(0),
+			debugAssertSent(false),
+			acceptPackets(false) {}
+
+		virtual void writeToOutputBuffer(const NetworkMessage& msg, bool broadcast = true) = 0;
+		void onConnect() final;
+
+		void checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown);
+		void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove);
+		void AddPlayerStats(NetworkMessage& msg);
+		void AddPlayerSkills(NetworkMessage& msg);
+		void AddWorldLight(NetworkMessage& msg, const LightInfo& lightInfo);
+		void AddCreatureLight(NetworkMessage& msg, const Creature* creature);
+		void AddOutfit(NetworkMessage& msg, const Outfit_t& outfit);
+
+		// translate a tile to clientreadable format
+		void GetTileDescription(const Tile* tile, NetworkMessage& msg);
+		// translate a floor to clientreadable format
+		void GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y, int32_t z,
+		                         int32_t width, int32_t height, int32_t offset, int32_t& skip);
+		// translate a map area to clientreadable format
+		void GetMapDescription(int32_t x, int32_t y, int32_t z,
+		                       int32_t width, int32_t height, NetworkMessage& msg);
+
+		static void RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos);
+
+		void sendUpdateTile(const Tile* tile, const Position& pos);
+		void sendContainer(uint8_t cid, const Container* container, bool hasParent, uint16_t firstIndex);
+		void sendChannel(uint16_t channelId, const std::string& channelName, const UsersMap* channelUsers, const InvitedMap* invitedUsers);
+		void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin);
+		void sendMagicEffect(const Position& pos, uint8_t type);
+		void sendStats();
+		void sendBasicData();
+		void sendPendingStateEntered();
+		void sendEnterWorld();
+		//inventory
+		void sendInventoryItem(slots_t slot, const Item* item);
+
+		void sendSkills();
+
+		void sendCreatureLight(const Creature* creature);
+		void sendWorldLight(const LightInfo& lightInfo);
+		void sendMapDescription(const Position& pos);
+
+		void sendVIP(uint32_t guid, const std::string& name, const std::string& description, uint32_t icon, bool notify, VipStatus_t status);
+		void sendCancelWalk();
+
+		void sendPing();
+		void sendPingBack();
+
+		bool canSee(int32_t x, int32_t y, int32_t z) const;
+		bool canSee(const Creature*) const;
+		bool canSee(const Position& pos) const;
+
+		Player* player;
+		uint32_t eventConnect;
+		uint16_t version;
+
+		uint32_t challengeTimestamp;
+		uint8_t challengeRandom;
+
+		bool debugAssertSent;
+		bool acceptPackets;
+
+		std::unordered_set<uint32_t> knownCreatureSet;
+};
+#endif

--- a/src/protocollogin.h
+++ b/src/protocollogin.h
@@ -43,7 +43,9 @@ class ProtocolLogin : public Protocol
 	protected:
 		void disconnectClient(const std::string& message, uint16_t version);
 
-		void getCharacterList(const std::string& accountName, const std::string& password, const std::string& token, uint16_t version);
+		void getCharacterList(const std::string& accountName, const std::string& password, const std::string&token, uint16_t version);
+		void getCastingStreamsList(const std::string& password, uint16_t version);
+		void addWorldInfo(OutputMessage_ptr& output, const std::string& accountName, const std::string& password, uint16_t version, bool isLiveCastLogin = false);
 };
 
 #endif

--- a/src/protocolspectator.cpp
+++ b/src/protocolspectator.cpp
@@ -1,0 +1,378 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2014  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "otpch.h"
+
+#include "protocolgame.h"
+#include "protocolspectator.h"
+
+#include "outputmessage.h"
+
+#include "tile.h"
+#include "player.h"
+#include "chat.h"
+
+#include "configmanager.h"
+
+#include "game.h"
+
+#include "connection.h"
+#include "scheduler.h"
+#include "ban.h"
+
+extern Game g_game;
+extern ConfigManager g_config;
+extern Chat* g_chat;
+
+ProtocolSpectator::ProtocolSpectator(Connection_ptr connection):
+	ProtocolGameBase(connection),
+	client(nullptr)
+{
+
+}
+
+void ProtocolSpectator::disconnectSpectator(const std::string& message) const
+{
+	auto output = OutputMessagePool::getOutputMessage();
+	output->addByte(0x14);
+	output->addString(message);
+	send(std::move(output));
+	disconnect();
+}
+
+void ProtocolSpectator::onRecvFirstMessage(NetworkMessage& msg)
+{
+	if (g_game.getGameState() == GAME_STATE_SHUTDOWN) {
+		disconnect();
+		return;
+	}
+
+	operatingSystem = (OperatingSystem_t)msg.get<uint16_t>();
+	version = msg.get<uint16_t>();
+
+	msg.skipBytes(7); // U32 clientVersion, U8 clientType
+
+	if (!RSA_decrypt(msg)) {
+		disconnect();
+		return;
+	}
+
+	uint32_t key[4];
+	key[0] = msg.get<uint32_t>();
+	key[1] = msg.get<uint32_t>();
+	key[2] = msg.get<uint32_t>();
+	key[3] = msg.get<uint32_t>();
+	enableXTEAEncryption();
+	setXTEAKey(key);
+
+	if (operatingSystem >= CLIENTOS_OTCLIENT_LINUX) {
+		NetworkMessage opcodeMessage;
+		opcodeMessage.addByte(0x32);
+		opcodeMessage.addByte(0x00);
+		opcodeMessage.add<uint16_t>(0x00);
+		writeToOutputBuffer(opcodeMessage);
+	}
+
+	msg.skipBytes(1); // gamemaster flag
+	std::string password = msg.getString();
+	std::string characterName = msg.getString();
+
+	uint32_t timeStamp = msg.get<uint32_t>();
+	uint8_t randNumber = msg.getByte();
+	if (challengeTimestamp != timeStamp || challengeRandom != randNumber) {
+		disconnect();
+		return;
+	}
+
+	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {
+		disconnectSpectator("Only clients with protocol " CLIENT_VERSION_STR " allowed!");
+		return;
+	}
+
+	if (g_game.getGameState() == GAME_STATE_STARTUP) {
+		disconnectSpectator("Gameworld is starting up. Please wait.");
+		return;
+	}
+
+	if (g_game.getGameState() == GAME_STATE_MAINTAIN) {
+		disconnectSpectator("Gameworld is under maintenance. Please re-connect in a while.");
+		return;
+	}
+
+	BanInfo banInfo;
+	if (IOBan::isIpBanned(getIP(), banInfo)) {
+		if (banInfo.reason.empty()) {
+			banInfo.reason = "(none)";
+		}
+
+		std::ostringstream ss;
+		ss << "Your IP has been banned until " << formatDateShort(banInfo.expiresAt) << " by " << banInfo.bannedBy << ".\n\nReason specified:\n" << banInfo.reason;
+		disconnectSpectator(ss.str());
+		return;
+	}
+	password.erase(password.begin()); //Erase whitespace from the front of the password string
+	g_dispatcher.addTask(createTask(std::bind(&ProtocolSpectator::login, std::static_pointer_cast<ProtocolSpectator>(shared_from_this()), characterName, password)));
+}
+
+void ProtocolSpectator::sendEmptyTileOnPlayerPos(const Tile* tile, const Position& playerPos)
+{
+	NetworkMessage msg;
+
+	msg.addByte(0x69);
+	msg.addPosition(playerPos);
+
+	msg.add<uint16_t>(0x00);
+	msg.addItem(tile->getGround());
+
+	msg.addByte(0x00);
+	msg.addByte(0xFF);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolSpectator::addDummyCreature(NetworkMessage& msg, const uint32_t& creatureID, const Position& playerPos)
+{
+	// add dummy creature
+	CreatureType_t creatureType = CREATURETYPE_NPC;
+	if(creatureID <= 0x10000000) {
+		creatureType = CREATURETYPE_PLAYER;
+	} else if(creatureID <= 0x40000000) {
+		creatureType = CREATURETYPE_MONSTER;
+	}
+	msg.addByte(0x6A);
+	msg.addPosition(playerPos);
+	msg.addByte(1); //stackpos
+	msg.add<uint16_t>(0x61); // is not known
+	msg.add<uint32_t>(0); // remove no creature
+	msg.add<uint32_t>(creatureID); // creature id
+	msg.addByte(creatureType); // creature type
+	msg.addString("Dummy");
+	msg.addByte(0x00); // health percent
+	msg.addByte(DIRECTION_NORTH); // direction
+	AddOutfit(msg, player->getCurrentOutfit()); // outfit
+	msg.addByte(0); // light level
+	msg.addByte(0); // light color
+	msg.add<uint16_t>(200); // speed
+	msg.addByte(SKULL_NONE); // skull type
+	msg.addByte(SHIELD_NONE); // party shield
+	msg.addByte(GUILDEMBLEM_NONE); // guild emblem
+	msg.addByte(creatureType); // creature type
+	msg.addByte(SPEECHBUBBLE_NONE); // speechbubble
+	msg.addByte(0xFF); // MARK_UNMARKED
+	msg.add<uint16_t>(0x00); // helpers
+	msg.addByte(0); // walkThrough
+}
+
+void ProtocolSpectator::syncKnownCreatureSets()
+{
+	const auto& casterKnownCreatures = client->getKnownCreatures();
+	const auto playerPos = player->getPosition();
+	const auto tile = player->getTile();
+
+	if (!tile || !tile->getGround()) {
+		disconnectSpectator("A sync error has occured.");
+		return;
+	}
+	sendEmptyTileOnPlayerPos(tile, playerPos);
+
+	bool known;
+	uint32_t removedKnown;
+	for (const auto creatureID : casterKnownCreatures) {
+		if (knownCreatureSet.find(creatureID) != knownCreatureSet.end()) {
+			continue;
+		}
+
+		NetworkMessage msg;
+		const auto creature = g_game.getCreatureByID(creatureID);
+		if (creature && !creature->isRemoved()) {
+			msg.addByte(0x6A);
+			msg.addPosition(playerPos);
+			msg.addByte(1); //stackpos
+			checkCreatureAsKnown(creature->getID(), known, removedKnown);
+			AddCreature(msg, creature, known, removedKnown);
+			RemoveTileThing(msg, playerPos, 1);
+		} else if (operatingSystem <= CLIENTOS_FLASH) { // otclient freeze with huge amount of creature add, but do not debug if there are unknown creatures, best solution for now :(
+			addDummyCreature(msg, creatureID, playerPos);
+			RemoveTileThing(msg, playerPos, 1);
+		}
+		writeToOutputBuffer(msg);
+	}
+
+	sendUpdateTile(tile, playerPos);
+}
+
+void ProtocolSpectator::syncChatChannels()
+{
+	const auto channels = g_chat->getChannelList(*player);
+	for (const auto channel : channels) {
+		const auto& channelUsers = channel->getUsers();
+		if (channelUsers.find(player->getID()) != channelUsers.end()) {
+			sendChannel(channel->getId(), channel->getName(), &channelUsers, channel->getInvitedUsers());
+		}
+	}
+	sendChannel(CHANNEL_CAST, LIVE_CAST_CHAT_NAME, nullptr, nullptr);
+}
+
+void ProtocolSpectator::syncOpenContainers()
+{
+	const auto& openContainers = player->getOpenContainers();
+	for (const auto& it : openContainers) {
+		auto openContainer = it.second;
+		auto container = openContainer.container;
+		sendContainer(it.first, container, container->hasParent(), openContainer.index);
+	}
+}
+
+void ProtocolSpectator::login(const std::string& liveCastName, const std::string& password)
+{
+	//dispatcher thread
+	auto _player = g_game.getPlayerByName(liveCastName);
+	if (!_player || _player->isRemoved()) {
+		disconnectSpectator("Live cast no longer exists. Please relogin to refresh the list.");
+		return;
+	}
+
+	const auto liveCasterProtocol = ProtocolGame::getLiveCast(_player);
+	if (!liveCasterProtocol) {
+		disconnectSpectator("Live cast no longer exists. Please relogin to refresh the list.");
+		return;
+	}
+
+	const auto& liveCastPassword = liveCasterProtocol->getLiveCastPassword();
+	if (liveCasterProtocol->isLiveCaster()) {
+		if (!liveCastPassword.empty() && password != liveCastPassword) {
+			disconnectSpectator("Wrong live cast password.");
+			return;
+		}
+
+		player = _player;
+		player->incrementReferenceCounter();
+		eventConnect = 0;
+		client = liveCasterProtocol;
+		acceptPackets = true;
+		OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
+		sendAddCreature(player, player->getPosition(), 0, false);
+		syncKnownCreatureSets();
+		syncChatChannels();
+		syncOpenContainers();
+
+		liveCasterProtocol->addSpectator(std::static_pointer_cast<ProtocolSpectator>(shared_from_this()));
+	} else {
+		disconnectSpectator("Live cast no longer exists. Please relogin to refresh the list.");
+	}
+}
+
+void ProtocolSpectator::logout()
+{
+	acceptPackets = false;
+	if (client && player) {
+		client->removeSpectator(std::static_pointer_cast<ProtocolSpectator>(shared_from_this()));
+		player->decrementReferenceCounter();
+		player = nullptr;
+	}
+	disconnect();
+}
+
+void ProtocolSpectator::parsePacket(NetworkMessage& msg)
+{
+	if (!acceptPackets || g_game.getGameState() == GAME_STATE_SHUTDOWN || msg.getLength() <= 0) {
+		return;
+	}
+
+	uint8_t recvbyte = msg.getByte();
+
+	if (!player) {
+		if (recvbyte == 0x0F) {
+			disconnect();
+		}
+
+		return;
+	}
+
+	//a dead player can not perform actions
+	if (player->isRemoved() || player->getHealth() <= 0) {
+		disconnect();
+		return;
+	}
+
+	switch (recvbyte) {
+		case 0x14: g_dispatcher.addTask(createTask(std::bind(&ProtocolSpectator::logout, getThis()))); break;
+		case 0x1D: g_dispatcher.addTask(createTask(std::bind(&ProtocolSpectator::sendPingBack, getThis()))); break;
+		case 0x1E: g_dispatcher.addTask(createTask(std::bind(&ProtocolSpectator::sendPing, getThis()))); break;
+		//Reset viewed position/direction if the spectator tries to move in any way
+		case 0x64: case 0x65: case 0x66: case 0x67: case 0x68: case 0x6A: case 0x6B: case 0x6C: case 0x6D: case 0x6F: case 0x70: case 0x71:
+		case 0x72: g_dispatcher.addTask(createTask(std::bind(&ProtocolSpectator::sendCancelWalk, getThis()))); break;
+		case 0x96: parseSpectatorSay(msg); break;
+		default:
+			break;
+	}
+
+	if (msg.isOverrun()) {
+		disconnect();
+	}
+}
+
+void ProtocolSpectator::parseSpectatorSay(NetworkMessage& msg)
+{
+	SpeakClasses type = (SpeakClasses)msg.getByte();
+	uint16_t channelId = 0;
+
+	if (type == TALKTYPE_CHANNEL_Y) {
+		channelId = msg.get<uint16_t>();
+	} else {
+		return;
+	}
+
+	const std::string text = msg.getString();
+
+	if (text.length() > 255 || channelId != CHANNEL_CAST || !client) {
+		return;
+	}
+
+	if (client) {
+		g_dispatcher.addTask(createTask(std::bind(&ProtocolGame::broadcastSpectatorMessage, client, text)));
+	}
+}
+
+void ProtocolSpectator::release()
+{
+	//dispatcher
+	if (client && player) {
+		client->removeSpectator(std::static_pointer_cast<ProtocolSpectator>(shared_from_this()));
+		player->decrementReferenceCounter();
+		player = nullptr;
+	}
+	Protocol::release();
+	OutputMessagePool::getInstance().removeProtocolFromAutosend(shared_from_this());
+}
+
+void ProtocolSpectator::writeToOutputBuffer(const NetworkMessage& msg, bool broadcast)
+{
+	OutputMessage_ptr out = getOutputBuffer(msg.getLength());
+	out->append(msg);
+}
+
+void ProtocolSpectator::onLiveCastStop()
+{
+	//dispatcher
+	if (player) {
+		player->decrementReferenceCounter();
+		player = nullptr;
+	}
+	disconnect();
+}

--- a/src/protocolspectator.h
+++ b/src/protocolspectator.h
@@ -1,0 +1,66 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2014  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FS_PROTOCOLSPECTATOR_H_67DF1C70909A3D52458F250DF5CE2492
+#define FS_PROTOCOLSPECTATOR_H_67DF1C70909A3D52458F250DF5CE2492
+
+#include "protocolgamebase.h"
+
+class ProtocolGame;
+class ProtocolSpectator;
+typedef std::shared_ptr<ProtocolGame> ProtocolGame_ptr;
+typedef std::shared_ptr<ProtocolSpectator> ProtocolSpectator_ptr;
+
+class ProtocolSpectator final : public ProtocolGameBase
+{
+	public:
+		static const char* protocol_name() {
+			return "spectator protocol";
+		}
+
+		ProtocolSpectator(Connection_ptr connection);
+		void onLiveCastStop();
+	private:
+		ProtocolSpectator_ptr getThis() {
+			return std::static_pointer_cast<ProtocolSpectator>(shared_from_this());
+		}
+		ProtocolGame_ptr client;
+		OperatingSystem_t operatingSystem;
+
+		void login(const std::string& liveCastName, const std::string& password);
+		void logout();
+
+		void disconnectSpectator(const std::string& message) const;
+		void writeToOutputBuffer(const NetworkMessage& msg, bool broadcast = true) final;
+
+		void syncKnownCreatureSets();
+		void syncChatChannels();
+		void syncOpenContainers();
+		void sendEmptyTileOnPlayerPos(const Tile* tile, const Position& playerPos);
+
+		void release() final;
+
+		void parsePacket(NetworkMessage& msg) final;
+		void onRecvFirstMessage(NetworkMessage& msg) final;
+
+		void parseSpectatorSay(NetworkMessage& msg);
+		void addDummyCreature(NetworkMessage& msg, const uint32_t& creatureID, const Position& playerPos);
+};
+
+#endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -28,7 +28,7 @@
 extern ConfigManager g_config;
 Ban g_bans;
 
-ServiceManager::ServiceManager(): 
+ServiceManager::ServiceManager():
 	death_timer(io_service),
 	running(false)
 {


### PR DESCRIPTION
Closes #984

 As for the internal details: broadcasting is done by the ASI/O thread. The dispatcher thread does only one additional copy (it is required, as the ASI/O thread receives the message object with it's content already encrypted) which is then used for broadcasting. All variables relevant to the casting system have been placed in the ProtocolGame class. The ProtocolSpectator class represents a subset of the game protocol used to directly communicate with the spectator's client. The rest of the protocol is broadcast from the caster's ProtocolGame. 

Starting a cast is achieved by using the !cast [password] talkaction. Stopping it is done by using !stopcast. Joining a stream as a spectator is achieved by logging in with an empty account name and a password, assuming the caster set one. 

If something isn't clear, feel free to ask. I'm open to suggestions if you think there's something that could be improved (probably there is).
