### PR TITLE
Modernize code to improve quality

### DIFF
--- a/src/chat.h
+++ b/src/chat.h
@@ -34,7 +34,7 @@ class ChatChannel
 	public:
 		ChatChannel() = default;
 		ChatChannel(uint16_t channelId, std::string channelName):
-			name(channelName),
+			name(std::move(channelName)),
 			id(channelId) {}
 
 		virtual ~ChatChannel() = default;

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1298,11 +1298,11 @@ void AreaCombat::setupArea(int32_t radius)
 
 	std::list<uint32_t> list;
 
-	for (int32_t y = 0; y < 13; ++y) {
-		for (int32_t x = 0; x < 13; ++x) {
-			if (area[y][x] == 1) {
+	for (auto& row : area) {
+		for (int cell : row) {
+			if (cell == 1) {
 				list.push_back(3);
-			} else if (area[y][x] > 0 && area[y][x] <= radius) {
+			} else if (cell > 0 && cell <= radius) {
 				list.push_back(1);
 			} else {
 				list.push_back(0);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -66,8 +66,8 @@ s_defcommands Commands::defined_commands[] = {
 Commands::Commands()
 {
 	// set up command map
-	for (uint32_t i = 0; i < sizeof(defined_commands) / sizeof(defined_commands[0]); i++) {
-		commandMap[defined_commands[i].name] = new Command(defined_commands[i].f, 1, ACCOUNT_TYPE_GOD, true);
+	for (auto& command : defined_commands) {
+		commandMap[command.name] = new Command(command.f, 1, ACCOUNT_TYPE_GOD, true);
 	}
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -77,7 +77,7 @@ class Connection : public std::enable_shared_from_this<Connection>
 		           ConstServicePort_ptr service_port) :
 			readTimer(io_service),
 			writeTimer(io_service),
-			service_port(service_port),
+			service_port(std::move(service_port)),
 			socket(io_service) {
 			connectionState = CONNECTION_STATE_OPEN;
 			receivedFirst = false;

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -91,7 +91,7 @@ bool CreatureEvents::registerEvent(Event* event, const pugi::xml_node&)
 
 CreatureEvent* CreatureEvents::getEventByName(const std::string& name, bool forceLoaded /*= true*/)
 {
-	CreatureEventList::iterator it = creatureEvents.find(name);
+	auto it = creatureEvents.find(name);
 	if (it != creatureEvents.end()) {
 		if (!forceLoaded || it->second->isLoaded()) {
 			return it->second;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -245,7 +245,7 @@ bool DBResult::next()
 	return row != nullptr;
 }
 
-DBInsert::DBInsert(std::string query) : query(query)
+DBInsert::DBInsert(std::string query) : query(std::move(query))
 {
 	this->length = this->query.length();
 }

--- a/src/databasetasks.h
+++ b/src/databasetasks.h
@@ -26,8 +26,8 @@
 #include "enums.h"
 
 struct DatabaseTask {
-	DatabaseTask(std::string query, const std::function<void(DBResult_ptr, bool)>& callback, bool store) :
-		query(query), callback(callback), store(store) {}
+	DatabaseTask(std::string query, std::function<void(DBResult_ptr, bool)> callback, bool store) :
+		query(std::move(query)), callback(std::move(callback)), store(store) {}
 
 	std::string query;
 	std::function<void(DBResult_ptr, bool)> callback;

--- a/src/enums.h
+++ b/src/enums.h
@@ -457,7 +457,7 @@ struct ShopInfo {
 	}
 
 	ShopInfo(uint16_t itemId, int32_t subType = 0, uint32_t buyPrice = 0, uint32_t sellPrice = 0, std::string realName = "")
-		: itemId(itemId), subType(subType), buyPrice(buyPrice), sellPrice(sellPrice), realName(realName) {}
+		: itemId(itemId), subType(subType), buyPrice(buyPrice), sellPrice(sellPrice), realName(std::move(realName)) {}
 };
 
 struct MarketOffer {
@@ -518,7 +518,7 @@ struct ModalWindow
 	bool priority;
 
 	ModalWindow(uint32_t id, std::string title, std::string message)
-		: title(title), message(message), id(id), defaultEnterButton(0xFF), defaultEscapeButton(0xFF), priority(false) {}
+		: title(std::move(title)), message(std::move(message)), id(id), defaultEnterButton(0xFF), defaultEscapeButton(0xFF), priority(false) {}
 };
 
 enum CombatOrigin

--- a/src/fileloader.cpp
+++ b/src/fileloader.cpp
@@ -31,8 +31,8 @@ FileLoader::~FileLoader()
 	NodeStruct::clearNet(root);
 	delete[] buffer;
 
-	for (int32_t i = 0; i < CACHE_BLOCKS; i++) {
-		delete[] cached_data[i].data;
+	for (auto& i : cached_data) {
+		delete[] i.data;
 	}
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2561,7 +2561,7 @@ void Game::playerAcceptTrade(uint32_t playerId)
 		player->setTradeState(TRADE_TRANSFER);
 		tradePartner->setTradeState(TRADE_TRANSFER);
 
-		std::map<Item*, uint32_t>::iterator it = tradeItems.find(tradeItem1);
+		auto it = tradeItems.find(tradeItem1);
 		if (it != tradeItems.end()) {
 			ReleaseItem(it->first);
 			tradeItems.erase(it);
@@ -2732,7 +2732,7 @@ void Game::internalCloseTrade(Player* player)
 	}
 
 	if (player->getTradeItem()) {
-		std::map<Item*, uint32_t>::iterator it = tradeItems.find(player->getTradeItem());
+		auto it = tradeItems.find(player->getTradeItem());
 		if (it != tradeItems.end()) {
 			ReleaseItem(it->first);
 			tradeItems.erase(it);
@@ -2750,7 +2750,7 @@ void Game::internalCloseTrade(Player* player)
 
 	if (tradePartner) {
 		if (tradePartner->getTradeItem()) {
-			std::map<Item*, uint32_t>::iterator it = tradeItems.find(tradePartner->getTradeItem());
+			auto it = tradeItems.find(tradePartner->getTradeItem());
 			if (it != tradeItems.end()) {
 				ReleaseItem(it->first);
 				tradeItems.erase(it);

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -49,9 +49,9 @@ void Guild::removeMember(Player* player)
 
 GuildRank* Guild::getRankById(uint32_t rankId)
 {
-	for (size_t i = 0; i < ranks.size(); ++i) {
-		if (ranks[i].id == rankId) {
-			return &ranks[i];
+	for (auto& rank : ranks) {
+		if (rank.id == rankId) {
+			return &rank;
 		}
 	}
 	return nullptr;
@@ -59,9 +59,9 @@ GuildRank* Guild::getRankById(uint32_t rankId)
 
 const GuildRank* Guild::getRankByLevel(uint8_t level) const
 {
-	for (size_t i = 0; i < ranks.size(); ++i) {
-		if (ranks[i].level == level) {
-			return &ranks[i];
+	for (const auto& rank : ranks) {
+		if (rank.level == level) {
+			return &rank;
 		}
 	}
 	return nullptr;

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -226,7 +226,7 @@ void IOMapSerialize::saveItem(PropWriteStream& stream, const Item* item)
 		// Hack our way into the attributes
 		stream.write<uint8_t>(ATTR_CONTAINER_ITEMS);
 		stream.write<uint32_t>(container->size());
-		for (ItemDeque::const_reverse_iterator it = container->getReversedItems(), end = container->getReversedEnd(); it != end; ++it) {
+		for (auto it = container->getReversedItems(), end = container->getReversedEnd(); it != end; ++it) {
 			saveItem(stream, *it);
 		}
 	}

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -663,8 +663,8 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 		} else if (tmpStrValue == "absorbpercentall" || tmpStrValue == "absorbpercentallelements") {
 			int16_t value = pugi::cast<int16_t>(valueAttribute.value());
 			Abilities& abilities = it.getAbilities();
-			for (size_t i = 0; i < COMBAT_COUNT; ++i) {
-				abilities.absorbPercent[i] += value;
+			for (auto& i : abilities.absorbPercent) {
+				i += value;
 			}
 		} else if (tmpStrValue == "absorbpercentelements") {
 			int16_t value = pugi::cast<int16_t>(valueAttribute.value());

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -853,9 +853,9 @@ int_fast32_t AStarNodes::getTileWalkCost(const Creature& creature, const Tile* t
 // Floor
 Floor::~Floor()
 {
-	for (uint32_t i = 0; i < FLOOR_SIZE; ++i) {
-		for (uint32_t j = 0; j < FLOOR_SIZE; ++j) {
-			delete tiles[i][j];
+	for (auto& row : tiles) {
+		for (auto tile : row) {
+			delete tile;
 		}
 	}
 }
@@ -927,7 +927,7 @@ void QTreeLeafNode::addCreature(Creature* c)
 
 void QTreeLeafNode::removeCreature(Creature* c)
 {
-	CreatureVector::iterator iter = std::find(creature_list.begin(), creature_list.end(), c);
+	auto iter = std::find(creature_list.begin(), creature_list.end(), c);
 	assert(iter != creature_list.end());
 	*iter = creature_list.back();
 	creature_list.pop_back();
@@ -964,9 +964,8 @@ uint32_t Map::clean() const
 					continue;
 				}
 
-				for (size_t x = 0; x < FLOOR_SIZE; ++x) {
-					for (size_t y = 0; y < FLOOR_SIZE; ++y) {
-						Tile* tile = floor->tiles[x][y];
+				for (auto& row : floor->tiles) {
+					for (auto tile : row) {
 						if (!tile || tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 							continue;
 						}
@@ -992,8 +991,7 @@ uint32_t Map::clean() const
 				}
 			}
 		} else {
-			for (size_t i = 0; i < 4; ++i) {
-				QTreeNode* childNode = node->child[i];
+			for (auto childNode : node->child) {
 				if (childNode) {
 					nodes.push_back(childNode);
 				}

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -44,8 +44,8 @@ void MoveEvents::clearMap(MoveListMap& map)
 	std::unordered_set<MoveEvent*> set;
 	for (const auto& it : map) {
 		const MoveEventList& moveEventList = it.second;
-		for (int32_t i = 0; i < MOVE_EVENT_LAST; ++i) {
-			for (MoveEvent* moveEvent : moveEventList.moveEvent[i]) {
+		for (const auto& i : moveEventList.moveEvent) {
+			for (MoveEvent* moveEvent : i) {
 				set.insert(moveEvent);
 			}
 		}
@@ -65,8 +65,8 @@ void MoveEvents::clear()
 
 	for (const auto& it : positionMap) {
 		const MoveEventList& moveEventList = it.second;
-		for (int32_t i = 0; i < MOVE_EVENT_LAST; ++i) {
-			for (MoveEvent* moveEvent : moveEventList.moveEvent[i]) {
+		for (const auto& i : moveEventList.moveEvent) {
+			for (MoveEvent* moveEvent : i) {
 				delete moveEvent;
 			}
 		}
@@ -285,7 +285,7 @@ void MoveEvents::addEvent(MoveEvent* moveEvent, const Position& pos, MovePosList
 
 MoveEvent* MoveEvents::getEvent(const Tile* tile, MoveEvent_t eventType)
 {
-	MovePosListMap::iterator it = positionMap.find(tile->getPosition());
+	auto it = positionMap.find(tile->getPosition());
 	if (it != positionMap.end()) {
 		std::list<MoveEvent*>& moveEventList = it->second.moveEvent[eventType];
 		if (!moveEventList.empty()) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -48,7 +48,7 @@ MuteCountMap Player::muteCountMap;
 uint32_t Player::playerAutoID = 0x10000000;
 
 Player::Player(ProtocolGame_ptr p) :
-	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), inbox(new Inbox(ITEM_INBOX)), client(p)
+	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), inbox(new Inbox(ITEM_INBOX)), client(std::move(p))
 {
 	inbox->incrementReferenceCounter();
 }

--- a/src/player.h
+++ b/src/player.h
@@ -1231,7 +1231,7 @@ class Player final : public Creature, public Cylinder
 		Group* group = nullptr;
 		Inbox* inbox;
 		Item* tradeItem = nullptr;
- 		Item* inventory[CONST_SLOT_LAST + 1] = { nullptr };
+ 		Item* inventory[CONST_SLOT_LAST + 1] = {};
 		Item* writeItem = nullptr;
 		House* editHouse = nullptr;
 		Npc* shopOwner = nullptr;
@@ -1259,8 +1259,8 @@ class Player final : public Creature, public Cylinder
 		uint32_t windowTextId = 0;
 		uint32_t editListId = 0;
 		uint32_t manaMax = 0;
-		int32_t varSkills[SKILL_LAST + 1] = { 0 };
-		int32_t varStats[STAT_LAST + 1] = { 0 };
+		int32_t varSkills[SKILL_LAST + 1] = {};
+		int32_t varStats[STAT_LAST + 1] = {};
 		int32_t purchaseCallback = -1;
 		int32_t saleCallback = -1;
 		int32_t MessageBufferCount = 0;
@@ -1296,7 +1296,7 @@ class Player final : public Creature, public Cylinder
 		bool pzLocked = false;
 		bool isConnecting = false;
 		bool addAttackSkillPoint = false;
-		bool inventoryAbilities[CONST_SLOT_LAST + 1] = { false };
+		bool inventoryAbilities[CONST_SLOT_LAST + 1] = {};
 
 		static uint32_t playerAutoID;
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -606,7 +606,7 @@ void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& remo
 
 	if (knownCreatureSet.size() > 1300) {
 		// Look for a creature to remove
-		for (std::unordered_set<uint32_t>::iterator it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
+		for (auto it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
 			Creature* creature = g_game.getCreatureByID(*it);
 			if (!canSee(creature)) {
 				removedKnown = *it;
@@ -616,7 +616,7 @@ void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& remo
 		}
 
 		// Bad situation. Let's just remove anyone.
-		std::unordered_set<uint32_t>::iterator it = knownCreatureSet.begin();
+		auto it = knownCreatureSet.begin();
 		if (*it == id) {
 			++it;
 		}
@@ -1433,7 +1433,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 		uint8_t itemsToSend = std::min<uint32_t>(std::min<uint32_t>(container->capacity(), containerSize - firstIndex), std::numeric_limits<uint8_t>::max());
 
 		msg.addByte(itemsToSend);
-		for (ItemDeque::const_iterator it = container->getItemList().begin() + firstIndex, end = it + itemsToSend; it != end; ++it) {
+		for (auto it = container->getItemList().begin() + firstIndex, end = it + itemsToSend; it != end; ++it) {
 			msg.addItem(*it);
 		}
 	} else {
@@ -1452,7 +1452,7 @@ void ProtocolGame::sendShop(Npc* npc, const ShopInfoList& itemList)
 	msg.add<uint16_t>(itemsToSend);
 
 	uint16_t i = 0;
-	for (ShopInfoList::const_iterator it = itemList.begin(); i < itemsToSend; ++it, ++i) {
+	for (auto it = itemList.begin(); i < itemsToSend; ++it, ++i) {
 		AddShopItem(msg, *it);
 	}
 
@@ -1735,7 +1735,7 @@ void ProtocolGame::sendMarketBrowseOwnHistory(const HistoryMarketOfferList& buyO
 	msg.add<uint16_t>(MARKETREQUEST_OWN_HISTORY);
 
 	msg.add<uint32_t>(buyOffersToSend);
-	for (HistoryMarketOfferList::const_iterator it = buyOffers.begin(); i < buyOffersToSend; ++it, ++i) {
+	for (auto it = buyOffers.begin(); i < buyOffersToSend; ++it, ++i) {
 		msg.add<uint32_t>(it->timestamp);
 		msg.add<uint16_t>(counterMap[it->timestamp]++);
 		msg.addItemId(it->itemId);
@@ -1748,7 +1748,7 @@ void ProtocolGame::sendMarketBrowseOwnHistory(const HistoryMarketOfferList& buyO
 	i = 0;
 
 	msg.add<uint32_t>(sellOffersToSend);
-	for (HistoryMarketOfferList::const_iterator it = sellOffers.begin(); i < sellOffersToSend; ++it, ++i) {
+	for (auto it = sellOffers.begin(); i < sellOffersToSend; ++it, ++i) {
 		msg.add<uint32_t>(it->timestamp);
 		msg.add<uint16_t>(counterMap[it->timestamp]++);
 		msg.addItemId(it->itemId);

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -49,7 +49,7 @@ struct TextMessage
 	} primary, secondary;
 
 	TextMessage() = default;
-	TextMessage(MessageClasses type, std::string text) : type(type), text(text) {}
+	TextMessage(MessageClasses type, std::string text) : type(type), text(std::move(text)) {}
 };
 
 class ProtocolGame final : public Protocol

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -31,8 +31,9 @@ class Task
 {
 	public:
 		// DO NOT allocate this class on the stack
-		explicit Task(const std::function<void (void)>& f) : func(f) {}
-		Task(uint32_t ms, const std::function<void (void)>& f) : expiration(std::chrono::system_clock::now() + std::chrono::milliseconds(ms)), func(f) {}
+		explicit Task(std::function<void (void)> f) : func(std::move(f)) {}
+		Task(uint32_t ms, std::function<void (void)> f) :
+			expiration(std::chrono::system_clock::now() + std::chrono::milliseconds(ms)), func(std::move(f)) {}
 
 		virtual ~Task() = default;
 		void operator()() {

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -145,7 +145,7 @@ Teleport* Tile::getTeleportItem() const
 	}
 
 	if (const TileItemVector* items = getItemList()) {
-		for (ItemVector::const_reverse_iterator it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getTeleport()) {
 				return (*it)->getTeleport();
 			}
@@ -165,7 +165,7 @@ MagicField* Tile::getFieldItem() const
 	}
 
 	if (const TileItemVector* items = getItemList()) {
-		for (ItemVector::const_reverse_iterator it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getMagicField()) {
 				return (*it)->getMagicField();
 			}
@@ -185,7 +185,7 @@ TrashHolder* Tile::getTrashHolder() const
 	}
 
 	if (const TileItemVector* items = getItemList()) {
-		for (ItemVector::const_reverse_iterator it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getTrashHolder()) {
 				return (*it)->getTrashHolder();
 			}
@@ -205,7 +205,7 @@ Mailbox* Tile::getMailbox() const
 	}
 
 	if (const TileItemVector* items = getItemList()) {
-		for (ItemVector::const_reverse_iterator it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getMailbox()) {
 				return (*it)->getMailbox();
 			}
@@ -225,7 +225,7 @@ BedItem* Tile::getBedItem() const
 	}
 
 	if (const TileItemVector* items = getItemList()) {
-		for (ItemVector::const_reverse_iterator it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getBed()) {
 				return (*it)->getBed();
 			}
@@ -291,13 +291,13 @@ const Creature* Tile::getBottomVisibleCreature(const Creature* creature) const
 				return getBottomCreature();
 			}
 
-			for (CreatureVector::const_reverse_iterator it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
+			for (auto it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
 				if (creature->canSeeCreature(*it)) {
 					return *it;
 				}
 			}
 		} else {
-			for (CreatureVector::const_reverse_iterator it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
+			for (auto it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
 				if (!(*it)->isInvisible()) {
 					const Player* player = (*it)->getPlayer();
 					if (!player || !player->isInGhostMode()) {
@@ -334,7 +334,7 @@ Item* Tile::getItemByTopOrder(int32_t topOrder)
 	//3: doors etc
 	//4: creatures
 	if (TileItemVector* items = getItemList()) {
-		for (ItemVector::const_reverse_iterator it = ItemVector::const_reverse_iterator(items->getEndTopItem()), end = ItemVector::const_reverse_iterator(items->getBeginTopItem()); it != end; ++it) {
+		for (auto it = ItemVector::const_reverse_iterator(items->getEndTopItem()), end = ItemVector::const_reverse_iterator(items->getBeginTopItem()); it != end; ++it) {
 			if (Item::items[(*it)->getID()].alwaysOnTopOrder == topOrder) {
 				return (*it);
 			}
@@ -359,7 +359,7 @@ Thing* Tile::getTopVisibleThing(const Creature* creature)
 			}
 		}
 
-		for (ItemVector::const_reverse_iterator it = ItemVector::const_reverse_iterator(items->getEndTopItem()), end = ItemVector::const_reverse_iterator(items->getBeginTopItem()); it != end; ++it) {
+		for (auto it = ItemVector::const_reverse_iterator(items->getEndTopItem()), end = ItemVector::const_reverse_iterator(items->getBeginTopItem()); it != end; ++it) {
 			const ItemType& iit = Item::items[(*it)->getID()];
 			if (!iit.lookThrough) {
 				return (*it);
@@ -881,7 +881,7 @@ void Tile::addThing(int32_t, Thing* thing)
 			bool isInserted = false;
 
 			if (items) {
-				for (ItemVector::iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
+				for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 					//Note: this is different from internalAddThing
 					if (itemType.alwaysOnTopOrder <= Item::items[(*it)->getID()].alwaysOnTopOrder) {
 						items->insert(it, item);
@@ -978,7 +978,7 @@ void Tile::replaceThing(uint32_t index, Thing* thing)
 	if (items && !isInserted) {
 		int32_t topItemSize = getTopItemCount();
 		if (pos < topItemSize) {
-			ItemVector::iterator it = items->getBeginTopItem();
+			auto it = items->getBeginTopItem();
 			it += pos;
 
 			oldItem = (*it);
@@ -1002,7 +1002,7 @@ void Tile::replaceThing(uint32_t index, Thing* thing)
 	if (items && !isInserted) {
 		int32_t downItemSize = getDownItemCount();
 		if (pos < downItemSize) {
-			ItemVector::iterator it = items->getBeginDownItem() + pos;
+			auto it = items->getBeginDownItem() + pos;
 			oldItem = *it;
 			it = items->erase(it);
 			items->insert(it, item);
@@ -1030,7 +1030,7 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 	if (creature) {
 		CreatureVector* creatures = getCreatures();
 		if (creatures) {
-			CreatureVector::iterator it = std::find(creatures->begin(), creatures->end(), thing);
+			auto it = std::find(creatures->begin(), creatures->end(), thing);
 			if (it != creatures->end()) {
 				g_game.map.clearSpectatorCache();
 				creatures->erase(it);
@@ -1133,7 +1133,7 @@ int32_t Tile::getThingIndex(const Thing* thing) const
 	if (items) {
 		const Item* item = thing->getItem();
 		if (item && item->isAlwaysOnTop()) {
-			for (ItemVector::const_iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
+			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 				++n;
 				if (*it == item) {
 					return n;
@@ -1160,7 +1160,7 @@ int32_t Tile::getThingIndex(const Thing* thing) const
 	if (items) {
 		const Item* item = thing->getItem();
 		if (item && !item->isAlwaysOnTop()) {
-			for (ItemVector::const_iterator it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
+			for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
 				++n;
 				if (*it == item) {
 					return n;
@@ -1241,7 +1241,7 @@ int32_t Tile::getStackposOfItem(const Player* player, const Item* item) const
 	const TileItemVector* items = getItemList();
 	if (items) {
 		if (item->isAlwaysOnTop()) {
-			for (ItemVector::const_iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
+			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 				if (*it == item) {
 					return n;
 				} else if (++n == 10) {
@@ -1267,7 +1267,7 @@ int32_t Tile::getStackposOfItem(const Player* player, const Item* item) const
 	}
 
 	if (items && !item->isAlwaysOnTop()) {
-		for (ItemVector::const_iterator it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
+		for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
 			if (*it == item) {
 				return n;
 			} else if (++n >= 10) {
@@ -1454,7 +1454,7 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 
 		if (itemType.alwaysOnTop) {
 			bool isInserted = false;
-			for (ItemVector::iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
+			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 				if (Item::items[(*it)->getID()].alwaysOnTopOrder > itemType.alwaysOnTopOrder) {
 					items->insert(it, item);
 					isInserted = true;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -723,9 +723,9 @@ SkullNames skullNames[] = {
 
 MagicEffectClasses getMagicEffect(const std::string& strValue)
 {
-	for (size_t i = 0; i < sizeof(magicEffectNames) / sizeof(MagicEffectNames); ++i) {
-		if (strcasecmp(strValue.c_str(), magicEffectNames[i].name) == 0) {
-			return magicEffectNames[i].effect;
+	for (auto& magicEffectName : magicEffectNames) {
+		if (strcasecmp(strValue.c_str(), magicEffectName.name) == 0) {
+			return magicEffectName.effect;
 		}
 	}
 	return CONST_ME_NONE;
@@ -854,9 +854,9 @@ uint32_t adlerChecksum(const uint8_t* data, size_t length)
 
 std::string ucfirst(std::string str)
 {
-	for (size_t i = 0; i < str.length(); ++i) {
-		if (str[i] != ' ') {
-			str[i] = toupper(str[i]);
+	for (char& i : str) {
+		if (i != ' ') {
+			i = toupper(i);
 			break;
 		}
 	}

--- a/src/waitlist.cpp
+++ b/src/waitlist.cpp
@@ -29,14 +29,14 @@ extern Game g_game;
 WaitListIterator WaitingList::findClient(const Player* player, uint32_t& slot)
 {
 	slot = 1;
-	for (WaitListIterator it = priorityWaitList.begin(), end = priorityWaitList.end(); it != end; ++it) {
+	for (auto it = priorityWaitList.begin(), end = priorityWaitList.end(); it != end; ++it) {
 		if (it->playerGUID == player->getGUID()) {
 			return it;
 		}
 		++slot;
 	}
 
-	for (WaitListIterator it = waitList.begin(), end = waitList.end(); it != end; ++it) {
+	for (auto it = waitList.begin(), end = waitList.end(); it != end; ++it) {
 		if (it->playerGUID == player->getGUID()) {
 			return it;
 		}
@@ -82,7 +82,7 @@ bool WaitingList::clientLogin(const Player* player)
 
 	uint32_t slot;
 
-	WaitListIterator it = findClient(player, slot);
+	auto it = findClient(player, slot);
 	if (it != waitList.end()) {
 		if ((g_game.getPlayersOnline() + slot) <= maxPlayers) {
 			//should be able to login now
@@ -108,7 +108,7 @@ bool WaitingList::clientLogin(const Player* player)
 uint32_t WaitingList::getClientSlot(const Player* player)
 {
 	uint32_t slot;
-	WaitListIterator it = findClient(player, slot);
+	auto it = findClient(player, slot);
 	if (it == waitList.end()) {
 		return 0;
 	}
@@ -119,7 +119,7 @@ void WaitingList::cleanupList(WaitList& list)
 {
 	int64_t time = OTSYS_TIME();
 
-	WaitListIterator it = list.begin(), end = list.end();
+	auto it = list.begin(), end = list.end();
 	while (it != end) {
 		if ((it->timeout - time) <= 0) {
 			it = list.erase(it);

--- a/src/wildcardtree.cpp
+++ b/src/wildcardtree.cpp
@@ -105,8 +105,8 @@ void WildcardTreeNode::remove(const std::string& str)
 ReturnValue WildcardTreeNode::findOne(const std::string& query, std::string& result) const
 {
 	const WildcardTreeNode* cur = this;
-	for (size_t pos = 0; pos < query.length(); ++pos) {
-		cur = cur->getChild(query[pos]);
+	for (char pos : query) {
+		cur = cur->getChild(pos);
 		if (!cur) {
 			return RETURNVALUE_PLAYERWITHTHISNAMEISNOTONLINE;
 		}


### PR DESCRIPTION
After #1876 I searched more about modernizing code and applied a few fixes to improve code quality, readability and maintainability:

- Modernize constructors with pass-by-value + move (the purpose of #1876)
- Modernize loops to use new range-based loops
- Use auto where it improves code readability and maintainability

Using range-based loops reduces indirection overhead.

The latter is mainly using `auto` for iterators, but could be extended to use auto for obvious return types (e.g. on `Player* player = something->getPlayer()` or `MatrixArea* area = new MatrixArea()`), though I saw it being rejected once.

It adds maintainability because if we ever change the underlying container we do not need to reflect the change elsewhere (e.g. there's a `std::map<Item*, uint32_t>::iterator` that could be changed to an unordered map).