### PR TITLE
RSA class improvements.

### DIFF
--- a/src/rsa.h
+++ b/src/rsa.h
@@ -32,7 +32,7 @@ class RSA
 		RSA(const RSA&) = delete;
 		RSA& operator=(const RSA&) = delete;
 
-		void setKey(const char* p_str, const char* q_str);
+		void setKey(const char* pString, const char* qString);
 		void decrypt(char* msg) const;
 
 	private:

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -32,14 +32,12 @@ class RSA
 		RSA(const RSA&) = delete;
 		RSA& operator=(const RSA&) = delete;
 
-		void setKey(const char* p, const char* q);
-		void decrypt(char* msg);
+		void setKey(const char* p_str, const char* q_str);
+		void decrypt(char* msg) const;
 
-	protected:
-		std::recursive_mutex lock;
-
+	private:
 		//use only GMP
-		mpz_t m_n, m_d;
+		mpz_t n, d;
 };
 
 #endif


### PR DESCRIPTION
Closes #1494
Added the const qualifier to RSA::decrypt(). Removed m_ prefix from
variables. Removed the mutex because it was unnecessary (decryption has
no side-effects and doesn't modify any state).