### PR TITLE
Scheduler thread fix & code improvement

### DIFF
--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -61,14 +61,6 @@ inline SchedulerTask* createSchedulerTask(uint32_t delay, const std::function<vo
 	return new SchedulerTask(std::max<uint32_t>(delay, SCHEDULER_MINTICKS), f);
 }
 
-class lessSchedTask : public std::binary_function<SchedulerTask*&, SchedulerTask*&, bool>
-{
-	public:
-		bool operator()(SchedulerTask*& t1, SchedulerTask*& t2) {
-			return (*t1) < (*t2);
-		}
-};
-
 class Scheduler
 {
 	public:
@@ -84,15 +76,22 @@ class Scheduler
 
 	protected:
 		void schedulerThread();
-
+		void setState(ThreadState newState) {
+			threadState.store(newState, std::memory_order_relaxed);
+		}
+		
+		ThreadState getState() const {
+			return threadState.load(std::memory_order_relaxed);
+		}
+		
 		std::thread thread;
 		std::mutex eventLock;
 		std::condition_variable eventSignal;
 
 		uint32_t lastEventId;
-		std::priority_queue<SchedulerTask*, std::vector<SchedulerTask*>, lessSchedTask > eventList;
+		std::priority_queue<SchedulerTask*> eventList;
 		std::unordered_set<uint32_t> eventIds;
-		ThreadState threadState;
+		std::atomic<ThreadState> threadState {THREAD_STATE_TERMINATED};
 };
 
 extern Scheduler g_scheduler;


### PR DESCRIPTION
Fix race condition on the threadState flag in the scheduler thread by using an atomic with relaxed ordering. Remove unnecessary comparator, use the default container for the priority_queue adapter template (which is more efficient than a vector in that role). Remove unnecessary flag check in scheduler loop.