### PR TITLE
Fix cooldown of spell Curse

### DIFF
--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -79,7 +79,7 @@
 		<vocation name="Royal Paladin" />
 		<vocation name="Elite Knight" />
 	</instant>
-	<instant group="attack" spellid="139" name="Curse" words="utori mort" lvl="75" mana="30" range="3" casterTargetOrDirection="1" aggressive="1" blockwalls="1" cooldown="50000" groupcooldown="2000" needlearn="0" script="attack/curse.lua">
+	<instant group="attack" spellid="139" name="Curse" words="utori mort" lvl="75" mana="30" range="3" casterTargetOrDirection="1" aggressive="1" blockwalls="1" cooldown="40000" groupcooldown="2000" needlearn="0" script="attack/curse.lua">
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>


### PR DESCRIPTION
Vanilla's site has incorrect information about the cooldown for this spell.

![compare_spell_cooldown](https://cloud.githubusercontent.com/assets/6445979/14231160/c30ee98e-f925-11e5-8627-c9180556e915.png)
