### PR TITLE
Fix Visual Studio Warning

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -684,11 +684,11 @@ void Creature::onDeath()
 					}
 				}
 
-				auto it = experienceMap.find(attacker);
-				if (it == experienceMap.end()) {
+				auto tmpIt = experienceMap.find(attacker);
+				if (tmpIt == experienceMap.end()) {
 					experienceMap[attacker] = gainExp;
 				} else {
-					it->second += gainExp;
+					tmpIt->second += gainExp;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes the compiler warning 4456, "hides previous local declaration".