### PR TITLE
Use correct block type for ethereal spells

### DIFF
--- a/data/spells/scripts/attack/ethereal spear.lua
+++ b/data/spells/scripts/attack/ethereal spear.lua
@@ -2,7 +2,7 @@ local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ETHEREALSPEAR)
-combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
+combat:setParameter(COMBAT_PARAM_BLOCKSHIELD, 1)
 
 function onGetFormulaValues(player, attack, factor)
 	local skillTotal = 2 * player:getEffectiveSkillLevel(SKILL_DISTANCE)

--- a/data/spells/scripts/attack/strong ethereal spear.lua
+++ b/data/spells/scripts/attack/strong ethereal spear.lua
@@ -2,7 +2,7 @@ local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ETHEREALSPEAR)
-combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
+combat:setParameter(COMBAT_PARAM_BLOCKSHIELD, 1)
 
 function onGetFormulaValues(player, attack, factor)
 	local skillTotal = 2 * player:getEffectiveSkillLevel(SKILL_DISTANCE)


### PR DESCRIPTION
The *correct* **block type** for these two specific paladin**¹** spells:
*Ethereal Spear* and *Strong Ethereal Spear* -- is ``BLOCKSHIELD``

This applies to damage dealt by distance weapons too. Do you think it is appropriate to make such change now?

**¹** *The damage reduction for those spells only take into account the
target's defense.*

research source: ts