### PR TITLE
Create empty flasks, closes #1326

### DIFF
--- a/data/talkactions/scripts/create_item.lua
+++ b/data/talkactions/scripts/create_item.lua
@@ -22,13 +22,17 @@ function onSay(player, words, param)
 	if count ~= nil then
 		if itemType:isStackable() then
 			count = math.min(10000, math.max(1, count))
-		elseif not itemType:hasSubType() then
+		elseif not itemType:isFluidContainer() then
 			count = math.min(100, math.max(1, count))
 		else
-			count = math.max(1, count)
+			count = math.max(0, count)
 		end
 	else
-		count = 1
+		if not itemType:isFluidContainer() then
+			count = 1
+		else
+			count = 0
+		end
 	end
 
 	local result = player:addItem(itemType:getId(), count)


### PR DESCRIPTION
This fixes the issue reported by @Alscara on #1326, that made it impossible to spawn empty fluid containers (flasks, buckets, ...). Fluid containers now also spawn empty by default, instead of filled with water or whatever was subtype 1.