### PR TITLE
Fix Undefined Behavior in Dispatcher.

### DIFF
--- a/src/tasks.h
+++ b/src/tasks.h
@@ -37,6 +37,7 @@ class Task
 		explicit Task(const std::function<void (void)>& f)
 			: expiration(SYSTEM_TIME_ZERO), func(f) {}
 
+		virtual ~Task() = default;
 		void operator()() {
 			func();
 		}


### PR DESCRIPTION
Scheduler tasks are deleted with the base pointer which
causes Undefined Behavior as the base class Task does not have
a virtual destructor.