### PR TITLE
Fix #1482 house list edit

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1480,6 +1480,11 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 			}
 		}
 	}
+
+	// unset editing house
+	if (editHouse && !newTile->hasFlag(TILESTATE_HOUSE)) {
+		editHouse = nullptr;
+	}
 }
 
 //container


### PR DESCRIPTION
The bug: #1482 
The player gets kicked but the house list editing window keeps open and the player still can edit and save it once. That way, he can put itself on the list and walk into the house.

The fix: just unset the player house being edited value to null when he gets kicked from the house, and the server silently ignores the update.

Video: https://youtu.be/sgNRSPQIV94