### PR TITLE
fixed #1334 - player should be able to mount only on registred outfits

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4285,6 +4285,11 @@ bool Player::toggleMount(bool mount)
 			sendCancelMessage(RETURNVALUE_ACTIONNOTPERMITTEDINPROTECTIONZONE);
 			return false;
 		}
+		
+		const Outfit* playerOutfit = Outfits::getInstance()->getOutfitByLookType(getSex(), defaultOutfit.lookType);
+		if (!playerOutfit) {
+			return false;
+		}
 
 		uint8_t currentMountId = getCurrentMount();
 		if (currentMountId == 0) {


### PR DESCRIPTION
On the 10.76+ the client get debugs when he tries to use mount on some specific looktypes. He should be able to mount only on the registred outfit in the outfits.xml