### PR TITLE
Fix attack scheduler

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3383,16 +3383,18 @@ void Player::doAttacking(uint32_t)
 		Item* tool = getWeapon();
 		const Weapon* weapon = g_weapons->getWeapon(tool);
 		if (weapon) {
-			if (!weapon->interruptSwing()) {
+			uint32_t delay;
+
+			if (!weapon->interruptSwing() || canDoAction()) {
 				result = weapon->useWeapon(this, tool, attackedCreature);
-			} else if (!canDoAction()) {
-				uint32_t delay = getNextActionTime();
-				SchedulerTask* task = createSchedulerTask(delay, std::bind(&Game::checkCreatureAttack,
-				                      &g_game, getID()));
-				setNextActionTask(task);
+				delay = getAttackSpeed();
 			} else {
-				result = weapon->useWeapon(this, tool, attackedCreature);
+				delay = getNextActionTime();
 			}
+
+			SchedulerTask* task = createSchedulerTask(delay, std::bind(&Game::checkCreatureAttack,
+									 &g_game, getID()));
+			setNextActionTask(task);
 		} else {
 			result = Weapon::useFist(this, attackedCreature);
 		}


### PR DESCRIPTION
I have stumbled across this problem when I was trying to use an attack speed that was not a multiple of 1000. Apparently the server only checks if there is a new action every 1000 ms, but this limits attack speed to multiples of this time frame, as the server won't check if there is a new attack to calculate in between time frames.

This fix changes it by adding a new SchedulerTask when the attack is in the middle of a time frame. I haven't had time and resources to check if this is a heavy change and if this works properly 100% of the time, but I hope @marksamman can have a look and say somethind :grinning: 