### PR TITLE
Enhance updatePercentSkills() -- closes #683

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -479,8 +479,8 @@ void ConditionAttributes::updatePercentSkills(Player* player)
 			continue;
 		}
 
-		int32_t currSkill = player->getSkillLevel(i);
-		skills[i] = static_cast<int32_t>(currSkill * ((skillsPercent[i] - 100) / 100.f));
+		int32_t unmodifiedSkill = player->getBaseSkill(i);
+		skills[i] = static_cast<int32_t>(unmodifiedSkill * ((skillsPercent[i] - 100) / 100.f));
 	}
 }
 


### PR DESCRIPTION
This *enhances* the ``updatePercentSkills()`` formula. Now it works as it was
supposed to, according to wikia (I have tested it myself too).

The correct calculation for this (namely spells that "increases" skills)
is:
``(unmodified_skill * percent_increase) + any_item_that_increases_skill``
Instead, it was:
``(unmodified_skill + any_item_that_increases_skill) * percent_increase``
