### PR TITLE
Use correct block type effect

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -608,7 +608,7 @@ BlockType_t Monster::blockHit(Creature* attacker, CombatType_t combatType, int32
 			damage = static_cast<int32_t>(std::ceil(damage * ((100 - elementMod) / 100.)));
 			if (damage <= 0) {
 				damage = 0;
-				blockType = BLOCK_DEFENSE;
+				blockType = BLOCK_ARMOR;
 			}
 		}
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1971,7 +1971,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 
 		if (damage <= 0) {
 			damage = 0;
-			blockType = BLOCK_DEFENSE;
+			blockType = BLOCK_ARMOR;
 		}
 	}
 	return blockType;


### PR DESCRIPTION
The correct (resembling vanilla) block type effect when (damage <= 0) due to element resistances is ``BLOCK_ARMOR``.