### PR TITLE
Fixed loot bug: thornback tortoise.xml

### DIFF
--- a/data/monster/Misc/Misc Reptiles/thornback tortoise.xml
+++ b/data/monster/Misc/Misc Reptiles/thornback tortoise.xml
@@ -34,7 +34,7 @@
 		<item id="2789" chance="700"/><!-- brown mushroom -->
 		<item id="2787" chance="1200"/><!-- white mushroom -->
 		<item id="2391" chance="260"/><!-- war hammer -->
-		<item id="2391" chance="15980"/><!-- thorn -->
+		<item id="10560" chance="15980"/><!-- thorn -->
 		<item id="2143" chance="1600"/><!-- white pearl -->
 		<item id="5899" chance="800"/><!-- turtle shell -->
 		<item id="2144" chance="800"/><!-- black pearl -->


### PR DESCRIPTION
Instead of a thorn, this turtle was dropping war hammers with 16% of chance because of an error in the id.