### PR TITLE
Use OpenSSL for SHA1 hashing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include(FindCXX11)
 
 # Find packages.
 find_package(GMP REQUIRED)
+find_package(OpenSSL REQUIRED)
 find_package(MySQL)
 find_package(LuaJIT)
 find_package(Threads)
@@ -42,8 +43,8 @@ find_package(Boost 1.42.0 COMPONENTS system REQUIRED)
 include(src/CMakeLists.txt)
 add_executable(tfs ${tfs_SRC})
 
-include_directories(${MYSQL_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${GMP_INCLUDE_DIR})
-target_link_libraries(tfs ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES} ${Boost_LIBRARIES} ${GMP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+include_directories(${MYSQL_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${GMP_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
+target_link_libraries(tfs ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES} ${Boost_LIBRARIES} ${GMP_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 set_target_properties(tfs PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "src/otpch.h")
 set_target_properties(tfs PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE)

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -19,6 +19,8 @@
 
 #include "otpch.h"
 
+#include <openssl/sha.h>
+
 #include "tools.h"
 #include "configmanager.h"
 
@@ -73,117 +75,18 @@ void printXMLError(const std::string& where, const std::string& fileName, const 
 	std::cout << '^' << std::endl;
 }
 
-inline static uint32_t circularShift(int bits, uint32_t value)
-{
-	return (value << bits) | (value >> (32 - bits));
-}
-
-static void processSHA1MessageBlock(const uint8_t* messageBlock, uint32_t* H)
-{
-	uint32_t W[80];
-	for (int i = 0; i < 16; ++i) {
-		const size_t offset = i << 2;
-		W[i] = messageBlock[offset] << 24 | messageBlock[offset + 1] << 16 | messageBlock[offset + 2] << 8 | messageBlock[offset + 3];
-	}
-
-	for (int i = 16; i < 80; ++i) {
-		W[i] = circularShift(1, W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16]);
-	}
-
-	uint32_t A = H[0], B = H[1], C = H[2], D = H[3], E = H[4];
-
-	for (int i = 0; i < 20; ++i) {
-		const uint32_t tmp = circularShift(5, A) + ((B & C) | ((~B) & D)) + E + W[i] + 0x5A827999;
-		E = D; D = C; C = circularShift(30, B); B = A; A = tmp;
-	}
-
-	for (int i = 20; i < 40; ++i) {
-		const uint32_t tmp = circularShift(5, A) + (B ^ C ^ D) + E + W[i] + 0x6ED9EBA1;
-		E = D; D = C; C = circularShift(30, B); B = A; A = tmp;
-	}
-
-	for (int i = 40; i < 60; ++i) {
-		const uint32_t tmp = circularShift(5, A) + ((B & C) | (B & D) | (C & D)) + E + W[i] + 0x8F1BBCDC;
-		E = D; D = C; C = circularShift(30, B); B = A; A = tmp;
-	}
-
-	for (int i = 60; i < 80; ++i) {
-		const uint32_t tmp = circularShift(5, A) + (B ^ C ^ D) + E + W[i] + 0xCA62C1D6;
-		E = D; D = C; C = circularShift(30, B); B = A; A = tmp;
-	}
-
-	H[0] += A;
-	H[1] += B;
-	H[2] += C;
-	H[3] += D;
-	H[4] += E;
-}
-
 std::string transformToSHA1(const std::string& input)
 {
-	uint32_t H[] = {
-		0x67452301,
-		0xEFCDAB89,
-		0x98BADCFE,
-		0x10325476,
-		0xC3D2E1F0
-	};
+	uint8_t digest[SHA_DIGEST_LENGTH];
+	SHA1(reinterpret_cast<const uint8_t*>(input.c_str()), input.length(), digest);
 
-	uint8_t messageBlock[64];
-	size_t index = 0;
-
-	uint32_t length_low = 0;
-	uint32_t length_high = 0;
-	for (char ch : input) {
-		messageBlock[index++] = ch;
-
-		length_low += 8;
-		if (length_low == 0) {
-			length_high++;
-		}
-
-		if (index == 64) {
-			processSHA1MessageBlock(messageBlock, H);
-			index = 0;
-		}
+	std::ostringstream oss;
+	oss.fill('0');
+	oss << std::hex;
+	for (uint8_t* it = digest; it < digest + sizeof(digest); ++it) {
+		oss << std::setw(2) << static_cast<uint32_t>(*it);
 	}
-
-	messageBlock[index++] = 0x80;
-
-	if (index > 56) {
-		while (index < 64) {
-			messageBlock[index++] = 0;
-		}
-
-		processSHA1MessageBlock(messageBlock, H);
-		index = 0;
-	}
-
-	while (index < 56) {
-		messageBlock[index++] = 0;
-	}
-
-	messageBlock[56] = length_high >> 24;
-	messageBlock[57] = length_high >> 16;
-	messageBlock[58] = length_high >> 8;
-	messageBlock[59] = length_high;
-
-	messageBlock[60] = length_low >> 24;
-	messageBlock[61] = length_low >> 16;
-	messageBlock[62] = length_low >> 8;
-	messageBlock[63] = length_low;
-
-	processSHA1MessageBlock(messageBlock, H);
-
-	char hexstring[41];
-	static const char hexDigits[] = {"0123456789abcdef"};
-	for (int hashByte = 20; --hashByte >= 0;) {
-		const uint8_t byte = H[hashByte >> 2] >> (((3 - hashByte) & 3) << 3);
-		size_t index = hashByte << 1;
-		hexstring[index++] = hexDigits[byte >> 4];
-		hexstring[index] = hexDigits[byte & 15];
-	}
-	return std::string(hexstring, 40);
+	return oss.str();
 }
 
 void replaceString(std::string& str, const std::string& sought, const std::string& replacement)


### PR DESCRIPTION
Being a game server, TFS should not have to worry with the implementation of cryptographic functions. As such, I have refactored the `transformToSHA1` function from the tools file to use the well tested OpenSSL library to hash messages.

This reduces the code in 100 lines and relies on a good quality library instead.