### PR TITLE
Small mounts optimization.

### DIFF
--- a/src/mounts.cpp
+++ b/src/mounts.cpp
@@ -48,25 +48,24 @@ bool Mounts::loadFromXml()
 			mountNode.attribute("premium").as_bool()
 		);
 	}
+	mounts.shrink_to_fit();
 	return true;
 }
 
 Mount* Mounts::getMountByID(uint8_t id)
 {
-	for (Mount& mount : mounts) {
-		if (mount.id == id) {
-			return &mount;
-		}
-	}
-	return nullptr;
+	auto it = std::find_if(mounts.begin(), mounts.end(), [id](const Mount& mount) {
+		return mount.id == id;
+	});
+
+	return it != mounts.end() ? &*it : nullptr;
 }
 
 Mount* Mounts::getMountByClientID(uint16_t clientId)
 {
-	for (Mount& mount : mounts) {
-		if (mount.clientId == clientId) {
-			return &mount;
-		}
-	}
-	return nullptr;
+	auto it = std::find_if(mounts.begin(), mounts.end(), [clientId](const Mount& mount) {
+		return mount.clientId == clientId;
+	});
+
+	return it != mounts.end() ? &*it : nullptr;
 }

--- a/src/mounts.h
+++ b/src/mounts.h
@@ -40,12 +40,12 @@ class Mounts
 		Mount* getMountByID(uint8_t id);
 		Mount* getMountByClientID(uint16_t clientId);
 
-		const std::list<Mount>& getMounts() const {
+		const std::vector<Mount>& getMounts() const {
 			return mounts;
 		}
 
 	private:
-		std::list<Mount> mounts;
+		std::vector<Mount> mounts;
 };
 
 #endif


### PR DESCRIPTION
Replace list with vector for better look-up performance. Also use the std::find_if algorithm for mounts search.