### PR TITLE
Fix bug while roping players, fix #1766

### DIFF
--- a/data/actions/scripts/other/teleport.lua
+++ b/data/actions/scripts/other/teleport.lua
@@ -5,6 +5,11 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	else
 		fromPosition.z = fromPosition.z + 1
 	end
+	local t = Tile(fromPosition)
+	if t:hasFlag(TILESTATE_PROTECTIONZONE) and player:isPzLocked() then
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You can not enter a protection zone after attacking another player.")
+		return true
+	end
 	player:teleportTo(fromPosition, false)
 	return true
 end

--- a/data/actions/scripts/tools/rope.lua
+++ b/data/actions/scripts/tools/rope.lua
@@ -1,8 +1,8 @@
 local holeId = {
-	294, 369, 370, 383, 392, 408, 409, 410, 427, 428, 430, 462, 469, 470, 482,
-	484, 485, 489, 924, 3135, 3136, 7933, 7938, 8170, 8286, 8285, 8284, 8281,
-	8280, 8279, 8277, 8276, 8323, 8567, 8585, 8596, 8595, 8249, 8250, 8251,
-	8252, 8253, 8254, 8255, 8256, 8972, 9606, 9625, 13190, 14461, 19519, 21536
+	294, 369, 370, 383, 392, 408, 409, 410, 427, 428, 429, 430, 462, 469, 470, 482,
+	484, 485, 489, 924, 1369, 3135, 3136, 4835, 4837, 7933, 7938, 8170, 8249, 8250,
+	8251, 8252, 8254, 8255, 8256, 8276, 8277, 8279, 8281, 8284, 8285, 8286, 8323,
+	8567, 8585, 8595, 8596, 8972, 9606, 9625, 13190, 14461, 19519, 21536
 }
 
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
@@ -12,13 +12,25 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	if isInArray(ropeSpots, tile:getGround():getId()) or tile:getItemById(14435) then
-		player:teleportTo(toPosition:moveUpstairs(), false)
+		tile = Tile(toPosition:moveUpstairs())
+		if tile:hasFlag(TILESTATE_PROTECTIONZONE) and player:isPzLocked() then
+			player:sendTextMessage(MESSAGE_STATUS_SMALL, "You can not enter a protection zone after attacking another player.")
+			return true
+		end
+		player:teleportTo(toPosition, false)
 		return true
 	elseif isInArray(holeId, target.itemid) then
 		toPosition.z = toPosition.z + 1
 		tile = Tile(toPosition)
 		if tile then
 			local thing = tile:getTopVisibleThing()
+			if thing:isPlayer() then
+				tile = Tile(toPosition:moveUpstairs())
+				if tile:hasFlag(TILESTATE_PROTECTIONZONE) and thing:isPzLocked() then
+					return false
+				end
+				return thing:teleportTo(toPosition, false)
+			end
 			if thing:isItem() and thing:getType():isMovable() then
 				return thing:moveTo(toPosition:moveUpstairs())
 			end


### PR DESCRIPTION
Idk if `moveTo()` are suppose to move players, if it should it is not working, so I switch it to `teleportTo()`
Also added some missing hole ids from table, removed 8253 because does not match with a hole and prevent roping players with pz-lock to a pz tile.