### PR TITLE
Add missing DB migration

### DIFF
--- a/data/migrations/19.lua
+++ b/data/migrations/19.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end


### PR DESCRIPTION
Not sure if needed, but on #1603 I changed `18.lua` and forgot to add `19.lua` returning false. It didn't seem to cause any issue, but just in case...