### PR TITLE
Use RAII to manage CombatParam && Combat memory.

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -44,11 +44,6 @@ Combat::~Combat()
 	for (const Condition* condition : params.conditionList) {
 		delete condition;
 	}
-
-	delete params.valueCallback;
-	delete params.tileCallback;
-	delete params.targetCallback;
-	delete area;
 }
 
 CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
@@ -461,26 +456,22 @@ bool Combat::setCallback(CallBackParam_t key)
 {
 	switch (key) {
 		case CALLBACK_PARAM_LEVELMAGICVALUE: {
-			delete params.valueCallback;
-			params.valueCallback = new ValueCallback(COMBAT_FORMULA_LEVELMAGIC);
+			params.valueCallback.reset(new ValueCallback(COMBAT_FORMULA_LEVELMAGIC));
 			return true;
 		}
 
 		case CALLBACK_PARAM_SKILLVALUE: {
-			delete params.valueCallback;
-			params.valueCallback = new ValueCallback(COMBAT_FORMULA_SKILL);
+			params.valueCallback.reset(new ValueCallback(COMBAT_FORMULA_SKILL));
 			return true;
 		}
 
 		case CALLBACK_PARAM_TARGETTILE: {
-			delete params.tileCallback;
-			params.tileCallback = new TileCallback();
+			params.tileCallback.reset(new TileCallback());
 			return true;
 		}
 
 		case CALLBACK_PARAM_TARGETCREATURE: {
-			delete params.targetCallback;
-			params.targetCallback = new TargetCallback();
+			params.targetCallback.reset(new TargetCallback());
 			return true;
 		}
 	}
@@ -492,15 +483,15 @@ CallBack* Combat::getCallback(CallBackParam_t key)
 	switch (key) {
 		case CALLBACK_PARAM_LEVELMAGICVALUE:
 		case CALLBACK_PARAM_SKILLVALUE: {
-			return params.valueCallback;
+			return params.valueCallback.get();
 		}
 
 		case CALLBACK_PARAM_TARGETTILE: {
-			return params.tileCallback;
+			return params.tileCallback.get();
 		}
 
 		case CALLBACK_PARAM_TARGETCREATURE: {
-			return params.targetCallback;
+			return params.targetCallback.get();
 		}
 	}
 	return nullptr;
@@ -779,12 +770,12 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 	if (params.combatType != COMBAT_NONE) {
 		CombatDamage damage = getCombatDamage(caster, nullptr);
 		if (damage.primary.type != COMBAT_MANADRAIN) {
-			doCombatHealth(caster, position, area, damage, params);
+			doCombatHealth(caster, position, area.get(), damage, params);
 		} else {
-			doCombatMana(caster, position, area, damage, params);
+			doCombatMana(caster, position, area.get(), damage, params);
 		}
 	} else {
-		CombatFunc(caster, position, area, params, CombatNullFunc, nullptr);
+		CombatFunc(caster, position, area.get(), params, CombatNullFunc, nullptr);
 	}
 }
 

--- a/src/combat.h
+++ b/src/combat.h
@@ -76,18 +76,14 @@ struct CombatParams {
 		distanceEffect = CONST_ANI_NONE;
 		useCharges = false;
 
-		valueCallback = nullptr;
-		tileCallback = nullptr;
-		targetCallback = nullptr;
-
 		origin = ORIGIN_SPELL;
 	}
 
 	std::forward_list<const Condition*> conditionList;
 
-	ValueCallback* valueCallback;
-	TileCallback* tileCallback;
-	TargetCallback* targetCallback;
+	std::unique_ptr<ValueCallback> valueCallback;
+	std::unique_ptr<TileCallback> tileCallback;
+	std::unique_ptr<TargetCallback> targetCallback;
 
 	uint16_t itemId;
 
@@ -312,9 +308,8 @@ class Combat
 		CallBack* getCallback(CallBackParam_t key);
 
 		bool setParam(CombatParam_t param, uint32_t value);
-		void setArea(AreaCombat* _area) {
-			delete area;
-			area = _area;
+		void setArea(AreaCombat* area) {
+			this->area.reset(area);
 		}
 		bool hasArea() const {
 			return area != nullptr;
@@ -356,7 +351,7 @@ class Combat
 		double maxa;
 		double maxb;
 
-		AreaCombat* area;
+		std::unique_ptr<AreaCombat> area;
 };
 
 class MagicField final : public Item


### PR DESCRIPTION
Use the RAII idiom to reduce the amount of memory management boilerplate.