### PR TITLE
Enhanced utori-like spells & soul fire rune

### DIFF
--- a/data/spells/lib/spells.lua
+++ b/data/spells/lib/spells.lua
@@ -248,3 +248,45 @@ CORPSES = {
 
 -- This array contains all destroyable field items
 FIELDS = {1487,1488,1489,1490,1491,1492,1493,1494,1495,1496,1500,1501,1502,1503,1504}
+
+-- The numbered-keys represents the damage values, and their table
+-- contains the minimum and maximum number of rounds of those damage values.
+RANGE = {
+[1]  = {19, 20}, [2]  = {10, 10}, [3]  = {6, 7}, [4]  = {4, 5}, [5]  = {3, 4},
+[6]  = {3, 4},   [7]  = {2, 3},   [8]  = {2, 3}, [9]  = {2, 3}, [10] = {1, 2},
+[11] = {1, 2},   [12] = {1, 2},   [13] = {1, 2}, [14] = {1, 2}, [15] = {1, 2},
+[16] = {1, 2},   [17] = {1, 2},   [18] = {1, 2}, [19] = {1, 2}
+}
+
+function Creature:addDamageCondition(target, conditionType, listType, damage, time, rounds)
+	local condition = Condition(conditionType)
+	condition:setParameter(CONDITION_PARAM_OWNER, self:getId())
+	condition:setParameter(CONDITION_PARAM_DELAYED, true)
+
+	if listType == 0 then
+		local exponent, value = -10, 0
+		while value < damage do
+			value = math.floor(10 * 1.2 ^ exponent + 0.5)
+			condition:addDamage(1, time or 4000, -value)
+
+			if value >= damage then
+				local permille = math.random(10, 1200) / 1000
+				condition:addDamage(1, time or 4000, -math.max(1, math.floor(value * permille + 0.5)))
+			else
+				exponent = exponent + 1
+			end
+		end
+	elseif listType == 1 then
+		while damage > 0 do
+			condition:addDamage(RANGE[damage] and math.random(RANGE[damage][1], RANGE[damage][2]) or 1, time or 4000, -damage)
+			damage = damage - (damage > 21 and math.floor(damage / 20) + math.random(0, 1) or 1)
+		end
+	elseif listType == 2 then
+		for _ = 1, rounds do
+			condition:addDamage(1, math.random(time[1], time[2]) * 1000, -damage)
+		end
+	end
+
+	target:addCondition(condition)
+	return true
+end

--- a/data/spells/scripts/attack/curse.lua
+++ b/data/spells/scripts/attack/curse.lua
@@ -3,27 +3,15 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_DEATHDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MORTAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_DEATH)
 
-local condition = Condition(CONDITION_CURSED)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
+function onTargetCreature(creature, target)
+	local min = (creature:getLevel() * 0.03) + (creature:getMagicLevel() * 0.45) + 4
+	local max = (creature:getLevel() * 0.03) + (creature:getMagicLevel() * 0.9) + 5
+	local damage = math.random(math.floor(min), math.floor(max))
+	creature:addDamageCondition(target, CONDITION_CURSED, 0, damage)
+	return true
+end
 
-condition:addDamage(1, 4000, -45)
-condition:addDamage(1, 4000, -40)
-condition:addDamage(1, 4000, -35)
-condition:addDamage(1, 4000, -34)
-condition:addDamage(2, 4000, -33)
-condition:addDamage(2, 4000, -32)
-condition:addDamage(2, 4000, -31)
-condition:addDamage(2, 4000, -30)
-condition:addDamage(3, 4000, -29)
-condition:addDamage(3, 4000, -25)
-condition:addDamage(3, 4000, -24)
-condition:addDamage(4, 4000, -23)
-condition:addDamage(4, 4000, -20)
-condition:addDamage(5, 4000, -19)
-condition:addDamage(5, 4000, -15)
-condition:addDamage(6, 4000, -10)
-condition:addDamage(10, 4000, -5)
-combat:setCondition(condition)
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)

--- a/data/spells/scripts/attack/electrify.lua
+++ b/data/spells/scripts/attack/electrify.lua
@@ -3,10 +3,16 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
 
-local condition = Condition(CONDITION_ENERGY)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
-condition:addDamage(10, 10000, -25)
-combat:setCondition(condition)
+function onTargetCreature(creature, target)
+	local min = (creature:getLevel() * 0.01) + (creature:getMagicLevel() * 0.13) + 1
+	local max = (creature:getLevel() * 0.01) + (creature:getMagicLevel() * 0.25) + 1
+	local rounds = math.random(math.floor(min), math.floor(max))
+	local damage = target:isPlayer() and 13 or 25
+	creature:addDamageCondition(target, CONDITION_ENERGY, 2, damage, {10, 12}, rounds)
+	return true
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)

--- a/data/spells/scripts/attack/envenom.lua
+++ b/data/spells/scripts/attack/envenom.lua
@@ -3,10 +3,15 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_EARTHDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_CARNIPHILA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_EARTH)
 
-local condition = Condition(CONDITION_POISON)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
-condition:addDamage(25, 4000, -45)
-combat:setCondition(condition)
+function onTargetCreature(creature, target)
+	local min = (creature:getLevel() * 0.01) + (creature:getMagicLevel() * 0.55) + 6
+	local max = (creature:getLevel() * 0.01) + (creature:getMagicLevel() * 0.75) + 7
+	local damage = math.random(math.floor(min), math.floor(max))
+	creature:addDamageCondition(target, CONDITION_POISON, 1, target:isPlayer() and math.floor(damage / 2 + 0.5) or damage)
+	return true
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)

--- a/data/spells/scripts/attack/holy_flash.lua
+++ b/data/spells/scripts/attack/holy_flash.lua
@@ -3,10 +3,22 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HOLYDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HOLYDAMAGE)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SMALLHOLY)
 
-local condition = Condition(CONDITION_DAZZLED)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
-condition:addDamage(50, 10000, -10)
-combat:setCondition(condition)
+function onTargetCreature(creature, target)
+	local damage = target:isPlayer() and 10 or 20
+	local time = math.random(10, 12) * 1000
+	local min = (creature:getLevel() * 0.01) + (creature:getMagicLevel() * 0.3) + 2
+	local max = (creature:getLevel() * 0.01) + (creature:getMagicLevel() * 0.5) + 3
+	local rounds = math.random(math.floor(min), math.floor(max))
+
+	local condition = Condition(CONDITION_DAZZLED)
+	condition:setParameter(CONDITION_PARAM_OWNER, creature:getId())
+	condition:setParameter(CONDITION_PARAM_DELAYED, true)
+	condition:addDamage(rounds, time, -damage)
+	target:addCondition(condition)
+	return true
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)

--- a/data/spells/scripts/attack/ignite.lua
+++ b/data/spells/scripts/attack/ignite.lua
@@ -3,10 +3,16 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
 
-local condition = Condition(CONDITION_FIRE)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
-condition:addDamage(23, 10000, -10)
-combat:setCondition(condition)
+function onTargetCreature(creature, target)
+	local min = (creature:getLevel() * 0.03) + (creature:getMagicLevel() * 0.3) + 2
+	local max = (creature:getLevel() * 0.03) + (creature:getMagicLevel() * 0.55) + 4
+	local rounds = math.random(math.floor(min), math.floor(max))
+	local damage = target:isPlayer() and 5 or 10
+	creature:addDamageCondition(target, CONDITION_FIRE, 2, damage, {8, 10}, rounds)
+	return true
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)

--- a/data/spells/scripts/attack/inflict_wound.lua
+++ b/data/spells/scripts/attack/inflict_wound.lua
@@ -3,10 +3,22 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_DRAWBLOOD)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_WEAPONTYPE)
 
-local condition = Condition(CONDITION_BLEEDING)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
-condition:addDamage(25, 4000, -45)
-combat:setCondition(condition)
+function onTargetCreature(creature, target)
+	local skill = 0
+	for i = SKILL_CLUB, SKILL_AXE do
+		if skill < creature:getEffectiveSkillLevel(i) then
+			skill = creature:getEffectiveSkillLevel(i)
+		end
+	end
+
+	local min = (creature:getLevel() * 0.01) + (skill * 0.2) + 2
+	local max = (creature:getLevel() * 0.01) + (skill * 0.4) + 2
+	local damage = math.random(math.floor(min), math.floor(max))
+	creature:addDamageCondition(target, CONDITION_BLEEDING, 1, target:isPlayer() and math.floor(damage / 4 + 0.5) or damage)
+	return true
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)

--- a/data/spells/scripts/attack/soul_fire.lua
+++ b/data/spells/scripts/attack/soul_fire.lua
@@ -3,10 +3,16 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITBYFIRE)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
 
-local condition = Condition(CONDITION_FIRE)
-condition:setParameter(CONDITION_PARAM_DELAYED, true)
-condition:addDamage(13, 10000, -10)
-combat:setCondition(condition)
+function onTargetCreature(creature, target)
+	local min = (creature:getLevel() * 0.03) + (creature:getMagicLevel() * 0.3) + 2
+	local max = (creature:getLevel() * 0.03) + (creature:getMagicLevel() * 0.55) + 4
+	local rounds = math.random(math.floor(min), math.floor(max))
+	local damage = target:isPlayer() and 5 or 10
+	creature:addDamageCondition(target, CONDITION_FIRE, 2, damage, {8, 10}, rounds)
+	return true
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETCREATURE, "onTargetCreature")
 
 function onCastSpell(creature, variant, isHotkey)
 	return combat:execute(creature, variant)


### PR DESCRIPTION
All the spells have been researched in the most recent test server.
The formulas for **rounds**, **time** _(if not constant)_, and the **damage** _(if not constant)_  are very close to vanilla ones.

- [x] **Soul Fire rune**
- [x] **Holy Flash** *"utori san"*
- [x] **Electrify** *"utori vis"*
- [x] **Ignite** *"utori flam"*
- [x] **Envenom** *"utori pox"*
- [x] **Inflict Wound** *"utori kor"*
- [x] **Curse** *"utori mort"*

All codes have now been moved from ``onCastSpell`` to ``onTargetCreature`` callback function (which fixed the #1625 and is also perfomance-wise.)
Some remaining issues have been solved in #1825 with the help of other contributors.