### PR TITLE
Fix script environment alignment padding

### DIFF
--- a/src/luascript.h
+++ b/src/luascript.h
@@ -156,25 +156,26 @@ class ScriptEnvironment
 		typedef std::map<uint32_t, int32_t> StorageMap;
 		typedef std::map<uint32_t, DBResult_ptr> DBResultMap;
 
-		//script file id
-		int32_t scriptId;
-		int32_t callbackId;
-		bool timerEvent;
 		LuaScriptInterface* interface;
 
-		//local item map
-		uint32_t lastUID;
-		std::unordered_map<uint32_t, Item*> localMap;
+		//for npc scripts
+		Npc* curNpc;
 
 		//temporary item list
 		static std::multimap<ScriptEnvironment*, Item*> tempItems;
 
+		//local item map
+		std::unordered_map<uint32_t, Item*> localMap;
+		uint32_t lastUID;
+
+		//script file id
+		int32_t scriptId;
+		int32_t callbackId;
+		bool timerEvent;
+
 		//result map
 		static uint32_t lastResultId;
 		static DBResultMap tempResults;
-
-		//for npc scripts
-		Npc* curNpc;
 };
 
 #define reportErrorFunc(a)  reportError(__FUNCTION__, a, true)


### PR DESCRIPTION
Script environment instances were taking 11 bytes of padding, taking a total of 96 bytes, which is suboptimal. It now takes a total of 88 bytes, an optimal padding for those members.

This is a very small optimization though, as only 16 script environments are ever constructed, saving 64 bytes in total.
