### PR TITLE
[WIP] Proper signal handling

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -76,8 +76,8 @@ void badAllocationHandler()
 	exit(-1);
 }
 
-void sigtermHandler(int) {
-	std::cout << "SIGTERM received, shutting game server down..." << std::endl;
+void sigintHandler(int) {
+	std::cout << "SIGINT received, shutting game server down..." << std::endl;
 	g_game.setGameState(GAME_STATE_SHUTDOWN);
 }
 
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
 
 	// Setup interrupt signal handler
 	struct sigaction sigint;
-	sigint.sa_handler = sigtermHandler;
+	sigint.sa_handler = sigintHandler;
 	sigint.sa_flags = 0;
 	sigemptyset(&sigint.sa_mask);
 	sigaction(SIGINT, &sigint, nullptr);

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -76,6 +76,11 @@ void badAllocationHandler()
 	exit(-1);
 }
 
+void sigtermHandler(int) {
+	std::cout << "SIGTERM received, shutting game server down..." << std::endl;
+	g_game.setGameState(GAME_STATE_SHUTDOWN);
+}
+
 int main(int argc, char* argv[])
 {
 	// Setup bad allocation handler
@@ -89,6 +94,13 @@ int main(int argc, char* argv[])
 	sigemptyset(&sigh.sa_mask);
 	sigaction(SIGPIPE, &sigh, nullptr);
 #endif
+
+	// Setup interrupt signal handler
+	struct sigaction sigint;
+	sigint.sa_handler = sigtermHandler;
+	sigint.sa_flags = 0;
+	sigemptyset(&sigint.sa_mask);
+	sigaction(SIGINT, &sigint, nullptr);
 
 	ServiceManager serviceManager;
 


### PR DESCRIPTION
I have started working in issue #770, which addresses the capability of handling signals. It is easy to implement some of the signals. In the issue, we have thought of handling SIGINT to shutdown the server properly e.g. on Ctrl+C, SIGSTOP/SIGCONT to close and open game server and SIGHUP to reload configuration files, as some system daemons (namely systemd and OpenRC) tend to do.

This would make it easy to run the server in background as a daemon without the need of tools such as nohup and screen, and maybe ship the server in package managers for even easier installation.

Preview with SIGINT:
![Preview](http://i.imgur.com/GoJ33Pw.png)

QUESTION: how could one reload the entirety of server configuration? Something like a `/reload all` command would do. I have checked the `/reload` command and it needs a keyword to reload only a single part of configuration, though it would be possible to just reload one by one, there may be a simpler way to do it.