### PR TITLE
Comment out unimplemented functions

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -108,10 +108,6 @@ class Actions final : public BaseEvents
 		Event* getEvent(const std::string& nodeName) final;
 		bool registerEvent(Event* event, const pugi::xml_node& node) final;
 
-		void registerItemID(int32_t itemId, Event* event);
-		void registerActionID(int32_t actionId, Event* event);
-		void registerUniqueID(int32_t uniqueId, Event* event);
-
 		typedef std::map<uint16_t, Action*> ActionUseMap;
 		ActionUseMap useItemMap;
 		ActionUseMap uniqueItemMap;

--- a/src/combat.h
+++ b/src/combat.h
@@ -203,7 +203,6 @@ class AreaCombat
 		// non-assignable
 		AreaCombat& operator=(const AreaCombat&) = delete;
 
-		ReturnValue doCombat(Creature* attacker, const Position& pos, const Combat& combat) const;
 		void getList(const Position& centerPos, const Position& targetPos, std::forward_list<Tile*>& list) const;
 
 		void setupArea(const std::list<uint32_t>& list, uint32_t rows);

--- a/src/condition.h
+++ b/src/condition.h
@@ -346,8 +346,6 @@ class ConditionOutfit final : public Condition
 
 	protected:
 		Outfit_t outfit;
-
-		void changeOutfit(Creature* creature);
 };
 
 class ConditionLight final : public Condition

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -48,7 +48,6 @@ class IOLoginData
 		static bool getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name);
 		static std::string getNameByGuid(uint32_t guid);
 		static bool formatPlayerName(std::string& name);
-		static bool addStorageValue(uint32_t guid, uint32_t storageKey, uint32_t storageValue);
 		static void increaseBankBalance(uint32_t guid, uint64_t bankBalance);
 		static bool hasBiddedOnHouse(uint32_t guid);
 

--- a/src/item.h
+++ b/src/item.h
@@ -279,7 +279,6 @@ class ItemAttributes
 		void setIntAttr(itemAttrTypes type, int64_t value);
 		void increaseIntAttr(itemAttrTypes type, int64_t value);
 
-		void addAttr(Attribute* attr);
 		const Attribute* getExistingAttr(itemAttrTypes type) const;
 		Attribute& getAttr(itemAttrTypes type);
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -506,7 +506,6 @@ class LuaScriptInterface
 		static int luaDatabaseEscapeString(lua_State* L);
 		static int luaDatabaseEscapeBlob(lua_State* L);
 		static int luaDatabaseLastInsertId(lua_State* L);
-		static int luaDatabaseConnected(lua_State* L);
 		static int luaDatabaseTableExists(lua_State* L);
 
 		static int luaResultGetNumber(lua_State* L);

--- a/src/map.h
+++ b/src/map.h
@@ -221,12 +221,6 @@ class Map
 
 		void moveCreature(Creature& creature, Tile& newTile, bool forceTeleport = false);
 
-		/**
-		  * Remove a creature from the map.
-		  * \param c Creature pointer to the creature to remove
-		  */
-		bool removeCreature(Creature* c);
-
 		void getSpectators(SpectatorVec& list, const Position& centerPos, bool multifloor = false, bool onlyPlayers = false,
 		                   int32_t minRangeX = 0, int32_t maxRangeX = 0,
 		                   int32_t minRangeY = 0, int32_t maxRangeY = 0);

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -180,7 +180,6 @@ class Monsters
 		bool reload();
 
 		MonsterType* getMonsterType(const std::string& name);
-		uint32_t getIdByName(const std::string& name);
 
 		static uint32_t getLootRandom();
 

--- a/src/movement.h
+++ b/src/movement.h
@@ -74,10 +74,6 @@ class MoveEvents final : public BaseEvents
 		Event* getEvent(const std::string& nodeName) final;
 		bool registerEvent(Event* event, const pugi::xml_node& node) final;
 
-		void registerItemID(int32_t itemId, MoveEvent_t eventType);
-		void registerActionID(int32_t actionId, MoveEvent_t eventType);
-		void registerUniqueID(int32_t uniqueId, MoveEvent_t eventType);
-
 		void addEvent(MoveEvent* moveEvent, int32_t id, MoveListMap& map);
 
 		void addEvent(MoveEvent* moveEvent, const Position& pos, MovePosListMap& map);

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -195,7 +195,6 @@ class ProtocolGame final : public Protocol
 		void sendCancelWalk();
 		void sendChangeSpeed(const Creature* creature, uint32_t speed);
 		void sendCancelTarget();
-		void sendCreatureVisible(const Creature* creature, bool visible);
 		void sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit);
 		void sendStats();
 		void sendBasicData();
@@ -297,14 +296,6 @@ class ProtocolGame final : public Protocol
 
 		void MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
 		void MoveDownCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
-
-		//container
-		void AddContainerItem(NetworkMessage& msg, uint8_t cid, const Item* item);
-		void UpdateContainerItem(NetworkMessage& msg, uint8_t cid, uint16_t slot, const Item* item);
-		void RemoveContainerItem(NetworkMessage& msg, uint8_t cid, uint16_t slot);
-
-		//inventory
-		void SetInventoryItem(NetworkMessage& msg, slots_t slot, const Item* item);
 
 		//shop
 		void AddShopItem(NetworkMessage& msg, const ShopInfo& item);

--- a/src/raids.h
+++ b/src/raids.h
@@ -204,8 +204,6 @@ class AreaSpawnEvent final : public RaidEvent
 	public:
 		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
 
-		void addMonster(const std::string& monsterName, uint32_t minAmount, uint32_t maxAmount);
-
 		bool executeEvent() final;
 
 	private:
@@ -217,7 +215,6 @@ class ScriptEvent final : public RaidEvent, public Event
 {
 	public:
 		explicit ScriptEvent(LuaScriptInterface* interface);
-		explicit ScriptEvent(const ScriptEvent* copy);
 
 		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
 		bool configureEvent(const pugi::xml_node&) final {

--- a/src/server.h
+++ b/src/server.h
@@ -104,8 +104,6 @@ class ServiceManager
 		void run();
 		void stop();
 
-		bool okay();
-
 		template <typename ProtocolType>
 		bool add(uint16_t port);
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -271,8 +271,6 @@ class ConjureSpell final : public InstantSpell
 		std::string getScriptEventName() const final;
 
 		bool conjureItem(Creature* creature) const;
-		bool internalCastSpell(Creature* creature, const LuaVariant& var);
-		Position getCasterPosition(Creature* creature);
 
 		uint32_t conjureId;
 		uint32_t conjureCount;


### PR DESCRIPTION
Those functions are not implemented and it can be confusing if someone tries to use them just because they're available on the headers. I commented out the signatures so they are hidden for autocomplete tools and if one wants to use them, it's clear they need to be implemented.