### PR TITLE
Connection.cpp code & efficiency improvements

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -71,7 +71,6 @@ class Connection : public std::enable_shared_from_this<Connection>
 			CONNECTION_STATE_CLOSED = 3
 		};
 
-	private:
 		Connection(boost::asio::ip::tcp::socket* socket,
 		           boost::asio::io_service& io_service,
 		           ServicePort_ptr service_port) :


### PR DESCRIPTION
Applied the RAII idiom to mutex locking in the Connection and ConnectionManager classes' methods. Use make_shared instead of initialization with a raw, owning pointer. This should improve performance by a small amount (make_shared groups memory allocation of the object and ref count structure together which means less allocation and better memory locality).