### PR TITLE
Remove most of underscore names

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -410,23 +410,11 @@ void Actions::showUseHotkeyMessage(Player* player, const Item* item, uint32_t co
 	player->sendTextMessage(MESSAGE_INFO_DESCR, ss.str());
 }
 
-Action::Action(LuaScriptInterface* _interface) :
-	Event(_interface)
-{
-	allowFarUse = false;
-	checkFloor = true;
-	checkLineOfSight = true;
-	function = nullptr;
-}
+Action::Action(LuaScriptInterface* interface) :
+	Event(interface), function(nullptr), allowFarUse(false), checkFloor(true), checkLineOfSight(true) {}
 
 Action::Action(const Action* copy) :
-	Event(copy)
-{
-	allowFarUse = copy->allowFarUse;
-	checkFloor = copy->checkFloor;
-	checkLineOfSight = copy->checkLineOfSight;
-	function = copy->function;
-}
+	Event(copy), function(copy->function), allowFarUse(copy->allowFarUse), checkFloor(copy->checkFloor), checkLineOfSight(copy->checkLineOfSight) {}
 
 bool Action::configureEvent(const pugi::xml_node& node)
 {

--- a/src/actions.h
+++ b/src/actions.h
@@ -30,7 +30,7 @@ class Action : public Event
 {
 	public:
 		explicit Action(const Action* copy);
-		explicit Action(LuaScriptInterface* _interface);
+		explicit Action(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) override;
 		bool loadFunction(const pugi::xml_attribute& attr) override;

--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -91,19 +91,11 @@ bool BaseEvents::reload()
 	return loadFromXml();
 }
 
-Event::Event(LuaScriptInterface* _interface)
-{
-	scriptInterface = _interface;
-	scriptId = 0;
-	scripted = false;
-}
+Event::Event(LuaScriptInterface* interface) :
+	scripted(false), scriptId(0), scriptInterface(interface) {}
 
-Event::Event(const Event* copy)
-{
-	scriptInterface = copy->scriptInterface;
-	scriptId = copy->scriptId;
-	scripted = copy->scripted;
-}
+Event::Event(const Event* copy) :
+	scripted(copy->scripted), scriptId(copy->scriptId), scriptInterface(copy->scriptInterface) {}
 
 bool Event::checkScript(const std::string& basePath, const std::string& scriptsName, const std::string& scriptFile) const
 {
@@ -164,14 +156,14 @@ CallBack::CallBack()
 	loaded = false;
 }
 
-bool CallBack::loadCallBack(LuaScriptInterface* _interface, const std::string& name)
+bool CallBack::loadCallBack(LuaScriptInterface* interface, const std::string& name)
 {
-	if (!_interface) {
+	if (!interface) {
 		std::cout << "Failure: [CallBack::loadCallBack] scriptInterface == nullptr" << std::endl;
 		return false;
 	}
 
-	scriptInterface = _interface;
+	scriptInterface = interface;
 
 	int32_t id = scriptInterface->getEvent(name.c_str());
 	if (id == -1) {

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -25,7 +25,7 @@
 class Event
 {
 	public:
-		explicit Event(LuaScriptInterface* _interface);
+		explicit Event(LuaScriptInterface* interface);
 		explicit Event(const Event* copy);
 		virtual ~Event() = default;
 
@@ -76,7 +76,7 @@ class CallBack
 	public:
 		CallBack();
 
-		bool loadCallBack(LuaScriptInterface* _interface, const std::string& name);
+		bool loadCallBack(LuaScriptInterface* interface, const std::string& name);
 
 	protected:
 		int32_t scriptId;

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -26,7 +26,7 @@
 
 extern Game g_game;
 
-BedItem::BedItem(uint16_t _id) : Item(_id)
+BedItem::BedItem(uint16_t id) : Item(id)
 {
 	house = nullptr;
 	internalRemoveSleeper();
@@ -185,10 +185,10 @@ void BedItem::wakeUp(Player* player)
 
 	if (sleeperGUID != 0) {
 		if (!player) {
-			Player _player(nullptr);
-			if (IOLoginData::loadPlayerById(&_player, sleeperGUID)) {
-				regeneratePlayer(&_player);
-				IOLoginData::savePlayer(&_player);
+			Player regenPlayer(nullptr);
+			if (IOLoginData::loadPlayerById(&regenPlayer, sleeperGUID)) {
+				regeneratePlayer(&regenPlayer);
+				IOLoginData::savePlayer(&regenPlayer);
 			}
 		} else {
 			regeneratePlayer(player);

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -380,13 +380,13 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 	return g_events->eventCreatureOnTargetCombat(attacker, target);
 }
 
-void Combat::setPlayerCombatValues(formulaType_t _type, double _mina, double _minb, double _maxa, double _maxb)
+void Combat::setPlayerCombatValues(formulaType_t formulaType, double mina, double minb, double maxa, double maxb)
 {
-	formulaType = _type;
-	mina = _mina;
-	minb = _minb;
-	maxa = _maxa;
-	maxb = _maxb;
+	this->formulaType = formulaType;
+	this->mina = mina;
+	this->minb = minb;
+	this->maxa = maxa;
+	this->maxb = maxb;
 }
 
 bool Combat::setParam(CombatParam_t param, uint32_t value)

--- a/src/combat.h
+++ b/src/combat.h
@@ -35,9 +35,7 @@ struct Position;
 class ValueCallback final : public CallBack
 {
 	public:
-		explicit ValueCallback(formulaType_t _type) {
-			type = _type;
-		}
+		explicit ValueCallback(formulaType_t type): type(type) {}
 		void getMinMaxValues(Player* player, CombatDamage& damage, bool useCharges) const;
 
 	protected:
@@ -106,12 +104,12 @@ typedef void (*COMBATFUNC)(Creature*, Creature*, const CombatParams&, CombatDama
 class MatrixArea
 {
 	public:
-		MatrixArea(uint32_t _rows, uint32_t _cols) {
+		MatrixArea(uint32_t rows, uint32_t cols) {
 			centerX = 0;
 			centerY = 0;
 
-			rows = _rows;
-			cols = _cols;
+			this->rows = rows;
+			this->cols = cols;
 
 			data_ = new bool*[rows];
 
@@ -316,7 +314,7 @@ class Combat
 		void setCondition(const Condition* condition) {
 			params.conditionList.emplace_front(condition);
 		}
-		void setPlayerCombatValues(formulaType_t _type, double _mina, double _minb, double _maxa, double _maxb);
+		void setPlayerCombatValues(formulaType_t formulaType, double mina, double minb, double maxa, double maxb);
 		void postCombatEffects(Creature* caster, const Position& pos) const {
 			postCombatEffects(caster, pos, params);
 		}
@@ -355,7 +353,7 @@ class Combat
 class MagicField final : public Item
 {
 	public:
-		explicit MagicField(uint16_t _type) : Item(_type) {
+		explicit MagicField(uint16_t type) : Item(type) {
 			createTime = OTSYS_TIME();
 		}
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -24,19 +24,14 @@
 
 extern Game g_game;
 
-Condition::Condition(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	subId(_subId),
-	ticks(_ticks),
-	conditionType(_type),
-	id(_id),
-	isBuff(_buff)
-{
-	if (_ticks == -1) {
-		endTime = std::numeric_limits<int64_t>::max();
-	} else {
-		endTime = 0;
-	}
-}
+Condition::Condition(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	endTime(ticks == -1 ? std::numeric_limits<int64_t>::max() : 0),
+	subId(subId),
+	ticks(ticks),
+	conditionType(type),
+	id(id),
+	isBuff(buff)
+{}
 
 bool Condition::setParam(ConditionParam_t param, int32_t value)
 {
@@ -157,9 +152,9 @@ bool Condition::executeCondition(Creature*, int32_t interval)
 	return getEndTime() >= OTSYS_TIME();
 }
 
-Condition* Condition::createCondition(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, int32_t param/* = 0*/, bool _buff/* = false*/, uint32_t _subId/* = 0*/)
+Condition* Condition::createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param/* = 0*/, bool buff/* = false*/, uint32_t subId/* = 0*/)
 {
-	switch (_type) {
+	switch (type) {
 		case CONDITION_POISON:
 		case CONDITION_FIRE:
 		case CONDITION_ENERGY:
@@ -168,35 +163,35 @@ Condition* Condition::createCondition(ConditionId_t _id, ConditionType_t _type, 
 		case CONDITION_DAZZLED:
 		case CONDITION_CURSED:
 		case CONDITION_BLEEDING:
-			return new ConditionDamage(_id, _type, _buff, _subId);
+			return new ConditionDamage(id, type, buff, subId);
 
 		case CONDITION_HASTE:
 		case CONDITION_PARALYZE:
-			return new ConditionSpeed(_id, _type, _ticks, _buff, _subId, param);
+			return new ConditionSpeed(id, type, ticks, buff, subId, param);
 
 		case CONDITION_INVISIBLE:
-			return new ConditionInvisible(_id, _type, _ticks, _buff, _subId);
+			return new ConditionInvisible(id, type, ticks, buff, subId);
 
 		case CONDITION_OUTFIT:
-			return new ConditionOutfit(_id, _type, _ticks, _buff, _subId);
+			return new ConditionOutfit(id, type, ticks, buff, subId);
 
 		case CONDITION_LIGHT:
-			return new ConditionLight(_id, _type, _ticks, _buff, _subId, param & 0xFF, (param & 0xFF00) >> 8);
+			return new ConditionLight(id, type, ticks, buff, subId, param & 0xFF, (param & 0xFF00) >> 8);
 
 		case CONDITION_REGENERATION:
-			return new ConditionRegeneration(_id, _type, _ticks, _buff, _subId);
+			return new ConditionRegeneration(id, type, ticks, buff, subId);
 
 		case CONDITION_SOUL:
-			return new ConditionSoul(_id, _type, _ticks, _buff, _subId);
+			return new ConditionSoul(id, type, ticks, buff, subId);
 
 		case CONDITION_ATTRIBUTES:
-			return new ConditionAttributes(_id, _type, _ticks, _buff, _subId);
+			return new ConditionAttributes(id, type, ticks, buff, subId);
 
 		case CONDITION_SPELLCOOLDOWN:
-			return new ConditionSpellCooldown(_id, _type, _ticks, _buff, _subId);
+			return new ConditionSpellCooldown(id, type, ticks, buff, subId);
 
 		case CONDITION_SPELLGROUPCOOLDOWN:
-			return new ConditionSpellGroupCooldown(_id, _type, _ticks, _buff, _subId);
+			return new ConditionSpellGroupCooldown(id, type, ticks, buff, subId);
 
 		case CONDITION_INFIGHT:
 		case CONDITION_DRUNK:
@@ -208,7 +203,7 @@ Condition* Condition::createCondition(ConditionId_t _id, ConditionType_t _type, 
 		case CONDITION_YELLTICKS:
 		case CONDITION_PACIFIED:
 		case CONDITION_MANASHIELD:
-			return new ConditionGeneric(_id, _type, _ticks, _buff, _subId);
+			return new ConditionGeneric(id, type, ticks, buff, subId);
 
 		default:
 			return nullptr;
@@ -222,8 +217,8 @@ Condition* Condition::createCondition(PropStream& propStream)
 		return nullptr;
 	}
 
-	uint32_t _type;
-	if (!propStream.read<uint32_t>(_type)) {
+	uint32_t type;
+	if (!propStream.read<uint32_t>(type)) {
 		return nullptr;
 	}
 
@@ -231,8 +226,8 @@ Condition* Condition::createCondition(PropStream& propStream)
 		return nullptr;
 	}
 
-	uint32_t _id;
-	if (!propStream.read<uint32_t>(_id)) {
+	uint32_t id;
+	if (!propStream.read<uint32_t>(id)) {
 		return nullptr;
 	}
 
@@ -240,8 +235,8 @@ Condition* Condition::createCondition(PropStream& propStream)
 		return nullptr;
 	}
 
-	uint32_t _ticks;
-	if (!propStream.read<uint32_t>(_ticks)) {
+	uint32_t ticks;
+	if (!propStream.read<uint32_t>(ticks)) {
 		return nullptr;
 	}
 
@@ -249,8 +244,8 @@ Condition* Condition::createCondition(PropStream& propStream)
 		return nullptr;
 	}
 
-	uint8_t _buff;
-	if (!propStream.read<uint8_t>(_buff)) {
+	uint8_t buff;
+	if (!propStream.read<uint8_t>(buff)) {
 		return nullptr;
 	}
 
@@ -258,12 +253,12 @@ Condition* Condition::createCondition(PropStream& propStream)
 		return nullptr;
 	}
 
-	uint32_t _subId;
-	if (!propStream.read<uint32_t>(_subId)) {
+	uint32_t subId;
+	if (!propStream.read<uint32_t>(subId)) {
 		return nullptr;
 	}
 
-	return createCondition(static_cast<ConditionId_t>(_id), static_cast<ConditionType_t>(_type), _ticks, 0, _buff != 0, _subId);
+	return createCondition(static_cast<ConditionId_t>(id), static_cast<ConditionType_t>(type), ticks, 0, buff != 0, subId);
 }
 
 bool Condition::startCondition(Creature*)
@@ -309,11 +304,8 @@ bool Condition::updateCondition(const Condition* addCondition)
 	return true;
 }
 
-ConditionGeneric::ConditionGeneric(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	Condition(_id, _type, _ticks, _buff, _subId)
-{
-	//
-}
+ConditionGeneric::ConditionGeneric(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	Condition(id, type, ticks, buff, subId) {}
 
 bool ConditionGeneric::startCondition(Creature* creature)
 {
@@ -361,12 +353,15 @@ uint32_t ConditionGeneric::getIcons() const
 	return icons;
 }
 
-ConditionAttributes::ConditionAttributes(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-ConditionGeneric(_id, _type, _ticks, _buff, _subId), skills(), skillsPercent(), stats(), statsPercent()
-{
-	currentSkill = 0;
-	currentStat = 0;
-}
+ConditionAttributes::ConditionAttributes(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	ConditionGeneric(id, type, ticks, buff, subId),
+	skills(),
+	skillsPercent(),
+	stats(),
+	statsPercent(),
+	currentSkill(0),
+	currentStat(0)
+{}
 
 void ConditionAttributes::addCondition(Creature* creature, const Condition* addCondition)
 {
@@ -661,18 +656,15 @@ bool ConditionAttributes::setParam(ConditionParam_t param, int32_t value)
 	}
 }
 
-ConditionRegeneration::ConditionRegeneration(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	ConditionGeneric(_id, _type, _ticks, _buff, _subId)
-{
-	internalHealthTicks = 0;
-	internalManaTicks = 0;
-
-	healthTicks = 1000;
-	manaTicks = 1000;
-
-	healthGain = 0;
-	manaGain = 0;
-}
+ConditionRegeneration::ConditionRegeneration(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	ConditionGeneric(id, type, ticks, buff, subId),
+	internalHealthTicks(0),
+	internalManaTicks(0),
+	healthTicks(1000),
+	manaTicks(1000),
+	healthGain(0),
+	manaGain(0)
+{}
 
 void ConditionRegeneration::addCondition(Creature*, const Condition* addCondition)
 {
@@ -793,13 +785,12 @@ bool ConditionRegeneration::setParam(ConditionParam_t param, int32_t value)
 	}
 }
 
-ConditionSoul::ConditionSoul(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	ConditionGeneric(_id, _type, _ticks, _buff, _subId)
-{
-	internalSoulTicks = 0;
-	soulTicks = 0;
-	soulGain = 0;
-}
+ConditionSoul::ConditionSoul(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	ConditionGeneric(id, type, ticks, buff, subId),
+	internalSoulTicks(0),
+	soulTicks(0),
+	soulGain(0)
+{}
 
 void ConditionSoul::addCondition(Creature*, const Condition* addCondition)
 {
@@ -867,20 +858,19 @@ bool ConditionSoul::setParam(ConditionParam_t param, int32_t value)
 	}
 }
 
-ConditionDamage::ConditionDamage(ConditionId_t _id, ConditionType_t _type, bool _buff, uint32_t _subId) :
-	Condition(_id, _type, 0, _buff, _subId)
-{
-	delayed = false;
-	forceUpdate = false;
-	field = false;
-	owner = 0;
-	minDamage = 0;
-	maxDamage = 0;
-	startDamage = 0;
-	periodDamage = 0;
-	periodDamageTick = 0;
-	tickInterval = 2000;
-}
+ConditionDamage::ConditionDamage(ConditionId_t id, ConditionType_t type, bool buff, uint32_t subId) :
+	Condition(id, type, 0, buff, subId),
+	maxDamage(0),
+	minDamage(0),
+	startDamage(0),
+	periodDamage(0),
+	periodDamageTick(0),
+	tickInterval(2000),
+	forceUpdate(false),
+	delayed(false),
+	field(false),
+	owner(0)
+{}
 
 bool ConditionDamage::setParam(ConditionParam_t param, int32_t value)
 {
@@ -1275,22 +1265,21 @@ void ConditionDamage::generateDamageList(int32_t amount, int32_t start, std::lis
 	}
 }
 
-ConditionSpeed::ConditionSpeed(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId, int32_t changeSpeed) :
-	Condition(_id, _type, _ticks, _buff, _subId)
-{
-	speedDelta = changeSpeed;
-	mina = 0.0f;
-	minb = 0.0f;
-	maxa = 0.0f;
-	maxb = 0.0f;
-}
+ConditionSpeed::ConditionSpeed(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, int32_t changeSpeed) :
+	Condition(id, type, ticks, buff, subId),
+	speedDelta(changeSpeed),
+	mina(0.0f),
+	minb(0.0f),
+	maxa(0.0f),
+	maxb(0.0f)
+{}
 
-void ConditionSpeed::setFormulaVars(float _mina, float _minb, float _maxa, float _maxb)
+void ConditionSpeed::setFormulaVars(float mina, float minb, float maxa, float maxb)
 {
-	mina = _mina;
-	minb = _minb;
-	maxa = _maxa;
-	maxb = _maxb;
+	this->mina = mina;
+	this->minb = minb;
+	this->maxa = maxa;
+	this->maxb = maxb;
 }
 
 void ConditionSpeed::getFormulaValues(int32_t var, int32_t& min, int32_t& max) const
@@ -1429,11 +1418,8 @@ uint32_t ConditionSpeed::getIcons() const
 	return icons;
 }
 
-ConditionInvisible::ConditionInvisible(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	ConditionGeneric(_id, _type, _ticks, _buff, _subId)
-{
-	//
-}
+ConditionInvisible::ConditionInvisible(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	ConditionGeneric(id, type, ticks, buff, subId) {}
 
 bool ConditionInvisible::startCondition(Creature* creature)
 {
@@ -1452,11 +1438,8 @@ void ConditionInvisible::endCondition(Creature* creature)
 	}
 }
 
-ConditionOutfit::ConditionOutfit(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	Condition(_id, _type, _ticks, _buff, _subId)
-{
-	//
-}
+ConditionOutfit::ConditionOutfit(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	Condition(id, type, ticks, buff, subId) {}
 
 void ConditionOutfit::setOutfit(const Outfit_t& outfit)
 {
@@ -1511,14 +1494,12 @@ void ConditionOutfit::addCondition(Creature* creature, const Condition* addCondi
 	}
 }
 
-ConditionLight::ConditionLight(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId, uint8_t _lightlevel, uint8_t _lightcolor) :
-	Condition(_id, _type, _ticks, _buff, _subId)
-{
-	lightInfo.level = _lightlevel;
-	lightInfo.color = _lightcolor;
-	internalLightTicks = 0;
-	lightChangeInterval = 0;
-}
+ConditionLight::ConditionLight(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, uint8_t lightlevel, uint8_t lightcolor) :
+	Condition(id, type, ticks, buff, subId),
+	lightInfo(lightlevel, lightcolor),
+	internalLightTicks(0),
+	lightChangeInterval(0)
+{}
 
 bool ConditionLight::startCondition(Creature* creature)
 {
@@ -1640,11 +1621,8 @@ void ConditionLight::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<uint32_t>(lightChangeInterval);
 }
 
-ConditionSpellCooldown::ConditionSpellCooldown(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	ConditionGeneric(_id, _type, _ticks, _buff, _subId)
-{
-	//
-}
+ConditionSpellCooldown::ConditionSpellCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	ConditionGeneric(id, type, ticks, buff, subId) {}
 
 void ConditionSpellCooldown::addCondition(Creature* creature, const Condition* addCondition)
 {
@@ -1675,11 +1653,8 @@ bool ConditionSpellCooldown::startCondition(Creature* creature)
 	return true;
 }
 
-ConditionSpellGroupCooldown::ConditionSpellGroupCooldown(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId) :
-	ConditionGeneric(_id, _type, _ticks, _buff, _subId)
-{
-	//
-}
+ConditionSpellGroupCooldown::ConditionSpellGroupCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
+	ConditionGeneric(id, type, ticks, buff, subId) {}
 
 void ConditionSpellGroupCooldown::addCondition(Creature* creature, const Condition* addCondition)
 {

--- a/src/condition.h
+++ b/src/condition.h
@@ -70,7 +70,7 @@ class Condition
 {
 	public:
 		Condition() = default;
-		Condition(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		Condition(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 		virtual ~Condition() = default;
 
 		virtual bool startCondition(Creature* creature);
@@ -98,7 +98,7 @@ class Condition
 		}
 		void setTicks(int32_t newTicks);
 
-		static Condition* createCondition(ConditionId_t _id, ConditionType_t _type, int32_t ticks, int32_t param = 0, bool _buff = false, uint32_t _subId = 0);
+		static Condition* createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param = 0, bool buff = false, uint32_t subId = 0);
 		static Condition* createCondition(PropStream& propStream);
 
 		virtual bool setParam(ConditionParam_t param, int32_t value);
@@ -124,7 +124,7 @@ class Condition
 class ConditionGeneric : public Condition
 {
 	public:
-		ConditionGeneric(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionGeneric(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		bool startCondition(Creature* creature) override;
 		bool executeCondition(Creature* creature, int32_t interval) override;
@@ -140,7 +140,7 @@ class ConditionGeneric : public Condition
 class ConditionAttributes final : public ConditionGeneric
 {
 	public:
-		ConditionAttributes(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionAttributes(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -174,7 +174,7 @@ class ConditionAttributes final : public ConditionGeneric
 class ConditionRegeneration final : public ConditionGeneric
 {
 	public:
-		ConditionRegeneration(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionRegeneration(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		void addCondition(Creature* creature, const Condition* addCondition) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -202,7 +202,7 @@ class ConditionRegeneration final : public ConditionGeneric
 class ConditionSoul final : public ConditionGeneric
 {
 	public:
-		ConditionSoul(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionSoul(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		void addCondition(Creature* creature, const Condition* addCondition) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -226,7 +226,7 @@ class ConditionSoul final : public ConditionGeneric
 class ConditionInvisible final : public ConditionGeneric
 {
 	public:
-		ConditionInvisible(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionInvisible(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		bool startCondition(Creature* creature) final;
 		void endCondition(Creature* creature) final;
@@ -240,7 +240,7 @@ class ConditionDamage final : public Condition
 {
 	public:
 		ConditionDamage() = default;
-		ConditionDamage(ConditionId_t _id, ConditionType_t _type, bool _buff = false, uint32_t _subId = 0);
+		ConditionDamage(ConditionId_t id, ConditionType_t type, bool buff = false, uint32_t subId = 0);
 
 		static void generateDamageList(int32_t amount, int32_t start, std::list<int32_t>& list);
 
@@ -292,7 +292,7 @@ class ConditionDamage final : public Condition
 class ConditionSpeed final : public Condition
 {
 	public:
-		ConditionSpeed(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId, int32_t changeSpeed);
+		ConditionSpeed(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, int32_t changeSpeed);
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -306,7 +306,7 @@ class ConditionSpeed final : public Condition
 
 		bool setParam(ConditionParam_t param, int32_t value) final;
 
-		void setFormulaVars(float _mina, float _minb, float _maxa, float _maxb);
+		void setFormulaVars(float mina, float minb, float maxa, float maxb);
 
 		//serialization
 		void serialize(PropWriteStream& propWriteStream) final;
@@ -327,7 +327,7 @@ class ConditionSpeed final : public Condition
 class ConditionOutfit final : public Condition
 {
 	public:
-		ConditionOutfit(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionOutfit(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -353,7 +353,7 @@ class ConditionOutfit final : public Condition
 class ConditionLight final : public Condition
 {
 	public:
-		ConditionLight(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff, uint32_t _subId, uint8_t _lightlevel, uint8_t _lightcolor);
+		ConditionLight(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, uint8_t lightlevel, uint8_t lightcolor);
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -379,7 +379,7 @@ class ConditionLight final : public Condition
 class ConditionSpellCooldown final : public ConditionGeneric
 {
 	public:
-		ConditionSpellCooldown(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionSpellCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		bool startCondition(Creature* creature) final;
 		void addCondition(Creature* creature, const Condition* condition) final;
@@ -392,7 +392,7 @@ class ConditionSpellCooldown final : public ConditionGeneric
 class ConditionSpellGroupCooldown final : public ConditionGeneric
 {
 	public:
-		ConditionSpellGroupCooldown(ConditionId_t _id, ConditionType_t _type, int32_t _ticks, bool _buff = false, uint32_t _subId = 0);
+		ConditionSpellGroupCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
 
 		bool startCondition(Creature* creature) final;
 		void addCondition(Creature* creature, const Condition* condition) final;

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -138,38 +138,38 @@ bool ConfigManager::reload()
 	return result;
 }
 
-const std::string& ConfigManager::getString(string_config_t _what) const
+const std::string& ConfigManager::getString(string_config_t what) const
 {
-	if (_what >= LAST_STRING_CONFIG) {
-		std::cout << "[Warning - ConfigManager::getString] Accessing invalid index: " << _what << std::endl;
+	if (what >= LAST_STRING_CONFIG) {
+		std::cout << "[Warning - ConfigManager::getString] Accessing invalid index: " << what << std::endl;
 		return string[DUMMY_STR];
 	}
-	return string[_what];
+	return string[what];
 }
 
-int32_t ConfigManager::getNumber(integer_config_t _what) const
+int32_t ConfigManager::getNumber(integer_config_t what) const
 {
-	if (_what >= LAST_INTEGER_CONFIG) {
-		std::cout << "[Warning - ConfigManager::getNumber] Accessing invalid index: " << _what << std::endl;
+	if (what >= LAST_INTEGER_CONFIG) {
+		std::cout << "[Warning - ConfigManager::getNumber] Accessing invalid index: " << what << std::endl;
 		return 0;
 	}
-	return integer[_what];
+	return integer[what];
 }
 
-bool ConfigManager::getBoolean(boolean_config_t _what) const
+bool ConfigManager::getBoolean(boolean_config_t what) const
 {
-	if (_what >= LAST_BOOLEAN_CONFIG) {
-		std::cout << "[Warning - ConfigManager::getBoolean] Accessing invalid index: " << _what << std::endl;
+	if (what >= LAST_BOOLEAN_CONFIG) {
+		std::cout << "[Warning - ConfigManager::getBoolean] Accessing invalid index: " << what << std::endl;
 		return false;
 	}
-	return boolean[_what];
+	return boolean[what];
 }
 
-std::string ConfigManager::getGlobalString(lua_State* L, const char* identifier, const char* _default)
+std::string ConfigManager::getGlobalString(lua_State* L, const char* identifier, const char* defaultValue)
 {
 	lua_getglobal(L, identifier);
 	if (!lua_isstring(L, -1)) {
-		return _default;
+		return defaultValue;
 	}
 
 	size_t len = lua_strlen(L, -1);
@@ -178,11 +178,11 @@ std::string ConfigManager::getGlobalString(lua_State* L, const char* identifier,
 	return ret;
 }
 
-int32_t ConfigManager::getGlobalNumber(lua_State* L, const char* identifier, const int32_t _default)
+int32_t ConfigManager::getGlobalNumber(lua_State* L, const char* identifier, const int32_t defaultValue)
 {
 	lua_getglobal(L, identifier);
 	if (!lua_isnumber(L, -1)) {
-		return _default;
+		return defaultValue;
 	}
 
 	int32_t val = lua_tonumber(L, -1);
@@ -190,12 +190,12 @@ int32_t ConfigManager::getGlobalNumber(lua_State* L, const char* identifier, con
 	return val;
 }
 
-bool ConfigManager::getGlobalBoolean(lua_State* L, const char* identifier, const bool _default)
+bool ConfigManager::getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultValue)
 {
 	lua_getglobal(L, identifier);
 	if (!lua_isboolean(L, -1)) {
 		if (!lua_isstring(L, -1)) {
-			return _default;
+			return defaultValue;
 		}
 
 		size_t len = lua_strlen(L, -1);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -110,14 +110,14 @@ class ConfigManager
 		bool load();
 		bool reload();
 
-		const std::string& getString(string_config_t _what) const;
-		int32_t getNumber(integer_config_t _what) const;
-		bool getBoolean(boolean_config_t _what) const;
+		const std::string& getString(string_config_t what) const;
+		int32_t getNumber(integer_config_t what) const;
+		bool getBoolean(boolean_config_t what) const;
 
 	private:
-		static std::string getGlobalString(lua_State* L, const char* identifier, const char* _default);
-		static int32_t getGlobalNumber(lua_State* L, const char* identifier, const int32_t _default = 0);
-		static bool getGlobalBoolean(lua_State* L, const char* identifier, const bool _default);
+		static std::string getGlobalString(lua_State* L, const char* identifier, const char* defaultValue);
+		static int32_t getGlobalNumber(lua_State* L, const char* identifier, const int32_t defaultValue = 0);
+		static bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultValue);
 
 		std::string string[LAST_STRING_CONFIG];
 		int32_t integer[LAST_INTEGER_CONFIG];

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -25,25 +25,19 @@
 
 extern Game g_game;
 
-Container::Container(uint16_t _type) : Item(_type)
-{
-	maxSize = items[_type].maxItems;
-	totalWeight = 0;
-	serializationCount = 0;
-	unlocked = true;
-	pagination = false;
-}
+Container::Container(uint16_t type) :
+	Container(type, items[type].maxItems) {}
 
-Container::Container(uint16_t _type, uint16_t _size) : Item(_type)
-{
-	maxSize = _size;
-	totalWeight = 0;
-	serializationCount = 0;
-	unlocked = true;
-	pagination = false;
-}
+Container::Container(uint16_t type, uint16_t size, bool unlocked /*= true*/, bool pagination /*= false*/) :
+	Item(type),
+	maxSize(size),
+	totalWeight(0),
+	serializationCount(0),
+	unlocked(unlocked),
+	pagination(pagination)
+{}
 
-Container::Container(Tile* tile) : Item(ITEM_BROWSEFIELD)
+Container::Container(Tile* tile) : Container(ITEM_BROWSEFIELD, 30, false, true)
 {
 	TileItemVector* itemVector = tile->getItemList();
 	if (itemVector) {
@@ -55,11 +49,6 @@ Container::Container(Tile* tile) : Item(ITEM_BROWSEFIELD)
 		}
 	}
 
-	maxSize = 30;
-	totalWeight = 0;
-	serializationCount = 0;
-	unlocked = false;
-	pagination = true;
 	setParent(tile);
 }
 

--- a/src/container.h
+++ b/src/container.h
@@ -49,9 +49,9 @@ class ContainerIterator
 class Container : public Item, public Cylinder
 {
 	public:
-		explicit Container(uint16_t _type);
-		Container(uint16_t _type, uint16_t _size);
-		explicit Container(Tile* tile);
+		explicit Container(uint16_t type);
+		Container(uint16_t type, uint16_t size, bool unlocked = true, bool pagination = false);
+		explicit Container(Tile* type);
 		~Container();
 
 		// non-copyable

--- a/src/creature.h
+++ b/src/creature.h
@@ -419,11 +419,11 @@ class Creature : virtual public Thing
 		size_t getSummonCount() const {
 			return summons.size();
 		}
-		void setDropLoot(bool _lootDrop) {
-			lootDrop = _lootDrop;
+		void setDropLoot(bool lootDrop) {
+			this->lootDrop = lootDrop;
 		}
-		void setLossSkill(bool _skillLoss) {
-			skillLoss = _skillLoss;
+		void setLossSkill(bool skillLoss) {
+			this->skillLoss = skillLoss;
 		}
 
 		//creature script events
@@ -431,22 +431,22 @@ class Creature : virtual public Thing
 		bool unregisterCreatureEvent(const std::string& name);
 
 		Cylinder* getParent() const final {
-			return _tile;
+			return tile;
 		}
 		void setParent(Cylinder* cylinder) final {
-			_tile = static_cast<Tile*>(cylinder);
-			_position = _tile->getPosition();
+			tile = static_cast<Tile*>(cylinder);
+			position = tile->getPosition();
 		}
 
 		inline const Position& getPosition() const final {
-			return _position;
+			return position;
 		}
 
 		Tile* getTile() final {
-			return _tile;
+			return tile;
 		}
 		const Tile* getTile() const final {
-			return _tile;
+			return tile;
 		}
 
 		int32_t getWalkCache(const Position& pos) const;
@@ -482,7 +482,7 @@ class Creature : virtual public Thing
 		static const int32_t maxWalkCacheWidth = (mapWalkWidth - 1) / 2;
 		static const int32_t maxWalkCacheHeight = (mapWalkHeight - 1) / 2;
 
-		Position _position;
+		Position position;
 
 		typedef std::map<uint32_t, CountBlock_t> CountMap;
 		CountMap damageMap;
@@ -493,7 +493,7 @@ class Creature : virtual public Thing
 
 		std::forward_list<Direction> listWalkDir;
 
-		Tile* _tile;
+		Tile* tile;
 		Creature* attackedCreature;
 		Creature* master;
 		Creature* followCreature;
@@ -504,7 +504,7 @@ class Creature : virtual public Thing
 		uint32_t scriptEventsBitField;
 		uint32_t eventWalk;
 		uint32_t walkUpdateTicks;
-		uint32_t lastHitCreature;
+		uint32_t lastHitCreatureId;
 		uint32_t blockCount;
 		uint32_t blockTicks;
 		uint32_t lastStepCost;
@@ -559,8 +559,8 @@ class Creature : virtual public Thing
 		}
 		virtual void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const;
 		virtual void death(Creature*) {}
-		virtual bool dropCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified);
-		virtual Item* getCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature);
+		virtual bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified);
+		virtual Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature);
 
 		friend class Game;
 		friend class Map;

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -141,12 +141,8 @@ bool CreatureEvents::playerAdvance(Player* player, skills_t skill, uint32_t oldL
 
 /////////////////////////////////////
 
-CreatureEvent::CreatureEvent(LuaScriptInterface* _interface) :
-	Event(_interface)
-{
-	type = CREATURE_EVENT_NONE;
-	loaded = false;
-}
+CreatureEvent::CreatureEvent(LuaScriptInterface* interface) :
+	Event(interface), type(CREATURE_EVENT_NONE), loaded(false) {}
 
 bool CreatureEvent::configureEvent(const pugi::xml_node& node)
 {

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -76,7 +76,7 @@ class CreatureEvents final : public BaseEvents
 class CreatureEvent final : public Event
 {
 	public:
-		explicit CreatureEvent(LuaScriptInterface* _interface);
+		explicit CreatureEvent(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) final;
 

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -22,11 +22,8 @@
 #include "depotchest.h"
 #include "tools.h"
 
-DepotChest::DepotChest(uint16_t _type) :
-	Container(_type)
-{
-	maxDepotItems = 1500;
-}
+DepotChest::DepotChest(uint16_t type) :
+	Container(type), maxDepotItems(1500) {}
 
 ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t count,
 		uint32_t flags, Creature* actor/* = nullptr*/) const

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -25,7 +25,7 @@
 class DepotChest final : public Container
 {
 	public:
-		explicit DepotChest(uint16_t _type);
+		explicit DepotChest(uint16_t type);
 
 		//serialization
 		void setMaxDepotItems(uint32_t maxitems) {

--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -21,12 +21,8 @@
 
 #include "depotlocker.h"
 
-DepotLocker::DepotLocker(uint16_t _type) :
-	Container(_type)
-{
-	depotId = 0;
-	maxSize = 3;
-}
+DepotLocker::DepotLocker(uint16_t type) :
+	Container(type, 3), depotId(0) {}
 
 Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 {

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -26,7 +26,7 @@
 class DepotLocker final : public Container
 {
 	public:
-		explicit DepotLocker(uint16_t _type);
+		explicit DepotLocker(uint16_t type);
 
 		DepotLocker* getDepotLocker() final {
 			return this;

--- a/src/enums.h
+++ b/src/enums.h
@@ -451,16 +451,10 @@ struct Outfit_t {
 };
 
 struct LightInfo {
-	uint8_t level;
-	uint8_t color;
-	LightInfo() {
-		level = 0;
-		color = 0;
-	}
-	LightInfo(uint8_t _level, uint8_t _color) {
-		level = _level;
-		color = _color;
-	}
+	uint8_t level = 0;
+	uint8_t color = 0;
+	LightInfo() = default;
+	LightInfo(uint8_t level, uint8_t color) : level(level), color(color) {}
 };
 
 struct ShopInfo {

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -122,7 +122,7 @@ class FileLoader
 		inline bool safeTell(int32_t& pos);
 
 	protected:
-		struct _cache {
+		struct cache {
 			uint8_t* data;
 			uint32_t loaded;
 			uint32_t base;
@@ -130,7 +130,7 @@ class FileLoader
 		};
 
 #define CACHE_BLOCKS 3
-		_cache cached_data[CACHE_BLOCKS];
+		cache cached_data[CACHE_BLOCKS];
 
 		uint8_t* buffer;
 		NODE root;
@@ -230,8 +230,8 @@ class PropWriteStream
 		PropWriteStream(const PropWriteStream&) = delete;
 		PropWriteStream& operator=(const PropWriteStream&) = delete;
 
-		const char* getStream(size_t& _size) const {
-			_size = size;
+		const char* getStream(size_t& size) const {
+			size = this->size;
 			return buffer;
 		}
 

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -209,13 +209,8 @@ GlobalEventMap GlobalEvents::getEventMap(GlobalEvent_t type)
 	}
 }
 
-GlobalEvent::GlobalEvent(LuaScriptInterface* _interface):
-	Event(_interface)
-{
-	eventType = GLOBALEVENT_NONE;
-	nextExecution = 0;
-	interval = 0;
-}
+GlobalEvent::GlobalEvent(LuaScriptInterface* interface):
+	Event(interface), eventType(GLOBALEVENT_NONE), nextExecution(0), interval(0) {}
 
 bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 {

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -75,7 +75,7 @@ class GlobalEvents final : public BaseEvents
 class GlobalEvent final : public Event
 {
 	public:
-		explicit GlobalEvent(LuaScriptInterface* _interface);
+		explicit GlobalEvent(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) final;
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -30,21 +30,18 @@
 extern ConfigManager g_config;
 extern Game g_game;
 
-House::House(uint32_t _houseid) :
-	transfer_container(ITEM_LOCKER1)
-{
-	isLoaded = false;
-	owner = 0;
-	posEntry.x = 0;
-	posEntry.y = 0;
-	posEntry.z = 0;
-	paidUntil = 0;
-	id = _houseid;
-	rentWarnings = 0;
-	rent = 0;
-	townid = 0;
-	transferItem = nullptr;
-}
+House::House(uint32_t houseId) :
+	transfer_container(ITEM_LOCKER1),
+	transferItem(nullptr),
+	paidUntil(0),
+	id(houseId),
+	owner(0),
+	rentWarnings(0),
+	rent(0),
+	townId(0),
+	posEntry(),
+	isLoaded(false)
+{}
 
 void House::addTile(HouseTile* tile)
 {
@@ -214,7 +211,7 @@ void House::setAccessList(uint32_t listId, const std::string& textlist)
 
 bool House::transferToDepot() const
 {
-	if (townid == 0 || owner == 0) {
+	if (townId == 0 || owner == 0) {
 		return false;
 	}
 
@@ -235,7 +232,7 @@ bool House::transferToDepot() const
 
 bool House::transferToDepot(Player* player) const
 {
-	if (townid == 0 || owner == 0) {
+	if (townId == 0 || owner == 0) {
 		return false;
 	}
 
@@ -405,18 +402,18 @@ bool House::executeTransfer(HouseTransferItem* item, Player* newOwner)
 	return true;
 }
 
-void AccessList::parseList(const std::string& _list)
+void AccessList::parseList(const std::string& list)
 {
 	playerList.clear();
 	guildList.clear();
 	expressionList.clear();
 	regExList.clear();
-	list = _list;
-	if (_list.empty()) {
+	this->list = list;
+	if (list.empty()) {
 		return;
 	}
 
-	std::istringstream listStream(_list);
+	std::istringstream listStream(list);
 	std::string line;
 
 	while (getline(listStream, line)) {
@@ -518,17 +515,13 @@ bool AccessList::isInList(const Player* player)
 	return guild && guildList.find(guild->getId()) != guildList.end();
 }
 
-void AccessList::getList(std::string& _list) const
+void AccessList::getList(std::string& list) const
 {
-	_list = list;
+	list = this->list;
 }
 
-Door::Door(uint16_t _type)
-	: Item(_type)
-{
-	house = nullptr;
-	accessList = nullptr;
-}
+Door::Door(uint16_t type) :
+	Item(type), house(nullptr), accessList(nullptr) {}
 
 Door::~Door()
 {
@@ -538,24 +531,24 @@ Door::~Door()
 Attr_ReadValue Door::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	if (attr == ATTR_HOUSEDOORID) {
-		uint8_t _doorId;
-		if (!propStream.read<uint8_t>(_doorId)) {
+		uint8_t doorId;
+		if (!propStream.read<uint8_t>(doorId)) {
 			return ATTR_READ_ERROR;
 		}
 
-		setDoorId(_doorId);
+		setDoorId(doorId);
 		return ATTR_READ_CONTINUE;
 	}
 	return Item::readAttr(attr, propStream);
 }
 
-void Door::setHouse(House* _house)
+void Door::setHouse(House* house)
 {
-	if (house != nullptr) {
+	if (this->house != nullptr) {
 		return;
 	}
 
-	house = _house;
+	this->house = house;
 
 	if (!accessList) {
 		accessList = new AccessList();

--- a/src/house.h
+++ b/src/house.h
@@ -33,14 +33,14 @@ class Player;
 class AccessList
 {
 	public:
-		void parseList(const std::string& _list);
+		void parseList(const std::string& list);
 		void addPlayer(const std::string& name);
 		void addGuild(const std::string& name);
 		void addExpression(const std::string& expression);
 
 		bool isInList(const Player* player);
 
-		void getList(std::string& _list) const;
+		void getList(std::string& list) const;
 
 	private:
 		std::string list;
@@ -53,7 +53,7 @@ class AccessList
 class Door final : public Item
 {
 	public:
-		explicit Door(uint16_t _type);
+		explicit Door(uint16_t type);
 		~Door();
 
 		// non-copyable
@@ -75,8 +75,8 @@ class Door final : public Item
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) final;
 		void serializeAttr(PropWriteStream&) const final {}
 
-		void setDoorId(uint32_t _doorId) {
-			setIntAttr(ITEM_ATTRIBUTE_DOORID, _doorId);
+		void setDoorId(uint32_t doorId) {
+			setIntAttr(ITEM_ATTRIBUTE_DOORID, doorId);
 		}
 		uint32_t getDoorId() const {
 			return getIntAttr(ITEM_ATTRIBUTE_DOORID);
@@ -90,7 +90,7 @@ class Door final : public Item
 		void onRemoved() final;
 
 	protected:
-		void setHouse(House* _house);
+		void setHouse(House* house);
 
 	private:
 		House* house;
@@ -118,9 +118,7 @@ class HouseTransferItem final : public Item
 	public:
 		static HouseTransferItem* createHouseTransferItem(House* house);
 
-		explicit HouseTransferItem(House* _house) : Item(0) {
-			house = _house;
-		}
+		explicit HouseTransferItem(House* house) : Item(0), house(house) {}
 
 		void onTradeEvent(TradeEvents_t event, Player* owner) final;
 		bool canTransform() const final {
@@ -134,7 +132,7 @@ class HouseTransferItem final : public Item
 class House
 {
 	public:
-		explicit House(uint32_t _houseid);
+		explicit House(uint32_t houseId);
 
 		void addTile(HouseTile* tile);
 		void updateDoorDescription() const;
@@ -177,8 +175,8 @@ class House
 			return paidUntil;
 		}
 
-		void setRent(uint32_t _rent) {
-			rent = _rent;
+		void setRent(uint32_t rent) {
+			this->rent = rent;
 		}
 		uint32_t getRent() const {
 			return rent;
@@ -191,11 +189,11 @@ class House
 			return rentWarnings;
 		}
 
-		void setTownId(uint32_t _town) {
-			townid = _town;
+		void setTownId(uint32_t townId) {
+			this->townId = townId;
 		}
 		uint32_t getTownId() const {
-			return townid;
+			return townId;
 		}
 
 		uint32_t getId() const {
@@ -251,7 +249,7 @@ class House
 		uint32_t owner;
 		uint32_t rentWarnings;
 		uint32_t rent;
-		uint32_t townid;
+		uint32_t townId;
 
 		Position posEntry;
 
@@ -293,8 +291,8 @@ class Houses
 			return house;
 		}
 
-		House* getHouse(uint32_t houseid) {
-			auto it = houseMap.find(houseid);
+		House* getHouse(uint32_t houseId) {
+			auto it = houseMap.find(houseId);
 			if (it == houseMap.end()) {
 				return nullptr;
 			}

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -25,11 +25,8 @@
 
 extern Game g_game;
 
-HouseTile::HouseTile(int32_t x, int32_t y, int32_t z, House* _house) :
-	DynamicTile(x, y, z)
-{
-	house = _house;
-}
+HouseTile::HouseTile(int32_t x, int32_t y, int32_t z, House* house) :
+	DynamicTile(x, y, z), house(house) {}
 
 void HouseTile::addThing(int32_t index, Thing* thing)
 {

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -27,7 +27,7 @@ class House;
 class HouseTile final : public DynamicTile
 {
 	public:
-		HouseTile(int32_t x, int32_t y, int32_t z, House* _house);
+		HouseTile(int32_t x, int32_t y, int32_t z, House* house);
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,

--- a/src/inbox.cpp
+++ b/src/inbox.cpp
@@ -22,13 +22,7 @@
 #include "inbox.h"
 #include "tools.h"
 
-Inbox::Inbox(uint16_t _type) :
-	Container(_type)
-{
-	maxSize = 30;
-	unlocked = false;
-	pagination = true;
-}
+Inbox::Inbox(uint16_t type) : Container(type, 30, false, true) {}
 
 ReturnValue Inbox::queryAdd(int32_t, const Thing& thing, uint32_t,
 		uint32_t flags, Creature*) const

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -25,7 +25,7 @@
 class Inbox final : public Container
 {
 	public:
-		explicit Inbox(uint16_t _type);
+		explicit Inbox(uint16_t type);
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -37,50 +37,50 @@ extern Vocations g_vocations;
 
 Items Item::items;
 
-Item* Item::CreateItem(const uint16_t _type, uint16_t _count /*= 0*/)
+Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/)
 {
 	Item* newItem = nullptr;
 
-	const ItemType& it = Item::items[_type];
+	const ItemType& it = Item::items[type];
 	if (it.group == ITEM_GROUP_DEPRECATED) {
 		return nullptr;
 	}
 
-	if (it.stackable && _count == 0) {
-		_count = 1;
+	if (it.stackable && count == 0) {
+		count = 1;
 	}
 
 	if (it.id != 0) {
 		if (it.isDepot()) {
-			newItem = new DepotLocker(_type);
+			newItem = new DepotLocker(type);
 		} else if (it.isContainer()) {
-			newItem = new Container(_type);
+			newItem = new Container(type);
 		} else if (it.isTeleport()) {
-			newItem = new Teleport(_type);
+			newItem = new Teleport(type);
 		} else if (it.isMagicField()) {
-			newItem = new MagicField(_type);
+			newItem = new MagicField(type);
 		} else if (it.isDoor()) {
-			newItem = new Door(_type);
+			newItem = new Door(type);
 		} else if (it.isTrashHolder()) {
-			newItem = new TrashHolder(_type);
+			newItem = new TrashHolder(type);
 		} else if (it.isMailbox()) {
-			newItem = new Mailbox(_type);
+			newItem = new Mailbox(type);
 		} else if (it.isBed()) {
-			newItem = new BedItem(_type);
+			newItem = new BedItem(type);
 		} else if (it.id >= 2210 && it.id <= 2212) {
-			newItem = new Item(_type - 3, _count);
+			newItem = new Item(type - 3, count);
 		} else if (it.id == 2215 || it.id == 2216) {
-			newItem = new Item(_type - 2, _count);
+			newItem = new Item(type - 2, count);
 		} else if (it.id >= 2202 && it.id <= 2206) {
-			newItem = new Item(_type - 37, _count);
+			newItem = new Item(type - 37, count);
 		} else if (it.id == 2640) {
-			newItem = new Item(6132, _count);
+			newItem = new Item(6132, count);
 		} else if (it.id == 6301) {
-			newItem = new Item(6300, _count);
+			newItem = new Item(6300, count);
 		} else if (it.id == 18528) {
-			newItem = new Item(18408, _count);
+			newItem = new Item(18408, count);
 		} else {
-			newItem = new Item(_type, _count);
+			newItem = new Item(type, count);
 		}
 
 		newItem->incrementReferenceCounter();
@@ -89,67 +89,67 @@ Item* Item::CreateItem(const uint16_t _type, uint16_t _count /*= 0*/)
 	return newItem;
 }
 
-Container* Item::CreateItemAsContainer(const uint16_t _type, uint16_t _size)
+Container* Item::CreateItemAsContainer(const uint16_t type, uint16_t size)
 {
-	const ItemType& it = Item::items[_type];
+	const ItemType& it = Item::items[type];
 	if (it.id == 0 || it.group == ITEM_GROUP_DEPRECATED || it.stackable || it.useable || it.moveable || it.pickupable || it.isDepot() || it.isSplash() || it.isDoor()) {
 		return nullptr;
 	}
 
-	Container* newItem = new Container(_type, _size);
+	Container* newItem = new Container(type, size);
 	newItem->incrementReferenceCounter();
 	return newItem;
 }
 
 Item* Item::CreateItem(PropStream& propStream)
 {
-	uint16_t _id;
-	if (!propStream.read<uint16_t>(_id)) {
+	uint16_t id;
+	if (!propStream.read<uint16_t>(id)) {
 		return nullptr;
 	}
 
-	switch (_id) {
+	switch (id) {
 		case ITEM_FIREFIELD_PVP_FULL:
-			_id = ITEM_FIREFIELD_PERSISTENT_FULL;
+			id = ITEM_FIREFIELD_PERSISTENT_FULL;
 			break;
 
 		case ITEM_FIREFIELD_PVP_MEDIUM:
-			_id = ITEM_FIREFIELD_PERSISTENT_MEDIUM;
+			id = ITEM_FIREFIELD_PERSISTENT_MEDIUM;
 			break;
 
 		case ITEM_FIREFIELD_PVP_SMALL:
-			_id = ITEM_FIREFIELD_PERSISTENT_SMALL;
+			id = ITEM_FIREFIELD_PERSISTENT_SMALL;
 			break;
 
 		case ITEM_ENERGYFIELD_PVP:
-			_id = ITEM_ENERGYFIELD_PERSISTENT;
+			id = ITEM_ENERGYFIELD_PERSISTENT;
 			break;
 
 		case ITEM_POISONFIELD_PVP:
-			_id = ITEM_POISONFIELD_PERSISTENT;
+			id = ITEM_POISONFIELD_PERSISTENT;
 			break;
 
 		case ITEM_MAGICWALL:
-			_id = ITEM_MAGICWALL_PERSISTENT;
+			id = ITEM_MAGICWALL_PERSISTENT;
 			break;
 
 		case ITEM_WILDGROWTH:
-			_id = ITEM_WILDGROWTH_PERSISTENT;
+			id = ITEM_WILDGROWTH_PERSISTENT;
 			break;
 
 		default:
 			break;
 	}
 
-	return Item::CreateItem(_id, 0);
+	return Item::CreateItem(id, 0);
 }
 
-Item::Item(const uint16_t _type, uint16_t _count /*= 0*/)
+Item::Item(const uint16_t type, uint16_t count /*= 0*/)
 {
 	parent = nullptr;
 	referenceCounter = 0;
 
-	id = _type;
+	id = type;
 	attributes = nullptr;
 
 	const ItemType& it = items[id];
@@ -157,16 +157,16 @@ Item::Item(const uint16_t _type, uint16_t _count /*= 0*/)
 	setItemCount(1);
 
 	if (it.isFluidContainer() || it.isSplash()) {
-		setFluidType(_count);
+		setFluidType(count);
 	} else if (it.stackable) {
-		if (_count != 0) {
-			setItemCount(_count);
+		if (count != 0) {
+			setItemCount(count);
 		} else if (it.charges != 0) {
 			setItemCount(it.charges);
 		}
 	} else if (it.charges != 0) {
-		if (_count != 0) {
-			setCharges(_count);
+		if (count != 0) {
+			setCharges(count);
 		} else {
 			setCharges(it.charges);
 		}
@@ -195,11 +195,11 @@ Item::Item(const Item& i) :
 
 Item* Item::clone() const
 {
-	Item* _item = Item::CreateItem(id, count);
+	Item* item = Item::CreateItem(id, count);
 	if (attributes) {
-		_item->attributes = new ItemAttributes(*attributes);
+		item->attributes = new ItemAttributes(*attributes);
 	}
-	return _item;
+	return item;
 }
 
 Item::~Item()
@@ -390,12 +390,12 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 	switch (attr) {
 		case ATTR_COUNT:
 		case ATTR_RUNE_CHARGES: {
-			uint8_t _count;
-			if (!propStream.read<uint8_t>(_count)) {
+			uint8_t count;
+			if (!propStream.read<uint8_t>(count)) {
 				return ATTR_READ_ERROR;
 			}
 
-			setSubType(_count);
+			setSubType(count);
 			break;
 		}
 
@@ -1454,10 +1454,10 @@ std::string Item::getNameDescription() const
 	return getNameDescription(it, this);
 }
 
-std::string Item::getWeightDescription(const ItemType& it, uint32_t weight, uint32_t _count /*= 1*/)
+std::string Item::getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count /*= 1*/)
 {
 	std::ostringstream ss;
-	if (it.stackable && _count > 1 && it.showCount != 0) {
+	if (it.stackable && count > 1 && it.showCount != 0) {
 		ss << "They weigh ";
 	} else {
 		ss << "It weighs ";

--- a/src/item.h
+++ b/src/item.h
@@ -137,8 +137,8 @@ class ItemAttributes
 			return static_cast<time_t>(getIntAttr(ITEM_ATTRIBUTE_DATE));
 		}
 
-		void setWriter(const std::string& _writer) {
-			setStrAttr(ITEM_ATTRIBUTE_WRITER, _writer);
+		void setWriter(const std::string& writer) {
+			setStrAttr(ITEM_ATTRIBUTE_WRITER, writer);
 		}
 		void resetWriter() {
 			removeAttribute(ITEM_ATTRIBUTE_WRITER);
@@ -175,15 +175,15 @@ class ItemAttributes
 			return static_cast<uint16_t>(getIntAttr(ITEM_ATTRIBUTE_FLUIDTYPE));
 		}
 
-		void setOwner(uint32_t _owner) {
-			setIntAttr(ITEM_ATTRIBUTE_OWNER, _owner);
+		void setOwner(uint32_t owner) {
+			setIntAttr(ITEM_ATTRIBUTE_OWNER, owner);
 		}
 		uint32_t getOwner() const {
 			return getIntAttr(ITEM_ATTRIBUTE_OWNER);
 		}
 
-		void setCorpseOwner(uint32_t _corpseOwner) {
-			setIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER, _corpseOwner);
+		void setCorpseOwner(uint32_t corpseOwner) {
+			setIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER, corpseOwner);
 		}
 		uint32_t getCorpseOwner() const {
 			return getIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER);
@@ -302,13 +302,13 @@ class Item : virtual public Thing
 {
 	public:
 		//Factory member to create item of right type based on type
-		static Item* CreateItem(const uint16_t _type, uint16_t _count = 0);
-		static Container* CreateItemAsContainer(const uint16_t _type, uint16_t size);
+		static Item* CreateItem(const uint16_t type, uint16_t count = 0);
+		static Container* CreateItemAsContainer(const uint16_t type, uint16_t size);
 		static Item* CreateItem(PropStream& propStream);
 		static Items items;
 
 		// Constructor for items
-		Item(const uint16_t _type, uint16_t _count = 0);
+		Item(const uint16_t type, uint16_t count = 0);
 		Item(const Item& i);
 		virtual Item* clone() const;
 
@@ -424,8 +424,8 @@ class Item : virtual public Thing
 			return static_cast<time_t>(getIntAttr(ITEM_ATTRIBUTE_DATE));
 		}
 
-		void setWriter(const std::string& _writer) {
-			setStrAttr(ITEM_ATTRIBUTE_WRITER, _writer);
+		void setWriter(const std::string& writer) {
+			setStrAttr(ITEM_ATTRIBUTE_WRITER, writer);
 		}
 		void resetWriter() {
 			removeAttribute(ITEM_ATTRIBUTE_WRITER);
@@ -475,8 +475,8 @@ class Item : virtual public Thing
 			return static_cast<uint16_t>(getIntAttr(ITEM_ATTRIBUTE_FLUIDTYPE));
 		}
 
-		void setOwner(uint32_t _owner) {
-			setIntAttr(ITEM_ATTRIBUTE_OWNER, _owner);
+		void setOwner(uint32_t owner) {
+			setIntAttr(ITEM_ATTRIBUTE_OWNER, owner);
 		}
 		uint32_t getOwner() const {
 			if (!attributes) {
@@ -485,8 +485,8 @@ class Item : virtual public Thing
 			return getIntAttr(ITEM_ATTRIBUTE_OWNER);
 		}
 
-		void setCorpseOwner(uint32_t _corpseOwner) {
-			setIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER, _corpseOwner);
+		void setCorpseOwner(uint32_t corpseOwner) {
+			setIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER, corpseOwner);
 		}
 		uint32_t getCorpseOwner() const {
 			if (!attributes) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -120,8 +120,8 @@ class Monster final : public Creature
 		uint32_t getManaCost() const {
 			return mType->manaCost;
 		}
-		void setSpawn(Spawn* _spawn) {
-			spawn = _spawn;
+		void setSpawn(Spawn* spawn) {
+			this->spawn = spawn;
 		}
 
 		void onAttackedCreatureDisappear(bool isLogout) final;
@@ -134,7 +134,7 @@ class Monster final : public Creature
 		void drainHealth(Creature* attacker, int32_t damage) final;
 		void changeHealth(int32_t healthChange, bool sendHealthChange = true) final;
 		void onWalk() final;
-		bool getNextStep(Direction& dir, uint32_t& flags) final;
+		bool getNextStep(Direction& direction, uint32_t& flags) final;
 		void onFollowCreatureComplete(const Creature* creature) final;
 
 		void onThink(uint32_t interval) final;
@@ -165,7 +165,7 @@ class Monster final : public Creature
 			return getHealth() <= mType->runAwayHealth;
 		}
 
-		bool getDistanceStep(const Position& targetPos, Direction& dir, bool flee = false);
+		bool getDistanceStep(const Position& targetPos, Direction& direction, bool flee = false);
 		bool isTargetNearby() const {
 			return stepDuration >= 1;
 		}
@@ -217,10 +217,10 @@ class Monster final : public Creature
 		void clearTargetList();
 		void clearFriendList();
 
-		void death(Creature* _lastHitCreature) final;
-		Item* getCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature) final;
+		void death(Creature* lastHitCreature) final;
+		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) final;
 
-		void setIdle(bool _idle);
+		void setIdle(bool idle);
 		void updateIdleStatus();
 		bool getIdleStatus() const {
 			return isIdle;
@@ -233,11 +233,11 @@ class Monster final : public Creature
 		bool canUseAttack(const Position& pos, const Creature* target) const;
 		bool canUseSpell(const Position& pos, const Position& targetPos,
 		                 const spellBlock_t& sb, uint32_t interval, bool& inRange, bool& resetTicks);
-		bool getRandomStep(const Position& creaturePos, Direction& dir) const;
-		bool getDanceStep(const Position& creaturePos, Direction& dir,
+		bool getRandomStep(const Position& creaturePos, Direction& direction) const;
+		bool getDanceStep(const Position& creaturePos, Direction& direction,
 		                  bool keepAttack = true, bool keepDistance = true);
 		bool isInSpawnRange(const Position& pos) const;
-		bool canWalkTo(Position pos, Direction dir) const;
+		bool canWalkTo(Position pos, Direction direction) const;
 
 		static bool pushItem(Item* item);
 		static void pushItems(Tile* tile);
@@ -257,7 +257,7 @@ class Monster final : public Creature
 		uint16_t getLookCorpse() const final {
 			return mType->lookcorpse;
 		}
-		void dropLoot(Container* corpse, Creature* _lastHitCreature) final;
+		void dropLoot(Container* corpse, Creature* lastHitCreature) final;
 		uint32_t getDamageImmunities() const final {
 			return mType->damageImmunities;
 		}

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -384,19 +384,18 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 	return ret;
 }
 
-MoveEvent::MoveEvent(LuaScriptInterface* _interface) :
-	Event(_interface)
-{
-	eventType = MOVE_EVENT_NONE;
-	stepFunction = nullptr;
-	moveFunction = nullptr;
-	equipFunction = nullptr;
-	slot = SLOTP_WHEREEVER;
-	wieldInfo = 0;
-	reqLevel = 0;
-	reqMagLevel = 0;
-	premium = false;
-}
+MoveEvent::MoveEvent(LuaScriptInterface* interface) :
+	Event(interface),
+	eventType(MOVE_EVENT_NONE),
+	stepFunction(nullptr),
+	moveFunction(nullptr),
+	equipFunction(nullptr),
+	slot(SLOTP_WHEREEVER),
+	reqLevel(0),
+	reqMagLevel(0),
+	premium(false),
+	wieldInfo(0)
+{}
 
 MoveEvent::MoveEvent(const MoveEvent* copy) :
 	Event(copy)

--- a/src/movement.h
+++ b/src/movement.h
@@ -100,7 +100,7 @@ typedef uint32_t (EquipFunction)(MoveEvent* moveEvent, Player* player, Item* ite
 class MoveEvent final : public Event
 {
 	public:
-		explicit MoveEvent(LuaScriptInterface* _interface);
+		explicit MoveEvent(LuaScriptInterface* interface);
 		explicit MoveEvent(const MoveEvent* copy);
 
 		MoveEvent_t getEventType() const;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -58,14 +58,13 @@ Npc* Npc::createNpc(const std::string& name)
 	return npc.release();
 }
 
-Npc::Npc(const std::string& _name) :
-	Creature(), filename("data/npc/" + _name + ".xml")
+Npc::Npc(const std::string& name) :
+	Creature(),
+	filename("data/npc/" + name + ".xml"),
+	npcEventHandler(nullptr),
+	masterRadius(-1),
+	loaded(false)
 {
-	loaded = false;
-
-	masterRadius = -1;
-
-	npcEventHandler = nullptr;
 	reset();
 }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -186,7 +186,7 @@ class Npc final : public Creature
 		static uint32_t npcAutoID;
 
 	protected:
-		explicit Npc(const std::string& _name);
+		explicit Npc(const std::string& name);
 
 		void onCreatureAppear(Creature* creature, bool isLogin) final;
 		void onRemoveCreature(Creature* creature, bool isLogout) final;

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -388,22 +388,22 @@ void Party::updateVocationsList()
 	}
 }
 
-bool Party::setSharedExperience(Player* player, bool _sharedExpActive)
+bool Party::setSharedExperience(Player* player, bool sharedExpActive)
 {
 	if (!player || leader != player) {
 		return false;
 	}
 
-	if (sharedExpActive == _sharedExpActive) {
+	if (this->sharedExpActive == sharedExpActive) {
 		return true;
 	}
 
-	sharedExpActive = _sharedExpActive;
+	this->sharedExpActive = sharedExpActive;
 
 	if (sharedExpActive) {
-		sharedExpEnabled = canEnableSharedExperience();
+		this->sharedExpEnabled = canEnableSharedExperience();
 
-		if (sharedExpEnabled) {
+		if (this->sharedExpEnabled) {
 			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience is now active.");
 		} else {
 			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience has been activated, but some members of your party are inactive.");

--- a/src/party.h
+++ b/src/party.h
@@ -68,7 +68,7 @@ class Party
 		bool canOpenCorpse(uint32_t ownerId) const;
 
 		void shareExperience(uint64_t experience, Creature* source = nullptr);
-		bool setSharedExperience(Player* player, bool _sharedExpActive);
+		bool setSharedExperience(Player* player, bool sharedExpActive);
 		bool isSharedExperienceActive() const {
 			return sharedExpActive;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -507,7 +507,7 @@ uint16_t Player::getClientIcons() const
 		icons |= ICON_REDSWORDS;
 	}
 
-	if (_tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		icons |= ICON_PIGEON;
 
 		// Don't show ICON_SWORDS if player is in protection zone.
@@ -969,14 +969,14 @@ void Player::sendPing()
 	}
 }
 
-Item* Player::getWriteItem(uint32_t& _windowTextId, uint16_t& _maxWriteLen)
+Item* Player::getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen)
 {
-	_windowTextId = windowTextId;
-	_maxWriteLen = maxWriteLen;
+	windowTextId = this->windowTextId;
+	maxWriteLen = this->maxWriteLen;
 	return writeItem;
 }
 
-void Player::setWriteItem(Item* item, uint16_t _maxWriteLen /*= 0*/)
+void Player::setWriteItem(Item* item, uint16_t maxWriteLen /*= 0*/)
 {
 	windowTextId++;
 
@@ -986,18 +986,18 @@ void Player::setWriteItem(Item* item, uint16_t _maxWriteLen /*= 0*/)
 
 	if (item) {
 		writeItem = item;
-		maxWriteLen = _maxWriteLen;
+		this->maxWriteLen = maxWriteLen;
 		writeItem->incrementReferenceCounter();
 	} else {
 		writeItem = nullptr;
-		maxWriteLen = 0;
+		this->maxWriteLen = 0;
 	}
 }
 
-House* Player::getEditHouse(uint32_t& _windowTextId, uint32_t& _listId)
+House* Player::getEditHouse(uint32_t& windowTextId, uint32_t& listId)
 {
-	_windowTextId = windowTextId;
-	_listId = editListId;
+	windowTextId = this->windowTextId;
+	listId = this->editListId;
 	return editHouse;
 }
 
@@ -1712,13 +1712,13 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		std::string expString = std::to_string(exp) + (exp != 1 ? " experience points." : " experience point.");
 
 		TextMessage message(MESSAGE_EXPERIENCE, "You gained " + expString);
-		message.position = _position;
+		message.position = position;
 		message.primary.value = exp;
 		message.primary.color = TEXTCOLOR_WHITE_EXP;
 		sendTextMessage(message);
 
 		SpectatorVec list;
-		g_game.map.getSpectators(list, _position, false, true);
+		g_game.map.getSpectators(list, position, false, true);
 		list.erase(this);
 		if (!list.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
@@ -1795,13 +1795,13 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		std::string expString = std::to_string(lostExp) + (lostExp != 1 ? " experience points." : " experience point.");
 
 		TextMessage message(MESSAGE_EXPERIENCE, "You lost " + expString);
-		message.position = _position;
+		message.position = position;
 		message.primary.value = lostExp;
 		message.primary.color = TEXTCOLOR_RED;
 		sendTextMessage(message);
 
 		SpectatorVec list;
-		g_game.map.getSpectators(list, _position, false, true);
+		g_game.map.getSpectators(list, position, false, true);
 		list.erase(this);
 		if (!list.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
@@ -1987,17 +1987,17 @@ uint32_t Player::getIP() const
 	return 0;
 }
 
-void Player::death(Creature* _lastHitCreature)
+void Player::death(Creature* lastHitCreature)
 {
 	loginPosition = town->getTemplePosition();
 
 	if (skillLoss) {
 		uint8_t unfairFightReduction = 100;
 
-		if (_lastHitCreature) {
-			Player* lastHitPlayer = _lastHitCreature->getPlayer();
+		if (lastHitCreature) {
+			Player* lastHitPlayer = lastHitCreature->getPlayer();
 			if (!lastHitPlayer) {
-				Creature* lastHitMaster = _lastHitCreature->getMaster();
+				Creature* lastHitMaster = lastHitCreature->getMaster();
 				if (lastHitMaster) {
 					lastHitPlayer = lastHitMaster->getPlayer();
 				}
@@ -2118,10 +2118,10 @@ void Player::death(Creature* _lastHitCreature)
 		if (bitset[5]) {
 			Player* lastHitPlayer;
 
-			if (_lastHitCreature) {
-				lastHitPlayer = _lastHitCreature->getPlayer();
+			if (lastHitCreature) {
+				lastHitPlayer = lastHitCreature->getPlayer();
 				if (!lastHitPlayer) {
-					Creature* lastHitMaster = _lastHitCreature->getMaster();
+					Creature* lastHitMaster = lastHitCreature->getMaster();
 					if (lastHitMaster) {
 						lastHitPlayer = lastHitMaster->getPlayer();
 					}
@@ -2191,22 +2191,22 @@ void Player::death(Creature* _lastHitCreature)
 	}
 }
 
-bool Player::dropCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified)
+bool Player::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified)
 {
 	if (getZone() == ZONE_PVP) {
 		setDropLoot(true);
 		return false;
 	}
-	return Creature::dropCorpse(_lastHitCreature, mostDamageCreature, lastHitUnjustified, mostDamageUnjustified);
+	return Creature::dropCorpse(lastHitCreature, mostDamageCreature, lastHitUnjustified, mostDamageUnjustified);
 }
 
-Item* Player::getCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature)
+Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
 {
-	Item* corpse = Creature::getCorpse(_lastHitCreature, mostDamageCreature);
+	Item* corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
 	if (corpse && corpse->getContainer()) {
 		std::ostringstream ss;
-		if (_lastHitCreature) {
-			ss << "You recognize " << getNameDescription() << ". " << (getSex() == PLAYERSEX_FEMALE ? "She" : "He") << " was killed by " << _lastHitCreature->getNameDescription() << '.';
+		if (lastHitCreature) {
+			ss << "You recognize " << getNameDescription() << ". " << (getSex() == PLAYERSEX_FEMALE ? "She" : "He") << " was killed by " << lastHitCreature->getNameDescription() << '.';
 		} else {
 			ss << "You recognize " << getNameDescription() << '.';
 		}
@@ -4187,7 +4187,7 @@ bool Player::toggleMount(bool mount)
 			return false;
 		}
 
-		if (!group->access && _tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+		if (!group->access && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 			sendCancelMessage(RETURNVALUE_ACTIONNOTPERMITTEDINPROTECTIONZONE);
 			return false;
 		}

--- a/src/player.h
+++ b/src/player.h
@@ -181,8 +181,8 @@ class Player final : public Creature, public Cylinder
 			}
 		}
 
-		void setGUID(uint32_t _guid) {
-			guid = _guid;
+		void setGUID(uint32_t guid) {
+			this->guid = guid;
 		}
 		uint32_t getGUID() const {
 			return guid;
@@ -294,8 +294,8 @@ class Player final : public Creature, public Cylinder
 			return secureMode;
 		}
 
-		void setParty(Party* _party) {
-			party = _party;
+		void setParty(Party* party) {
+			this->party = party;
 		}
 		Party* getParty() const {
 			return party;
@@ -448,8 +448,8 @@ class Player final : public Creature, public Cylinder
 		Town* getTown() const {
 			return town;
 		}
-		void setTown(Town* _town) {
-			town = _town;
+		void setTown(Town* town) {
+			this->town = town;
 		}
 
 		void clearModalWindows();
@@ -1126,10 +1126,10 @@ class Player final : public Creature, public Cylinder
 		}
 		uint32_t getNextActionTime() const;
 
-		Item* getWriteItem(uint32_t& _windowTextId, uint16_t& _maxWriteLen);
-		void setWriteItem(Item* item, uint16_t _maxWriteLen = 0);
+		Item* getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen);
+		void setWriteItem(Item* item, uint16_t maxWriteLen = 0);
 
-		House* getEditHouse(uint32_t& _windowTextId, uint32_t& _listId);
+		House* getEditHouse(uint32_t& windowTextId, uint32_t& listId);
 		void setEditHouse(House* house, uint32_t listId = 0);
 
 		void learnInstantSpell(const std::string& spellName);
@@ -1152,9 +1152,9 @@ class Player final : public Creature, public Cylinder
 		void setNextWalkTask(SchedulerTask* task);
 		void setNextActionTask(SchedulerTask* task);
 
-		void death(Creature* _lastHitCreature) final;
-		bool dropCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified) final;
-		Item* getCorpse(Creature* _lastHitCreature, Creature* mostDamageCreature) final;
+		void death(Creature* lastHitCreature) final;
+		bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified) final;
+		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) final;
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -70,8 +70,8 @@ void ProtocolGame::release()
 void ProtocolGame::login(const std::string& name, uint32_t accountId, OperatingSystem_t operatingSystem)
 {
 	//dispatcher thread
-	Player* _player = g_game.getPlayerByName(name);
-	if (!_player || g_config.getBoolean(ConfigManager::ALLOW_CLONES)) {
+	Player* foundPlayer = g_game.getPlayerByName(name);
+	if (!foundPlayer || g_config.getBoolean(ConfigManager::ALLOW_CLONES)) {
 		player = new Player(getThis());
 		player->setName(name);
 
@@ -166,13 +166,13 @@ void ProtocolGame::login(const std::string& name, uint32_t accountId, OperatingS
 			return;
 		}
 
-		if (_player->client) {
-			_player->disconnect();
-			_player->isConnecting = true;
+		if (foundPlayer->client) {
+			foundPlayer->disconnect();
+			foundPlayer->isConnecting = true;
 
-			eventConnect = g_scheduler.addEvent(createSchedulerTask(1000, std::bind(&ProtocolGame::connect, getThis(), _player->getID(), operatingSystem)));
+			eventConnect = g_scheduler.addEvent(createSchedulerTask(1000, std::bind(&ProtocolGame::connect, getThis(), foundPlayer->getID(), operatingSystem)));
 		} else {
-			connect(_player->getID(), operatingSystem);
+			connect(foundPlayer->getID(), operatingSystem);
 		}
 	}
 	OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
@@ -182,8 +182,8 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 {
 	eventConnect = 0;
 
-	Player* _player = g_game.getPlayerByID(playerId);
-	if (!_player || _player->client) {
+	Player* foundPlayer = g_game.getPlayerByID(playerId);
+	if (!foundPlayer || foundPlayer->client) {
 		disconnectClient("You are already logged in.");
 		return;
 	}
@@ -194,7 +194,7 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 		return;
 	}
 
-	player = _player;
+	player = foundPlayer;
 	player->incrementReferenceCounter();
 
 	g_chat->removeUserFromAllChannels(*player);

--- a/src/raids.cpp
+++ b/src/raids.cpp
@@ -199,16 +199,16 @@ Raid::~Raid()
 	}
 }
 
-bool Raid::loadFromXml(const std::string& _filename)
+bool Raid::loadFromXml(const std::string& filename)
 {
 	if (isLoaded()) {
 		return true;
 	}
 
 	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file(_filename.c_str());
+	pugi::xml_parse_result result = doc.load_file(filename.c_str());
 	if (!result) {
-		printXMLError("Error - Raid::loadFromXml", _filename, result);
+		printXMLError("Error - Raid::loadFromXml", filename, result);
 		return false;
 	}
 
@@ -229,7 +229,7 @@ bool Raid::loadFromXml(const std::string& _filename)
 		if (event->configureRaidEvent(eventNode)) {
 			raidEvents.push_back(event);
 		} else {
-			std::cout << "[Error - Raid::loadFromXml] In file (" << _filename << "), eventNode: " << eventNode.name() << std::endl;
+			std::cout << "[Error - Raid::loadFromXml] In file (" << filename << "), eventNode: " << eventNode.name() << std::endl;
 			delete event;
 		}
 	}
@@ -553,10 +553,7 @@ bool AreaSpawnEvent::executeEvent()
 	return true;
 }
 
-ScriptEvent::ScriptEvent(LuaScriptInterface* _interface) :
-	Event(_interface)
-{
-}
+ScriptEvent::ScriptEvent(LuaScriptInterface* interface) : Event(interface) {}
 
 bool ScriptEvent::configureRaidEvent(const pugi::xml_node& eventNode)
 {

--- a/src/raids.h
+++ b/src/raids.h
@@ -111,7 +111,7 @@ class Raid
 		Raid(const Raid&) = delete;
 		Raid& operator=(const Raid&) = delete;
 
-		bool loadFromXml(const std::string& _filename);
+		bool loadFromXml(const std::string& filename);
 
 		void startRaid();
 
@@ -216,7 +216,7 @@ class AreaSpawnEvent final : public RaidEvent
 class ScriptEvent final : public RaidEvent, public Event
 {
 	public:
-		explicit ScriptEvent(LuaScriptInterface* _interface);
+		explicit ScriptEvent(LuaScriptInterface* interface);
 		explicit ScriptEvent(const ScriptEvent* copy);
 
 		bool configureRaidEvent(const pugi::xml_node& eventNode) final;

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -39,20 +39,20 @@ Spawns::Spawns()
 	started = false;
 }
 
-bool Spawns::loadFromXml(const std::string& _filename)
+bool Spawns::loadFromXml(const std::string& filename)
 {
 	if (loaded) {
 		return true;
 	}
 
 	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file(_filename.c_str());
+	pugi::xml_parse_result result = doc.load_file(filename.c_str());
 	if (!result) {
-		printXMLError("Error - Spawns::loadFromXml", _filename, result);
+		printXMLError("Error - Spawns::loadFromXml", filename, result);
 		return false;
 	}
 
-	filename = _filename;
+	this->filename = filename;
 	loaded = true;
 
 	for (auto spawnNode : doc.child("spawns").children()) {
@@ -290,23 +290,21 @@ void Spawn::cleanup()
 	}
 }
 
-bool Spawn::addMonster(const std::string& _name, const Position& _pos, Direction _dir, uint32_t _interval)
+bool Spawn::addMonster(const std::string& name, const Position& pos, Direction dir, uint32_t interval)
 {
-	MonsterType* mType = g_monsters.getMonsterType(_name);
+	MonsterType* mType = g_monsters.getMonsterType(name);
 	if (!mType) {
-		std::cout << "[Spawn::addMonster] Can not find " << _name << std::endl;
+		std::cout << "[Spawn::addMonster] Can not find " << name << std::endl;
 		return false;
 	}
 
-	if (_interval < interval) {
-		interval = _interval;
-	}
+	this->interval = std::min(this->interval, interval);
 
 	spawnBlock_t sb;
 	sb.mType = mType;
-	sb.pos = _pos;
-	sb.direction = _dir;
-	sb.interval = _interval;
+	sb.pos = pos;
+	sb.direction = dir;
+	sb.interval = interval;
 	sb.lastSpawn = 0;
 
 	uint32_t spawnId = spawnMap.size() + 1;

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -45,7 +45,7 @@ class Spawn
 		Spawn(const Spawn&) = delete;
 		Spawn& operator=(const Spawn&) = delete;
 
-		bool addMonster(const std::string& _name, const Position& _pos, Direction _dir, uint32_t _interval);
+		bool addMonster(const std::string& name, const Position& pos, Direction dir, uint32_t interval);
 		void removeMonster(Monster* monster);
 
 		uint32_t getInterval() const {
@@ -86,7 +86,7 @@ class Spawns
 
 		static bool isInZone(const Position& centerPos, int32_t radius, const Position& pos);
 
-		bool loadFromXml(const std::string& _filename);
+		bool loadFromXml(const std::string& filename);
 		void startup();
 		void clear();
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -265,13 +265,12 @@ Position Spells::getCasterPosition(Creature* creature, Direction dir)
 	return getNextPosition(dir, creature->getPosition());
 }
 
-CombatSpell::CombatSpell(Combat* _combat, bool _needTarget, bool _needDirection) :
-	Event(&g_spells->getScriptInterface())
-{
-	combat = _combat;
-	needTarget = _needTarget;
-	needDirection = _needDirection;
-}
+CombatSpell::CombatSpell(Combat* combat, bool needTarget, bool needDirection) :
+	Event(&g_spells->getScriptInterface()),
+	combat(combat),
+	needDirection(needDirection),
+	needTarget(needTarget)
+{}
 
 CombatSpell::~CombatSpell()
 {
@@ -881,16 +880,15 @@ ReturnValue Spell::CreateIllusion(Creature* creature, uint32_t itemId, int32_t t
 	return CreateIllusion(creature, outfit, time);
 }
 
-InstantSpell::InstantSpell(LuaScriptInterface* _interface) :
-	TalkAction(_interface)
-{
-	needDirection = false;
-	hasParam = false;
-	hasPlayerNameParam = false;
-	checkLineOfSight = true;
-	casterTargetOrDirection = false;
-	function = nullptr;
-}
+InstantSpell::InstantSpell(LuaScriptInterface* interface) :
+	TalkAction(interface),
+	function(nullptr),
+	needDirection(false),
+	hasParam(false),
+	hasPlayerNameParam(false),
+	checkLineOfSight(true),
+	casterTargetOrDirection(false)
+{}
 
 std::string InstantSpell::getScriptEventName() const
 {
@@ -1607,14 +1605,12 @@ bool InstantSpell::canCast(const Player* player) const
 }
 
 
-ConjureSpell::ConjureSpell(LuaScriptInterface* _interface) :
-	InstantSpell(_interface)
-{
-	aggressive = false;
-	conjureId = 0;
-	conjureCount = 1;
-	reagentId = 0;
-}
+ConjureSpell::ConjureSpell(LuaScriptInterface* interface) :
+	InstantSpell(interface),
+	conjureId(0),
+	conjureCount(1),
+	reagentId(0)
+{}
 
 std::string ConjureSpell::getScriptEventName() const
 {
@@ -1703,15 +1699,12 @@ bool ConjureSpell::playerCastInstant(Player* player, std::string& param)
 	return conjureItem(player);
 }
 
-RuneSpell::RuneSpell(LuaScriptInterface* _interface) :
-	Action(_interface)
-{
-	hasCharges = true;
-	runeId = 0;
-	runeFunction = nullptr;
-
-	allowFarUse = true;
-}
+RuneSpell::RuneSpell(LuaScriptInterface* interface) :
+	Action(interface),
+	runeFunction(nullptr),
+	runeId(0),
+	hasCharges(true)
+{}
 
 std::string RuneSpell::getScriptEventName() const
 {

--- a/src/spells.h
+++ b/src/spells.h
@@ -87,7 +87,7 @@ class BaseSpell
 class CombatSpell final : public Event, public BaseSpell
 {
 	public:
-		CombatSpell(Combat* _combat, bool _needTarget, bool _needDirection);
+		CombatSpell(Combat* combat, bool needTarget, bool needDirection);
 		~CombatSpell();
 
 		// non-copyable
@@ -200,7 +200,7 @@ class Spell : public BaseSpell
 class InstantSpell : public TalkAction, public Spell
 {
 	public:
-		explicit InstantSpell(LuaScriptInterface* _interface);
+		explicit InstantSpell(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) override;
 		bool loadFunction(const pugi::xml_attribute& attr) override;
@@ -253,7 +253,7 @@ class InstantSpell : public TalkAction, public Spell
 class ConjureSpell final : public InstantSpell
 {
 	public:
-		explicit ConjureSpell(LuaScriptInterface* _interface);
+		explicit ConjureSpell(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) final;
 		bool loadFunction(const pugi::xml_attribute& attr) final;
@@ -282,7 +282,7 @@ class ConjureSpell final : public InstantSpell
 class RuneSpell final : public Action, public Spell
 {
 	public:
-		explicit RuneSpell(LuaScriptInterface* _interface);
+		explicit RuneSpell(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) final;
 		bool loadFunction(const pugi::xml_attribute& attr) final;

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -107,11 +107,8 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 	return TALKACTION_CONTINUE;
 }
 
-TalkAction::TalkAction(LuaScriptInterface* _interface) :
-	Event(_interface)
-{
-	separator = '"';
-}
+TalkAction::TalkAction(LuaScriptInterface* interface) :
+	Event(interface), separator('"') {}
 
 bool TalkAction::configureEvent(const pugi::xml_node& node)
 {

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -60,7 +60,7 @@ class TalkActions : public BaseEvents
 class TalkAction : public Event
 {
 	public:
-		explicit TalkAction(LuaScriptInterface* _interface);
+		explicit TalkAction(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) override;
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -24,9 +24,7 @@
 
 extern Game g_game;
 
-Teleport::Teleport(uint16_t _type) : Item(_type)
-{
-}
+Teleport::Teleport(uint16_t type) : Item(type) {}
 
 Attr_ReadValue Teleport::readAttr(AttrTypes_t attr, PropStream& propStream)
 {

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -25,7 +25,7 @@
 class Teleport final : public Item, public Cylinder
 {
 	public:
-		explicit Teleport(uint16_t _type);
+		explicit Teleport(uint16_t type);
 
 		Teleport* getTeleport() final {
 			return this;

--- a/src/town.h
+++ b/src/town.h
@@ -25,7 +25,7 @@
 class Town
 {
 	public:
-		explicit Town(uint32_t _id) : id(_id) {}
+		explicit Town(uint32_t id) : id(id) {}
 
 		const Position& getTemplePosition() const {
 			return templePosition;

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -145,8 +145,8 @@ int32_t Weapons::getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t
 	return static_cast<int32_t>(std::ceil((2 * (attackValue * (attackSkill + 5.8) / 25 + (level - 1) / 10.)) / attackFactor));
 }
 
-Weapon::Weapon(LuaScriptInterface* _interface) :
-	Event(_interface)
+Weapon::Weapon(LuaScriptInterface* interface) :
+	Event(interface)
 {
 	scripted = false;
 	id = 0;
@@ -509,8 +509,8 @@ void Weapon::decrementItemCount(Item* item)
 	}
 }
 
-WeaponMelee::WeaponMelee(LuaScriptInterface* _interface) :
-	Weapon(_interface), elementType(COMBAT_NONE), elementDamage(0)
+WeaponMelee::WeaponMelee(LuaScriptInterface* interface) :
+	Weapon(interface), elementType(COMBAT_NONE), elementDamage(0)
 {
 	params.blockedByArmor = true;
 	params.blockedByShield = true;
@@ -602,8 +602,8 @@ int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, cons
 	return -normal_random(0, maxValue);
 }
 
-WeaponDistance::WeaponDistance(LuaScriptInterface* _interface) :
-	Weapon(_interface), elementType(COMBAT_NONE), elementDamage(0)
+WeaponDistance::WeaponDistance(LuaScriptInterface* interface) :
+	Weapon(interface), elementType(COMBAT_NONE), elementDamage(0)
 {
 	params.blockedByArmor = true;
 	params.combatType = COMBAT_PHYSICALDAMAGE;
@@ -874,8 +874,8 @@ bool WeaponDistance::getSkillType(const Player* player, const Item*, skills_t& s
 	return true;
 }
 
-WeaponWand::WeaponWand(LuaScriptInterface* _interface) :
-	Weapon(_interface)
+WeaponWand::WeaponWand(LuaScriptInterface* interface) :
+	Weapon(interface)
 {
 	minChange = 0;
 	maxChange = 0;

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -62,7 +62,7 @@ class Weapons final : public BaseEvents
 class Weapon : public Event
 {
 	public:
-		explicit Weapon(LuaScriptInterface* _interface);
+		explicit Weapon(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) override;
 		bool loadFunction(const pugi::xml_attribute&) final {
@@ -136,7 +136,7 @@ class Weapon : public Event
 class WeaponMelee final : public Weapon
 {
 	public:
-		explicit WeaponMelee(LuaScriptInterface* _interface);
+		explicit WeaponMelee(LuaScriptInterface* interface);
 
 		void configureWeapon(const ItemType& it) final;
 
@@ -156,7 +156,7 @@ class WeaponMelee final : public Weapon
 class WeaponDistance final : public Weapon
 {
 	public:
-		explicit WeaponDistance(LuaScriptInterface* _interface);
+		explicit WeaponDistance(LuaScriptInterface* interface);
 
 		void configureWeapon(const ItemType& it) final;
 		bool interruptSwing() const final {
@@ -179,7 +179,7 @@ class WeaponDistance final : public Weapon
 class WeaponWand final : public Weapon
 {
 	public:
-		explicit WeaponWand(LuaScriptInterface* _interface);
+		explicit WeaponWand(LuaScriptInterface* interface);
 
 		bool configureEvent(const pugi::xml_node& node) final;
 		void configureWeapon(const ItemType& it) final;


### PR DESCRIPTION
Almost all underscore-named variables were removed from the code. There's only one missing in `internalMoveItem` where both an argument and an internal variable are called `moveItem` and I couldn't figure a suitable name for any.

Also I refactored the constructors I stumbled upon with RAII.

Where a function would have both an argument and a variable with the same name (e.g. `_dir` and `dir` in `Monster::getRandomStep`, I renamed the argument to `direction` and the internal is still `dir`.

This PR is very open to suggestions.