### PR TITLE
Move enchant spear from conjure to instant

### DIFF
--- a/data/spells/scripts/support/enchant staff.lua
+++ b/data/spells/scripts/support/enchant staff.lua
@@ -6,12 +6,11 @@ function onCastSpell(creature, var)
 	local item = creature:getSlotItem(CONST_SLOT_LEFT)
 	if not item or item:getId() ~= 2401 then
 		item = creature:getSlotItem(CONST_SLOT_RIGHT)
-	end
-
-	if not item or item:getId() ~= 2401 then
-		creature:getPosition():sendMagicEffect(CONST_ME_POFF)
-		creature:sendTextMessage(MESSAGE_STATUS_SMALL, "You need a magic item to cast this spell.")
-		return false
+		if not item or item:getId() ~= 2401 then
+			creature:getPosition():sendMagicEffect(CONST_ME_POFF)
+			creature:sendTextMessage(MESSAGE_STATUS_SMALL, "You need a magic item to cast this spell.")
+			return false
+		end
 	end
 
 	item:transform(2433)

--- a/data/spells/scripts/support/enchant staff.lua
+++ b/data/spells/scripts/support/enchant staff.lua
@@ -10,6 +10,7 @@ function onCastSpell(creature, var)
 
 	if not item or item:getId() ~= 2401 then
 		creature:getPosition():sendMagicEffect(CONST_ME_POFF)
+		creature:sendTextMessage(MESSAGE_STATUS_SMALL, "You need a magic item to cast this spell.")
 		return false
 	end
 

--- a/data/spells/scripts/support/enchant staff.lua
+++ b/data/spells/scripts/support/enchant staff.lua
@@ -1,0 +1,19 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_RED)
+combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
+
+function onCastSpell(creature, var)
+	local item = creature:getSlotItem(CONST_SLOT_LEFT)
+	if not item or item:getId() ~= 2401 then
+		item = creature:getSlotItem(CONST_SLOT_RIGHT)
+	end
+
+	if not item or item:getId() ~= 2401 then
+		creature:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
+
+	item:transform(2433)
+	item:decay()
+	return combat:execute(creature, var)
+end

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -121,6 +121,9 @@
 		<vocation name="Paladin"/>
 		<vocation name="Royal Paladin"/>
 	</instant>
+	<instant group="support" spellid="92" name="Enchant Staff" words="exeta vis" lvl="41" mana="80" prem="1" exhaustion="2000" groupcooldown="2000" needlearn="0" script="support/enchant staff.lua">
+		<vocation name="Master Sorcerer" />
+	</instant>
 	<instant group="attack" spellid="105" name="Fierce Berserk" words="exori gran" lvl="90" mana="340" prem="1" needweapon="1" exhaustion="6000" groupcooldown="2000" needlearn="0" script="attack/fierce berserk.lua">
 		<vocation name="Knight"/>
 		<vocation name="Elite Knight"/>


### PR DESCRIPTION
Fixes #1336 
As enchant staff is the only conjure spell that needs to start decay on the item, it would be easier to just make an specific script for it.

I moved from conjure to instant because with conjure, if I used the tag script, it would not automatically apply the exhaust, group exhaust, mana consumption, level requirement check and so on for some reason, if anyone could explain to me why as I didn't look into it too much I would appreciate. :)