### PR TITLE
Fix #1338

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -849,6 +849,7 @@ ReturnValue Game::internalMoveCreature(Creature& creature, Tile& toTile, uint32_
 
 		if (creature.getParent() != subCylinder) {
 			//could happen if a script move the creature
+			fromCylinder = nullptr;
 			break;
 		}
 
@@ -866,7 +867,12 @@ ReturnValue Game::internalMoveCreature(Creature& creature, Tile& toTile, uint32_
 		const Position& fromPosition = fromCylinder->getPosition();
 		const Position& toPosition = toCylinder->getPosition();
 		if (fromPosition.z != toPosition.z && (fromPosition.x != toPosition.x || fromPosition.y != toPosition.y)) {
-			internalCreatureTurn(&creature, creature.getDirection());
+			Direction dir = getDirectionTo(fromPosition, toPosition);
+			if ((dir & DIRECTION_DIAGONAL_MASK) != 0) {
+				return RETURNVALUE_NOERROR;
+			}
+
+			internalCreatureTurn(&creature, dir);
 		}
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -849,7 +849,6 @@ ReturnValue Game::internalMoveCreature(Creature& creature, Tile& toTile, uint32_
 
 		if (creature.getParent() != subCylinder) {
 			//could happen if a script move the creature
-			fromCylinder = nullptr;
 			break;
 		}
 
@@ -867,7 +866,7 @@ ReturnValue Game::internalMoveCreature(Creature& creature, Tile& toTile, uint32_
 		const Position& fromPosition = fromCylinder->getPosition();
 		const Position& toPosition = toCylinder->getPosition();
 		if (fromPosition.z != toPosition.z && (fromPosition.x != toPosition.x || fromPosition.y != toPosition.y)) {
-			internalCreatureTurn(&creature, getDirectionTo(fromPosition, toPosition));
+			internalCreatureTurn(&creature, creature.getDirection());
 		}
 	}
 


### PR DESCRIPTION
The issue was that, as @PrinterLUA  said, getDirectionTo could return diagonal directions and a creature can't turn to a diagonal direction. The fix, as I believe, maintain the behaviour that 6c03744 implemented.