### PR TITLE
Added condition type immunity check

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2030,7 +2030,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "isCreature", LuaScriptInterface::luaCreatureIsCreature);
 	registerMethod("Creature", "isInGhostMode", LuaScriptInterface::luaCreatureIsInGhostMode);
 	registerMethod("Creature", "isHealthHidden", LuaScriptInterface::luaCreatureIsHealthHidden);
-	registerMethod("Creature", "isImmuneTo", LuaScriptInterface::luaCreatureIsImmuneTo);
+	registerMethod("Creature", "isImmune", LuaScriptInterface::luaCreatureIsImmune);
 
 	registerMethod("Creature", "canSee", LuaScriptInterface::luaCreatureCanSee);
 	registerMethod("Creature", "canSeeCreature", LuaScriptInterface::luaCreatureCanSeeCreature);
@@ -7254,9 +7254,9 @@ int LuaScriptInterface::luaCreatureRemoveCondition(lua_State* L)
 	return 1;
 }
 
-int LuaScriptInterface::luaCreatureIsImmuneTo(lua_State* L)
+int LuaScriptInterface::luaCreatureIsImmune(lua_State* L)
 {
-	// creature:isImmuneTo(condition or conditionType)
+	// creature:isImmune(condition or conditionType)
 	Creature* creature = getUserdata<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2030,6 +2030,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "isCreature", LuaScriptInterface::luaCreatureIsCreature);
 	registerMethod("Creature", "isInGhostMode", LuaScriptInterface::luaCreatureIsInGhostMode);
 	registerMethod("Creature", "isHealthHidden", LuaScriptInterface::luaCreatureIsHealthHidden);
+	registerMethod("Creature", "isImmuneTo", LuaScriptInterface::luaCreatureIsImmuneTo);
 
 	registerMethod("Creature", "canSee", LuaScriptInterface::luaCreatureCanSee);
 	registerMethod("Creature", "canSeeCreature", LuaScriptInterface::luaCreatureCanSeeCreature);
@@ -7249,6 +7250,28 @@ int LuaScriptInterface::luaCreatureRemoveCondition(lua_State* L)
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureIsImmuneTo(lua_State* L)
+{
+	// creature:isImmuneTo(condition or conditionType)
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (isNumber(L, 2)) {
+		pushBoolean(L, creature->isImmune(getNumber<ConditionType_t>(L, 2)));
+	} else {
+		Condition* condition = getUserdata<Condition>(L, 2);
+		if (condition) {
+			pushBoolean(L, creature->isImmune(condition->getType()));
+		} else {
+			lua_pushnil(L);
+		}
 	}
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7265,13 +7265,10 @@ int LuaScriptInterface::luaCreatureIsImmune(lua_State* L)
 
 	if (isNumber(L, 2)) {
 		pushBoolean(L, creature->isImmune(getNumber<ConditionType_t>(L, 2)));
+	} else if (Condition* condition = getUserdata<Condition>(L, 2)) {
+		pushBoolean(L, creature->isImmune(condition->getType()));
 	} else {
-		Condition* condition = getUserdata<Condition>(L, 2);
-		if (condition) {
-			pushBoolean(L, creature->isImmune(condition->getType()));
-		} else {
-			lua_pushnil(L);
-		}
+		lua_pushnil(L);
 	}
 	return 1;
 }

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -740,6 +740,7 @@ class LuaScriptInterface
 		static int luaCreatureIsCreature(lua_State* L);
 		static int luaCreatureIsInGhostMode(lua_State* L);
 		static int luaCreatureIsHealthHidden(lua_State* L);
+		static int luaCreatureIsImmuneTo(lua_State* L);
 
 		static int luaCreatureCanSee(lua_State* L);
 		static int luaCreatureCanSeeCreature(lua_State* L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -740,7 +740,7 @@ class LuaScriptInterface
 		static int luaCreatureIsCreature(lua_State* L);
 		static int luaCreatureIsInGhostMode(lua_State* L);
 		static int luaCreatureIsHealthHidden(lua_State* L);
-		static int luaCreatureIsImmuneTo(lua_State* L);
+		static int luaCreatureIsImmune(lua_State* L);
 
 		static int luaCreatureCanSee(lua_State* L);
 		static int luaCreatureCanSeeCreature(lua_State* L);


### PR DESCRIPTION
We can now check if a creature is immune to a condition type.

This I something I had to add to address a latter issue at #1635 when using callbacks, but it is more like a optimization really, since the condition object is in onTargetCreature callback function, and is not bound to a combat object, so it would be added to the target creature everytime (no damage is added, but the block effect keeps happening) regardless of its immunity to that condition.
Example: http://imgur.com/64u6snS

When using combat:setCondition(condition) if the target creature is immune to that condition type then **only** the impact block type effects occurs, but the condition is not added to the creature.

With this, we could prevent a lot of code to be run if we don't need to.
