### PR TITLE
Remove not necessary statements

### DIFF
--- a/data/actions/scripts/tools/pick.lua
+++ b/data/actions/scripts/tools/pick.lua
@@ -1,10 +1,6 @@
 local groundIds = {354, 355}
 
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if toPosition.x == CONTAINER_POSITION then
-		return false
-	end
-
 	local tile = Tile(toPosition)
 	if not tile then
 		return false

--- a/data/actions/scripts/tools/shovel.lua
+++ b/data/actions/scripts/tools/shovel.lua
@@ -1,9 +1,5 @@
 local holes = {468, 481, 483}
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if toPosition.x == CONTAINER_POSITION then
-		return false
-	end
-
 	local tile = Tile(toPosition)
 	if not tile then
 		return false

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spells>
-	<instant group="attack" spellid="62" name="Annihilation" words="exori gran ico" lvl="110" mana="300" prem="1" range="1" needtarget="1" blockwalls="1" needweapon="1" cooldown="30000" groupcooldown="4000" needlearn="0" script="attack/annihilation.lua">
+	<instant group="attack" spellid="62" name="Annihilation" words="exori gran ico" lvl="110" mana="300" prem="1" range="1" needtarget="1" needweapon="1" cooldown="30000" groupcooldown="4000" needlearn="0" script="attack/annihilation.lua">
 		<vocation name="Knight" />
 		<vocation name="Elite Knight" />
 	</instant>
@@ -22,7 +22,7 @@
 		<vocation name="Knight" />
 		<vocation name="Elite Knight" />
 	</instant>
-	<instant group="attack" spellid="61" name="Brutal Strike" words="exori ico" lvl="16" mana="30" prem="1" range="1" needtarget="1" blockwalls="1" needweapon="1" cooldown="6000" groupcooldown="2000" needlearn="0" script="attack/brutal_strike.lua">
+	<instant group="attack" spellid="61" name="Brutal Strike" words="exori ico" lvl="16" mana="30" prem="1" range="1" needtarget="1" needweapon="1" cooldown="6000" groupcooldown="2000" needlearn="0" script="attack/brutal_strike.lua">
 		<vocation name="Knight" />
 		<vocation name="Elite Knight" />
 	</instant>
@@ -223,7 +223,7 @@
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>
-	<instant group="attack" spellid="141" name="Inflict Wound" words="utori kor" lvl="40" mana="30" prem="1" range="1" aggressive="1" blockwalls="1" needtarget="1" needweapon="1" cooldown="30000" groupcooldown="2000" needlearn="0" script="attack/inflict_wound.lua">
+	<instant group="attack" spellid="141" name="Inflict Wound" words="utori kor" lvl="40" mana="30" prem="1" range="1" aggressive="1" needtarget="1" needweapon="1" cooldown="30000" groupcooldown="2000" needlearn="0" script="attack/inflict_wound.lua">
 		<vocation name="Knight" />
 		<vocation name="Elite Knight" />
 	</instant>


### PR DESCRIPTION
Items used to a container position will return false in the statment below, about change in spells i see no way to a spell with a range of 1 can pass through walls.

I'd like to ask a question here, why tfs uses 0/1 for booleans in all xml files but outfits.xml? sometimes it confuses and need to check in sources to be sure, like in this thread in [OTLand] (https://otland.net/threads/tfs-1-2-lottery-system.244420/#post-2376102), personally in my distro i changed all booleans to true/false, i think it is more readable.