### PR TITLE
Set NPCs to idle state when no player is in range

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -412,11 +412,8 @@ void Npc::setIdle(bool idle)
 
 	isIdle = idle;
 
-	if (!isIdle) {
-		g_game.addCreatureCheck(this);
-	} else {
+	if (isIdle) {
 		onIdleStatus();
-		Game::removeCreatureCheck(this);
 	}
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -97,7 +97,6 @@ bool Npc::load()
 
 void Npc::reset()
 {
-	isIdle = true;
 	loaded = false;
 	walkTicks = 1500;
 	floorChange = false;
@@ -111,7 +110,6 @@ void Npc::reset()
 
 	parameters.clear();
 	shopPlayerSet.clear();
-	spectators.clear();
 }
 
 void Npc::reload()

--- a/src/npc.h
+++ b/src/npc.h
@@ -24,7 +24,6 @@
 #include "luascript.h"
 
 #include <set>
-#include <unordered_set>
 
 class Npc;
 class Player;
@@ -225,7 +224,7 @@ class Npc final : public Creature
 		std::map<std::string, std::string> parameters;
 
 		std::set<Player*> shopPlayerSet;
-		std::unordered_set<Player*> spectators;
+		std::set<Player*> spectators;
 
 		std::string name;
 		std::string filename;

--- a/src/npc.h
+++ b/src/npc.h
@@ -24,6 +24,7 @@
 #include "luascript.h"
 
 #include <set>
+#include <unordered_set>
 
 class Npc;
 class Player;
@@ -208,6 +209,12 @@ class Npc final : public Creature
 		}
 		bool getNextStep(Direction& dir, uint32_t& flags) final;
 
+		void setIdle(bool idle);
+		void updateIdleStatus();
+		bool getIdleStatus() const {
+			return isIdle;
+		}
+
 		bool canWalkTo(const Position& fromPos, Direction dir) const;
 		bool getRandomStep(Direction& dir) const;
 
@@ -221,6 +228,7 @@ class Npc final : public Creature
 		std::map<std::string, std::string> parameters;
 
 		std::set<Player*> shopPlayerSet;
+		std::unordered_set<Player*> spectators;
 
 		std::string name;
 		std::string filename;
@@ -239,6 +247,7 @@ class Npc final : public Creature
 		bool attackable;
 		bool ignoreHeight;
 		bool loaded;
+		bool isIdle;
 
 		static NpcScriptInterface* scriptInterface;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -211,9 +211,6 @@ class Npc final : public Creature
 
 		void setIdle(bool idle);
 		void updateIdleStatus();
-		bool getIdleStatus() const {
-			return isIdle;
-		}
 
 		bool canWalkTo(const Position& fromPos, Direction dir) const;
 		bool getRandomStep(Direction& dir) const;


### PR DESCRIPTION
NPCs now idle when no player is near (using `player->canSee(NPC position)`). Idle status callbak is only fired once per update. Updates spectators even if player logs in/out near the NPC.
