### PR TITLE
Fix race condition in DatabaseTasks

### DIFF
--- a/src/databasetasks.cpp
+++ b/src/databasetasks.cpp
@@ -46,14 +46,14 @@ void DatabaseTasks::run()
 			taskSignal.wait(taskLockUnique);
 		}
 
-		if (!tasks.empty() && threadState != THREAD_STATE_TERMINATED) {
-			const DatabaseTask& task = tasks.front();
+		if (!tasks.empty()) {
+			DatabaseTask task = std::move(tasks.front());
+			tasks.pop_front();
 			taskLockUnique.unlock();
 			runTask(task);
-			taskLockUnique.lock();
-			tasks.pop_front();
+		} else {
+			taskLockUnique.unlock();
 		}
-		taskLockUnique.unlock();
 	}
 }
 


### PR DESCRIPTION
Fix race condition (runTask() would race with task flushing on the front queue object during server shutdown). Remove unnecessary thread state check.