### PR TITLE
New default value for the spread attribute

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -383,7 +383,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 		if ((attr = node.attribute("length"))) {
 			int32_t length = pugi::cast<int32_t>(attr.value());
 			if (length > 0) {
-				int32_t spread = 3;
+				int32_t spread = 0;
 
 				//need direction spell
 				if ((attr = node.attribute("spread"))) {


### PR DESCRIPTION
Changed the default value of the spread attribute to 0 (zero).
Therefore, this will avoid inumerous unnecessary occurences of (spread="0") across monster files.

Currently, there are 126 occurences of(spread="0") across 107 files.