### PR TITLE
Change blueberry bush topOrder, fix #989

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -4665,7 +4665,9 @@
 	<item id="2782" name="jungle grass" />
 	<item id="2783" article="an" name="agave" />
 	<item id="2784" article="a" name="dry bush" />
-	<item id="2785" article="a" name="blueberry bush" />
+    <item id="2785" article="a" name="blueberry bush">
+        <attribute key="topOrder" value="3" />
+    </item>
 	<item id="2786" article="a" name="blueberry bush">
 		<attribute key="decayTo" value="2785" />
 		<attribute key="duration" value="300" />


### PR DESCRIPTION
The blueberry bush currently has a topOrder of 2. When you try to eat the blueberries on top of the bush the client thinks you are clicking the blueberries and the server thinks you are clicking the bush. The server compares the sprite IDs and since they are not the same you get  the message "You cannot use this object".
Changing the topOrder to 3 solves the problem.