### PR TITLE
Update Travis to new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
       - boost-latest
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
       - g++-4.8
       - libboost1.55-dev
       - libboost-system1.55-dev
@@ -15,6 +14,6 @@ addons:
       - liblua5.2-dev
       - libmysqlclient-dev
 install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
 before_script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
 script: make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: required
 dist: trusty
 language: cpp
-compiler: gcc
+compiler:
+  - clang
+  - gcc
 cache: apt
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ addons:
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 before_script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
-script: make
+script: make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
+sudo: required
+dist: trusty
 language: cpp
 compiler: gcc
 cache: apt
 addons:
   apt:
-    sources:
-      - boost-latest
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
-      - libboost1.55-dev
-      - libboost-system1.55-dev
-      - libgmp3-dev
+      - libboost-dev
+      - libboost-system-dev
       - liblua5.2-dev
       - libmysqlclient-dev
-install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
 before_script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
 script: make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: cpp
 compiler: gcc
 cache: apt
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository ppa:apokluda/boost1.53 -y
-  - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+      - libboost1.55-dev
+      - libboost-system1.55-dev
+      - libgmp3-dev
+      - liblua5.2-dev
+      - libmysqlclient-dev
+install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-install: sudo apt-get install libboost1.53-dev libboost-system1.53-dev liblua5.2-dev libgmp3-dev libmysqlclient-dev
 before_script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
 script: make


### PR DESCRIPTION
This changes the Travis build to the modern infrastructure, which provides faster speed and less complex configuration. Mainly there's no need to manually configure PPAs, apt installs and has two dedicated cores and extra memory instead of the previous 1.5 cores. It usually takes 3 to 4 minutes to build compared to currently 7 minutes most of the builds.

What's the opinion on adding clang to the build matrix?