### PR TITLE
Threads cleanup

### DIFF
--- a/src/databasetasks.cpp
+++ b/src/databasetasks.cpp
@@ -24,22 +24,17 @@
 
 extern Dispatcher g_dispatcher;
 
-DatabaseTasks::DatabaseTasks()
-{
-	threadState = THREAD_STATE_TERMINATED;
-}
 
 void DatabaseTasks::start()
 {
 	db.connect();
-	threadState = THREAD_STATE_RUNNING;
-	thread = std::thread(&DatabaseTasks::run, this);
+	ThreadHolder::start();
 }
 
-void DatabaseTasks::run()
+void DatabaseTasks::threadMain()
 {
 	std::unique_lock<std::mutex> taskLockUnique(taskLock, std::defer_lock);
-	while (threadState != THREAD_STATE_TERMINATED) {
+	while (getState() != THREAD_STATE_TERMINATED) {
 		taskLockUnique.lock();
 		if (tasks.empty()) {
 			taskSignal.wait(taskLockUnique);
@@ -60,7 +55,7 @@ void DatabaseTasks::addTask(const std::string& query, const std::function<void(D
 {
 	bool signal = false;
 	taskLock.lock();
-	if (threadState == THREAD_STATE_RUNNING) {
+	if (getState() == THREAD_STATE_RUNNING) {
 		signal = tasks.empty();
 		tasks.emplace_back(query, callback, store);
 	}
@@ -96,25 +91,11 @@ void DatabaseTasks::flush()
 	}
 }
 
-void DatabaseTasks::stop()
-{
-	taskLock.lock();
-	threadState = THREAD_STATE_CLOSING;
-	taskLock.unlock();
-}
-
 void DatabaseTasks::shutdown()
 {
 	taskLock.lock();
-	threadState = THREAD_STATE_TERMINATED;
+	setState(THREAD_STATE_TERMINATED);
 	flush();
 	taskLock.unlock();
 	taskSignal.notify_one();
-}
-
-void DatabaseTasks::join()
-{
-	if (thread.joinable()) {
-		thread.join();
-	}
 }

--- a/src/databasetasks.h
+++ b/src/databasetasks.h
@@ -21,9 +21,7 @@
 #define FS_DATABASETASKS_H_9CBA08E9F5FEBA7275CCEE6560059576
 
 #include <condition_variable>
-#include <list>
-#include <thread>
-
+#include "thread_holder_base.h"
 #include "database.h"
 #include "enums.h"
 
@@ -36,19 +34,17 @@ struct DatabaseTask {
 	bool store;
 };
 
-class DatabaseTasks {
+class DatabaseTasks : public ThreadHolder<DatabaseTasks>
+{
 	public:
-		DatabaseTasks();
-
+		DatabaseTasks() = default;
 		void start();
-		void run();
 		void flush();
-		void stop();
 		void shutdown();
-		void join();
 
 		void addTask(const std::string& query, const std::function<void(DBResult_ptr, bool)>& callback = nullptr, bool store = false);
 
+		void threadMain();
 	private:
 		void runTask(const DatabaseTask& task);
 
@@ -57,7 +53,6 @@ class DatabaseTasks {
 		std::list<DatabaseTask> tasks;
 		std::mutex taskLock;
 		std::condition_variable taskSignal;
-		ThreadState threadState;
 };
 
 extern DatabaseTasks g_databaseTasks;

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -110,16 +110,9 @@ int main(int argc, char* argv[])
 		serviceManager.run();
 	} else {
 		std::cout << ">> No services running. The server is NOT online." << std::endl;
-		g_dispatcher.addTask(createTask([]() {
-			g_dispatcher.addTask(createTask([]() {
-				g_scheduler.shutdown();
-				g_databaseTasks.shutdown();
-				g_dispatcher.shutdown();
-			}));
-			g_scheduler.stop();
-			g_databaseTasks.stop();
-			g_dispatcher.stop();
-		}));
+		g_scheduler.shutdown();
+		g_databaseTasks.shutdown();
+		g_dispatcher.shutdown();
 	}
 
 	g_scheduler.join();

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -21,18 +21,7 @@
 
 #include "scheduler.h"
 
-Scheduler::Scheduler()
-{
-	lastEventId = 0;
-}
-
-void Scheduler::start()
-{
-	setState(THREAD_STATE_RUNNING);
-	thread = std::thread(&Scheduler::schedulerThread, this);
-}
-
-void Scheduler::schedulerThread()
+void Scheduler::threadMain()
 {
 	std::unique_lock<std::mutex> eventLockUnique(eventLock, std::defer_lock);
 	while (getState() != THREAD_STATE_TERMINATED) {
@@ -127,11 +116,6 @@ bool Scheduler::stopEvent(uint32_t eventid)
 	return true;
 }
 
-void Scheduler::stop()
-{
-	setState(THREAD_STATE_CLOSING);
-}
-
 void Scheduler::shutdown()
 {
 	setState(THREAD_STATE_TERMINATED);
@@ -148,9 +132,3 @@ void Scheduler::shutdown()
 	eventSignal.notify_one();
 }
 
-void Scheduler::join()
-{
-	if (thread.joinable()) {
-		thread.join();
-	}
-}

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -24,7 +24,9 @@
 #include <unordered_set>
 #include <queue>
 
-#include <condition_variable>
+
+#include "thread_holder_base.h"
+
 
 #define SCHEDULER_MINTICKS 50
 
@@ -63,37 +65,23 @@ struct TaskComparator {
 	}
 };
 
-class Scheduler
+class Scheduler : public ThreadHolder<Scheduler>
 {
 	public:
-		Scheduler();
-
 		uint32_t addEvent(SchedulerTask* task);
 		bool stopEvent(uint32_t eventId);
 
-		void start();
-		void stop();
 		void shutdown();
-		void join();
 
+		void threadMain();
 	protected:
-		void schedulerThread();
-		void setState(ThreadState newState) {
-			threadState.store(newState, std::memory_order_relaxed);
-		}
-
-		ThreadState getState() const {
-			return threadState.load(std::memory_order_relaxed);
-		}
-
 		std::thread thread;
 		std::mutex eventLock;
 		std::condition_variable eventSignal;
 
-		uint32_t lastEventId;
+		uint32_t lastEventId {0};
 		std::priority_queue<SchedulerTask*, std::deque<SchedulerTask*>, TaskComparator> eventList;
 		std::unordered_set<uint32_t> eventIds;
-		std::atomic<ThreadState> threadState {THREAD_STATE_TERMINATED};
 };
 
 extern Scheduler g_scheduler;

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -24,13 +24,7 @@
 
 extern Game g_game;
 
-void Dispatcher::start()
-{
-	setState(THREAD_STATE_RUNNING);
-	thread = std::thread(&Dispatcher::dispatcherThread, this);
-}
-
-void Dispatcher::dispatcherThread()
+void Dispatcher::threadMain()
 {
 	// NOTE: second argument defer_lock is to prevent from immediate locking
 	std::unique_lock<std::mutex> taskLockUnique(taskLock, std::defer_lock);
@@ -90,11 +84,6 @@ void Dispatcher::addTask(Task* task, bool push_front /*= false*/)
 	}
 }
 
-void Dispatcher::stop()
-{
-	setState(THREAD_STATE_CLOSING);
-}
-
 void Dispatcher::shutdown()
 {
 	Task* task = createTask([this]() {
@@ -106,11 +95,4 @@ void Dispatcher::shutdown()
 	taskList.push_back(task);
 
 	taskSignal.notify_one();
-}
-
-void Dispatcher::join()
-{
-	if (thread.joinable()) {
-		thread.join();
-	}
 }

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -21,8 +21,7 @@
 #define FS_TASKS_H_A66AC384766041E59DCA059DAB6E1976
 
 #include <condition_variable>
-#include <atomic>
-
+#include "thread_holder_base.h"
 #include "enums.h"
 
 const int DISPATCHER_TASK_EXPIRATION = 2000;
@@ -71,35 +70,22 @@ inline Task* createTask(uint32_t expiration, const std::function<void (void)>& f
 	return new Task(expiration, f);
 }
 
-class Dispatcher
+class Dispatcher : public ThreadHolder<Dispatcher>
 {
 	public:
 		void addTask(Task* task, bool push_front = false);
-
-		void start();
-		void stop();
 		void shutdown();
-		void join();
 
 		uint64_t getDispatcherCycle() const {
 			return dispatcherCycle;
 		}
+		void threadMain();
 	protected:
-		void dispatcherThread();
-		void setState(ThreadState newState) {
-			threadState.store(newState, std::memory_order_relaxed);
-		}
-
-		ThreadState getState() const {
-			return threadState.load(std::memory_order_relaxed);
-		}
-
 		std::thread thread;
 		std::mutex taskLock;
 		std::condition_variable taskSignal;
 
 		std::list<Task*> taskList;
-		std::atomic<ThreadState> threadState {THREAD_STATE_TERMINATED};
 		uint64_t dispatcherCycle {0};
 };
 

--- a/src/thread_holder_base.h
+++ b/src/thread_holder_base.h
@@ -1,0 +1,58 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2015  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FS_THREAD_HOLDER_H_BEB56FC46748E71D15A5BF0773ED2E67
+#define FS_THREAD_HOLDER_H_BEB56FC46748E71D15A5BF0773ED2E67
+
+#include <thread>
+#include "enums.h"
+
+template <typename Derived>
+class ThreadHolder
+{
+	public:
+		ThreadHolder(): threadState(THREAD_STATE_TERMINATED) {}
+		void start() {
+			setState(THREAD_STATE_RUNNING);
+			thread = std::thread(&Derived::threadMain, static_cast<Derived*>(this));
+		}
+
+		void stop() {
+			setState(THREAD_STATE_CLOSING);
+		}
+
+		void join() {
+			if (thread.joinable()) {
+				thread.join();
+			}
+		}
+	protected:
+		void setState(ThreadState newState) {
+			threadState.store(newState, std::memory_order_relaxed);
+		}
+
+		ThreadState getState() const {
+			return threadState.load(std::memory_order_relaxed);
+		}
+	private:
+		std::atomic<ThreadState> threadState;
+		std::thread thread;
+};
+
+#endif


### PR DESCRIPTION
Simplified shutdown sequence when an error occurs in the main loader because there is
no point in letting threads go into the `CLOSING` state as there is most likely no meaningful change in game state and no work items in their queues. Moved common thread management member variables into a common base class for better code reuse. This also fixes a data race on the thread state flag in the async db task runner.