### PR TITLE
Replace reinterpret_casts.

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -86,7 +86,7 @@ Event* Actions::getEvent(const std::string& nodeName)
 
 bool Actions::registerEvent(Event* event, const pugi::xml_node& node)
 {
-	Action* action = reinterpret_cast<Action*>(event);
+	Action* action = static_cast<Action*>(event); //event is guaranteed to be an Action
 
 	pugi::xml_attribute attr;
 	if ((attr = node.attribute("itemid"))) {

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -81,7 +81,7 @@ Container::~Container()
 
 Item* Container::clone() const
 {
-	Container* clone = reinterpret_cast<Container*>(Item::clone());
+	Container* clone = static_cast<Container*>(Item::clone());
 	for (Item* item : itemlist) {
 		clone->addItem(item->clone());
 	}

--- a/src/creature.h
+++ b/src/creature.h
@@ -435,7 +435,7 @@ class Creature : virtual public Thing
 			return _tile;
 		}
 		void setParent(Cylinder* cylinder) final {
-			_tile = reinterpret_cast<Tile*>(cylinder);
+			_tile = static_cast<Tile*>(cylinder);
 			_position = _tile->getPosition();
 		}
 

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -67,7 +67,7 @@ Event* CreatureEvents::getEvent(const std::string& nodeName)
 
 bool CreatureEvents::registerEvent(Event* event, const pugi::xml_node&)
 {
-	CreatureEvent* creatureEvent = reinterpret_cast<CreatureEvent*>(event);
+	CreatureEvent* creatureEvent = static_cast<CreatureEvent*>(event); //event is guaranteed to be a CreatureEvent
 	if (creatureEvent->getEventType() == CREATURE_EVENT_NONE) {
 		std::cout << "Error: [CreatureEvents::registerEvent] Trying to register event without type!" << std::endl;
 		return false;

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -72,7 +72,7 @@ Event* GlobalEvents::getEvent(const std::string& nodeName)
 
 bool GlobalEvents::registerEvent(Event* event, const pugi::xml_node&)
 {
-	GlobalEvent* globalEvent = reinterpret_cast<GlobalEvent*>(event);
+	GlobalEvent* globalEvent = static_cast<GlobalEvent*>(event); //event is guaranteed to be a GlobalEvent
 	if (globalEvent->getEventType() == GLOBALEVENT_TIMER) {
 		auto result = timerMap.emplace(globalEvent->getName(), globalEvent);
 		if (result.second) {

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -254,7 +254,7 @@ bool IOMap::loadMap(Map* map, const std::string& identifier)
 					}
 
 					tile = new HouseTile(px, py, pz, house);
-					house->addTile(reinterpret_cast<HouseTile*>(tile));
+					house->addTile(static_cast<HouseTile*>(tile));
 					isHouseTile = true;
 				}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -891,7 +891,7 @@ QTreeNode::~QTreeNode()
 QTreeLeafNode* QTreeNode::getLeaf(uint32_t x, uint32_t y)
 {
 	if (m_isLeaf) {
-		return reinterpret_cast<QTreeLeafNode*>(this);
+		return static_cast<QTreeLeafNode*>(this);
 	}
 
 	QTreeNode* node = m_child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
@@ -915,7 +915,7 @@ QTreeLeafNode* QTreeNode::createLeaf(uint32_t x, uint32_t y, uint32_t level)
 		}
 		return m_child[index]->createLeaf(x * 2, y * 2, level - 1);
 	}
-	return reinterpret_cast<QTreeLeafNode*>(this);
+	return static_cast<QTreeLeafNode*>(this);
 }
 
 // QTreeLeafNode
@@ -987,7 +987,7 @@ uint32_t Map::clean() const
 		const QTreeNode* node = nodes.back();
 		nodes.pop_back();
 		if (node->isLeaf()) {
-			const QTreeLeafNode* leafNode = reinterpret_cast<const QTreeLeafNode*>(node);
+			const QTreeLeafNode* leafNode = static_cast<const QTreeLeafNode*>(node);
 			for (uint8_t z = 0; z < MAP_MAX_LAYERS; ++z) {
 				Floor* floor = leafNode->getFloor(z);
 				if (!floor) {

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -96,7 +96,7 @@ Event* MoveEvents::getEvent(const std::string& nodeName)
 
 bool MoveEvents::registerEvent(Event* event, const pugi::xml_node& node)
 {
-	MoveEvent* moveEvent = reinterpret_cast<MoveEvent*>(event);
+	MoveEvent* moveEvent = static_cast<MoveEvent*>(event); //event is guaranteed to be a MoveEvent
 
 	const MoveEvent_t eventType = moveEvent->getEventType();
 	if (eventType == MOVE_EVENT_ADD_ITEM || eventType == MOVE_EVENT_REMOVE_ITEM) {

--- a/src/tile.h
+++ b/src/tile.h
@@ -459,49 +459,49 @@ inline Tile::~Tile()
 inline CreatureVector* Tile::getCreatures()
 {
 	if (isDynamic()) {
-		return reinterpret_cast<DynamicTile*>(this)->DynamicTile::getCreatures();
+		return static_cast<DynamicTile*>(this)->DynamicTile::getCreatures();
 	}
-	return reinterpret_cast<StaticTile*>(this)->StaticTile::getCreatures();
+	return static_cast<StaticTile*>(this)->StaticTile::getCreatures();
 }
 
 inline const CreatureVector* Tile::getCreatures() const
 {
 	if (isDynamic()) {
-		return reinterpret_cast<const DynamicTile*>(this)->DynamicTile::getCreatures();
+		return static_cast<const DynamicTile*>(this)->DynamicTile::getCreatures();
 	}
-	return reinterpret_cast<const StaticTile*>(this)->StaticTile::getCreatures();
+	return static_cast<const StaticTile*>(this)->StaticTile::getCreatures();
 }
 
 inline TileItemVector* Tile::getItemList()
 {
 	if (isDynamic()) {
-		return reinterpret_cast<DynamicTile*>(this)->DynamicTile::getItemList();
+		return static_cast<DynamicTile*>(this)->DynamicTile::getItemList();
 	}
-	return reinterpret_cast<StaticTile*>(this)->StaticTile::getItemList();
+	return static_cast<StaticTile*>(this)->StaticTile::getItemList();
 }
 
 inline const TileItemVector* Tile::getItemList() const
 {
 	if (isDynamic()) {
-		return reinterpret_cast<const DynamicTile*>(this)->DynamicTile::getItemList();
+		return static_cast<const DynamicTile*>(this)->DynamicTile::getItemList();
 	}
-	return reinterpret_cast<const StaticTile*>(this)->StaticTile::getItemList();
+	return static_cast<const StaticTile*>(this)->StaticTile::getItemList();
 }
 
 inline CreatureVector* Tile::makeCreatures()
 {
 	if (isDynamic()) {
-		return reinterpret_cast<DynamicTile*>(this)->DynamicTile::makeCreatures();
+		return static_cast<DynamicTile*>(this)->DynamicTile::makeCreatures();
 	}
-	return reinterpret_cast<StaticTile*>(this)->StaticTile::makeCreatures();
+	return static_cast<StaticTile*>(this)->StaticTile::makeCreatures();
 }
 
 inline TileItemVector* Tile::makeItemList()
 {
 	if (isDynamic()) {
-		return reinterpret_cast<DynamicTile*>(this)->DynamicTile::makeItemList();
+		return static_cast<DynamicTile*>(this)->DynamicTile::makeItemList();
 	}
-	return reinterpret_cast<StaticTile*>(this)->StaticTile::makeItemList();
+	return static_cast<StaticTile*>(this)->StaticTile::makeItemList();
 }
 
 inline StaticTile::StaticTile(uint16_t x, uint16_t y, uint8_t z) :

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -124,7 +124,7 @@ Event* Weapons::getEvent(const std::string& nodeName)
 
 bool Weapons::registerEvent(Event* event, const pugi::xml_node&)
 {
-	Weapon* weapon = reinterpret_cast<Weapon*>(event);
+	Weapon* weapon = static_cast<Weapon*>(event); //event is guaranteed to be a Weapon
 
 	auto result = weapons.emplace(weapon->getID(), weapon);
 	if (!result.second) {


### PR DESCRIPTION
Replaced reinterpret_casts where the semantic meaning of the type
cast is satisfied by a static_cast (in other word where we cast
pointers/references to objects that are related).