### PR TITLE
Add `explicit` keyword to single-argument ctors

### DIFF
--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -42,7 +42,8 @@ bool Vocations::loadFromXml()
 
 		uint16_t id = pugi::cast<uint16_t>(attr.value());
 
-		auto res = vocationsMap.emplace(id, id);
+		auto res = vocationsMap.emplace(std::piecewise_construct,
+				std::forward_as_tuple(id), std::forward_as_tuple(id));
 		Vocation& voc = res.first->second;
 
 		if ((attr = vocationNode.attribute("name"))) {

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -26,7 +26,7 @@
 class Vocation
 {
 	public:
-		Vocation(uint16_t id);
+		explicit Vocation(uint16_t id);
 
 		const std::string& getVocName() const {
 			return name;

--- a/src/wildcardtree.cpp
+++ b/src/wildcardtree.cpp
@@ -49,7 +49,8 @@ WildcardTreeNode* WildcardTreeNode::addChild(char ch, bool breakpoint)
 			child->breakpoint = true;
 		}
 	} else {
-		auto pair = children.emplace(ch, breakpoint);
+		auto pair = children.emplace(std::piecewise_construct,
+				std::forward_as_tuple(ch), std::forward_as_tuple(breakpoint));
 		child = &pair.first->second;
 	}
 	return child;

--- a/src/wildcardtree.h
+++ b/src/wildcardtree.h
@@ -25,7 +25,7 @@
 class WildcardTreeNode
 {
 	public:
-		WildcardTreeNode(bool breakpoint) : breakpoint(breakpoint) {}
+		explicit WildcardTreeNode(bool breakpoint) : breakpoint(breakpoint) {}
 		WildcardTreeNode(WildcardTreeNode&& other) : children(std::move(other.children)), breakpoint(other.breakpoint) {}
 
 		// non-copyable


### PR DESCRIPTION
Two constructors (for `Vocation` and `WildcardTreeNode`) receive a single `uint16_t` argument and are not marked as `explicit` and could accidentally be (and were) used as conversion constructors ([source](https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=3416)) and thus should be marked as `explicit`, else code like `if (someVoc == 2)` would be allowed instead of `if (someVoc.getID() == 2)`.