### PR TITLE
Move bug report to Lua

### DIFF
--- a/data/creaturescripts/creaturescripts.xml
+++ b/data/creaturescripts/creaturescripts.xml
@@ -7,5 +7,6 @@
 	<event type="login" name="RegenerateStamina" script="regeneratestamina.lua" />
 	<event type="death" name="PlayerDeath" script="playerdeath.lua" />
 	<event type="death" name="DropLoot" script="droploot.lua" />
+	<event type="report" name="PlayerReport" script="report.lua" />
 	<event type="extendedopcode" name="ExtendedOpcode" script="extendedopcode.lua" />
 </creaturescripts>

--- a/data/creaturescripts/scripts/report.lua
+++ b/data/creaturescripts/scripts/report.lua
@@ -1,0 +1,26 @@
+function onReport(player, message, position, category)
+	if player:getAccountType() == ACCOUNT_TYPE_NORMAL then
+		return false
+	end
+
+	local name, playerPos = player:getName(), player:getPosition()
+	local file = io.open("data/reports/" .. name .. " report.txt", "a")
+
+	if not file then
+		player:sendTextMessage(MESSAGE_EVENT_DEFAULT, "There was an error when processing your report, please contact a gamemaster.")
+		return true
+	end
+
+	io.output(file)
+	io.write("------------------------------\n")
+	io.write("Name: " .. name)
+	if category == BUG_CATEGORY_MAP then
+		io.write(" [Map position: " .. position.x .. ", " .. position.y .. ", " .. position.z .. "]")
+	end
+	io.write(" [Player position: " .. playerPos.x .. ", " .. playerPos.y .. ", " .. playerPos.z .. "]\n")
+	io.write("Comment: " .. message .. "\n")
+	io.close(file)
+
+	player:sendTextMessage(MESSAGE_EVENT_DEFAULT, "Your report has been sent to " .. configManager.getString(configKeys.SERVER_NAME) .. ".")
+	return true
+end

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -37,6 +37,7 @@ enum CreatureEventType_t {
 	CREATURE_EVENT_TEXTEDIT,
 	CREATURE_EVENT_HEALTHCHANGE,
 	CREATURE_EVENT_MANACHANGE,
+	CREATURE_EVENT_REPORT,
 	CREATURE_EVENT_EXTENDED_OPCODE, // otclient additional network opcodes
 };
 
@@ -56,6 +57,7 @@ class CreatureEvents final : public BaseEvents
 		bool playerLogin(Player* player) const;
 		bool playerLogout(Player* player) const;
 		bool playerAdvance(Player* player, skills_t, uint32_t, uint32_t);
+		bool playerReport(Player* player, const std::string&, const Position&, uint8_t) const;
 
 		CreatureEvent* getEventByName(const std::string& name, bool forceLoaded = true);
 
@@ -105,6 +107,7 @@ class CreatureEvent final : public Event
 		bool executeTextEdit(Player* player, Item* item, const std::string& text);
 		void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 		void executeManaChange(Creature* creature, Creature* attacker, int32_t& manaChange, CombatOrigin origin);
+		void executeOnReport(Player* player, const std::string& message, const Position& position, uint8_t category);
 		void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);
 		//
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -46,6 +46,7 @@ extern TalkActions* g_talkActions;
 extern Spells* g_spells;
 extern Vocations g_vocations;
 extern GlobalEvents* g_globalEvents;
+extern CreatureEvents* g_creatureEvents;
 extern Events* g_events;
 
 Game::Game() :
@@ -4840,26 +4841,7 @@ void Game::playerReportBug(uint32_t playerId, const std::string& message, const 
 		return;
 	}
 
-	if (player->getAccountType() == ACCOUNT_TYPE_NORMAL) {
-		return;
-	}
-
-	std::string fileName = "data/reports/" + player->getName() + " report.txt";
-	FILE* file = fopen(fileName.c_str(), "a");
-	if (!file) {
-		player->sendTextMessage(MESSAGE_EVENT_DEFAULT, "There was an error when processing your report, please contact a gamemaster.");
-		return;
-	}
-
-	const Position& playerPosition = player->getPosition();
-	if (category == BUG_CATEGORY_MAP) {
-		fprintf(file, "------------------------------\nName: %s [Map Position: %u, %u, %u] [Player Position: %u, %u, %u]\nComment: %s\n", player->getName().c_str(), position.x, position.y, position.z, playerPosition.x, playerPosition.y, playerPosition.z, message.c_str());
-	} else {
-		fprintf(file, "------------------------------\nName: %s [Player Position: %u, %u, %u]\nComment: %s\n", player->getName().c_str(), playerPosition.x, playerPosition.y, playerPosition.z, message.c_str());
-	}
-	fclose(file);
-
-	player->sendTextMessage(MESSAGE_EVENT_DEFAULT, "Your report has been sent to " + g_config.getString(ConfigManager::SERVER_NAME) + ".");
+	g_creatureEvents->playerReport(player, message, position, category);
 }
 
 void Game::playerDebugAssert(uint32_t playerId, const std::string& assertLine, const std::string& date, const std::string& description, const std::string& comment)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1056,6 +1056,11 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(ACCOUNT_TYPE_GAMEMASTER)
 	registerEnum(ACCOUNT_TYPE_GOD)
 
+	registerEnum(BUG_CATEGORY_MAP)
+	registerEnum(BUG_CATEGORY_TYPO)
+	registerEnum(BUG_CATEGORY_TECHNICAL)
+	registerEnum(BUG_CATEGORY_OTHER)
+
 	registerEnum(CALLBACK_PARAM_LEVELMAGICVALUE)
 	registerEnum(CALLBACK_PARAM_SKILLVALUE)
 	registerEnum(CALLBACK_PARAM_TARGETTILE)


### PR DESCRIPTION
This was requested by **beastn** from OTLand.

Moving the bug report system to Lua allows for better control over bug reports. One can write to a file (as previously and defaulted by this PR), or maybe save to the database, and change who can report and add filters easily using Lua.
