### PR TITLE
Reduce static tile memory usage

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1448,17 +1448,21 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 			return;
 		}
 
+		const ItemType& itemType = Item::items[item->getID()];
+		if (itemType.isGroundTile()) {
+			if (ground == nullptr) {
+				ground = item;
+				setTileFlags(item);
+			}
+			return;
+		}
+
 		TileItemVector* items = makeItemList();
 		if (items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
 		}
 
-		const ItemType& itemType = Item::items[item->getID()];
-		if (itemType.isGroundTile()) {
-			if (ground == nullptr) {
-				ground = item;
-			}
-		} else if (itemType.alwaysOnTop) {
+		if (itemType.alwaysOnTop) {
 			bool isInserted = false;
 			for (ItemVector::iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 				if (Item::items[(*it)->getID()].alwaysOnTopOrder > itemType.alwaysOnTopOrder) {


### PR DESCRIPTION
The item vector will no longer be created if the item being added is a ground tile. This will considerably drop memory usage for static tiles (approximately 13 MiBs on an x64 build, with the default data pack).