### PR TITLE
Monsters memory management improvements

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -417,6 +417,10 @@ enum MapMark_t
 
 struct Outfit_t {
 	Outfit_t() {
+		reset();
+	}
+
+	void reset() {
 		lookType = 0;
 		lookTypeEx = 0;
 		lookMount = 0;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -11682,14 +11682,14 @@ int LuaScriptInterface::luaConditionAddDamage(lua_State* L)
 // MonsterType
 int LuaScriptInterface::luaMonsterTypeCreate(lua_State* L)
 {
-	// MonsterType(id or name)
-	MonsterType* monsterType;
-	if (isNumber(L, 2)) {
-		monsterType = g_monsters.getMonsterType(getNumber<uint32_t>(L, 2));
-	} else {
-		monsterType = g_monsters.getMonsterType(getString(L, 2));
+	// MonsterType(name)
+	
+	if (!isString(L, 2)) {
+		lua_pushnil(L);
+		return 1;
 	}
-
+	MonsterType* monsterType = g_monsters.getMonsterType(getString(L, 2));
+	
 	if (monsterType) {
 		pushUserdata<MonsterType>(L, monsterType);
 		setMetatable(L, -1, "MonsterType");
@@ -11912,10 +11912,10 @@ int LuaScriptInterface::luaMonsterTypeGetAttackList(lua_State* L)
 		return 1;
 	}
 
-	lua_createtable(L, monsterType->spellAttackList.size(), 0);
+	lua_createtable(L, monsterType->attackSpells.size(), 0);
 
 	int index = 0;
-	for (const auto& spellBlock : monsterType->spellAttackList) {
+	for (const auto& spellBlock : monsterType->attackSpells) {
 		lua_createtable(L, 0, 8);
 
 		setField(L, "chance", spellBlock.chance);
@@ -11942,10 +11942,11 @@ int LuaScriptInterface::luaMonsterTypeGetDefenseList(lua_State* L)
 		return 1;
 	}
 
-	lua_createtable(L, monsterType->spellDefenseList.size(), 0);
+	lua_createtable(L, monsterType->defenseSpells.size(), 0);
+
 
 	int index = 0;
-	for (const auto& spellBlock : monsterType->spellDefenseList) {
+	for (const auto& spellBlock : monsterType->attackSpells) {
 		lua_createtable(L, 0, 8);
 
 		setField(L, "chance", spellBlock.chance);
@@ -12009,7 +12010,7 @@ int LuaScriptInterface::luaMonsterTypeGetLoot(lua_State* L)
 		return 1;
 	}
 
-	static const std::function<void(const std::list<LootBlock>&)> parseLoot = [&](const std::list<LootBlock>& lootList) {
+	static const std::function<void(const std::vector<LootBlock>&)> parseLoot = [&](const std::vector<LootBlock>& lootList) {
 		lua_createtable(L, lootList.size(), 0);
 
 		int index = 0;
@@ -12043,8 +12044,8 @@ int LuaScriptInterface::luaMonsterTypeGetCreatureEvents(lua_State* L)
 	}
 
 	int index = 0;
-	lua_createtable(L, monsterType->scriptList.size(), 0);
-	for (const std::string& creatureEvent : monsterType->scriptList) {
+	lua_createtable(L, monsterType->scripts.size(), 0);
+	for (const std::string& creatureEvent : monsterType->scripts) {
 		pushString(L, creatureEvent);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -12061,8 +12062,8 @@ int LuaScriptInterface::luaMonsterTypeGetSummonList(lua_State* L)
 	}
 
 	int index = 0;
-	lua_createtable(L, monsterType->summonList.size(), 0);
-	for (const auto& summonBlock : monsterType->summonList) {
+	lua_createtable(L, monsterType->summons.size(), 0);
+	for (const auto& summonBlock : monsterType->summons) {
 		lua_createtable(L, 0, 3);
 		setField(L, "name", summonBlock.name);
 		setField(L, "speed", summonBlock.speed);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -83,7 +83,7 @@ Monster::Monster(MonsterType* _mtype) :
 	lastMeleeAttack = 0;
 
 	// register creature events
-	for (const std::string& scriptName : mType->scriptList) {
+	for (const std::string& scriptName : mType->scripts) {
 		if (!registerCreatureEvent(scriptName)) {
 			std::cout << "[Warning - Monster::Monster] Unknown event name: " << scriptName << std::endl;
 		}
@@ -789,7 +789,7 @@ void Monster::doAttacking(uint32_t interval)
 	const Position& myPos = getPosition();
 	const Position& targetPos = attackedCreature->getPosition();
 
-	for (const spellBlock_t& spellBlock : mType->spellAttackList) {
+	for (const spellBlock_t& spellBlock : mType->attackSpells) {
 		bool inRange = false;
 
 		if (canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
@@ -832,7 +832,7 @@ bool Monster::canUseAttack(const Position& pos, const Creature* target) const
 	if (isHostile()) {
 		const Position& targetPos = target->getPosition();
 		uint32_t distance = std::max<uint32_t>(Position::getDistanceX(pos, targetPos), Position::getDistanceY(pos, targetPos));
-		for (const spellBlock_t& spellBlock : mType->spellAttackList) {
+		for (const spellBlock_t& spellBlock : mType->attackSpells) {
 			if (spellBlock.range != 0 && distance <= spellBlock.range) {
 				return g_game.isSightClear(pos, targetPos, true);
 			}
@@ -918,7 +918,7 @@ void Monster::onThinkDefense(uint32_t interval)
 	bool resetTicks = true;
 	defenseTicks += interval;
 
-	for (const spellBlock_t& spellBlock : mType->spellDefenseList) {
+	for (const spellBlock_t& spellBlock : mType->defenseSpells) {
 		if (spellBlock.speed > defenseTicks) {
 			resetTicks = false;
 			continue;
@@ -937,7 +937,7 @@ void Monster::onThinkDefense(uint32_t interval)
 	}
 
 	if (!isSummon() && summons.size() < mType->maxSummons) {
-		for (const summonBlock_t& summonBlock : mType->summonList) {
+		for (const summonBlock_t& summonBlock : mType->summons) {
 			if (summonBlock.speed > defenseTicks) {
 				resetTicks = false;
 				continue;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -858,12 +858,7 @@ ReturnValue Spell::CreateIllusion(Creature* creature, const Outfit_t& outfit, in
 
 ReturnValue Spell::CreateIllusion(Creature* creature, const std::string& name, int32_t time)
 {
-	uint32_t mId = g_monsters.getIdByName(name);
-	if (mId == 0) {
-		return RETURNVALUE_CREATUREDOESNOTEXIST;
-	}
-
-	const MonsterType* mType = g_monsters.getMonsterType(mId);
+	const auto mType = g_monsters.getMonsterType(name);
 	if (mType == nullptr) {
 		return RETURNVALUE_CREATUREDOESNOTEXIST;
 	}


### PR DESCRIPTION
Applied the RAII idiom to the MonsterType and Monsters classes. Changed lists in MonsterType to vector for slightly better performance (these containers are only iterated over in a linear fashion and rarely modified so a vector makes more sense than a list). Moved ownership of MonsterType objects from an owning pointer to the monsters map.  I made each logical change in a separate commit, however if you want I can squash them together.