### PR TITLE
Fix #1634: show vocations on runes look message

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -827,53 +827,52 @@ std::string Item::getDescription(const ItemType& it, int32_t lookDistance,
 
 			s << ". " << (it.stackable && tmpSubType > 1 ? "They" : "It") << " can only be used by ";
 
-			VocSpellMap vocMap = g_spells->getRuneSpell(it.id)->getVocMap();
-			if (vocMap.empty()) {
-				s << "players";
-			} else {
-				std::vector<Vocation*> showVocMap;
+			if (RuneSpell* rune = g_spells->getRuneSpell(it.id)) {
+				const VocSpellMap& vocMap = rune->getVocMap();
+				if (vocMap.empty()) {
+					s << "players";
+				} else {
+					std::vector<Vocation*> showVocMap;
 
-				// vocations listed are mostly unpromoted ones and the promoted version, with the latter hidden from
-				// description, so probably always `total / 2` is the amount of vocations to be shown.
-				showVocMap.reserve(vocMap.size() / 2);
+					// vocations listed are mostly unpromoted ones and the promoted version, with the latter hidden from
+					// description, so probably always `total / 2` is the amount of vocations to be shown.
+					showVocMap.reserve(vocMap.size() / 2);
 
-				for (const auto& voc: vocMap) {
-					if (voc.second) {
-						showVocMap.push_back(g_vocations.getVocation(voc.first));
+					for (const auto& voc : vocMap) {
+						if (voc.second) {
+							showVocMap.push_back(g_vocations.getVocation(voc.first));
+						}
 					}
+
+					auto vocIt = showVocMap.begin(), vocLast = (showVocMap.end() - 1);
+					while (vocIt != vocLast) {
+						s << asLowerCaseString((*vocIt)->getVocName()) << "s";
+
+						if (++vocIt == vocLast) {
+							s << " and ";
+						} else {
+							s << ", ";
+						}
+					}
+					s << asLowerCaseString((*vocLast)->getVocName()) << "s";
 				}
 
-				auto vocIt = showVocMap.begin(), vocLast = (showVocMap.end() - 1);
+				s << " with";
 
-				while (vocIt != vocLast) {
-					auto vocName = asLowerCaseString((*vocIt)->getVocName());
-					++vocIt;
-
-					s << vocName << "s";
-					if (vocIt == vocLast) {
-						s << " and ";
-					} else {
-						s << ", ";
-					}
-				}
-				s << asLowerCaseString((*vocLast)->getVocName()) << "s";
-			}
-
-			s << " with";
-
-			if (it.runeLevel > 0) {
-				s << " level " << it.runeLevel;
-			}
-
-			if (it.runeMagLevel > 0) {
 				if (it.runeLevel > 0) {
-					s << " and";
+					s << " level " << it.runeLevel;
 				}
 
-				s << " magic level " << it.runeMagLevel;
-			}
+				if (it.runeMagLevel > 0) {
+					if (it.runeLevel > 0) {
+						s << " and";
+					}
 
-			s << " or higher";
+					s << " magic level " << it.runeMagLevel;
+				}
+
+				s << " or higher";
+			}
 		}
 	} else if (it.weaponType != WEAPON_NONE) {
 		if (it.weaponType == WEAPON_DISTANCE && it.ammoType != AMMO_NONE) {

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -572,11 +572,8 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 
 		int32_t vocationId = g_vocations.getVocationId(attr.as_string());
 		if (vocationId != -1) {
-			vocSpellMap[vocationId] = true;
-			int32_t promotedVocation = g_vocations.getPromotedVocation(vocationId);
-			if (promotedVocation != VOCATION_NONE) {
-				vocSpellMap[promotedVocation] = true;
-			}
+			attr = vocationNode.attribute("showInDescription");
+			vocSpellMap[vocationId] = not attr or attr.as_bool();
 		} else {
 			std::cout << "[Warning - Spell::configureSpell] Wrong vocation name: " << attr.as_string() << std::endl;
 		}

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -573,7 +573,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		int32_t vocationId = g_vocations.getVocationId(attr.as_string());
 		if (vocationId != -1) {
 			attr = vocationNode.attribute("showInDescription");
-			vocSpellMap[vocationId] = not attr or attr.as_bool();
+			vocSpellMap[vocationId] = !attr || attr.as_bool();
 		} else {
 			std::cout << "[Warning - Spell::configureSpell] Wrong vocation name: " << attr.as_string() << std::endl;
 		}


### PR DESCRIPTION
As @Zbizu reported, vocation names were missing from runes look message.

Things changed a bit: vocations are now required to be listed on `spells.xml` even if the unpromoted version already is. Also, it is assumed that if you specify no vocation, it is available to all of them (except, of course, `none`) and it will show `by players` instead of the vocation list.

The vocation list is, when used, shows as `(...) used by as, bs, cs... and zs with level (...)`. Examples:
```
It can only be used by players with level 54 and magic level 18 or higher.
It can only be used by druids with level 54 and magic level 18 or higher.
It can only be used by druids and sorcerers with level 54 and magic level 18 or higher.
It can only be used by druids, paladins and sorcerers with level 54 and magic level 18 or higher.
```

Runes do not show magic words anymore, but I feel like it could be toggled by a configuration flag (not the matter of this PR).

Please report any errors. Thanks to @slavidodo who was also developing a solution.