### PR TITLE
Spectator cache allocation efficiency improvement

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -453,9 +453,9 @@ void Map::getSpectators(SpectatorVec& list, const Position& centerPos, bool mult
 
 		if (cacheResult) {
 			if (onlyPlayers) {
-				playersSpectatorCache[centerPos].reset(new SpectatorVec(list));
+				playersSpectatorCache[centerPos] = std::make_shared<SpectatorVec>(list);
 			} else {
-				spectatorCache[centerPos].reset(new SpectatorVec(list));
+				spectatorCache[centerPos] = std::make_shared<SpectatorVec>(list);
 			}
 		}
 	}


### PR DESCRIPTION
Use std::make_shared<> to avoid an unnecessary, additional heap allocation.