### PR TITLE
FIX Autostack bugs.

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -443,9 +443,15 @@ Cylinder* Container::queryDestination(int32_t& index, const Thing &thing, Item**
 		return this;
 	}
 
+	if (index != INDEX_WHEREEVER) {
+		Item* itemFromIndex = getItemByIndex(index);
+		if (itemFromIndex) {
+			*destItem = itemFromIndex;
+		}
+	}
+
 	bool autoStack = !hasBitSet(FLAG_IGNOREAUTOSTACK, flags);
-	if (autoStack && item->isStackable() && item->getParent() != this) {
-		//try find a suitable item to stack with
+	if (autoStack && item->isStackable() && item->getParent() != this && !(*destItem && (*destItem)->isStackable() && (*destItem)->equals(item))) {		//try find a suitable item to stack with
 		uint32_t n = 0;
 		for (Item* listItem : itemlist) {
 			if (listItem != item && listItem->equals(item) && listItem->getItemCount() < 100) {
@@ -457,18 +463,12 @@ Cylinder* Container::queryDestination(int32_t& index, const Thing &thing, Item**
 		}
 	}
 
-	if (index != INDEX_WHEREEVER) {
-		Item* itemFromIndex = getItemByIndex(index);
-		if (itemFromIndex) {
-			*destItem = itemFromIndex;
-		}
 
-		Cylinder* subCylinder = dynamic_cast<Cylinder*>(*destItem);
-		if (subCylinder) {
-			index = INDEX_WHEREEVER;
-			*destItem = nullptr;
-			return subCylinder;
-		}
+	Cylinder* subCylinder = dynamic_cast<Cylinder*>(*destItem);
+	if (subCylinder) {
+		index = INDEX_WHEREEVER;
+		*destItem = nullptr;
+		return subCylinder;
 	}
 	return this;
 }

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -452,7 +452,7 @@ Cylinder* Container::queryDestination(int32_t& index, const Thing &thing, Item**
 
 	bool autoStack = !hasBitSet(FLAG_IGNOREAUTOSTACK, flags);
 	//try find a suitable item to stack with
-	if (autoStack && item->isStackable() && item->getParent() != this && !(*destItem && (*destItem)->isStackable() && (*destItem)->equals(item))) {
+	if (autoStack && item->isStackable() && item->getParent() != this && !(*destItem && (*destItem)->equals(item))) {
 		uint32_t n = 0;
 		for (Item* listItem : itemlist) {
 			if (listItem != item && listItem->equals(item) && listItem->getItemCount() < 100) {

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -451,7 +451,8 @@ Cylinder* Container::queryDestination(int32_t& index, const Thing &thing, Item**
 	}
 
 	bool autoStack = !hasBitSet(FLAG_IGNOREAUTOSTACK, flags);
-	if (autoStack && item->isStackable() && item->getParent() != this && !(*destItem && (*destItem)->isStackable() && (*destItem)->equals(item))) {		//try find a suitable item to stack with
+	//try find a suitable item to stack with
+	if (autoStack && item->isStackable() && item->getParent() != this && !(*destItem && (*destItem)->isStackable() && (*destItem)->equals(item))) {
 		uint32_t n = 0;
 		for (Item* listItem : itemlist) {
 			if (listItem != item && listItem->equals(item) && listItem->getItemCount() < 100) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1183,7 +1183,12 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 
 	//add item
 	if (moveItem /*m - n > 0*/) {
-		toCylinder->addThing(index, moveItem);
+		if (fromCylinder == toCylinder) {
+			toCylinder->addThing(index, moveItem);
+			
+		} else {
+			internalAddItem(toCylinder, moveItem, INDEX_WHEREEVER);
+		}
 	}
 
 	if (itemIndex != -1) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1187,7 +1187,7 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 			toCylinder->addThing(index, moveItem);
 			
 		} else {
-			internalAddItem(toCylinder, moveItem, INDEX_WHEREEVER);
+			internalAddItem(toCylinder, moveItem, INDEX_WHEREEVER, flags);
 		}
 	}
 


### PR DESCRIPTION
There are 2 bugs in the current autostack code:

1) When moving from a stackable item to the same item but in a different
cylinder it should stack them but currently it stacks with the first
stack in the container.

2) When moving a stackable item to a different cylinder it should
autostack the remain count if it exceeds 100.

Video: https://www.youtube.com/watch?v=jJHsi9MoWNE
