### PR TITLE
Improve compile speed & server performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(cotire)
 
 # Initialize CXXFLAGS.
-set(CMAKE_CXX_FLAGS                "-Wall -Werror")
+set(CMAKE_CXX_FLAGS                "-Wall -Werror -pipe")
 set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE        "-Ofast -DNDEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(cotire)
 set(CMAKE_CXX_FLAGS                "-Wall -Werror -pipe")
 set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")
 set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE        "-Ofast -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE        "-Ofast -march=native -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 
 if (CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
What are your opinions about turning on aggressive optimization flags for compilation, which could improve server performance and memory usage, at the cost of making it ~less portable~?

I have just managed to compile with the flags `-Ofast -march=native` which should take the performance to the bleeding edge, since it enables the most deep optimizations for GCC, and I also enabled `-pipe` which improved compile time by a lot.

This doesn't require a lot of memory or processing power: I done it with the worst Amazon VPS, the one eligible for the free tier, so it's ok. On a more powerful rig with a couple of cores and some gigabytes of memory, the job is pretty fast.

The native flag would be the only problem IF someone tries to change the machine but... I don't believe this is done very often, plus one would benefit from recompiling it with edge optimizations again.

Let's discuss about it if there is any issue about those optimizations. I'm a -march-native fan enough to build my kernel with it :laughing: 