### PR TITLE
Replace const_cast with mutable

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -836,18 +836,17 @@ bool Player::canWalkthrough(const Creature* creature) const
 		return false;
 	}
 
-	Player* thisPlayer = const_cast<Player*>(this);
 	if ((OTSYS_TIME() - lastWalkthroughAttempt) > 2000) {
-		thisPlayer->setLastWalkthroughAttempt(OTSYS_TIME());
+		setLastWalkthroughAttempt(OTSYS_TIME());
 		return false;
 	}
 
 	if (creature->getPosition() != lastWalkthroughPosition) {
-		thisPlayer->setLastWalkthroughPosition(creature->getPosition());
+		setLastWalkthroughPosition(creature->getPosition());
 		return false;
 	}
 
-	thisPlayer->setLastWalkthroughPosition(creature->getPosition());
+	setLastWalkthroughPosition(creature->getPosition());
 	return true;
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -254,10 +254,10 @@ class Player final : public Creature, public Cylinder
 		bool isInWar(const Player* player) const;
 		bool isInWarList(uint32_t guild_id) const;
 
-		void setLastWalkthroughAttempt(int64_t walkthroughAttempt) {
+		void setLastWalkthroughAttempt(int64_t walkthroughAttempt) const {
 			lastWalkthroughAttempt = walkthroughAttempt;
 		}
-		void setLastWalkthroughPosition(Position walkthroughPosition) {
+		void setLastWalkthroughPosition(Position walkthroughPosition) const {
 			lastWalkthroughPosition = walkthroughPosition;
 		}
 
@@ -1207,7 +1207,7 @@ class Player final : public Creature, public Cylinder
 		Skill skills[SKILL_LAST + 1];
 		LightInfo itemsLight;
 		Position loginPosition;
-		Position lastWalkthroughPosition;
+		mutable Position lastWalkthroughPosition;
 
 		time_t lastLoginSaved;
 		time_t lastLogout;
@@ -1219,7 +1219,7 @@ class Player final : public Creature, public Cylinder
 		uint64_t lastQuestlogUpdate;
 		int64_t lastFailedFollow;
 		int64_t skullTicks;
-		int64_t lastWalkthroughAttempt;
+		mutable int64_t lastWalkthroughAttempt;
 		int64_t lastToggleMount;
 		int64_t lastPing;
 		int64_t lastPong;


### PR DESCRIPTION
A `const_cast` inside player was not needed since it was possible to have a `mutable` variable instead. This cast was invoking undefined behavior and there's another two `const_cast` further in the file that may cause players [to travel time](https://blogs.msdn.microsoft.com/oldnewthing/20140627-00/?p=633).