### PR TITLE
fromPosition now behaves properly

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -286,11 +286,11 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 	Action* action = getAction(item);
 	if (action) {
 		if (action->isScripted()) {
-			if (action->executeUse(player, item, pos, nullptr, pos, isHotkey)) {
+			if (action->executeUse(player, item, player->getPosition(), nullptr, pos, isHotkey)) {
 				return RETURNVALUE_NOERROR;
 			}
 		} else if (action->function) {
-			if (action->function(player, item, pos, nullptr, pos, isHotkey)) {
+			if (action->function(player, item, player->getPosition(), nullptr, pos, isHotkey)) {
 				return RETURNVALUE_NOERROR;
 			}
 		}


### PR DESCRIPTION
fromPosition was not behaving properly in some cases.
Example:
When using a ladder, fromPosition should be where the player is and toPosition where the ladder is.
When using anything that was on the floor, it would behave like this, fromPosition and toPosition would be the position of the thing you used.