### PR TITLE
os.mtime more precision to timing

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1891,6 +1891,9 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)
 	registerEnumIn("configKeys", ConfigManager::MAX_PACKETS_PER_SECOND)
 
+	// os
+	registerMethod("os", "mtime", LuaScriptInterface::luaSystemTime);
+
 	// table
 	registerMethod("table", "create", LuaScriptInterface::luaTableCreate);
 
@@ -4639,6 +4642,14 @@ int32_t LuaScriptInterface::luaIsType(lua_State* L)
 	size_t hashA = getNumber<size_t>(L, 1);
 
 	pushBoolean(L, hashA == hashB);
+	return 1;
+}
+
+// os
+int32_t LuaScriptInterface::luaSystemTime(lua_State* L)
+{
+	// os.mtime()
+	lua_pushnumber(L, OTSYS_TIME());
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -544,6 +544,9 @@ class LuaScriptInterface
 		// _G
 		static int32_t luaIsType(lua_State* L);
 
+		// os
+		static int32_t luaSystemTime(lua_State* L);
+
 		// table
 		static int32_t luaTableCreate(lua_State* L);
 


### PR DESCRIPTION
Since os.time doesn't return time in milseconds precision and for some
exhaustion scripts it's really necessary, I implemented this function.
