### PR TITLE
Optimize build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,14 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 project(tfs)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(cotire)
 
-# Initialize CXXFLAGS.
-set(CMAKE_CXX_FLAGS                "-Wall -Werror -pipe")
-set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")
-set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE        "-Ofast -march=native -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+add_compile_options(-Wall -Werror -pipe -fvisibility=hidden)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+    add_compile_options(-fno-strict-aliasing)
 endif()
 
 include(FindCXX11)

--- a/cmake/FindCXX11.cmake
+++ b/cmake/FindCXX11.cmake
@@ -8,19 +8,14 @@ enable_language(CXX)
 
 check_cxx_compiler_flag("-std=c++11" COMPILER_KNOWS_CXX11)
 if(COMPILER_KNOWS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    add_compile_options(-std=c++11)
 
     # Tested on Mac OS X 10.8.2 with XCode 4.6 Command Line Tools
     # Clang requires this to find the correct c++11 headers
     check_cxx_compiler_flag("-stdlib=libc++" COMPILER_KNOWS_STDLIB)
     if(APPLE AND COMPILER_KNOWS_STDLIB)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+        add_compile_options(-stdlib=libc++)
     endif()
 else()
-    check_cxx_compiler_flag("-std=c++0x" COMPILER_KNOWS_CXX0X)
-    if(COMPILER_KNOWS_CXX0X)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-    else()
-        message(FATAL_ERROR "Your C++ compiler does not support C++11.")
-    endif()
+    message(FATAL_ERROR "Your C++ compiler does not support C++11.")
 endif()


### PR DESCRIPTION
Those options reduce the binary size by 30% (for me, 3.55MB to 2.56MB), though compilation times take longer with LTO. Visibility change is responsible for around 400kB, while link time optimization shrinks binary by >600kB and improves performance.

On the other hand, `-Ofast` is not supported by clang until 3.8 which is very recent and did little extra optimization over `-O3`, besides doing optimizations that are not compliant to the spec, so `-O3` is a safer option.