### PR TITLE
Fix an issue with Shared Experience

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -666,6 +666,7 @@ void Creature::onDeath()
 	const int64_t timeNow = OTSYS_TIME();
 	const uint32_t inFightTicks = g_config.getNumber(ConfigManager::PZ_LOCKED);
 	int32_t mostDamage = 0;
+	std::map<Creature*, uint64_t> experienceMap;
 	for (const auto& it : damageMap) {
 		if (Creature* attacker = g_game.getCreatureByID(it.first)) {
 			CountBlock_t cb = it.second;
@@ -673,8 +674,28 @@ void Creature::onDeath()
 				mostDamage = cb.total;
 				mostDamageCreature = attacker;
 			}
-			attacker->onAttackedCreatureKilled(this);
+
+			if (attacker != this) {
+				uint64_t gainExp = getGainedExperience(attacker);
+				if (Player* player = attacker->getPlayer()) {
+					Party* party = player->getParty();
+					if (party && party->getLeader() && party->isSharedExperienceActive() && party->isSharedExperienceEnabled()) {
+						attacker = party->getLeader();
+					}
+				}
+
+				auto it = experienceMap.find(attacker);
+				if (it == experienceMap.end()) {
+					experienceMap[attacker] = gainExp;
+				} else {
+					it->second += gainExp;
+				}
+			}
 		}
+	}
+
+	for (const auto& it : experienceMap) {
+		it.first->onGainExperience(it.second, this);
 	}
 
 	if (mostDamageCreature) {
@@ -1102,14 +1123,6 @@ void Creature::onAttacked()
 void Creature::onAttackedCreatureDrainHealth(Creature* target, int32_t points)
 {
 	target->addDamagePoints(this, points);
-}
-
-void Creature::onAttackedCreatureKilled(Creature* target)
-{
-	if (target != this) {
-		uint64_t gainExp = target->getGainedExperience(this);
-		onGainExperience(gainExp, target);
-	}
 }
 
 bool Creature::onKilledCreature(Creature* target, bool)

--- a/src/creature.h
+++ b/src/creature.h
@@ -374,7 +374,6 @@ class Creature : virtual public Thing
 		virtual void onAttacked();
 		virtual void onAttackedCreatureDrainHealth(Creature* target, int32_t points);
 		virtual void onTargetCreatureGainHealth(Creature*, int32_t) {}
-		void onAttackedCreatureKilled(Creature* target);
 		virtual bool onKilledCreature(Creature* target, bool lastHit = true);
 		virtual void onGainExperience(uint64_t gainExp, Creature* target);
 		virtual void onAttackedCreatureBlockHit(BlockType_t) {}


### PR DESCRIPTION
The experience gained is now being distributed once through the party leader, hence fixing the issue where you would receive multiple experience gained message depending on how many party members participated in the kill.