### PR TITLE
Optional LuaJIT + Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: cpp
 compiler:
   - clang
   - gcc
+env:
+  - LUAJIT=OFF
+  - LUAJIT=ON
 cache: apt
 addons:
   apt:
@@ -11,6 +14,9 @@ addons:
       - libboost-dev
       - libboost-system-dev
       - liblua5.2-dev
+      - libluajit-5.1-dev
       - libmysqlclient-dev
-before_script: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+before_script:
+  - mkdir build && cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_LUAJIT=${LUAJIT} ..
 script: make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,14 +24,14 @@ include(FindCXX11)
 
 # Find packages.
 find_package(GMP REQUIRED)
+find_package(LuaJIT)
 find_package(MySQL)
 find_package(Threads)
 
-option(USE_LUAJIT "Use LuaJIT" OFF)
+option(USE_LUAJIT "Use LuaJIT" ${LUAJIT_FOUND})
 
-if (USE_LUAJIT)
+if(USE_LUAJIT)
     find_package(LuaJIT REQUIRED)
-    add_definitions(-D__LUAJIT__)
     if(APPLE)
       set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,12 @@ include(FindCXX11)
 # Find packages.
 find_package(GMP REQUIRED)
 find_package(MySQL)
-find_package(LuaJIT)
 find_package(Threads)
 
-if (LUAJIT_FOUND)
+option(USE_LUAJIT "Use LuaJIT" OFF)
+
+if (USE_LUAJIT)
+    find_package(LuaJIT REQUIRED)
     add_definitions(-D__LUAJIT__)
     if(APPLE)
       set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")


### PR DESCRIPTION
Currently LuaJIT is not optional, it is used whenever available and not used otherwise.

I changed it to be more smart: the user can specify if he wants LuaJIT or not but, by default, it uses LuaJIT when available. This way I could set environment variables on Travis to toggle LuaJIT (it would be a pain to conditionally install) and  I found a nice way to compile under both conditions without having to uninstall LuaJIT or mess with CMakeLists.

LuaJIT is togglable with the `USE_LUAJIT` flag, meaning you can force LuaJIT with `cmake -DUSE_LUAJIT=ON` or `cmake -DUSE_LUAJIT=OFF`.