### PR TITLE
Renamed data members using "m_"-style names

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -33,9 +33,9 @@ extern Actions* g_actions;
 extern ConfigManager g_config;
 
 Actions::Actions() :
-	m_scriptInterface("Action Interface")
+	scriptInterface("Action Interface")
 {
-	m_scriptInterface.initState();
+	scriptInterface.initState();
 }
 
 Actions::~Actions()
@@ -63,12 +63,12 @@ void Actions::clear()
 	clearMap(uniqueItemMap);
 	clearMap(actionItemMap);
 
-	m_scriptInterface.reInitState();
+	scriptInterface.reInitState();
 }
 
 LuaScriptInterface& Actions::getScriptInterface()
 {
-	return m_scriptInterface;
+	return scriptInterface;
 }
 
 std::string Actions::getScriptBaseName() const
@@ -81,7 +81,7 @@ Event* Actions::getEvent(const std::string& nodeName)
 	if (strcasecmp(nodeName.c_str(), "action") != 0) {
 		return nullptr;
 	}
-	return new Action(&m_scriptInterface);
+	return new Action(&scriptInterface);
 }
 
 bool Actions::registerEvent(Event* event, const pugi::xml_node& node)
@@ -462,7 +462,7 @@ bool Action::loadFunction(const pugi::xml_attribute& attr)
 		return false;
 	}
 
-	m_scripted = false;
+	scripted = false;
 	return true;
 }
 
@@ -513,17 +513,17 @@ Thing* Action::getTarget(Player* player, Creature* targetCreature, const Positio
 bool Action::executeUse(Player* player, Item* item, const Position& fromPos, Thing* target, const Position& toPos, bool isHotkey)
 {
 	//onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - Action::executeUse] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -535,5 +535,5 @@ bool Action::executeUse(Player* player, Item* item, const Position& fromPos, Thi
 	LuaScriptInterface::pushPosition(L, toPos);
 
 	LuaScriptInterface::pushBoolean(L, isHotkey);
-	return m_scriptInterface->callFunction(6);
+	return scriptInterface->callFunction(6);
 }

--- a/src/actions.h
+++ b/src/actions.h
@@ -120,7 +120,7 @@ class Actions final : public BaseEvents
 		Action* getAction(const Item* item);
 		void clearMap(ActionUseMap& map);
 
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 };
 
 #endif

--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -28,12 +28,12 @@ extern LuaEnvironment g_luaEnvironment;
 
 BaseEvents::BaseEvents()
 {
-	m_loaded = false;
+	loaded = false;
 }
 
 bool BaseEvents::loadFromXml()
 {
-	if (m_loaded) {
+	if (loaded) {
 		std::cout << "[Error - BaseEvents::loadFromXml] It's already loaded." << std::endl;
 		return false;
 	}
@@ -53,7 +53,7 @@ bool BaseEvents::loadFromXml()
 		return false;
 	}
 
-	m_loaded = true;
+	loaded = true;
 
 	for (auto node : doc.child(scriptsName.c_str()).children()) {
 		Event* event = getEvent(node.name());
@@ -86,23 +86,23 @@ bool BaseEvents::loadFromXml()
 
 bool BaseEvents::reload()
 {
-	m_loaded = false;
+	loaded = false;
 	clear();
 	return loadFromXml();
 }
 
 Event::Event(LuaScriptInterface* _interface)
 {
-	m_scriptInterface = _interface;
-	m_scriptId = 0;
-	m_scripted = false;
+	scriptInterface = _interface;
+	scriptId = 0;
+	scripted = false;
 }
 
 Event::Event(const Event* copy)
 {
-	m_scriptInterface = copy->m_scriptInterface;
-	m_scriptId = copy->m_scriptId;
-	m_scripted = copy->m_scripted;
+	scriptInterface = copy->scriptInterface;
+	scriptId = copy->scriptId;
+	scripted = copy->scripted;
 }
 
 bool Event::checkScript(const std::string& basePath, const std::string& scriptsName, const std::string& scriptFile) const
@@ -114,8 +114,8 @@ bool Event::checkScript(const std::string& basePath, const std::string& scriptsN
 		std::cout << "[Warning - Event::checkScript] Can not load " << scriptsName << " lib/" << scriptsName << ".lua" << std::endl;
 	}
 
-	if (m_scriptId != 0) {
-		std::cout << "[Failure - Event::checkScript] scriptid = " << m_scriptId << std::endl;
+	if (scriptId != 0) {
+		std::cout << "[Failure - Event::checkScript] scriptid = " << scriptId << std::endl;
 		return false;
 	}
 
@@ -135,52 +135,52 @@ bool Event::checkScript(const std::string& basePath, const std::string& scriptsN
 
 bool Event::loadScript(const std::string& scriptFile)
 {
-	if (!m_scriptInterface || m_scriptId != 0) {
-		std::cout << "Failure: [Event::loadScript] m_scriptInterface == nullptr. scriptid = " << m_scriptId << std::endl;
+	if (!scriptInterface || scriptId != 0) {
+		std::cout << "Failure: [Event::loadScript] scriptInterface == nullptr. scriptid = " << scriptId << std::endl;
 		return false;
 	}
 
-	if (m_scriptInterface->loadFile(scriptFile) == -1) {
+	if (scriptInterface->loadFile(scriptFile) == -1) {
 		std::cout << "[Warning - Event::loadScript] Can not load script. " << scriptFile << std::endl;
-		std::cout << m_scriptInterface->getLastLuaError() << std::endl;
+		std::cout << scriptInterface->getLastLuaError() << std::endl;
 		return false;
 	}
 
-	int32_t id = m_scriptInterface->getEvent(getScriptEventName());
+	int32_t id = scriptInterface->getEvent(getScriptEventName());
 	if (id == -1) {
 		std::cout << "[Warning - Event::loadScript] Event " << getScriptEventName() << " not found. " << scriptFile << std::endl;
 		return false;
 	}
 
-	m_scripted = true;
-	m_scriptId = id;
+	scripted = true;
+	scriptId = id;
 	return true;
 }
 
 CallBack::CallBack()
 {
-	m_scriptId = 0;
-	m_scriptInterface = nullptr;
-	m_loaded = false;
+	scriptId = 0;
+	scriptInterface = nullptr;
+	loaded = false;
 }
 
 bool CallBack::loadCallBack(LuaScriptInterface* _interface, const std::string& name)
 {
 	if (!_interface) {
-		std::cout << "Failure: [CallBack::loadCallBack] m_scriptInterface == nullptr" << std::endl;
+		std::cout << "Failure: [CallBack::loadCallBack] scriptInterface == nullptr" << std::endl;
 		return false;
 	}
 
-	m_scriptInterface = _interface;
+	scriptInterface = _interface;
 
-	int32_t id = m_scriptInterface->getEvent(name.c_str());
+	int32_t id = scriptInterface->getEvent(name.c_str());
 	if (id == -1) {
 		std::cout << "[Warning - CallBack::loadCallBack] Event " << name << " not found." << std::endl;
 		return false;
 	}
 
-	m_callbackName = name;
-	m_scriptId = id;
-	m_loaded = true;
+	callbackName = name;
+	scriptId = id;
+	loaded = true;
 	return true;
 }

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -38,15 +38,15 @@ class Event
 		}
 
 		bool isScripted() const {
-			return m_scripted;
+			return scripted;
 		}
 
 	protected:
 		virtual std::string getScriptEventName() const = 0;
 
-		bool m_scripted;
-		int32_t m_scriptId;
-		LuaScriptInterface* m_scriptInterface;
+		bool scripted;
+		int32_t scriptId;
+		LuaScriptInterface* scriptInterface;
 };
 
 class BaseEvents
@@ -58,7 +58,7 @@ class BaseEvents
 		bool loadFromXml();
 		bool reload();
 		bool isLoaded() const {
-			return m_loaded;
+			return loaded;
 		}
 
 	protected:
@@ -68,7 +68,7 @@ class BaseEvents
 		virtual bool registerEvent(Event* event, const pugi::xml_node& node) = 0;
 		virtual void clear() = 0;
 
-		bool m_loaded;
+		bool loaded;
 };
 
 class CallBack
@@ -79,12 +79,12 @@ class CallBack
 		bool loadCallBack(LuaScriptInterface* _interface, const std::string& name);
 
 	protected:
-		int32_t m_scriptId;
-		LuaScriptInterface* m_scriptInterface;
+		int32_t scriptId;
+		LuaScriptInterface* scriptInterface;
 
-		bool m_loaded;
+		bool loaded;
 
-		std::string m_callbackName;
+		std::string callbackName;
 };
 
 #endif

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -159,22 +159,22 @@ bool ChatChannel::executeCanJoinEvent(const Player& player)
 	}
 
 	//canJoin(player)
-	LuaScriptInterface* m_scriptInterface = g_chat->getScriptInterface();
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	LuaScriptInterface* scriptInterface = g_chat->getScriptInterface();
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - CanJoinChannelEvent::execute] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(canJoinEvent, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(canJoinEvent, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(canJoinEvent);
+	scriptInterface->pushFunction(canJoinEvent);
 	LuaScriptInterface::pushUserdata(L, &player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	return m_scriptInterface->callFunction(1);
+	return scriptInterface->callFunction(1);
 }
 
 bool ChatChannel::executeOnJoinEvent(const Player& player)
@@ -184,22 +184,22 @@ bool ChatChannel::executeOnJoinEvent(const Player& player)
 	}
 
 	//onJoin(player)
-	LuaScriptInterface* m_scriptInterface = g_chat->getScriptInterface();
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	LuaScriptInterface* scriptInterface = g_chat->getScriptInterface();
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - OnJoinChannelEvent::execute] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(onJoinEvent, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(onJoinEvent, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(onJoinEvent);
+	scriptInterface->pushFunction(onJoinEvent);
 	LuaScriptInterface::pushUserdata(L, &player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	return m_scriptInterface->callFunction(1);
+	return scriptInterface->callFunction(1);
 }
 
 bool ChatChannel::executeOnLeaveEvent(const Player& player)
@@ -209,22 +209,22 @@ bool ChatChannel::executeOnLeaveEvent(const Player& player)
 	}
 
 	//onLeave(player)
-	LuaScriptInterface* m_scriptInterface = g_chat->getScriptInterface();
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	LuaScriptInterface* scriptInterface = g_chat->getScriptInterface();
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - OnLeaveChannelEvent::execute] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(onLeaveEvent, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(onLeaveEvent, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(onLeaveEvent);
+	scriptInterface->pushFunction(onLeaveEvent);
 	LuaScriptInterface::pushUserdata(L, &player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	return m_scriptInterface->callFunction(1);
+	return scriptInterface->callFunction(1);
 }
 
 bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, const std::string& message)
@@ -234,18 +234,18 @@ bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, 
 	}
 
 	//onSpeak(player, type, message)
-	LuaScriptInterface* m_scriptInterface = g_chat->getScriptInterface();
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	LuaScriptInterface* scriptInterface = g_chat->getScriptInterface();
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - OnSpeakChannelEvent::execute] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(onSpeakEvent, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(onSpeakEvent, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(onSpeakEvent);
+	scriptInterface->pushFunction(onSpeakEvent);
 	LuaScriptInterface::pushUserdata(L, &player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
@@ -254,7 +254,7 @@ bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, 
 
 	bool result = false;
 	int size0 = lua_gettop(L);
-	int ret = m_scriptInterface->protectedCall(L, 3, 1);
+	int ret = scriptInterface->protectedCall(L, 3, 1);
 	if (ret != 0) {
 		LuaScriptInterface::reportError(nullptr, LuaScriptInterface::popString(L));
 	} else if (lua_gettop(L) > 0) {
@@ -270,7 +270,7 @@ bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, 
 	if ((lua_gettop(L) + 4) != size0) {
 		LuaScriptInterface::reportError(nullptr, "Stack size changed!");
 	}
-	m_scriptInterface->resetScriptEnv();
+	scriptInterface->resetScriptEnv();
 	return result;
 }
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -900,20 +900,20 @@ void Combat::doCombatDefault(Creature* caster, Creature* target, const CombatPar
 void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage, bool useCharges) const
 {
 	//onGetPlayerMinMaxValues(...)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - ValueCallback::getMinMaxValues] Call stack overflow" << std::endl;
 		return;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	if (!env->setCallbackId(m_scriptId, m_scriptInterface)) {
-		m_scriptInterface->resetScriptEnv();
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	if (!env->setCallbackId(scriptId, scriptInterface)) {
+		scriptInterface->resetScriptEnv();
 		return;
 	}
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -962,7 +962,7 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage, bool u
 
 		default: {
 			std::cout << "ValueCallback::getMinMaxValues - unknown callback type" << std::endl;
-			m_scriptInterface->resetScriptEnv();
+			scriptInterface->resetScriptEnv();
 			return;
 		}
 	}
@@ -982,7 +982,7 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage, bool u
 		LuaScriptInterface::reportError(nullptr, "Stack size changed!");
 	}
 
-	m_scriptInterface->resetScriptEnv();
+	scriptInterface->resetScriptEnv();
 }
 
 //**********************************************************//
@@ -990,20 +990,20 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage, bool u
 void TileCallback::onTileCombat(Creature* creature, Tile* tile) const
 {
 	//onTileCombat(creature, pos)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - TileCallback::onTileCombat] Call stack overflow" << std::endl;
 		return;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	if (!env->setCallbackId(m_scriptId, m_scriptInterface)) {
-		m_scriptInterface->resetScriptEnv();
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	if (!env->setCallbackId(scriptId, scriptInterface)) {
+		scriptInterface->resetScriptEnv();
 		return;
 	}
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 	if (creature) {
 		LuaScriptInterface::pushUserdata<Creature>(L, creature);
 		LuaScriptInterface::setCreatureMetatable(L, -1, creature);
@@ -1012,7 +1012,7 @@ void TileCallback::onTileCombat(Creature* creature, Tile* tile) const
 	}
 	LuaScriptInterface::pushPosition(L, tile->getPosition());
 
-	m_scriptInterface->callFunction(2);
+	scriptInterface->callFunction(2);
 }
 
 //**********************************************************//
@@ -1020,20 +1020,20 @@ void TileCallback::onTileCombat(Creature* creature, Tile* tile) const
 void TargetCallback::onTargetCombat(Creature* creature, Creature* target) const
 {
 	//onTargetCombat(creature, target)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - TargetCallback::onTargetCombat] Call stack overflow" << std::endl;
 		return;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	if (!env->setCallbackId(m_scriptId, m_scriptInterface)) {
-		m_scriptInterface->resetScriptEnv();
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	if (!env->setCallbackId(scriptId, scriptInterface)) {
+		scriptInterface->resetScriptEnv();
 		return;
 	}
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	if (creature) {
 		LuaScriptInterface::pushUserdata<Creature>(L, creature);
@@ -1059,7 +1059,7 @@ void TargetCallback::onTargetCombat(Creature* creature, Creature* target) const
 		LuaScriptInterface::reportError(nullptr, "Stack size changed!");
 	}
 
-	m_scriptInterface->resetScriptEnv();
+	scriptInterface->resetScriptEnv();
 }
 
 //**********************************************************//

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -68,9 +68,9 @@ class CreatureEvents final : public BaseEvents
 
 		//creature events
 		typedef std::map<std::string, CreatureEvent*> CreatureEventList;
-		CreatureEventList m_creatureEvents;
+		CreatureEventList creatureEvents;
 
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 };
 
 class CreatureEvent final : public Event
@@ -81,13 +81,13 @@ class CreatureEvent final : public Event
 		bool configureEvent(const pugi::xml_node& node) final;
 
 		CreatureEventType_t getEventType() const {
-			return m_type;
+			return type;
 		}
 		const std::string& getName() const {
-			return m_eventName;
+			return eventName;
 		}
 		bool isLoaded() const {
-			return m_isLoaded;
+			return loaded;
 		}
 
 		void clearEvent();
@@ -111,9 +111,9 @@ class CreatureEvent final : public Event
 	protected:
 		std::string getScriptEventName() const final;
 
-		std::string m_eventName;
-		CreatureEventType_t m_type;
-		bool m_isLoaded;
+		std::string eventName;
+		CreatureEventType_t type;
+		bool loaded;
 };
 
 #endif

--- a/src/fileloader.cpp
+++ b/src/fileloader.cpp
@@ -21,75 +21,75 @@
 
 #include "fileloader.h"
 
-FileLoader::FileLoader() : m_cached_data()
+FileLoader::FileLoader() : cached_data()
 {
-	m_file = nullptr;
-	m_root = nullptr;
-	m_buffer = new uint8_t[1024];
-	m_buffer_size = 1024;
-	m_lastError = ERROR_NONE;
+	file = nullptr;
+	root = nullptr;
+	buffer = new uint8_t[1024];
+	buffer_size = 1024;
+	lastError = ERROR_NONE;
 
 	//cache
-	m_cache_size = 0;
-	m_cache_index = NO_VALID_CACHE;
-	m_cache_offset = NO_VALID_CACHE;
+	cache_size = 0;
+	cache_index = NO_VALID_CACHE;
+	cache_offset = NO_VALID_CACHE;
 }
 
 FileLoader::~FileLoader()
 {
-	if (m_file) {
-		fclose(m_file);
-		m_file = nullptr;
+	if (file) {
+		fclose(file);
+		file = nullptr;
 	}
 
-	NodeStruct::clearNet(m_root);
-	delete[] m_buffer;
+	NodeStruct::clearNet(root);
+	delete[] buffer;
 
 	for (int32_t i = 0; i < CACHE_BLOCKS; i++) {
-		delete[] m_cached_data[i].data;
+		delete[] cached_data[i].data;
 	}
 }
 
 bool FileLoader::openFile(const char* filename, const char* accept_identifier)
 {
-	m_file = fopen(filename, "rb");
-	if (!m_file) {
-		m_lastError = ERROR_CAN_NOT_OPEN;
+	file = fopen(filename, "rb");
+	if (!file) {
+		lastError = ERROR_CAN_NOT_OPEN;
 		return false;
 	}
 
 	char identifier[4];
-	if (fread(identifier, 1, 4, m_file) < 4) {
-		fclose(m_file);
-		m_file = nullptr;
-		m_lastError = ERROR_EOF;
+	if (fread(identifier, 1, 4, file) < 4) {
+		fclose(file);
+		file = nullptr;
+		lastError = ERROR_EOF;
 		return false;
 	}
 
 	// The first four bytes must either match the accept identifier or be 0x00000000 (wildcard)
 	if (memcmp(identifier, accept_identifier, 4) != 0 && memcmp(identifier, "\0\0\0\0", 4) != 0) {
-		fclose(m_file);
-		m_file = nullptr;
-		m_lastError = ERROR_INVALID_FILE_VERSION;
+		fclose(file);
+		file = nullptr;
+		lastError = ERROR_INVALID_FILE_VERSION;
 		return false;
 	}
 
-	fseek(m_file, 0, SEEK_END);
-	int32_t file_size = ftell(m_file);
-	m_cache_size = std::min<uint32_t>(32768, std::max<uint32_t>(file_size / 20, 8192)) & ~0x1FFF;
+	fseek(file, 0, SEEK_END);
+	int32_t file_size = ftell(file);
+	cache_size = std::min<uint32_t>(32768, std::max<uint32_t>(file_size / 20, 8192)) & ~0x1FFF;
 
 	if (!safeSeek(4)) {
-		m_lastError = ERROR_INVALID_FORMAT;
+		lastError = ERROR_INVALID_FORMAT;
 		return false;
 	}
 
-	delete m_root;
-	m_root = new NodeStruct();
-	m_root->start = 4;
+	delete root;
+	root = new NodeStruct();
+	root->start = 4;
 
 	int32_t byte;
 	if (safeSeek(4) && readByte(byte) && byte == NODE_START) {
-		return parseNode(m_root);
+		return parseNode(root);
 	}
 
 	return false;
@@ -165,7 +165,7 @@ bool FileLoader::parseNode(NODE node)
 							return safeTell(pos) && safeSeek(pos);
 
 						default:
-							m_lastError = ERROR_INVALID_FORMAT;
+							lastError = ERROR_INVALID_FORMAT;
 							return false;
 					}
 
@@ -198,18 +198,18 @@ const uint8_t* FileLoader::getProps(const NODE node, size_t& size)
 		return nullptr;
 	}
 
-	if (node->propsSize >= m_buffer_size) {
-		delete[] m_buffer;
+	if (node->propsSize >= buffer_size) {
+		delete[] buffer;
 
-		while (node->propsSize >= m_buffer_size) {
-			m_buffer_size *= 2;
+		while (node->propsSize >= buffer_size) {
+			buffer_size *= 2;
 		}
 
-		m_buffer = new uint8_t[m_buffer_size];
+		buffer = new uint8_t[buffer_size];
 	}
 
 	//get buffer
-	if (!readBytes(m_buffer, node->propsSize, node->start + 2)) {
+	if (!readBytes(buffer, node->propsSize, node->start + 2)) {
 		return nullptr;
 	}
 
@@ -217,19 +217,19 @@ const uint8_t* FileLoader::getProps(const NODE node, size_t& size)
 	size_t j = 0;
 	bool escaped = false;
 	for (uint32_t i = 0; i < node->propsSize; ++i, ++j) {
-		if (m_buffer[i] == ESCAPE_CHAR) {
+		if (buffer[i] == ESCAPE_CHAR) {
 			//escape char found, skip it and write next
-			m_buffer[j] = m_buffer[++i];
+			buffer[j] = buffer[++i];
 			//is neede a displacement for next bytes
 			escaped = true;
 		} else if (escaped) {
 			//perform that displacement
-			m_buffer[j] = m_buffer[i];
+			buffer[j] = buffer[i];
 		}
 	}
 
 	size = j;
-	return m_buffer;
+	return buffer;
 }
 
 bool FileLoader::getProps(const NODE node, PropStream& props)
@@ -255,8 +255,8 @@ NODE FileLoader::getChildNode(const NODE parent, uint32_t& type)
 		return child;
 	}
 
-	type = m_root->type;
-	return m_root;
+	type = root->type;
+	return root;
 }
 
 NODE FileLoader::getNextNode(const NODE prev, uint32_t& type)
@@ -274,26 +274,26 @@ NODE FileLoader::getNextNode(const NODE prev, uint32_t& type)
 
 inline bool FileLoader::readByte(int32_t& value)
 {
-	if (m_cache_index == NO_VALID_CACHE) {
-		m_lastError = ERROR_CACHE_ERROR;
+	if (cache_index == NO_VALID_CACHE) {
+		lastError = ERROR_CACHE_ERROR;
 		return false;
 	}
 
-	if (m_cache_offset >= m_cached_data[m_cache_index].size) {
-		int32_t pos = m_cache_offset + m_cached_data[m_cache_index].base;
+	if (cache_offset >= cached_data[cache_index].size) {
+		int32_t pos = cache_offset + cached_data[cache_index].base;
 		int32_t tmp = getCacheBlock(pos);
 		if (tmp < 0) {
 			return false;
 		}
 
-		m_cache_index = tmp;
-		m_cache_offset = pos - m_cached_data[m_cache_index].base;
-		if (m_cache_offset >= m_cached_data[m_cache_index].size) {
+		cache_index = tmp;
+		cache_offset = pos - cached_data[cache_index].base;
+		if (cache_offset >= cached_data[cache_index].size) {
 			return false;
 		}
 	}
 
-	value = m_cached_data[m_cache_index].data[m_cache_offset++];
+	value = cached_data[cache_index].data[cache_offset++];
 	return true;
 }
 
@@ -308,18 +308,18 @@ inline bool FileLoader::readBytes(uint8_t* buffer, uint32_t size, int32_t pos)
 			return false;
 		}
 
-		m_cache_index = i;
-		m_cache_offset = pos - m_cached_data[i].base;
+		cache_index = i;
+		cache_offset = pos - cached_data[i].base;
 
 		//get maximum read block size and calculate remaining bytes
-		uint32_t reading = std::min<int32_t>(remain, m_cached_data[i].size - m_cache_offset);
+		uint32_t reading = std::min<int32_t>(remain, cached_data[i].size - cache_offset);
 		remain -= reading;
 
 		//read it
-		memcpy(buffer + bufferPos, m_cached_data[m_cache_index].data + m_cache_offset, reading);
+		memcpy(buffer + bufferPos, cached_data[cache_index].data + cache_offset, reading);
 
 		//update variables
-		m_cache_offset += reading;
+		cache_offset += reading;
 		bufferPos += reading;
 		pos += reading;
 	} while (remain > 0);
@@ -333,30 +333,30 @@ inline bool FileLoader::safeSeek(uint32_t pos)
 		return false;
 	}
 
-	m_cache_index = i;
-	m_cache_offset = pos - m_cached_data[i].base;
+	cache_index = i;
+	cache_offset = pos - cached_data[i].base;
 	return true;
 }
 
 inline bool FileLoader::safeTell(int32_t& pos)
 {
-	if (m_cache_index == NO_VALID_CACHE) {
-		m_lastError = ERROR_CACHE_ERROR;
+	if (cache_index == NO_VALID_CACHE) {
+		lastError = ERROR_CACHE_ERROR;
 		return false;
 	}
 
-	pos = m_cached_data[m_cache_index].base + m_cache_offset - 1;
+	pos = cached_data[cache_index].base + cache_offset - 1;
 	return true;
 }
 
 inline uint32_t FileLoader::getCacheBlock(uint32_t pos)
 {
 	bool found = false;
-	uint32_t i, base_pos = pos & ~(m_cache_size - 1);
+	uint32_t i, base_pos = pos & ~(cache_size - 1);
 
 	for (i = 0; i < CACHE_BLOCKS; i++) {
-		if (m_cached_data[i].loaded) {
-			if (m_cached_data[i].base == base_pos) {
+		if (cached_data[i].loaded) {
+			if (cached_data[i].base == base_pos) {
 				found = true;
 				break;
 			}
@@ -372,10 +372,10 @@ inline uint32_t FileLoader::getCacheBlock(uint32_t pos)
 
 int32_t FileLoader::loadCacheBlock(uint32_t pos)
 {
-	int32_t i, loading_cache = -1, base_pos = pos & ~(m_cache_size - 1);
+	int32_t i, loading_cache = -1, base_pos = pos & ~(cache_size - 1);
 
 	for (i = 0; i < CACHE_BLOCKS; i++) {
-		if (!m_cached_data[i].loaded) {
+		if (!cached_data[i].loaded) {
 			loading_cache = i;
 			break;
 		}
@@ -383,7 +383,7 @@ int32_t FileLoader::loadCacheBlock(uint32_t pos)
 
 	if (loading_cache == -1) {
 		for (i = 0; i < CACHE_BLOCKS; i++) {
-			if (std::abs(static_cast<long>(m_cached_data[i].base) - base_pos) > static_cast<long>(2 * m_cache_size)) {
+			if (std::abs(static_cast<long>(cached_data[i].base) - base_pos) > static_cast<long>(2 * cache_size)) {
 				loading_cache = i;
 				break;
 			}
@@ -394,25 +394,25 @@ int32_t FileLoader::loadCacheBlock(uint32_t pos)
 		}
 	}
 
-	if (m_cached_data[loading_cache].data == nullptr) {
-		m_cached_data[loading_cache].data = new uint8_t[m_cache_size];
+	if (cached_data[loading_cache].data == nullptr) {
+		cached_data[loading_cache].data = new uint8_t[cache_size];
 	}
 
-	m_cached_data[loading_cache].base = base_pos;
+	cached_data[loading_cache].base = base_pos;
 
-	if (fseek(m_file, m_cached_data[loading_cache].base, SEEK_SET) != 0) {
-		m_lastError = ERROR_SEEK_ERROR;
+	if (fseek(file, cached_data[loading_cache].base, SEEK_SET) != 0) {
+		lastError = ERROR_SEEK_ERROR;
 		return -1;
 	}
 
-	uint32_t size = fread(m_cached_data[loading_cache].data, 1, m_cache_size, m_file);
-	m_cached_data[loading_cache].size = size;
+	uint32_t size = fread(cached_data[loading_cache].data, 1, cache_size, file);
+	cached_data[loading_cache].size = size;
 
-	if (size < (pos - m_cached_data[loading_cache].base)) {
-		m_lastError = ERROR_SEEK_ERROR;
+	if (size < (pos - cached_data[loading_cache].base)) {
+		lastError = ERROR_SEEK_ERROR;
 		return -1;
 	}
 
-	m_cached_data[loading_cache].loaded = 1;
+	cached_data[loading_cache].loaded = 1;
 	return loading_cache;
 }

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -104,7 +104,7 @@ class FileLoader
 		NODE getNextNode(const NODE prev, uint32_t& type);
 
 		FILELOADER_ERRORS getError() const {
-			return m_lastError;
+			return lastError;
 		}
 
 	protected:
@@ -130,19 +130,19 @@ class FileLoader
 		};
 
 #define CACHE_BLOCKS 3
-		_cache m_cached_data[CACHE_BLOCKS];
+		_cache cached_data[CACHE_BLOCKS];
 
-		uint8_t* m_buffer;
-		NODE m_root;
-		FILE* m_file;
+		uint8_t* buffer;
+		NODE root;
+		FILE* file;
 
-		FILELOADER_ERRORS m_lastError;
-		uint32_t m_buffer_size;
+		FILELOADER_ERRORS lastError;
+		uint32_t buffer_size;
 
-		uint32_t m_cache_size;
+		uint32_t cache_size;
 #define NO_VALID_CACHE 0xFFFFFFFF
-		uint32_t m_cache_index;
-		uint32_t m_cache_offset;
+		uint32_t cache_index;
+		uint32_t cache_offset;
 
 		inline uint32_t getCacheBlock(uint32_t pos);
 		int32_t loadCacheBlock(uint32_t pos);

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -28,9 +28,9 @@
 extern ConfigManager g_config;
 
 GlobalEvents::GlobalEvents() :
-	m_scriptInterface("GlobalEvent Interface")
+	scriptInterface("GlobalEvent Interface")
 {
-	m_scriptInterface.initState();
+	scriptInterface.initState();
 	thinkEventId = 0;
 	timerEventId = 0;
 }
@@ -59,7 +59,7 @@ void GlobalEvents::clear()
 	clearMap(serverMap);
 	clearMap(timerMap);
 
-	m_scriptInterface.reInitState();
+	scriptInterface.reInitState();
 }
 
 Event* GlobalEvents::getEvent(const std::string& nodeName)
@@ -67,7 +67,7 @@ Event* GlobalEvents::getEvent(const std::string& nodeName)
 	if (strcasecmp(nodeName.c_str(), "globalevent") != 0) {
 		return nullptr;
 	}
-	return new GlobalEvent(&m_scriptInterface);
+	return new GlobalEvent(&scriptInterface);
 }
 
 bool GlobalEvents::registerEvent(Event* event, const pugi::xml_node&)
@@ -212,9 +212,9 @@ GlobalEventMap GlobalEvents::getEventMap(GlobalEvent_t type)
 GlobalEvent::GlobalEvent(LuaScriptInterface* _interface):
 	Event(_interface)
 {
-	m_eventType = GLOBALEVENT_NONE;
-	m_nextExecution = 0;
-	m_interval = 0;
+	eventType = GLOBALEVENT_NONE;
+	nextExecution = 0;
+	interval = 0;
 }
 
 bool GlobalEvent::configureEvent(const pugi::xml_node& node)
@@ -225,8 +225,8 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 		return false;
 	}
 
-	m_name = nameAttribute.as_string();
-	m_eventType = GLOBALEVENT_NONE;
+	name = nameAttribute.as_string();
+	eventType = GLOBALEVENT_NONE;
 
 	pugi::xml_attribute attr;
 	if ((attr = node.attribute("time"))) {
@@ -234,25 +234,25 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 
 		int32_t hour = params.front();
 		if (hour < 0 || hour > 23) {
-			std::cout << "[Error - GlobalEvent::configureEvent] Invalid hour \"" << attr.as_string() << "\" for globalevent with name: " << m_name << std::endl;
+			std::cout << "[Error - GlobalEvent::configureEvent] Invalid hour \"" << attr.as_string() << "\" for globalevent with name: " << name << std::endl;
 			return false;
 		}
 
-		m_interval |= hour << 16;
+		interval |= hour << 16;
 
 		int32_t min = 0;
 		int32_t sec = 0;
 		if (params.size() > 1) {
 			min = params[1];
 			if (min < 0 || min > 59) {
-				std::cout << "[Error - GlobalEvent::configureEvent] Invalid minute \"" << attr.as_string() << "\" for globalevent with name: " << m_name << std::endl;
+				std::cout << "[Error - GlobalEvent::configureEvent] Invalid minute \"" << attr.as_string() << "\" for globalevent with name: " << name << std::endl;
 				return false;
 			}
 
 			if (params.size() > 2) {
 				sec = params[2];
 				if (sec < 0 || sec > 59) {
-					std::cout << "[Error - GlobalEvent::configureEvent] Invalid second \"" << attr.as_string() << "\" for globalevent with name: " << m_name << std::endl;
+					std::cout << "[Error - GlobalEvent::configureEvent] Invalid second \"" << attr.as_string() << "\" for globalevent with name: " << name << std::endl;
 					return false;
 				}
 			}
@@ -269,25 +269,25 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 			difference += 86400;
 		}
 
-		m_nextExecution = current_time + difference;
-		m_eventType = GLOBALEVENT_TIMER;
+		nextExecution = current_time + difference;
+		eventType = GLOBALEVENT_TIMER;
 	} else if ((attr = node.attribute("type"))) {
 		const char* value = attr.value();
 		if (strcasecmp(value, "startup") == 0) {
-			m_eventType = GLOBALEVENT_STARTUP;
+			eventType = GLOBALEVENT_STARTUP;
 		} else if (strcasecmp(value, "shutdown") == 0) {
-			m_eventType = GLOBALEVENT_SHUTDOWN;
+			eventType = GLOBALEVENT_SHUTDOWN;
 		} else if (strcasecmp(value, "record") == 0) {
-			m_eventType = GLOBALEVENT_RECORD;
+			eventType = GLOBALEVENT_RECORD;
 		} else {
-			std::cout << "[Error - GlobalEvent::configureEvent] No valid type \"" << attr.as_string() << "\" for globalevent with name " << m_name << std::endl;
+			std::cout << "[Error - GlobalEvent::configureEvent] No valid type \"" << attr.as_string() << "\" for globalevent with name " << name << std::endl;
 			return false;
 		}
 	} else if ((attr = node.attribute("interval"))) {
-		m_interval = std::max<int32_t>(SCHEDULER_MINTICKS, pugi::cast<int32_t>(attr.value()));
-		m_nextExecution = OTSYS_TIME() + m_interval;
+		interval = std::max<int32_t>(SCHEDULER_MINTICKS, pugi::cast<int32_t>(attr.value()));
+		nextExecution = OTSYS_TIME() + interval;
 	} else {
-		std::cout << "[Error - GlobalEvent::configureEvent] No interval for globalevent with name " << m_name << std::endl;
+		std::cout << "[Error - GlobalEvent::configureEvent] No interval for globalevent with name " << name << std::endl;
 		return false;
 	}
 	return true;
@@ -295,7 +295,7 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 
 std::string GlobalEvent::getScriptEventName() const
 {
-	switch (m_eventType) {
+	switch (eventType) {
 		case GLOBALEVENT_STARTUP: return "onStartup";
 		case GLOBALEVENT_SHUTDOWN: return "onShutdown";
 		case GLOBALEVENT_RECORD: return "onRecord";
@@ -307,39 +307,39 @@ std::string GlobalEvent::getScriptEventName() const
 bool GlobalEvent::executeRecord(uint32_t current, uint32_t old)
 {
 	//onRecord(current, old)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - GlobalEvent::executeRecord] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
-	m_scriptInterface->pushFunction(m_scriptId);
+	lua_State* L = scriptInterface->getLuaState();
+	scriptInterface->pushFunction(scriptId);
 
 	lua_pushnumber(L, current);
 	lua_pushnumber(L, old);
-	return m_scriptInterface->callFunction(2);
+	return scriptInterface->callFunction(2);
 }
 
 bool GlobalEvent::executeEvent()
 {
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - GlobalEvent::executeEvent] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
-	lua_State* L = m_scriptInterface->getLuaState();
-	m_scriptInterface->pushFunction(m_scriptId);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
+	lua_State* L = scriptInterface->getLuaState();
+	scriptInterface->pushFunction(scriptId);
 
 	int32_t params = 0;
-	if (m_eventType == GLOBALEVENT_NONE || m_eventType == GLOBALEVENT_TIMER) {
-		lua_pushnumber(L, m_interval);
+	if (eventType == GLOBALEVENT_NONE || eventType == GLOBALEVENT_TIMER) {
+		lua_pushnumber(L, interval);
 		params = 1;
 	}
 
-	return m_scriptInterface->callFunction(params);
+	return scriptInterface->callFunction(params);
 }

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -64,9 +64,9 @@ class GlobalEvents final : public BaseEvents
 		bool registerEvent(Event* event, const pugi::xml_node& node) final;
 
 		LuaScriptInterface& getScriptInterface() final {
-			return m_scriptInterface;
+			return scriptInterface;
 		}
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 
 		GlobalEventMap thinkMap, serverMap, timerMap;
 		int32_t thinkEventId, timerEventId;
@@ -83,31 +83,31 @@ class GlobalEvent final : public Event
 		bool executeEvent();
 
 		GlobalEvent_t getEventType() const {
-			return m_eventType;
+			return eventType;
 		}
 		std::string getName() const {
-			return m_name;
+			return name;
 		}
 
 		uint32_t getInterval() const {
-			return m_interval;
+			return interval;
 		}
 
 		int64_t getNextExecution() const {
-			return m_nextExecution;
+			return nextExecution;
 		}
 		void setNextExecution(int64_t time) {
-			m_nextExecution = time;
+			nextExecution = time;
 		}
 
 	protected:
-		GlobalEvent_t m_eventType;
+		GlobalEvent_t eventType;
 
 		std::string getScriptEventName() const final;
 
-		std::string m_name;
-		int64_t m_nextExecution;
-		uint32_t m_interval;
+		std::string name;
+		int64_t nextExecution;
+		uint32_t interval;
 };
 
 #endif

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -48,8 +48,8 @@ enum {
 	EVENT_ID_USER = 1000,
 };
 
-ScriptEnvironment::DBResultMap ScriptEnvironment::m_tempResults;
-uint32_t ScriptEnvironment::m_lastResultId = 0;
+ScriptEnvironment::DBResultMap ScriptEnvironment::tempResults;
+uint32_t ScriptEnvironment::lastResultId = 0;
 
 std::multimap<ScriptEnvironment*, Item*> ScriptEnvironment::tempItems;
 
@@ -57,9 +57,9 @@ LuaEnvironment g_luaEnvironment;
 
 ScriptEnvironment::ScriptEnvironment()
 {
-	m_curNpc = nullptr;
+	curNpc = nullptr;
 	resetEnv();
-	m_lastUID = std::numeric_limits<uint16_t>::max();
+	lastUID = std::numeric_limits<uint16_t>::max();
 }
 
 ScriptEnvironment::~ScriptEnvironment()
@@ -69,12 +69,12 @@ ScriptEnvironment::~ScriptEnvironment()
 
 void ScriptEnvironment::resetEnv()
 {
-	m_scriptId = 0;
-	m_callbackId = 0;
-	m_timerEvent = false;
-	m_interface = nullptr;
+	scriptId = 0;
+	callbackId = 0;
+	timerEvent = false;
+	interface = nullptr;
 	localMap.clear();
-	m_tempResults.clear();
+	tempResults.clear();
 
 	auto pair = tempItems.equal_range(this);
 	auto it = pair.first;
@@ -89,25 +89,25 @@ void ScriptEnvironment::resetEnv()
 
 bool ScriptEnvironment::setCallbackId(int32_t callbackId, LuaScriptInterface* scriptInterface)
 {
-	if (m_callbackId != 0) {
+	if (this->callbackId != 0) {
 		//nested callbacks are not allowed
-		if (m_interface) {
-			m_interface->reportErrorFunc("Nested callbacks!");
+		if (interface) {
+			interface->reportErrorFunc("Nested callbacks!");
 		}
 		return false;
 	}
 
-	m_callbackId = callbackId;
-	m_interface = scriptInterface;
+	this->callbackId = callbackId;
+	interface = scriptInterface;
 	return true;
 }
 
 void ScriptEnvironment::getEventInfo(int32_t& scriptId, LuaScriptInterface*& scriptInterface, int32_t& callbackId, bool& timerEvent) const
 {
-	scriptId = m_scriptId;
-	scriptInterface = m_interface;
-	callbackId = m_callbackId;
-	timerEvent = m_timerEvent;
+	scriptId = this->scriptId;
+	scriptInterface = interface;
+	callbackId = this->callbackId;
+	timerEvent = this->timerEvent;
 }
 
 uint32_t ScriptEnvironment::addThing(Thing* thing)
@@ -132,8 +132,8 @@ uint32_t ScriptEnvironment::addThing(Thing* thing)
 		}
 	}
 
-	localMap[++m_lastUID] = item;
-	return m_lastUID;
+	localMap[++lastUID] = item;
+	return lastUID;
 }
 
 void ScriptEnvironment::insertItem(uint32_t uid, Item* item)
@@ -216,25 +216,25 @@ void ScriptEnvironment::removeTempItem(Item* item)
 
 uint32_t ScriptEnvironment::addResult(DBResult_ptr res)
 {
-	m_tempResults[++m_lastResultId] = res;
-	return m_lastResultId;
+	tempResults[++lastResultId] = res;
+	return lastResultId;
 }
 
 bool ScriptEnvironment::removeResult(uint32_t id)
 {
-	auto it = m_tempResults.find(id);
-	if (it == m_tempResults.end()) {
+	auto it = tempResults.find(id);
+	if (it == tempResults.end()) {
 		return false;
 	}
 
-	m_tempResults.erase(it);
+	tempResults.erase(it);
 	return true;
 }
 
 DBResult_ptr ScriptEnvironment::getResultByID(uint32_t id)
 {
-	auto it = m_tempResults.find(id);
-	if (it == m_tempResults.end()) {
+	auto it = tempResults.find(id);
+	if (it == tempResults.end()) {
 		return nullptr;
 	}
 	return it->second;
@@ -260,11 +260,11 @@ std::string LuaScriptInterface::getErrorDesc(ErrorCode_t code)
 	}
 }
 
-ScriptEnvironment LuaScriptInterface::m_scriptEnv[16];
-int32_t LuaScriptInterface::m_scriptEnvIndex = -1;
+ScriptEnvironment LuaScriptInterface::scriptEnv[16];
+int32_t LuaScriptInterface::scriptEnvIndex = -1;
 
 LuaScriptInterface::LuaScriptInterface(std::string interfaceName)
-	: m_luaState(nullptr), m_interfaceName(interfaceName), m_eventTableRef(-1), m_runningEventId(EVENT_ID_USER)
+	: luaState(nullptr), interfaceName(interfaceName), eventTableRef(-1), runningEventId(EVENT_ID_USER)
 {
 	if (!g_luaEnvironment.getLuaState()) {
 		g_luaEnvironment.initState();
@@ -300,18 +300,18 @@ int LuaScriptInterface::protectedCall(lua_State* L, int nargs, int nresults)
 int32_t LuaScriptInterface::loadFile(const std::string& file, Npc* npc /* = nullptr*/)
 {
 	//loads file as a chunk at stack top
-	int ret = luaL_loadfile(m_luaState, file.c_str());
+	int ret = luaL_loadfile(luaState, file.c_str());
 	if (ret != 0) {
-		m_lastLuaError = popString(m_luaState);
+		lastLuaError = popString(luaState);
 		return -1;
 	}
 
 	//check that it is loaded as a function
-	if (!isFunction(m_luaState, -1)) {
+	if (!isFunction(luaState, -1)) {
 		return -1;
 	}
 
-	m_loadingFile = file;
+	loadingFile = file;
 
 	if (!reserveScriptEnv()) {
 		return -1;
@@ -322,9 +322,9 @@ int32_t LuaScriptInterface::loadFile(const std::string& file, Npc* npc /* = null
 	env->setNpc(npc);
 
 	//execute it
-	ret = protectedCall(m_luaState, 0, 0);
+	ret = protectedCall(luaState, 0, 0);
 	if (ret != 0) {
-		reportError(nullptr, popString(m_luaState));
+		reportError(nullptr, popString(luaState));
 		resetScriptEnv();
 		return -1;
 	}
@@ -336,71 +336,71 @@ int32_t LuaScriptInterface::loadFile(const std::string& file, Npc* npc /* = null
 int32_t LuaScriptInterface::getEvent(const std::string& eventName)
 {
 	//get our events table
-	lua_rawgeti(m_luaState, LUA_REGISTRYINDEX, m_eventTableRef);
-	if (!isTable(m_luaState, -1)) {
-		lua_pop(m_luaState, 1);
+	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
+	if (!isTable(luaState, -1)) {
+		lua_pop(luaState, 1);
 		return -1;
 	}
 
 	//get current event function pointer
-	lua_getglobal(m_luaState, eventName.c_str());
-	if (!isFunction(m_luaState, -1)) {
-		lua_pop(m_luaState, 2);
+	lua_getglobal(luaState, eventName.c_str());
+	if (!isFunction(luaState, -1)) {
+		lua_pop(luaState, 2);
 		return -1;
 	}
 
 	//save in our events table
-	lua_pushvalue(m_luaState, -1);
-	lua_rawseti(m_luaState, -3, m_runningEventId);
-	lua_pop(m_luaState, 2);
+	lua_pushvalue(luaState, -1);
+	lua_rawseti(luaState, -3, runningEventId);
+	lua_pop(luaState, 2);
 
 	//reset global value of this event
-	lua_pushnil(m_luaState);
-	lua_setglobal(m_luaState, eventName.c_str());
+	lua_pushnil(luaState);
+	lua_setglobal(luaState, eventName.c_str());
 
-	m_cacheFiles[m_runningEventId] = m_loadingFile + ":" + eventName;
-	return m_runningEventId++;
+	cacheFiles[runningEventId] = loadingFile + ":" + eventName;
+	return runningEventId++;
 }
 
 int32_t LuaScriptInterface::getMetaEvent(const std::string& globalName, const std::string& eventName)
 {
 	//get our events table
-	lua_rawgeti(m_luaState, LUA_REGISTRYINDEX, m_eventTableRef);
-	if (!isTable(m_luaState, -1)) {
-		lua_pop(m_luaState, 1);
+	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
+	if (!isTable(luaState, -1)) {
+		lua_pop(luaState, 1);
 		return -1;
 	}
 
 	//get current event function pointer
-	lua_getglobal(m_luaState, globalName.c_str());
-	lua_getfield(m_luaState, -1, eventName.c_str());
-	if (!isFunction(m_luaState, -1)) {
-		lua_pop(m_luaState, 3);
+	lua_getglobal(luaState, globalName.c_str());
+	lua_getfield(luaState, -1, eventName.c_str());
+	if (!isFunction(luaState, -1)) {
+		lua_pop(luaState, 3);
 		return -1;
 	}
 
 	//save in our events table
-	lua_pushvalue(m_luaState, -1);
-	lua_rawseti(m_luaState, -4, m_runningEventId);
-	lua_pop(m_luaState, 1);
+	lua_pushvalue(luaState, -1);
+	lua_rawseti(luaState, -4, runningEventId);
+	lua_pop(luaState, 1);
 
 	//reset global value of this event
-	lua_pushnil(m_luaState);
-	lua_setfield(m_luaState, -2, eventName.c_str());
-	lua_pop(m_luaState, 2);
+	lua_pushnil(luaState);
+	lua_setfield(luaState, -2, eventName.c_str());
+	lua_pop(luaState, 2);
 
-	m_cacheFiles[m_runningEventId] = m_loadingFile + ":" + globalName + "@" + eventName;
-	return m_runningEventId++;
+	cacheFiles[runningEventId] = loadingFile + ":" + globalName + "@" + eventName;
+	return runningEventId++;
 }
 
 const std::string& LuaScriptInterface::getFileById(int32_t scriptId)
 {
 	if (scriptId == EVENT_ID_LOADING) {
-		return m_loadingFile;
+		return loadingFile;
 	}
 
-	auto it = m_cacheFiles.find(scriptId);
-	if (it == m_cacheFiles.end()) {
+	auto it = cacheFiles.find(scriptId);
+	if (it == cacheFiles.end()) {
 		static const std::string& unk = "(Unknown scriptfile)";
 		return unk;
 	}
@@ -409,22 +409,22 @@ const std::string& LuaScriptInterface::getFileById(int32_t scriptId)
 
 std::string LuaScriptInterface::getStackTrace(const std::string& error_desc)
 {
-	lua_getglobal(m_luaState, "debug");
-	if (!isTable(m_luaState, -1)) {
-		lua_pop(m_luaState, 1);
+	lua_getglobal(luaState, "debug");
+	if (!isTable(luaState, -1)) {
+		lua_pop(luaState, 1);
 		return error_desc;
 	}
 
-	lua_getfield(m_luaState, -1, "traceback");
-	if (!isFunction(m_luaState, -1)) {
-		lua_pop(m_luaState, 2);
+	lua_getfield(luaState, -1, "traceback");
+	if (!isFunction(luaState, -1)) {
+		lua_pop(luaState, 2);
 		return error_desc;
 	}
 
-	lua_replace(m_luaState, -2);
-	pushString(m_luaState, error_desc);
-	lua_call(m_luaState, 1, 1);
-	return popString(m_luaState);
+	lua_replace(luaState, -2);
+	pushString(luaState, error_desc);
+	lua_call(luaState, 1, 1);
+	return popString(luaState);
 }
 
 void LuaScriptInterface::reportError(const char* function, const std::string& error_desc, bool stack_trace/* = false*/)
@@ -464,42 +464,42 @@ void LuaScriptInterface::reportError(const char* function, const std::string& er
 
 bool LuaScriptInterface::pushFunction(int32_t functionId)
 {
-	lua_rawgeti(m_luaState, LUA_REGISTRYINDEX, m_eventTableRef);
-	if (!isTable(m_luaState, -1)) {
+	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
+	if (!isTable(luaState, -1)) {
 		return false;
 	}
 
-	lua_rawgeti(m_luaState, -1, functionId);
-	lua_replace(m_luaState, -2);
-	return isFunction(m_luaState, -1);
+	lua_rawgeti(luaState, -1, functionId);
+	lua_replace(luaState, -2);
+	return isFunction(luaState, -1);
 }
 
 bool LuaScriptInterface::initState()
 {
-	m_luaState = g_luaEnvironment.getLuaState();
-	if (!m_luaState) {
+	luaState = g_luaEnvironment.getLuaState();
+	if (!luaState) {
 		return false;
 	}
 
-	lua_newtable(m_luaState);
-	m_eventTableRef = luaL_ref(m_luaState, LUA_REGISTRYINDEX);
-	m_runningEventId = EVENT_ID_USER;
+	lua_newtable(luaState);
+	eventTableRef = luaL_ref(luaState, LUA_REGISTRYINDEX);
+	runningEventId = EVENT_ID_USER;
 	return true;
 }
 
 bool LuaScriptInterface::closeState()
 {
-	if (!g_luaEnvironment.getLuaState() || !m_luaState) {
+	if (!g_luaEnvironment.getLuaState() || !luaState) {
 		return false;
 	}
 
-	m_cacheFiles.clear();
-	if (m_eventTableRef != -1) {
-		luaL_unref(m_luaState, LUA_REGISTRYINDEX, m_eventTableRef);
-		m_eventTableRef = -1;
+	cacheFiles.clear();
+	if (eventTableRef != -1) {
+		luaL_unref(luaState, LUA_REGISTRYINDEX, eventTableRef);
+		eventTableRef = -1;
 	}
 
-	m_luaState = nullptr;
+	luaState = nullptr;
 	return true;
 }
 
@@ -515,15 +515,15 @@ int LuaScriptInterface::luaErrorHandler(lua_State* L)
 bool LuaScriptInterface::callFunction(int params)
 {
 	bool result = false;
-	int size = lua_gettop(m_luaState);
-	if (protectedCall(m_luaState, params, 1) != 0) {
-		LuaScriptInterface::reportError(nullptr, LuaScriptInterface::getString(m_luaState, -1));
+	int size = lua_gettop(luaState);
+	if (protectedCall(luaState, params, 1) != 0) {
+		LuaScriptInterface::reportError(nullptr, LuaScriptInterface::getString(luaState, -1));
 	} else {
-		result = LuaScriptInterface::getBoolean(m_luaState, -1);
+		result = LuaScriptInterface::getBoolean(luaState, -1);
 	}
 
-	lua_pop(m_luaState, 1);
-	if ((lua_gettop(m_luaState) + params + 1) != size) {
+	lua_pop(luaState, 1);
+	if ((lua_gettop(luaState) + params + 1) != size) {
 		LuaScriptInterface::reportError(nullptr, "Stack size changed!");
 	}
 
@@ -533,12 +533,12 @@ bool LuaScriptInterface::callFunction(int params)
 
 void LuaScriptInterface::callVoidFunction(int params)
 {
-	int size = lua_gettop(m_luaState);
-	if (protectedCall(m_luaState, params, 0) != 0) {
-		LuaScriptInterface::reportError(nullptr, LuaScriptInterface::popString(m_luaState));
+	int size = lua_gettop(luaState);
+	if (protectedCall(luaState, params, 0) != 0) {
+		LuaScriptInterface::reportError(nullptr, LuaScriptInterface::popString(luaState));
 	}
 
-	if ((lua_gettop(m_luaState) + params + 1) != size) {
+	if ((lua_gettop(luaState) + params + 1) != size) {
 		LuaScriptInterface::reportError(nullptr, "Stack size changed!");
 	}
 
@@ -898,145 +898,145 @@ void LuaScriptInterface::pushOutfit(lua_State* L, const Outfit_t& outfit)
 void LuaScriptInterface::registerFunctions()
 {
 	//getPlayerFlagValue(cid, flag)
-	lua_register(m_luaState, "getPlayerFlagValue", LuaScriptInterface::luaGetPlayerFlagValue);
+	lua_register(luaState, "getPlayerFlagValue", LuaScriptInterface::luaGetPlayerFlagValue);
 
 	//getPlayerInstantSpellCount(cid)
-	lua_register(m_luaState, "getPlayerInstantSpellCount", LuaScriptInterface::luaGetPlayerInstantSpellCount);
+	lua_register(luaState, "getPlayerInstantSpellCount", LuaScriptInterface::luaGetPlayerInstantSpellCount);
 
 	//getPlayerInstantSpellInfo(cid, index)
-	lua_register(m_luaState, "getPlayerInstantSpellInfo", LuaScriptInterface::luaGetPlayerInstantSpellInfo);
+	lua_register(luaState, "getPlayerInstantSpellInfo", LuaScriptInterface::luaGetPlayerInstantSpellInfo);
 
 	//doPlayerAddItem(uid, itemid, <optional: default: 1> count/subtype)
 	//doPlayerAddItem(cid, itemid, <optional: default: 1> count, <optional: default: 1> canDropOnMap, <optional: default: 1>subtype)
 	//Returns uid of the created item
-	lua_register(m_luaState, "doPlayerAddItem", LuaScriptInterface::luaDoPlayerAddItem);
+	lua_register(luaState, "doPlayerAddItem", LuaScriptInterface::luaDoPlayerAddItem);
 
 	//doCreateItem(itemid, type/count, pos)
 	//Returns uid of the created item, only works on tiles.
-	lua_register(m_luaState, "doCreateItem", LuaScriptInterface::luaDoCreateItem);
+	lua_register(luaState, "doCreateItem", LuaScriptInterface::luaDoCreateItem);
 
 	//doCreateItemEx(itemid, <optional> count/subtype)
-	lua_register(m_luaState, "doCreateItemEx", LuaScriptInterface::luaDoCreateItemEx);
+	lua_register(luaState, "doCreateItemEx", LuaScriptInterface::luaDoCreateItemEx);
 
 	//doTileAddItemEx(pos, uid)
-	lua_register(m_luaState, "doTileAddItemEx", LuaScriptInterface::luaDoTileAddItemEx);
+	lua_register(luaState, "doTileAddItemEx", LuaScriptInterface::luaDoTileAddItemEx);
 
 	//doMoveCreature(cid, direction)
-	lua_register(m_luaState, "doMoveCreature", LuaScriptInterface::luaDoMoveCreature);
+	lua_register(luaState, "doMoveCreature", LuaScriptInterface::luaDoMoveCreature);
 
 	//doSetCreatureLight(cid, lightLevel, lightColor, time)
-	lua_register(m_luaState, "doSetCreatureLight", LuaScriptInterface::luaDoSetCreatureLight);
+	lua_register(luaState, "doSetCreatureLight", LuaScriptInterface::luaDoSetCreatureLight);
 
 	//getCreatureCondition(cid, condition[, subId])
-	lua_register(m_luaState, "getCreatureCondition", LuaScriptInterface::luaGetCreatureCondition);
+	lua_register(luaState, "getCreatureCondition", LuaScriptInterface::luaGetCreatureCondition);
 
 	//isValidUID(uid)
-	lua_register(m_luaState, "isValidUID", LuaScriptInterface::luaIsValidUID);
+	lua_register(luaState, "isValidUID", LuaScriptInterface::luaIsValidUID);
 
 	//isDepot(uid)
-	lua_register(m_luaState, "isDepot", LuaScriptInterface::luaIsDepot);
+	lua_register(luaState, "isDepot", LuaScriptInterface::luaIsDepot);
 
 	//isMovable(uid)
-	lua_register(m_luaState, "isMovable", LuaScriptInterface::luaIsMoveable);
+	lua_register(luaState, "isMovable", LuaScriptInterface::luaIsMoveable);
 
 	//doAddContainerItem(uid, itemid, <optional> count/subtype)
-	lua_register(m_luaState, "doAddContainerItem", LuaScriptInterface::luaDoAddContainerItem);
+	lua_register(luaState, "doAddContainerItem", LuaScriptInterface::luaDoAddContainerItem);
 
 	//getDepotId(uid)
-	lua_register(m_luaState, "getDepotId", LuaScriptInterface::luaGetDepotId);
+	lua_register(luaState, "getDepotId", LuaScriptInterface::luaGetDepotId);
 
 	//getWorldTime()
-	lua_register(m_luaState, "getWorldTime", LuaScriptInterface::luaGetWorldTime);
+	lua_register(luaState, "getWorldTime", LuaScriptInterface::luaGetWorldTime);
 
 	//getWorldLight()
-	lua_register(m_luaState, "getWorldLight", LuaScriptInterface::luaGetWorldLight);
+	lua_register(luaState, "getWorldLight", LuaScriptInterface::luaGetWorldLight);
 
 	//getWorldUpTime()
-	lua_register(m_luaState, "getWorldUpTime", LuaScriptInterface::luaGetWorldUpTime);
+	lua_register(luaState, "getWorldUpTime", LuaScriptInterface::luaGetWorldUpTime);
 
 	//createCombatArea( {area}, <optional> {extArea} )
-	lua_register(m_luaState, "createCombatArea", LuaScriptInterface::luaCreateCombatArea);
+	lua_register(luaState, "createCombatArea", LuaScriptInterface::luaCreateCombatArea);
 
 	//doAreaCombatHealth(cid, type, pos, area, min, max, effect)
-	lua_register(m_luaState, "doAreaCombatHealth", LuaScriptInterface::luaDoAreaCombatHealth);
+	lua_register(luaState, "doAreaCombatHealth", LuaScriptInterface::luaDoAreaCombatHealth);
 
 	//doTargetCombatHealth(cid, target, type, min, max, effect)
-	lua_register(m_luaState, "doTargetCombatHealth", LuaScriptInterface::luaDoTargetCombatHealth);
+	lua_register(luaState, "doTargetCombatHealth", LuaScriptInterface::luaDoTargetCombatHealth);
 
 	//doAreaCombatMana(cid, pos, area, min, max, effect)
-	lua_register(m_luaState, "doAreaCombatMana", LuaScriptInterface::luaDoAreaCombatMana);
+	lua_register(luaState, "doAreaCombatMana", LuaScriptInterface::luaDoAreaCombatMana);
 
 	//doTargetCombatMana(cid, target, min, max, effect)
-	lua_register(m_luaState, "doTargetCombatMana", LuaScriptInterface::luaDoTargetCombatMana);
+	lua_register(luaState, "doTargetCombatMana", LuaScriptInterface::luaDoTargetCombatMana);
 
 	//doAreaCombatCondition(cid, pos, area, condition, effect)
-	lua_register(m_luaState, "doAreaCombatCondition", LuaScriptInterface::luaDoAreaCombatCondition);
+	lua_register(luaState, "doAreaCombatCondition", LuaScriptInterface::luaDoAreaCombatCondition);
 
 	//doTargetCombatCondition(cid, target, condition, effect)
-	lua_register(m_luaState, "doTargetCombatCondition", LuaScriptInterface::luaDoTargetCombatCondition);
+	lua_register(luaState, "doTargetCombatCondition", LuaScriptInterface::luaDoTargetCombatCondition);
 
 	//doAreaCombatDispel(cid, pos, area, type, effect)
-	lua_register(m_luaState, "doAreaCombatDispel", LuaScriptInterface::luaDoAreaCombatDispel);
+	lua_register(luaState, "doAreaCombatDispel", LuaScriptInterface::luaDoAreaCombatDispel);
 
 	//doTargetCombatDispel(cid, target, type, effect)
-	lua_register(m_luaState, "doTargetCombatDispel", LuaScriptInterface::luaDoTargetCombatDispel);
+	lua_register(luaState, "doTargetCombatDispel", LuaScriptInterface::luaDoTargetCombatDispel);
 
 	//doChallengeCreature(cid, target)
-	lua_register(m_luaState, "doChallengeCreature", LuaScriptInterface::luaDoChallengeCreature);
+	lua_register(luaState, "doChallengeCreature", LuaScriptInterface::luaDoChallengeCreature);
 
 	//doSetMonsterOutfit(cid, name, time)
-	lua_register(m_luaState, "doSetMonsterOutfit", LuaScriptInterface::luaSetMonsterOutfit);
+	lua_register(luaState, "doSetMonsterOutfit", LuaScriptInterface::luaSetMonsterOutfit);
 
 	//doSetItemOutfit(cid, item, time)
-	lua_register(m_luaState, "doSetItemOutfit", LuaScriptInterface::luaSetItemOutfit);
+	lua_register(luaState, "doSetItemOutfit", LuaScriptInterface::luaSetItemOutfit);
 
 	//doSetCreatureOutfit(cid, outfit, time)
-	lua_register(m_luaState, "doSetCreatureOutfit", LuaScriptInterface::luaSetCreatureOutfit);
+	lua_register(luaState, "doSetCreatureOutfit", LuaScriptInterface::luaSetCreatureOutfit);
 
 	//isInArray(array, value)
-	lua_register(m_luaState, "isInArray", LuaScriptInterface::luaIsInArray);
+	lua_register(luaState, "isInArray", LuaScriptInterface::luaIsInArray);
 
 	//addEvent(callback, delay, ...)
-	lua_register(m_luaState, "addEvent", LuaScriptInterface::luaAddEvent);
+	lua_register(luaState, "addEvent", LuaScriptInterface::luaAddEvent);
 
 	//stopEvent(eventid)
-	lua_register(m_luaState, "stopEvent", LuaScriptInterface::luaStopEvent);
+	lua_register(luaState, "stopEvent", LuaScriptInterface::luaStopEvent);
 
 	//saveServer()
-	lua_register(m_luaState, "saveServer", LuaScriptInterface::luaSaveServer);
+	lua_register(luaState, "saveServer", LuaScriptInterface::luaSaveServer);
 
 	//cleanMap()
-	lua_register(m_luaState, "cleanMap", LuaScriptInterface::luaCleanMap);
+	lua_register(luaState, "cleanMap", LuaScriptInterface::luaCleanMap);
 
 	//debugPrint(text)
-	lua_register(m_luaState, "debugPrint", LuaScriptInterface::luaDebugPrint);
+	lua_register(luaState, "debugPrint", LuaScriptInterface::luaDebugPrint);
 
 	//isInWar(cid, target)
-	lua_register(m_luaState, "isInWar", LuaScriptInterface::luaIsInWar);
+	lua_register(luaState, "isInWar", LuaScriptInterface::luaIsInWar);
 
 	//getWaypointPosition(name)
-	lua_register(m_luaState, "getWaypointPositionByName", LuaScriptInterface::luaGetWaypointPositionByName);
+	lua_register(luaState, "getWaypointPositionByName", LuaScriptInterface::luaGetWaypointPositionByName);
 
 	//sendChannelMessage(channelId, type, message)
-	lua_register(m_luaState, "sendChannelMessage", LuaScriptInterface::luaSendChannelMessage);
+	lua_register(luaState, "sendChannelMessage", LuaScriptInterface::luaSendChannelMessage);
 
 	//sendGuildChannelMessage(guildId, type, message)
-	lua_register(m_luaState, "sendGuildChannelMessage", LuaScriptInterface::luaSendGuildChannelMessage);
+	lua_register(luaState, "sendGuildChannelMessage", LuaScriptInterface::luaSendGuildChannelMessage);
 
 #ifndef LUAJIT_VERSION
 	//bit operations for Lua, based on bitlib project release 24
 	//bit.bnot, bit.band, bit.bor, bit.bxor, bit.lshift, bit.rshift
-	luaL_register(m_luaState, "bit", LuaScriptInterface::luaBitReg);
+	luaL_register(luaState, "bit", LuaScriptInterface::luaBitReg);
 #endif
 
 	//configManager table
-	luaL_register(m_luaState, "configManager", LuaScriptInterface::luaConfigManagerTable);
+	luaL_register(luaState, "configManager", LuaScriptInterface::luaConfigManagerTable);
 
 	//db table
-	luaL_register(m_luaState, "db", LuaScriptInterface::luaDatabaseTable);
+	luaL_register(luaState, "db", LuaScriptInterface::luaDatabaseTable);
 
 	//result table
-	luaL_register(m_luaState, "result", LuaScriptInterface::luaResultTable);
+	luaL_register(luaState, "result", LuaScriptInterface::luaResultTable);
 
 	/* New functions */
 	//registerClass(className, baseClass, newFunction)
@@ -2541,135 +2541,135 @@ void LuaScriptInterface::registerFunctions()
 void LuaScriptInterface::registerClass(const std::string& className, const std::string& baseClass, lua_CFunction newFunction/* = nullptr*/)
 {
 	// className = {}
-	lua_newtable(m_luaState);
-	lua_pushvalue(m_luaState, -1);
-	lua_setglobal(m_luaState, className.c_str());
-	int methods = lua_gettop(m_luaState);
+	lua_newtable(luaState);
+	lua_pushvalue(luaState, -1);
+	lua_setglobal(luaState, className.c_str());
+	int methods = lua_gettop(luaState);
 
 	// methodsTable = {}
-	lua_newtable(m_luaState);
-	int methodsTable = lua_gettop(m_luaState);
+	lua_newtable(luaState);
+	int methodsTable = lua_gettop(luaState);
 
 	if (newFunction) {
 		// className.__call = newFunction
-		lua_pushcfunction(m_luaState, newFunction);
-		lua_setfield(m_luaState, methodsTable, "__call");
+		lua_pushcfunction(luaState, newFunction);
+		lua_setfield(luaState, methodsTable, "__call");
 	}
 
 	uint32_t parents = 0;
 	if (!baseClass.empty()) {
-		lua_getglobal(m_luaState, baseClass.c_str());
-		lua_rawgeti(m_luaState, -1, 'p');
-		parents = getNumber<uint32_t>(m_luaState, -1) + 1;
-		lua_pop(m_luaState, 1);
-		lua_setfield(m_luaState, methodsTable, "__index");
+		lua_getglobal(luaState, baseClass.c_str());
+		lua_rawgeti(luaState, -1, 'p');
+		parents = getNumber<uint32_t>(luaState, -1) + 1;
+		lua_pop(luaState, 1);
+		lua_setfield(luaState, methodsTable, "__index");
 	}
 
 	// setmetatable(className, methodsTable)
-	lua_setmetatable(m_luaState, methods);
+	lua_setmetatable(luaState, methods);
 
 	// className.metatable = {}
-	luaL_newmetatable(m_luaState, className.c_str());
-	int metatable = lua_gettop(m_luaState);
+	luaL_newmetatable(luaState, className.c_str());
+	int metatable = lua_gettop(luaState);
 
 	// className.metatable.__metatable = className
-	lua_pushvalue(m_luaState, methods);
-	lua_setfield(m_luaState, metatable, "__metatable");
+	lua_pushvalue(luaState, methods);
+	lua_setfield(luaState, metatable, "__metatable");
 
 	// className.metatable.__index = className
-	lua_pushvalue(m_luaState, methods);
-	lua_setfield(m_luaState, metatable, "__index");
+	lua_pushvalue(luaState, methods);
+	lua_setfield(luaState, metatable, "__index");
 
 	// className.metatable['h'] = hash
-	lua_pushnumber(m_luaState, std::hash<std::string>()(className));
-	lua_rawseti(m_luaState, metatable, 'h');
+	lua_pushnumber(luaState, std::hash<std::string>()(className));
+	lua_rawseti(luaState, metatable, 'h');
 
 	// className.metatable['p'] = parents
-	lua_pushnumber(m_luaState, parents);
-	lua_rawseti(m_luaState, metatable, 'p');
+	lua_pushnumber(luaState, parents);
+	lua_rawseti(luaState, metatable, 'p');
 
 	// className.metatable['t'] = type
 	if (className == "Item") {
-		lua_pushnumber(m_luaState, LuaData_Item);
+		lua_pushnumber(luaState, LuaData_Item);
 	} else if (className == "Container") {
-		lua_pushnumber(m_luaState, LuaData_Container);
+		lua_pushnumber(luaState, LuaData_Container);
 	} else if (className == "Teleport") {
-		lua_pushnumber(m_luaState, LuaData_Teleport);
+		lua_pushnumber(luaState, LuaData_Teleport);
 	} else if (className == "Player") {
-		lua_pushnumber(m_luaState, LuaData_Player);
+		lua_pushnumber(luaState, LuaData_Player);
 	} else if (className == "Monster") {
-		lua_pushnumber(m_luaState, LuaData_Monster);
+		lua_pushnumber(luaState, LuaData_Monster);
 	} else if (className == "Npc") {
-		lua_pushnumber(m_luaState, LuaData_Npc);
+		lua_pushnumber(luaState, LuaData_Npc);
 	} else if (className == "Tile") {
-		lua_pushnumber(m_luaState, LuaData_Tile);
+		lua_pushnumber(luaState, LuaData_Tile);
 	} else {
-		lua_pushnumber(m_luaState, LuaData_Unknown);
+		lua_pushnumber(luaState, LuaData_Unknown);
 	}
-	lua_rawseti(m_luaState, metatable, 't');
+	lua_rawseti(luaState, metatable, 't');
 
 	// pop className, className.metatable
-	lua_pop(m_luaState, 2);
+	lua_pop(luaState, 2);
 }
 
 void LuaScriptInterface::registerTable(const std::string& tableName)
 {
 	// _G[tableName] = {}
-	lua_newtable(m_luaState);
-	lua_setglobal(m_luaState, tableName.c_str());
+	lua_newtable(luaState);
+	lua_setglobal(luaState, tableName.c_str());
 }
 
 void LuaScriptInterface::registerMethod(const std::string& globalName, const std::string& methodName, lua_CFunction func)
 {
 	// globalName.methodName = func
-	lua_getglobal(m_luaState, globalName.c_str());
-	lua_pushcfunction(m_luaState, func);
-	lua_setfield(m_luaState, -2, methodName.c_str());
+	lua_getglobal(luaState, globalName.c_str());
+	lua_pushcfunction(luaState, func);
+	lua_setfield(luaState, -2, methodName.c_str());
 
 	// pop globalName
-	lua_pop(m_luaState, 1);
+	lua_pop(luaState, 1);
 }
 
 void LuaScriptInterface::registerMetaMethod(const std::string& className, const std::string& methodName, lua_CFunction func)
 {
 	// className.metatable.methodName = func
-	luaL_getmetatable(m_luaState, className.c_str());
-	lua_pushcfunction(m_luaState, func);
-	lua_setfield(m_luaState, -2, methodName.c_str());
+	luaL_getmetatable(luaState, className.c_str());
+	lua_pushcfunction(luaState, func);
+	lua_setfield(luaState, -2, methodName.c_str());
 
 	// pop className.metatable
-	lua_pop(m_luaState, 1);
+	lua_pop(luaState, 1);
 }
 
 void LuaScriptInterface::registerGlobalMethod(const std::string& functionName, lua_CFunction func)
 {
 	// _G[functionName] = func
-	lua_pushcfunction(m_luaState, func);
-	lua_setglobal(m_luaState, functionName.c_str());
+	lua_pushcfunction(luaState, func);
+	lua_setglobal(luaState, functionName.c_str());
 }
 
 void LuaScriptInterface::registerVariable(const std::string& tableName, const std::string& name, lua_Number value)
 {
 	// tableName.name = value
-	lua_getglobal(m_luaState, tableName.c_str());
-	setField(m_luaState, name.c_str(), value);
+	lua_getglobal(luaState, tableName.c_str());
+	setField(luaState, name.c_str(), value);
 
 	// pop tableName
-	lua_pop(m_luaState, 1);
+	lua_pop(luaState, 1);
 }
 
 void LuaScriptInterface::registerGlobalVariable(const std::string& name, lua_Number value)
 {
 	// _G[name] = value
-	lua_pushnumber(m_luaState, value);
-	lua_setglobal(m_luaState, name.c_str());
+	lua_pushnumber(luaState, value);
+	lua_setglobal(luaState, name.c_str());
 }
 
 void LuaScriptInterface::registerGlobalBoolean(const std::string& name, bool value)
 {
 	// _G[name] = value
-	pushBoolean(m_luaState, value);
-	lua_setglobal(m_luaState, name.c_str());
+	pushBoolean(luaState, value);
+	lua_setglobal(luaState, name.c_str());
 }
 
 int LuaScriptInterface::luaGetPlayerFlagValue(lua_State* L)
@@ -3619,12 +3619,12 @@ int LuaScriptInterface::luaAddEvent(lua_State* L)
 	eventDesc.function = luaL_ref(globalState, LUA_REGISTRYINDEX);
 	eventDesc.scriptId = getScriptEnv()->getScriptId();
 
-	auto& lastTimerEventId = g_luaEnvironment.m_lastEventTimerId;
+	auto& lastTimerEventId = g_luaEnvironment.lastEventTimerId;
 	eventDesc.eventId = g_scheduler.addEvent(createSchedulerTask(
 		delay, std::bind(&LuaEnvironment::executeTimerEvent, &g_luaEnvironment, lastTimerEventId)
 	));
 
-	g_luaEnvironment.m_timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
+	g_luaEnvironment.timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
 	lua_pushnumber(L, lastTimerEventId++);
 	return 1;
 }
@@ -3641,7 +3641,7 @@ int LuaScriptInterface::luaStopEvent(lua_State* L)
 
 	uint32_t eventId = getNumber<uint32_t>(L, 1);
 
-	auto& timerEvents = g_luaEnvironment.m_timerEvents;
+	auto& timerEvents = g_luaEnvironment.timerEvents;
 	auto it = timerEvents.find(eventId);
 	if (it == timerEvents.end()) {
 		pushBoolean(L, false);
@@ -12056,29 +12056,29 @@ int LuaScriptInterface::luaPartySetSharedExperience(lua_State* L)
 
 //
 LuaEnvironment::LuaEnvironment() :
-	LuaScriptInterface("Main Interface"), m_testInterface(nullptr),
-	m_lastEventTimerId(1), m_lastCombatId(0), m_lastAreaId(0)
+	LuaScriptInterface("Main Interface"), testInterface(nullptr),
+	lastEventTimerId(1), lastCombatId(0), lastAreaId(0)
 {
 	//
 }
 
 LuaEnvironment::~LuaEnvironment()
 {
-	delete m_testInterface;
+	delete testInterface;
 	closeState();
 }
 
 bool LuaEnvironment::initState()
 {
-	m_luaState = luaL_newstate();
-	if (!m_luaState) {
+	luaState = luaL_newstate();
+	if (!luaState) {
 		return false;
 	}
 
-	luaL_openlibs(m_luaState);
+	luaL_openlibs(luaState);
 	registerFunctions();
 
-	m_runningEventId = EVENT_ID_USER;
+	runningEventId = EVENT_ID_USER;
 	return true;
 }
 
@@ -12091,49 +12091,49 @@ bool LuaEnvironment::reInitState()
 
 bool LuaEnvironment::closeState()
 {
-	if (!m_luaState) {
+	if (!luaState) {
 		return false;
 	}
 
-	for (const auto& combatEntry : m_combatIdMap) {
+	for (const auto& combatEntry : combatIdMap) {
 		clearCombatObjects(combatEntry.first);
 	}
 
-	for (const auto& areaEntry : m_areaIdMap) {
+	for (const auto& areaEntry : areaIdMap) {
 		clearAreaObjects(areaEntry.first);
 	}
 
-	for (auto& timerEntry : m_timerEvents) {
+	for (auto& timerEntry : timerEvents) {
 		LuaTimerEventDesc timerEventDesc = std::move(timerEntry.second);
 		for (int32_t parameter : timerEventDesc.parameters) {
-			luaL_unref(m_luaState, LUA_REGISTRYINDEX, parameter);
+			luaL_unref(luaState, LUA_REGISTRYINDEX, parameter);
 		}
-		luaL_unref(m_luaState, LUA_REGISTRYINDEX, timerEventDesc.function);
+		luaL_unref(luaState, LUA_REGISTRYINDEX, timerEventDesc.function);
 	}
 
-	m_combatIdMap.clear();
-	m_areaIdMap.clear();
-	m_timerEvents.clear();
-	m_cacheFiles.clear();
+	combatIdMap.clear();
+	areaIdMap.clear();
+	timerEvents.clear();
+	cacheFiles.clear();
 
-	lua_close(m_luaState);
-	m_luaState = nullptr;
+	lua_close(luaState);
+	luaState = nullptr;
 	return true;
 }
 
 LuaScriptInterface* LuaEnvironment::getTestInterface()
 {
-	if (!m_testInterface) {
-		m_testInterface = new LuaScriptInterface("Test Interface");
-		m_testInterface->initState();
+	if (!testInterface) {
+		testInterface = new LuaScriptInterface("Test Interface");
+		testInterface->initState();
 	}
-	return m_testInterface;
+	return testInterface;
 }
 
 Combat* LuaEnvironment::getCombatObject(uint32_t id) const
 {
-	auto it = m_combatMap.find(id);
-	if (it == m_combatMap.end()) {
+	auto it = combatMap.find(id);
+	if (it == combatMap.end()) {
 		return nullptr;
 	}
 	return it->second;
@@ -12142,23 +12142,23 @@ Combat* LuaEnvironment::getCombatObject(uint32_t id) const
 Combat* LuaEnvironment::createCombatObject(LuaScriptInterface* interface)
 {
 	Combat* combat = new Combat;
-	m_combatMap[++m_lastCombatId] = combat;
-	m_combatIdMap[interface].push_back(m_lastCombatId);
+	combatMap[++lastCombatId] = combat;
+	combatIdMap[interface].push_back(lastCombatId);
 	return combat;
 }
 
 void LuaEnvironment::clearCombatObjects(LuaScriptInterface* interface)
 {
-	auto it = m_combatIdMap.find(interface);
-	if (it == m_combatIdMap.end()) {
+	auto it = combatIdMap.find(interface);
+	if (it == combatIdMap.end()) {
 		return;
 	}
 
 	for (uint32_t id : it->second) {
-		auto itt = m_combatMap.find(id);
-		if (itt != m_combatMap.end()) {
+		auto itt = combatMap.find(id);
+		if (itt != combatMap.end()) {
 			delete itt->second;
-			m_combatMap.erase(itt);
+			combatMap.erase(itt);
 		}
 	}
 	it->second.clear();
@@ -12166,8 +12166,8 @@ void LuaEnvironment::clearCombatObjects(LuaScriptInterface* interface)
 
 AreaCombat* LuaEnvironment::getAreaObject(uint32_t id) const
 {
-	auto it = m_areaMap.find(id);
-	if (it == m_areaMap.end()) {
+	auto it = areaMap.find(id);
+	if (it == areaMap.end()) {
 		return nullptr;
 	}
 	return it->second;
@@ -12175,23 +12175,23 @@ AreaCombat* LuaEnvironment::getAreaObject(uint32_t id) const
 
 uint32_t LuaEnvironment::createAreaObject(LuaScriptInterface* interface)
 {
-	m_areaMap[++m_lastAreaId] = new AreaCombat;
-	m_areaIdMap[interface].push_back(m_lastAreaId);
-	return m_lastAreaId;
+	areaMap[++lastAreaId] = new AreaCombat;
+	areaIdMap[interface].push_back(lastAreaId);
+	return lastAreaId;
 }
 
 void LuaEnvironment::clearAreaObjects(LuaScriptInterface* interface)
 {
-	auto it = m_areaIdMap.find(interface);
-	if (it == m_areaIdMap.end()) {
+	auto it = areaIdMap.find(interface);
+	if (it == areaIdMap.end()) {
 		return;
 	}
 
 	for (uint32_t id : it->second) {
-		auto itt = m_areaMap.find(id);
-		if (itt != m_areaMap.end()) {
+		auto itt = areaMap.find(id);
+		if (itt != areaMap.end()) {
 			delete itt->second;
-			m_areaMap.erase(itt);
+			areaMap.erase(itt);
 		}
 	}
 	it->second.clear();
@@ -12199,20 +12199,20 @@ void LuaEnvironment::clearAreaObjects(LuaScriptInterface* interface)
 
 void LuaEnvironment::executeTimerEvent(uint32_t eventIndex)
 {
-	auto it = m_timerEvents.find(eventIndex);
-	if (it == m_timerEvents.end()) {
+	auto it = timerEvents.find(eventIndex);
+	if (it == timerEvents.end()) {
 		return;
 	}
 
 	LuaTimerEventDesc timerEventDesc = std::move(it->second);
-	m_timerEvents.erase(it);
+	timerEvents.erase(it);
 
 	//push function
-	lua_rawgeti(m_luaState, LUA_REGISTRYINDEX, timerEventDesc.function);
+	lua_rawgeti(luaState, LUA_REGISTRYINDEX, timerEventDesc.function);
 
 	//push parameters
 	for (auto parameter : boost::adaptors::reverse(timerEventDesc.parameters)) {
-		lua_rawgeti(m_luaState, LUA_REGISTRYINDEX, parameter);
+		lua_rawgeti(luaState, LUA_REGISTRYINDEX, parameter);
 	}
 
 	//call the function
@@ -12226,8 +12226,8 @@ void LuaEnvironment::executeTimerEvent(uint32_t eventIndex)
 	}
 
 	//free resources
-	luaL_unref(m_luaState, LUA_REGISTRYINDEX, timerEventDesc.function);
+	luaL_unref(luaState, LUA_REGISTRYINDEX, timerEventDesc.function);
 	for (auto parameter : timerEventDesc.parameters) {
-		luaL_unref(m_luaState, LUA_REGISTRYINDEX, parameter);
+		luaL_unref(luaState, LUA_REGISTRYINDEX, parameter);
 	}
 }

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -112,20 +112,20 @@ class ScriptEnvironment
 		void resetEnv();
 
 		void setScriptId(int32_t scriptId, LuaScriptInterface* scriptInterface) {
-			m_scriptId = scriptId;
-			m_interface = scriptInterface;
+			this->scriptId = scriptId;
+			interface = scriptInterface;
 		}
 		bool setCallbackId(int32_t callbackId, LuaScriptInterface* scriptInterface);
 
 		int32_t getScriptId() const {
-			return m_scriptId;
+			return scriptId;
 		}
 		LuaScriptInterface* getScriptInterface() {
-			return m_interface;
+			return interface;
 		}
 
 		void setTimerEvent() {
-			m_timerEvent = true;
+			timerEvent = true;
 		}
 
 		void getEventInfo(int32_t& scriptId, LuaScriptInterface*& scriptInterface, int32_t& callbackId, bool& timerEvent) const;
@@ -140,10 +140,10 @@ class ScriptEnvironment
 		static bool removeResult(uint32_t id);
 
 		void setNpc(Npc* npc) {
-			m_curNpc = npc;
+			curNpc = npc;
 		}
 		Npc* getNpc() const {
-			return m_curNpc;
+			return curNpc;
 		}
 
 		Thing* getThingByUID(uint32_t uid);
@@ -157,24 +157,24 @@ class ScriptEnvironment
 		typedef std::map<uint32_t, DBResult_ptr> DBResultMap;
 
 		//script file id
-		int32_t m_scriptId;
-		int32_t m_callbackId;
-		bool m_timerEvent;
-		LuaScriptInterface* m_interface;
+		int32_t scriptId;
+		int32_t callbackId;
+		bool timerEvent;
+		LuaScriptInterface* interface;
 
 		//local item map
-		uint32_t m_lastUID;
+		uint32_t lastUID;
 		std::unordered_map<uint32_t, Item*> localMap;
 
 		//temporary item list
 		static std::multimap<ScriptEnvironment*, Item*> tempItems;
 
 		//result map
-		static uint32_t m_lastResultId;
-		static DBResultMap m_tempResults;
+		static uint32_t lastResultId;
+		static DBResultMap tempResults;
 
 		//for npc scripts
-		Npc* m_curNpc;
+		Npc* curNpc;
 };
 
 #define reportErrorFunc(a)  reportError(__FUNCTION__, a, true)
@@ -215,30 +215,30 @@ class LuaScriptInterface
 		int32_t getMetaEvent(const std::string& globalName, const std::string& eventName);
 
 		static ScriptEnvironment* getScriptEnv() {
-			assert(m_scriptEnvIndex >= 0 && m_scriptEnvIndex < 16);
-			return m_scriptEnv + m_scriptEnvIndex;
+			assert(scriptEnvIndex >= 0 && scriptEnvIndex < 16);
+			return scriptEnv + scriptEnvIndex;
 		}
 
 		static bool reserveScriptEnv() {
-			return ++m_scriptEnvIndex < 16;
+			return ++scriptEnvIndex < 16;
 		}
 
 		static void resetScriptEnv() {
-			assert(m_scriptEnvIndex >= 0);
-			m_scriptEnv[m_scriptEnvIndex--].resetEnv();
+			assert(scriptEnvIndex >= 0);
+			scriptEnv[scriptEnvIndex--].resetEnv();
 		}
 
 		static void reportError(const char* function, const std::string& error_desc, bool stack_trace = false);
 
 		const std::string& getInterfaceName() const {
-			return m_interfaceName;
+			return interfaceName;
 		}
 		const std::string& getLastLuaError() const {
-			return m_lastLuaError;
+			return lastLuaError;
 		}
 
 		lua_State* getLuaState() const {
-			return m_luaState;
+			return luaState;
 		}
 
 		bool pushFunction(int32_t functionId);
@@ -1240,20 +1240,20 @@ class LuaScriptInterface
 		static int luaPartySetSharedExperience(lua_State* L);
 
 		//
-		lua_State* m_luaState;
-		std::string m_lastLuaError;
+		lua_State* luaState;
+		std::string lastLuaError;
 
-		std::string m_interfaceName;
-		int32_t m_eventTableRef;
+		std::string interfaceName;
+		int32_t eventTableRef;
 
-		static ScriptEnvironment m_scriptEnv[16];
-		static int32_t m_scriptEnvIndex;
+		static ScriptEnvironment scriptEnv[16];
+		static int32_t scriptEnvIndex;
 
-		int32_t m_runningEventId;
-		std::string m_loadingFile;
+		int32_t runningEventId;
+		std::string loadingFile;
 
 		//script file cache
-		std::map<int32_t, std::string> m_cacheFiles;
+		std::map<int32_t, std::string> cacheFiles;
 };
 
 class LuaEnvironment : public LuaScriptInterface
@@ -1284,18 +1284,18 @@ class LuaEnvironment : public LuaScriptInterface
 		void executeTimerEvent(uint32_t eventIndex);
 
 		//
-		std::unordered_map<uint32_t, LuaTimerEventDesc> m_timerEvents;
-		std::unordered_map<uint32_t, Combat*> m_combatMap;
-		std::unordered_map<uint32_t, AreaCombat*> m_areaMap;
+		std::unordered_map<uint32_t, LuaTimerEventDesc> timerEvents;
+		std::unordered_map<uint32_t, Combat*> combatMap;
+		std::unordered_map<uint32_t, AreaCombat*> areaMap;
 
-		std::unordered_map<LuaScriptInterface*, std::vector<uint32_t>> m_combatIdMap;
-		std::unordered_map<LuaScriptInterface*, std::vector<uint32_t>> m_areaIdMap;
+		std::unordered_map<LuaScriptInterface*, std::vector<uint32_t>> combatIdMap;
+		std::unordered_map<LuaScriptInterface*, std::vector<uint32_t>> areaIdMap;
 
-		LuaScriptInterface* m_testInterface;
+		LuaScriptInterface* testInterface;
 
-		uint32_t m_lastEventTimerId;
-		uint32_t m_lastCombatId;
-		uint32_t m_lastAreaId;
+		uint32_t lastEventTimerId;
+		uint32_t lastCombatId;
+		uint32_t lastAreaId;
 
 		//
 		friend class LuaScriptInterface;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -106,25 +106,25 @@ void Map::setTile(uint16_t x, uint16_t y, uint8_t z, Tile* newTile)
 		//update north
 		QTreeLeafNode* northLeaf = root.getLeaf(x, y - FLOOR_SIZE);
 		if (northLeaf) {
-			northLeaf->m_leafS = leaf;
+			northLeaf->leafS = leaf;
 		}
 
 		//update west leaf
 		QTreeLeafNode* westLeaf = root.getLeaf(x - FLOOR_SIZE, y);
 		if (westLeaf) {
-			westLeaf->m_leafE = leaf;
+			westLeaf->leafE = leaf;
 		}
 
 		//update south
 		QTreeLeafNode* southLeaf = root.getLeaf(x, y + FLOOR_SIZE);
 		if (southLeaf) {
-			leaf->m_leafS = southLeaf;
+			leaf->leafS = southLeaf;
 		}
 
 		//update east
 		QTreeLeafNode* eastLeaf = root.getLeaf(x + FLOOR_SIZE, y);
 		if (eastLeaf) {
-			leaf->m_leafE = eastLeaf;
+			leaf->leafE = eastLeaf;
 		}
 	}
 
@@ -351,14 +351,14 @@ void Map::getSpectatorsInternal(SpectatorVec& list, const Position& centerPos, i
 						list.insert(creature);
 					} while (++node_iter != node_end);
 				}
-				leafE = leafE->m_leafE;
+				leafE = leafE->leafE;
 			} else {
 				leafE = QTreeNode::getLeafStatic<const QTreeLeafNode*, const QTreeNode*>(&root, nx + FLOOR_SIZE, ny);
 			}
 		}
 
 		if (leafS) {
-			leafS = leafS->m_leafS;
+			leafS = leafS->leafS;
 		} else {
 			leafS = QTreeNode::getLeafStatic<const QTreeLeafNode*, const QTreeNode*>(&root, startx1, ny + FLOOR_SIZE);
 		}
@@ -873,28 +873,28 @@ Floor::~Floor()
 // QTreeNode
 QTreeNode::QTreeNode()
 {
-	m_isLeaf = false;
-	m_child[0] = nullptr;
-	m_child[1] = nullptr;
-	m_child[2] = nullptr;
-	m_child[3] = nullptr;
+	leaf = false;
+	child[0] = nullptr;
+	child[1] = nullptr;
+	child[2] = nullptr;
+	child[3] = nullptr;
 }
 
 QTreeNode::~QTreeNode()
 {
-	delete m_child[0];
-	delete m_child[1];
-	delete m_child[2];
-	delete m_child[3];
+	delete child[0];
+	delete child[1];
+	delete child[2];
+	delete child[3];
 }
 
 QTreeLeafNode* QTreeNode::getLeaf(uint32_t x, uint32_t y)
 {
-	if (m_isLeaf) {
+	if (leaf) {
 		return static_cast<QTreeLeafNode*>(this);
 	}
 
-	QTreeNode* node = m_child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
+	QTreeNode* node = child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
 	if (!node) {
 		return nullptr;
 	}
@@ -905,15 +905,15 @@ QTreeLeafNode* QTreeNode::createLeaf(uint32_t x, uint32_t y, uint32_t level)
 {
 	if (!isLeaf()) {
 		uint32_t index = ((x & 0x8000) >> 15) | ((y & 0x8000) >> 14);
-		if (!m_child[index]) {
+		if (!child[index]) {
 			if (level != FLOOR_BITS) {
-				m_child[index] = new QTreeNode();
+				child[index] = new QTreeNode();
 			} else {
-				m_child[index] = new QTreeLeafNode();
+				child[index] = new QTreeLeafNode();
 				QTreeLeafNode::newLeaf = true;
 			}
 		}
-		return m_child[index]->createLeaf(x * 2, y * 2, level - 1);
+		return child[index]->createLeaf(x * 2, y * 2, level - 1);
 	}
 	return static_cast<QTreeLeafNode*>(this);
 }
@@ -923,27 +923,27 @@ bool QTreeLeafNode::newLeaf = false;
 QTreeLeafNode::QTreeLeafNode()
 {
 	for (uint32_t i = 0; i < MAP_MAX_LAYERS; ++i) {
-		m_array[i] = nullptr;
+		array[i] = nullptr;
 	}
 
-	m_isLeaf = true;
-	m_leafS = nullptr;
-	m_leafE = nullptr;
+	leaf = true;
+	leafS = nullptr;
+	leafE = nullptr;
 }
 
 QTreeLeafNode::~QTreeLeafNode()
 {
 	for (uint32_t i = 0; i < MAP_MAX_LAYERS; ++i) {
-		delete m_array[i];
+		delete array[i];
 	}
 }
 
 Floor* QTreeLeafNode::createFloor(uint32_t z)
 {
-	if (!m_array[z]) {
-		m_array[z] = new Floor();
+	if (!array[z]) {
+		array[z] = new Floor();
 	}
-	return m_array[z];
+	return array[z];
 }
 
 void QTreeLeafNode::addCreature(Creature* c)
@@ -1023,7 +1023,7 @@ uint32_t Map::clean() const
 			}
 		} else {
 			for (size_t i = 0; i < 4; ++i) {
-				QTreeNode* childNode = node->m_child[i];
+				QTreeNode* childNode = node->child[i];
 				if (childNode) {
 					nodes.push_back(childNode);
 				}

--- a/src/map.h
+++ b/src/map.h
@@ -104,7 +104,7 @@ class QTreeNode
 		QTreeNode& operator=(const QTreeNode&) = delete;
 
 		bool isLeaf() const {
-			return m_isLeaf;
+			return leaf;
 		}
 
 		QTreeLeafNode* getLeaf(uint32_t x, uint32_t y);
@@ -113,23 +113,23 @@ class QTreeNode
 		inline static Leaf getLeafStatic(Node node, uint32_t x, uint32_t y)
 		{
 			do {
-				node = node->m_child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
+				node = node->child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
 				if (!node) {
 					return nullptr;
 				}
 
 				x <<= 1;
 				y <<= 1;
-			} while (!node->m_isLeaf);
+			} while (!node->leaf);
 			return static_cast<Leaf>(node);
 		}
 
 		QTreeLeafNode* createLeaf(uint32_t x, uint32_t y, uint32_t level);
 
 	protected:
-		QTreeNode* m_child[4];
+		QTreeNode* child[4];
 
-		bool m_isLeaf;
+		bool leaf;
 
 		friend class Map;
 };
@@ -146,7 +146,7 @@ class QTreeLeafNode final : public QTreeNode
 
 		Floor* createFloor(uint32_t z);
 		Floor* getFloor(uint8_t z) const {
-			return m_array[z];
+			return array[z];
 		}
 
 		void addCreature(Creature* c);
@@ -154,9 +154,9 @@ class QTreeLeafNode final : public QTreeNode
 
 	protected:
 		static bool newLeaf;
-		QTreeLeafNode* m_leafS;
-		QTreeLeafNode* m_leafE;
-		Floor* m_array[MAP_MAX_LAYERS];
+		QTreeLeafNode* leafS;
+		QTreeLeafNode* leafE;
+		Floor* array[MAP_MAX_LAYERS];
 		CreatureVector creature_list;
 		CreatureVector player_list;
 

--- a/src/movement.h
+++ b/src/movement.h
@@ -85,12 +85,12 @@ class MoveEvents final : public BaseEvents
 
 		MoveEvent* getEvent(Item* item, MoveEvent_t eventType, slots_t slot);
 
-		MoveListMap m_uniqueIdMap;
-		MoveListMap m_actionIdMap;
-		MoveListMap m_itemIdMap;
-		MovePosListMap m_positionMap;
+		MoveListMap uniqueIdMap;
+		MoveListMap actionIdMap;
+		MoveListMap itemIdMap;
+		MovePosListMap positionMap;
 
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 };
 
 typedef uint32_t (StepFunction)(Creature* creature, Item* item, const Position& pos, const Position& fromPos);
@@ -154,7 +154,7 @@ class MoveEvent final : public Event
 		static EquipFunction EquipItem;
 		static EquipFunction DeEquipItem;
 
-		MoveEvent_t m_eventType;
+		MoveEvent_t eventType;
 		StepFunction* stepFunction;
 		MoveFunction* moveFunction;
 		EquipFunction* equipFunction;

--- a/src/npc.h
+++ b/src/npc.h
@@ -68,7 +68,7 @@ class NpcScriptInterface final : public LuaScriptInterface
 		bool initState() final;
 		bool closeState() final;
 
-		bool m_libLoaded;
+		bool libLoaded;
 };
 
 class NpcEventsHandler
@@ -88,17 +88,17 @@ class NpcEventsHandler
 		bool isLoaded() const;
 
 	protected:
-		Npc* m_npc;
-		NpcScriptInterface* m_scriptInterface;
+		Npc* npc;
+		NpcScriptInterface* scriptInterface;
 
-		int32_t m_onCreatureAppear;
-		int32_t m_onCreatureDisappear;
-		int32_t m_onCreatureMove;
-		int32_t m_onCreatureSay;
-		int32_t m_onPlayerCloseChannel;
-		int32_t m_onPlayerEndTrade;
-		int32_t m_onThink;
-		bool m_loaded;
+		int32_t creatureAppear;
+		int32_t creatureDisappear;
+		int32_t creatureMove;
+		int32_t creatureSay;
+		int32_t playerCloseChannel;
+		int32_t playerEndTrade;
+		int32_t think;
+		bool loaded;
 };
 
 class Npc final : public Creature
@@ -218,14 +218,14 @@ class Npc final : public Creature
 		void removeShopPlayer(Player* player);
 		void closeAllShopWindows();
 
-		std::map<std::string, std::string> m_parameters;
+		std::map<std::string, std::string> parameters;
 
 		std::set<Player*> shopPlayerSet;
 
 		std::string name;
-		std::string m_filename;
+		std::string filename;
 
-		NpcEventsHandler* m_npcEventHandler;
+		NpcEventsHandler* npcEventHandler;
 
 		Position masterPos;
 
@@ -240,7 +240,7 @@ class Npc final : public Creature
 		bool ignoreHeight;
 		bool loaded;
 
-		static NpcScriptInterface* m_scriptInterface;
+		static NpcScriptInterface* scriptInterface;
 
 		friend class Npcs;
 		friend class NpcScriptInterface;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -27,19 +27,19 @@ extern RSA g_RSA;
 
 void Protocol::onSendMessage(const OutputMessage_ptr& msg) const
 {
-	if (!m_rawMessages) {
+	if (!rawMessages) {
 		msg->writeMessageLength();
 
-		if (m_encryptionEnabled) {
+		if (encryptionEnabled) {
 			XTEA_encrypt(*msg);
-			msg->addCryptoHeader(m_checksumEnabled);
+			msg->addCryptoHeader(checksumEnabled);
 		}
 	}
 }
 
 void Protocol::onRecvMessage(NetworkMessage& msg)
 {
-	if (m_encryptionEnabled && !XTEA_decrypt(msg)) {
+	if (encryptionEnabled && !XTEA_decrypt(msg)) {
 		return;
 	}
 
@@ -49,11 +49,11 @@ void Protocol::onRecvMessage(NetworkMessage& msg)
 OutputMessage_ptr Protocol::getOutputBuffer(int32_t size)
 {
 	//dispatcher thread
-	if (m_outputBuffer && NetworkMessage::MAX_PROTOCOL_BODY_LENGTH >= m_outputBuffer->getLength() + size) {
-		return m_outputBuffer;
+	if (outputBuffer && NetworkMessage::MAX_PROTOCOL_BODY_LENGTH >= outputBuffer->getLength() + size) {
+		return outputBuffer;
 	} else {
-		m_outputBuffer = OutputMessagePool::getOutputMessage();
-		return m_outputBuffer;
+		outputBuffer = OutputMessagePool::getOutputMessage();
+		return outputBuffer;
 	}
 }
 
@@ -70,7 +70,7 @@ void Protocol::XTEA_encrypt(OutputMessage& msg) const
 	uint8_t* buffer = msg.getOutputBuffer();
 	const size_t messageLength = msg.getLength();
 	size_t readPos = 0;
-	const uint32_t k[] = {m_key[0], m_key[1], m_key[2], m_key[3]};
+	const uint32_t k[] = {key[0], key[1], key[2], key[3]};
 	while (readPos < messageLength) {
 		uint32_t v0;
 		memcpy(&v0, buffer + readPos, 4);
@@ -103,7 +103,7 @@ bool Protocol::XTEA_decrypt(NetworkMessage& msg) const
 	uint8_t* buffer = msg.getBuffer() + msg.getBufferPosition();
 	const size_t messageLength = (msg.getLength() - 6);
 	size_t readPos = 0;
-	const uint32_t k[] = {m_key[0], m_key[1], m_key[2], m_key[3]};
+	const uint32_t k[] = {key[0], key[1], key[2], key[3]};
 	while (readPos < messageLength) {
 		uint32_t v0;
 		memcpy(&v0, buffer + readPos, 4);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -25,7 +25,7 @@
 class Protocol : public std::enable_shared_from_this<Protocol>
 {
 	public:
-		explicit Protocol(Connection_ptr connection) : m_connection(connection), m_key(), m_encryptionEnabled(false), m_checksumEnabled(true), m_rawMessages(false) {}
+		explicit Protocol(Connection_ptr connection) : connection(connection), key(), encryptionEnabled(false), checksumEnabled(true), rawMessages(false) {}
 		virtual ~Protocol() = default;
 
 		// non-copyable
@@ -40,11 +40,11 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		virtual void onConnect() {}
 
 		bool isConnectionExpired() const {
-			return m_connection.expired();
+			return connection.expired();
 		}
 
 		Connection_ptr getConnection() const {
-			return m_connection.lock();
+			return connection.lock();
 		}
 
 		uint32_t getIP() const;
@@ -53,7 +53,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		OutputMessage_ptr getOutputBuffer(int32_t size);
 
 		OutputMessage_ptr& getCurrentBuffer() {
-			return m_outputBuffer;
+			return outputBuffer;
 		}
 
 		void send(OutputMessage_ptr msg) const {
@@ -69,13 +69,13 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 			}
 		}
 		void enableXTEAEncryption() {
-			m_encryptionEnabled = true;
+			encryptionEnabled = true;
 		}
 		void setXTEAKey(const uint32_t* key) {
-			memcpy(m_key, key, sizeof(*key) * 4);
+			memcpy(this->key, key, sizeof(*key) * 4);
 		}
 		void disableChecksum() {
-			m_checksumEnabled = false;
+			checksumEnabled = false;
 		}
 
 		void XTEA_encrypt(OutputMessage& msg) const;
@@ -83,19 +83,19 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		static bool RSA_decrypt(NetworkMessage& msg);
 
 		void setRawMessages(bool value) {
-			m_rawMessages = value;
+			rawMessages = value;
 		}
 
 		virtual void release() {}
 		friend class Connection;
 
-		OutputMessage_ptr m_outputBuffer;
+		OutputMessage_ptr outputBuffer;
 	private:
-		const ConnectionWeak_ptr m_connection;
-		uint32_t m_key[4];
-		bool m_encryptionEnabled;
-		bool m_checksumEnabled;
-		bool m_rawMessages;
+		const ConnectionWeak_ptr connection;
+		uint32_t key[4];
+		bool encryptionEnabled;
+		bool checksumEnabled;
+		bool rawMessages;
 };
 
 #endif

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -45,11 +45,11 @@ ProtocolGame::ProtocolGame(Connection_ptr connection) :
 	Protocol(connection),
 	player(nullptr),
 	eventConnect(0),
-	m_challengeTimestamp(0),
+	challengeTimestamp(0),
 	version(CLIENT_VERSION_MIN),
-	m_challengeRandom(0),
-	m_debugAssertSent(false),
-	m_acceptPackets(false)
+	challengeRandom(0),
+	debugAssertSent(false),
+	acceptPackets(false)
 {
 	//
 }
@@ -158,7 +158,7 @@ void ProtocolGame::login(const std::string& name, uint32_t accountId, OperatingS
 
 		player->lastIP = player->getIP();
 		player->lastLoginSaved = std::max<time_t>(time(nullptr), player->lastLoginSaved + 1);
-		m_acceptPackets = true;
+		acceptPackets = true;
 	} else {
 		if (eventConnect != 0 || !g_config.getBoolean(ConfigManager::REPLACE_KICK_ON_LOGIN)) {
 			//Already trying to connect
@@ -206,7 +206,7 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	sendAddCreature(player, player->getPosition(), 0, false);
 	player->lastIP = player->getIP();
 	player->lastLoginSaved = std::max<time_t>(time(nullptr), player->lastLoginSaved + 1);
-	m_acceptPackets = true;
+	acceptPackets = true;
 }
 
 void ProtocolGame::logout(bool displayEffect, bool forced)
@@ -301,7 +301,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 
 	uint32_t timeStamp = msg.get<uint32_t>();
 	uint8_t randNumber = msg.getByte();
-	if (m_challengeTimestamp != timeStamp || m_challengeRandom != randNumber) {
+	if (challengeTimestamp != timeStamp || challengeRandom != randNumber) {
 		disconnect();
 		return;
 	}
@@ -357,11 +357,11 @@ void ProtocolGame::onConnect()
 	output->addByte(0x1F);
 
 	// Add timestamp & random number
-	m_challengeTimestamp = static_cast<uint32_t>(time(nullptr));
-	output->add<uint32_t>(m_challengeTimestamp);
+	challengeTimestamp = static_cast<uint32_t>(time(nullptr));
+	output->add<uint32_t>(challengeTimestamp);
 
-	m_challengeRandom = randNumber(generator);
-	output->addByte(m_challengeRandom);
+	challengeRandom = randNumber(generator);
+	output->addByte(challengeRandom);
 
 	// Go back and write checksum
 	output->skipBytes(-12);
@@ -387,7 +387,7 @@ void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg)
 
 void ProtocolGame::parsePacket(NetworkMessage& msg)
 {
-	if (!m_acceptPackets || g_game.getGameState() == GAME_STATE_SHUTDOWN || msg.getLength() <= 0) {
+	if (!acceptPackets || g_game.getGameState() == GAME_STATE_SHUTDOWN || msg.getLength() <= 0) {
 		return;
 	}
 
@@ -1017,11 +1017,11 @@ void ProtocolGame::parseBugReport(NetworkMessage& msg)
 
 void ProtocolGame::parseDebugAssert(NetworkMessage& msg)
 {
-	if (m_debugAssertSent) {
+	if (debugAssertSent) {
 		return;
 	}
 
-	m_debugAssertSent = true;
+	debugAssertSent = true;
 
 	std::string assertLine = msg.getString();
 	std::string date = msg.getString();

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -329,13 +329,13 @@ class ProtocolGame final : public Protocol
 		Player* player;
 
 		uint32_t eventConnect;
-		uint32_t m_challengeTimestamp;
+		uint32_t challengeTimestamp;
 		uint16_t version;
 
-		uint8_t m_challengeRandom;
+		uint8_t challengeRandom;
 
-		bool m_debugAssertSent;
-		bool m_acceptPackets;
+		bool debugAssertSent;
+		bool acceptPackets;
 };
 
 #endif

--- a/src/raids.cpp
+++ b/src/raids.cpp
@@ -585,15 +585,15 @@ std::string ScriptEvent::getScriptEventName() const
 bool ScriptEvent::executeEvent()
 {
 	//onRaid()
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - ScriptEvent::onRaid] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
-	return m_scriptInterface->callFunction(0);
+	return scriptInterface->callFunction(0);
 }

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -34,9 +34,9 @@ extern ConfigManager g_config;
 extern LuaEnvironment g_luaEnvironment;
 
 Spells::Spells():
-	m_scriptInterface("Spell Interface")
+	scriptInterface("Spell Interface")
 {
-	m_scriptInterface.initState();
+	scriptInterface.initState();
 }
 
 Spells::~Spells()
@@ -110,12 +110,12 @@ void Spells::clear()
 	}
 	instants.clear();
 
-	m_scriptInterface.reInitState();
+	scriptInterface.reInitState();
 }
 
 LuaScriptInterface& Spells::getScriptInterface()
 {
-	return m_scriptInterface;
+	return scriptInterface;
 }
 
 std::string Spells::getScriptBaseName() const
@@ -126,11 +126,11 @@ std::string Spells::getScriptBaseName() const
 Event* Spells::getEvent(const std::string& nodeName)
 {
 	if (strcasecmp(nodeName.c_str(), "rune") == 0) {
-		return new RuneSpell(&m_scriptInterface);
+		return new RuneSpell(&scriptInterface);
 	} else if (strcasecmp(nodeName.c_str(), "instant") == 0) {
-		return new InstantSpell(&m_scriptInterface);
+		return new InstantSpell(&scriptInterface);
 	} else if (strcasecmp(nodeName.c_str(), "conjure") == 0) {
-		return new ConjureSpell(&m_scriptInterface);
+		return new ConjureSpell(&scriptInterface);
 	}
 	return nullptr;
 }
@@ -275,20 +275,20 @@ CombatSpell::CombatSpell(Combat* _combat, bool _needTarget, bool _needDirection)
 
 CombatSpell::~CombatSpell()
 {
-	if (!m_scripted) {
+	if (!scripted) {
 		delete combat;
 	}
 }
 
 bool CombatSpell::loadScriptCombat()
 {
-	combat = g_luaEnvironment.getCombatObject(g_luaEnvironment.m_lastCombatId);
+	combat = g_luaEnvironment.getCombatObject(g_luaEnvironment.lastCombatId);
 	return combat != nullptr;
 }
 
 bool CombatSpell::castSpell(Creature* creature)
 {
-	if (m_scripted) {
+	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_POSITION;
 
@@ -314,7 +314,7 @@ bool CombatSpell::castSpell(Creature* creature)
 
 bool CombatSpell::castSpell(Creature* creature, Creature* target)
 {
-	if (m_scripted) {
+	if (scripted) {
 		LuaVariant var;
 
 		if (combat->hasArea()) {
@@ -349,24 +349,24 @@ bool CombatSpell::castSpell(Creature* creature, Creature* target)
 bool CombatSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 {
 	//onCastSpell(creature, var)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - CombatSpell::executeCastSpell] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushVariant(L, var);
 
-	return m_scriptInterface->callFunction(2);
+	return scriptInterface->callFunction(2);
 }
 
 Spell::Spell()
@@ -952,7 +952,7 @@ bool InstantSpell::loadFunction(const pugi::xml_attribute& attr)
 		return false;
 	}
 
-	m_scripted = false;
+	scripted = false;
 	return true;
 }
 
@@ -1148,7 +1148,7 @@ bool InstantSpell::castSpell(Creature* creature, Creature* target)
 
 bool InstantSpell::internalCastSpell(Creature* creature, const LuaVariant& var)
 {
-	if (m_scripted) {
+	if (scripted) {
 		return executeCastSpell(creature, var);
 	} else if (function) {
 		return function(this, creature, var.text);
@@ -1160,24 +1160,24 @@ bool InstantSpell::internalCastSpell(Creature* creature, const LuaVariant& var)
 bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 {
 	//onCastSpell(creature, var)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - InstantSpell::executeCastSpell] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushVariant(L, var);
 
-	return m_scriptInterface->callFunction(2);
+	return scriptInterface->callFunction(2);
 }
 
 House* InstantSpell::getHouseFromPos(Creature* creature)
@@ -1651,7 +1651,7 @@ bool ConjureSpell::configureEvent(const pugi::xml_node& node)
 
 bool ConjureSpell::loadFunction(const pugi::xml_attribute&)
 {
-	m_scripted = false;
+	scripted = false;
 	return true;
 }
 
@@ -1694,7 +1694,7 @@ bool ConjureSpell::playerCastInstant(Player* player, std::string& param)
 		return false;
 	}
 
-	if (m_scripted) {
+	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_STRING;
 		var.text = param;
@@ -1766,7 +1766,7 @@ bool RuneSpell::loadFunction(const pugi::xml_attribute& attr)
 		return false;
 	}
 
-	m_scripted = false;
+	scripted = false;
 	return true;
 }
 
@@ -1873,7 +1873,7 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	}
 
 	bool result = false;
-	if (m_scripted) {
+	if (scripted) {
 		LuaVariant var;
 
 		if (needTarget) {
@@ -1931,7 +1931,7 @@ bool RuneSpell::castSpell(Creature* creature, Creature* target)
 bool RuneSpell::internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey)
 {
 	bool result;
-	if (m_scripted) {
+	if (scripted) {
 		result = executeCastSpell(creature, var, isHotkey);
 	} else {
 		result = false;
@@ -1942,17 +1942,17 @@ bool RuneSpell::internalCastSpell(Creature* creature, const LuaVariant& var, boo
 bool RuneSpell::executeCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey)
 {
 	//onCastSpell(creature, var, isHotkey)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - RuneSpell::executeCastSpell] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
@@ -1961,5 +1961,5 @@ bool RuneSpell::executeCastSpell(Creature* creature, const LuaVariant& var, bool
 
 	LuaScriptInterface::pushBoolean(L, isHotkey);
 
-	return m_scriptInterface->callFunction(3);
+	return scriptInterface->callFunction(3);
 }

--- a/src/spells.h
+++ b/src/spells.h
@@ -68,7 +68,7 @@ class Spells final : public BaseEvents
 		std::map<std::string, InstantSpell*> instants;
 
 		friend class CombatSpell;
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 };
 
 typedef bool (InstantSpellFunction)(const InstantSpell* spell, Creature* creature, const std::string& param);

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -24,9 +24,9 @@
 #include "pugicast.h"
 
 TalkActions::TalkActions()
-	: m_scriptInterface("TalkAction Interface")
+	: scriptInterface("TalkAction Interface")
 {
-	m_scriptInterface.initState();
+	scriptInterface.initState();
 }
 
 TalkActions::~TalkActions()
@@ -41,12 +41,12 @@ void TalkActions::clear()
 	}
 	talkActions.clear();
 
-	m_scriptInterface.reInitState();
+	scriptInterface.reInitState();
 }
 
 LuaScriptInterface& TalkActions::getScriptInterface()
 {
-	return m_scriptInterface;
+	return scriptInterface;
 }
 
 std::string TalkActions::getScriptBaseName() const
@@ -59,7 +59,7 @@ Event* TalkActions::getEvent(const std::string& nodeName)
 	if (strcasecmp(nodeName.c_str(), "talkaction") != 0) {
 		return nullptr;
 	}
-	return new TalkAction(&m_scriptInterface);
+	return new TalkAction(&scriptInterface);
 }
 
 bool TalkActions::registerEvent(Event* event, const pugi::xml_node&)
@@ -138,17 +138,17 @@ std::string TalkAction::getScriptEventName() const
 bool TalkAction::executeSay(Player* player, const std::string& param, SpeakClasses type) const
 {
 	//onSay(player, words, param, type)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - TalkAction::executeSay] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -157,5 +157,5 @@ bool TalkAction::executeSay(Player* player, const std::string& param, SpeakClass
 	LuaScriptInterface::pushString(L, param);
 	lua_pushnumber(L, type);
 
-	return m_scriptInterface->callFunction(4);
+	return scriptInterface->callFunction(4);
 }

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -54,7 +54,7 @@ class TalkActions : public BaseEvents
 		// TODO: Store TalkAction objects directly in the list instead of using pointers
 		std::forward_list<TalkAction*> talkActions;
 
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 };
 
 class TalkAction : public Event

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -31,9 +31,9 @@ extern ConfigManager g_config;
 extern Weapons* g_weapons;
 
 Weapons::Weapons():
-	m_scriptInterface("Weapon Interface")
+	scriptInterface("Weapon Interface")
 {
-	m_scriptInterface.initState();
+	scriptInterface.initState();
 }
 
 Weapons::~Weapons()
@@ -61,12 +61,12 @@ void Weapons::clear()
 	}
 	weapons.clear();
 
-	m_scriptInterface.reInitState();
+	scriptInterface.reInitState();
 }
 
 LuaScriptInterface& Weapons::getScriptInterface()
 {
-	return m_scriptInterface;
+	return scriptInterface;
 }
 
 std::string Weapons::getScriptBaseName() const
@@ -86,7 +86,7 @@ void Weapons::loadDefaults()
 			case WEAPON_AXE:
 			case WEAPON_SWORD:
 			case WEAPON_CLUB: {
-				WeaponMelee* weapon = new WeaponMelee(&m_scriptInterface);
+				WeaponMelee* weapon = new WeaponMelee(&scriptInterface);
 				weapon->configureWeapon(it);
 				weapons[i] = weapon;
 				break;
@@ -98,7 +98,7 @@ void Weapons::loadDefaults()
 					continue;
 				}
 
-				WeaponDistance* weapon = new WeaponDistance(&m_scriptInterface);
+				WeaponDistance* weapon = new WeaponDistance(&scriptInterface);
 				weapon->configureWeapon(it);
 				weapons[i] = weapon;
 				break;
@@ -113,11 +113,11 @@ void Weapons::loadDefaults()
 Event* Weapons::getEvent(const std::string& nodeName)
 {
 	if (strcasecmp(nodeName.c_str(), "melee") == 0) {
-		return new WeaponMelee(&m_scriptInterface);
+		return new WeaponMelee(&scriptInterface);
 	} else if (strcasecmp(nodeName.c_str(), "distance") == 0) {
-		return new WeaponDistance(&m_scriptInterface);
+		return new WeaponDistance(&scriptInterface);
 	} else if (strcasecmp(nodeName.c_str(), "wand") == 0) {
-		return new WeaponWand(&m_scriptInterface);
+		return new WeaponWand(&scriptInterface);
 	}
 	return nullptr;
 }
@@ -148,7 +148,7 @@ int32_t Weapons::getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t
 Weapon::Weapon(LuaScriptInterface* _interface) :
 	Event(_interface)
 {
-	m_scripted = false;
+	scripted = false;
 	id = 0;
 	level = 0;
 	magLevel = 0;
@@ -380,7 +380,7 @@ bool Weapon::useFist(Player* player, Creature* target)
 
 void Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int32_t damageModifier) const
 {
-	if (m_scripted) {
+	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_NUMBER;
 		var.number = target->getID();
@@ -405,7 +405,7 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int
 
 void Weapon::internalUseWeapon(Player* player, Item* item, Tile* tile) const
 {
-	if (m_scripted) {
+	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_TARGETPOSITION;
 		var.pos = tile->getPosition();
@@ -481,22 +481,22 @@ uint32_t Weapon::getManaCost(const Player* player) const
 bool Weapon::executeUseWeapon(Player* player, const LuaVariant& var) const
 {
 	//onUseWeapon(player, var)
-	if (!m_scriptInterface->reserveScriptEnv()) {
+	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - Weapon::executeUseWeapon] Call stack overflow" << std::endl;
 		return false;
 	}
 
-	ScriptEnvironment* env = m_scriptInterface->getScriptEnv();
-	env->setScriptId(m_scriptId, m_scriptInterface);
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
 
-	lua_State* L = m_scriptInterface->getLuaState();
+	lua_State* L = scriptInterface->getLuaState();
 
-	m_scriptInterface->pushFunction(m_scriptId);
+	scriptInterface->pushFunction(scriptId);
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
-	m_scriptInterface->pushVariant(L, var);
+	scriptInterface->pushVariant(L, var);
 
-	return m_scriptInterface->callFunction(2);
+	return scriptInterface->callFunction(2);
 }
 
 void Weapon::decrementItemCount(Item* item)

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -56,7 +56,7 @@ class Weapons final : public BaseEvents
 
 		std::map<uint32_t, Weapon*> weapons;
 
-		LuaScriptInterface m_scriptInterface;
+		LuaScriptInterface scriptInterface;
 };
 
 class Weapon : public Event


### PR DESCRIPTION
**Renamed** data members that have the prefix ``m_``.
**Use** ``this->`` whenever necessary.

Besides removing the **"m_"** prefix from some some data members in **npc** I also had to remove *(because member-functions and data members having the same name would conflict)* the **on** prefix -- i.e. ``m_onCreatureAppear`` to ``creatureAppear`` -- otherwise, VS 2015 would give the following errors:
* *declaration is incompatible with "int32_t NpcEventsHandler::onCreatureAppear".*
* *expression preceding parentheses of apparent call must have (pointer-to-) function type.*
* *member "NpcEventsHandler::onCreatureAppear" is inaccessible.*

Additionally, I had to rename data members ``isLeaf`` to ``leaf`` and ``isLoaded`` to ``loaded`` *(I'm not sure if in this case, the clarity of the code is compromised)* for the same reasons.

**This is something that is on the [Roadmap for 1.2] (https://github.com/otland/forgottenserver/wiki/Roadmap-1.2).**