### PR TITLE
Fix effect for not attackable creatures

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3872,7 +3872,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 	} else {
 		if (!target->isAttackable()) {
 			if (!target->isInGhostMode()) {
-				addMagicEffect(targetPos, CONST_ME_POFF);
+				addMagicEffect(targetPos, CONST_ME_BLOCKHIT);
 			}
 			return true;
 		}


### PR DESCRIPTION
This ensures the correct block type effect is used - when a  creature is
not attackable -- i.e. Lava Hole - otherwise we see two different block type effects
"CONST_ME_POFF" and "CONST_ME_BLOCKHIT" at the same time.

This is something I didn't notice in #1655 .
