### PR TITLE
Update Weapons::getMaxWeaponDamage() formula

### DIFF
--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -142,7 +142,7 @@ int32_t Weapons::getMaxMeleeDamage(int32_t attackSkill, int32_t attackValue)
 //players
 int32_t Weapons::getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t attackValue, float attackFactor)
 {
-	return static_cast<int32_t>(std::ceil((2 * (attackValue * (attackSkill + 5.8) / 25 + (level - 1) / 10.)) / attackFactor));
+	return static_cast<int32_t>(std::round((level / 5) + (((((attackSkill / 4.) + 1) * (attackValue / 3.)) * 1.03) / attackFactor)));
 }
 
 Weapon::Weapon(LuaScriptInterface* _interface) :


### PR DESCRIPTION
This formula is based on *tibia-stats.com* Melee / Distance Damage Calculator. Check the links below.
[distance damage calculator] (http://www.tibia-stats.com/index.php?akcja=distanceCalc)
[melee damage calculator] (http://www.tibia-stats.com/index.php?akcja=meleDmgCalc)

**Level** = 100
**Weapon skill** = 100
**Weapon attack** = 50

| **Attack Factor** | **New Formula** | **Current Formula** | **Diff. range** |
|:------------:|:---------------:|:-----:|:-----:|
| **Offensive** | 466 | 443 | 23 |
| **Balanced**  | 392 | 370 | 22 |
| **Defensive** | 243 | 222 | 21 |
Uses [t-s] (http://www.tibia-stats.com/) rounding method.

It is written like this:
* round( (level / 5) + (damage / factor) )

``update``
I've been doing some rigorous researches and, unfortunately, ts' calculators are not up to date. Therefore, I have updated the formula constant and multiplier to address this.
This is the reason:
* I dealt a damage of 469 hitpoints (so far it was 463, and in tibia this is a huge amount of luck) to a Dragon, which has a armor value of 25 (or 24), and a defense value of 38, and it has neutral resistance to physical damage. Considering that (it is indeed) the minimum armor reduction for a armor value of 25 is 12 (floor(25 / 2) or 24 / 2), and the minimum defense reduction for a defense value of 38 is 19 (38 / 2), then the maximum damage my character could've dealt is: 469 + minimum armor reduction + minimum defense reduction = 500 (no reduction), whereas ts gives me 496 (no reduction), and if applied the reductions, it equals 465.
* This considers the damage dealt was indeed reduced with the min. arm./def. reduction, if this was not true, then the hit could even be higher than 469, hence higher than 500.

**Character skills**
* level = 160, skill = 103, attack = 51