### PR TITLE
Fix #1462 debug when mounted with non-mountable outfits

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3164,6 +3164,11 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit)
 		return;
 	}
 
+	const Outfit* playerOutfit = Outfits::getInstance()->getOutfitByLookType(player->getSex(), outfit.lookType);
+	if (!playerOutfit) {
+		outfit.lookMount = 0;
+	}
+
 	if (outfit.lookMount != 0) {
 		Mount* mount = mounts.getMountByClientID(outfit.lookMount);
 		if (!mount) {


### PR DESCRIPTION
#1462 

Fixes debug assertion when mounted and changing to an outfit that has no mounts (e.g. gamemaster) by checking before changing the outfit if that one is able to mount.

Considering outfits from outfits.xml as mountable, all others as non-mountable.
Also this should have been fixed with #1368 but that PR only fixes half of the problem.