### PR TITLE
Remove unused imports

### DIFF
--- a/src/databasetasks.cpp
+++ b/src/databasetasks.cpp
@@ -20,7 +20,6 @@
 #include "otpch.h"
 
 #include "databasetasks.h"
-#include "database.h"
 #include "tasks.h"
 
 extern Dispatcher g_dispatcher;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -24,9 +24,7 @@
 #include "house.h"
 #include "iologindata.h"
 #include "game.h"
-#include "town.h"
 #include "configmanager.h"
-#include "tools.h"
 #include "bed.h"
 
 extern ConfigManager g_config;

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -20,7 +20,6 @@
 #include "otpch.h"
 
 #include "party.h"
-#include "player.h"
 #include "game.h"
 #include "configmanager.h"
 #include "events.h"

--- a/src/raids.cpp
+++ b/src/raids.cpp
@@ -24,7 +24,6 @@
 #include "pugicast.h"
 
 #include "game.h"
-#include "player.h"
 #include "configmanager.h"
 #include "scheduler.h"
 #include "monster.h"

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -19,8 +19,6 @@
 
 #include "otpch.h"
 
-#include <cctype>
-
 #include "tools.h"
 #include "configmanager.h"
 


### PR DESCRIPTION
Any reason why those files are still being imported despite not being used?

The generated binary is exactly the same after removing those imports.