### PR TITLE
New Armor Reduction Formula

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -865,15 +865,10 @@ BlockType_t Creature::blockHit(Creature* attacker, CombatType_t combatType, int3
 		}
 
 		if (checkArmor) {
-			int32_t armorValue = getArmor();
-			if (armorValue > 1) {
-				double armorFormula = armorValue * 0.475;
-				int32_t armorReduction = static_cast<int32_t>(std::ceil(armorFormula));
-				damage -= uniform_random(
-					armorReduction,
-					armorReduction + static_cast<int32_t>(std::floor(armorFormula))
-				);
-			} else if (armorValue == 1) {
+			int32_t armor = getArmor();
+			if (armor > 3) {
+				damage -= uniform_random(armor / 2, armor - (armor % 2 + 1));
+			} else if (armor > 0) {
 				--damage;
 			}
 


### PR DESCRIPTION
This is a re-re-remake of #1581, 

This new formula for damage reduction by armor value is based of off tibia-stats research (which I have also researched and confirmed on my own).

There's just one mistake about t-s research which is that their calculator shows that the damage is reduced by 1 when the armor value is 0.

This also brings a small refactor to this block of code.

I have researched and confirmed that there's no damage reduction for an armor value of 0.

A comparison table

* Armor = 50

| **Reduction**  | **New Formula**  | **Current Formula** | **Diff. range** |
|:------------:|:---------------:|:-----:|:-----:|
| **Maximum**     | 49  | 47 | +2 |
| **Minimum**      | 25  | 24 | +1 |
| **Variation**      | 24 | 23 | +1|