### PR TITLE
Add time-based one-time password support

### DIFF
--- a/data/migrations/18.lua
+++ b/data/migrations/18.lua
@@ -1,3 +1,5 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 19 (authenticator token support)")
+	db.query("ALTER TABLE `accounts` ADD COLUMN `secret` CHAR(16) NULL AFTER `password`")
+	return true
 end

--- a/src/account.h
+++ b/src/account.h
@@ -25,6 +25,7 @@
 struct Account {
 	std::vector<std::string> characters;
 	std::string name;
+	std::string key;
 	time_t lastDay;
 	uint32_t id;
 	uint16_t premiumDays;

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -28,6 +28,9 @@
 #define CLIENT_VERSION_MAX 1077
 #define CLIENT_VERSION_STR "10.77"
 
+#define AUTHENTICATOR_DIGITS 6U
+#define AUTHENTICATOR_PERIOD 30U
+
 #ifndef __FUNCTION__
 #define __FUNCTION__ __func__
 #endif

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -52,12 +52,40 @@ bool IOLoginData::saveAccount(const Account& acc)
 	return Database::getInstance()->executeQuery(query.str());
 }
 
+std::string decodeSecret(const std::string& secret) {
+	// simple base32 decoding
+	std::string key;
+	key.reserve(10);
+
+	uint32_t buffer = 0, left = 0;
+	for (const auto& ch : secret) {
+		buffer <<= 5;
+		if (ch >= 'A' && ch <= 'Z') {
+			buffer |= (ch & 0x1F) - 1;
+		} else if (ch >= '2' && ch <= '7') {
+			buffer |= ch - 24;
+		} else {
+			// if a key is broken, return empty and the comparison
+			// will always be false since the token must not be empty
+			return {};
+		}
+
+		left += 5;
+		if (left >= 8) {
+			left -= 8;
+			key.push_back(static_cast<char>(buffer >> left));
+		}
+	}
+
+	return key;
+}
+
 bool IOLoginData::loginserverAuthentication(const std::string& name, const std::string& password, Account& account)
 {
 	Database* db = Database::getInstance();
 
 	std::ostringstream query;
-	query << "SELECT `id`, `name`, `password`, `type`, `premdays`, `lastday` FROM `accounts` WHERE `name` = " << db->escapeString(name);
+	query << "SELECT `id`, `name`, `password`, `secret`, `type`, `premdays`, `lastday` FROM `accounts` WHERE `name` = " << db->escapeString(name);
 	DBResult_ptr result = db->storeQuery(query.str());
 	if (!result) {
 		return false;
@@ -69,6 +97,7 @@ bool IOLoginData::loginserverAuthentication(const std::string& name, const std::
 
 	account.id = result->getNumber<uint32_t>("id");
 	account.name = result->getString("name");
+	account.key = decodeSecret(result->getString("secret"));
 	account.accountType = static_cast<AccountType_t>(result->getNumber<int32_t>("type"));
 	account.premiumDays = result->getNumber<uint16_t>("premdays");
 	account.lastDay = result->getNumber<time_t>("lastday");

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -52,7 +52,8 @@ bool IOLoginData::saveAccount(const Account& acc)
 	return Database::getInstance()->executeQuery(query.str());
 }
 
-std::string decodeSecret(const std::string& secret) {
+std::string decodeSecret(const std::string& secret)
+{
 	// simple base32 decoding
 	std::string key;
 	key.reserve(10);

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -43,7 +43,7 @@ void ProtocolLogin::disconnectClient(const std::string& message, uint16_t versio
 	disconnect();
 }
 
-void ProtocolLogin::getCharacterList(const std::string& accountName, const std::string& password, uint16_t version)
+void ProtocolLogin::getCharacterList(const std::string& accountName, const std::string& password, const std::string& token, uint16_t version)
 {
 	Account account;
 	if (!IOLoginData::loginserverAuthentication(accountName, password, account)) {
@@ -52,6 +52,19 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	}
 
 	auto output = OutputMessagePool::getOutputMessage();
+	if (!account.key.empty()) {
+		int32_t ticks = static_cast<int32_t>(time(nullptr) / AUTHENTICATOR_PERIOD);
+		if (token.empty() || !(token == generateToken(account.key, ticks) || token == generateToken(account.key, ticks - 1) || token == generateToken(account.key, ticks + 1))) {
+			output->addByte(0x0D);
+			output->addByte(0);
+			send(output);
+			disconnect();
+			return;
+		}
+		output->addByte(0x0C);
+		output->addByte(0);
+	}
+
 	//Update premium days
 	Game::updatePremium(account);
 
@@ -178,6 +191,20 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	std::string password = msg.getString();
+	if (password.empty()) {
+		disconnectClient("Invalid password.", version);
+		return;
+	}
+
+	// read authenticator token and stay logged in flag from last 128 bytes
+	msg.setBufferPosition(msg.getLength() - 128);
+	if (!Protocol::RSA_decrypt(msg)) {
+		disconnectClient("Invalid authentification token.", version);
+		return;
+	}
+
+	std::string authToken = msg.getString();
+
 	auto thisPtr = std::dynamic_pointer_cast<ProtocolLogin>(shared_from_this());
-	g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::getCharacterList, thisPtr, accountName, password, version)));
+	g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::getCharacterList, thisPtr, accountName, password, authToken, version)));
 }

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -197,7 +197,7 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	// read authenticator token and stay logged in flag from last 128 bytes
-	msg.setBufferPosition(msg.getLength() - 128);
+	msg.skipBytes((msg.getLength() - 128) - msg.getBufferPosition());
 	if (!Protocol::RSA_decrypt(msg)) {
 		disconnectClient("Invalid authentification token.", version);
 		return;

--- a/src/protocollogin.h
+++ b/src/protocollogin.h
@@ -43,7 +43,7 @@ class ProtocolLogin : public Protocol
 	protected:
 		void disconnectClient(const std::string& message, uint16_t version);
 
-		void getCharacterList(const std::string& accountName, const std::string& password, uint16_t version);
+		void getCharacterList(const std::string& accountName, const std::string& password, const std::string& token, uint16_t version);
 };
 
 #endif

--- a/src/tools.h
+++ b/src/tools.h
@@ -29,6 +29,7 @@
 void printXMLError(const std::string& where, const std::string& fileName, const pugi::xml_parse_result& result);
 
 std::string transformToSHA1(const std::string& input);
+std::string generateToken(const std::string& secret, uint32_t ticks);
 
 void replaceString(std::string& str, const std::string& sought, const std::string& replacement);
 void trim_right(std::string& source, char t);


### PR DESCRIPTION
This adds support for the one-time password support introduced in a recent Tibia version. I opted for the time-based since it is much more widely used.

It is possible to configure the life span and the length of tokens, but the user won't be able to use Google Authenticator, only other solutions such as Authy that support different time and length parameters.

You can use a third party tool to generate QR codes to the users to automatically provide the (encrypted) secret, or just hand them the secret to enter in token generation apps. I will provide a reference implementation soon.

If one wants to use counter-based tokens, it would be necessary an extra column at the account table for the use count, and replacing the "time" with this new column value. Don't forget to increase this counter on every use!

Last but not least: the token is *optional*, just null the column and the token will not be checked. If there is something other than null, then the token will be *required* for that account.