### PR TITLE
Fix #1339

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -25642,7 +25642,7 @@
 		<attribute key="weight" value="105" />
 		<attribute key="slotType" value="ring" />
 		<attribute key="absorbPercentPhysical" value="10" />
-		<attribute key="absorbPercentEarth" value="8" />
+		<attribute key="absorbPercentEnergy" value="8" />
 		<attribute key="transformDeEquipTo" value="18408" />
 		<attribute key="decayTo" value="0" />
 		<attribute key="duration" value="3600" />


### PR DESCRIPTION
Prismatic Ring
(protection physical +10%, energy +8%).
It can only be wielded properly by players of level 120 or higher.
It weighs 1.05 oz.