### PR TITLE
Walkthrough players lower than protection level

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -957,7 +957,7 @@ bool Player::canWalkthrough(const Creature* creature) const
 	}
 
 	const Tile* playerTile = player->getTile();
-	if (playerTile && playerTile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (playerTile && (playerTile->hasFlag(TILESTATE_PROTECTIONZONE) || player->getLevel() < static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL)))) {
 		Item* playerTileGround = playerTile->ground;
 		if (playerTileGround && playerTileGround->hasWalkStack()) {
 			Player* thisPlayer = const_cast<Player*>(this);
@@ -991,7 +991,7 @@ bool Player::canWalkthroughEx(const Creature* creature) const
 	}
 
 	const Tile* playerTile = player->getTile();
-	return playerTile && playerTile->hasFlag(TILESTATE_PROTECTIONZONE);
+	return playerTile && (playerTile->hasFlag(TILESTATE_PROTECTIONZONE) || player->getLevel() < static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL)));
 }
 
 void Player::onReceiveMail()


### PR DESCRIPTION
Now it's possible to walkthrough those who are under protection level.

Also closing this issue:
https://github.com/otland/forgottenserver/issues/566