### PR TITLE
Use standard variable name

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -104,7 +104,7 @@ bool Scheduler::stopEvent(uint32_t eventid)
 		return false;
 	}
 
-	std::lock_guard<std::mutex> lockGuard(eventLock);
+	std::lock_guard<std::mutex> lockClass(eventLock);
 
 	// search the event id..
 	auto it = eventIds.find(eventid);

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -91,7 +91,7 @@ void Dispatcher::shutdown()
 		taskSignal.notify_one();
 	});
 
-	std::lock_guard<std::mutex> lockGuard(taskLock);
+	std::lock_guard<std::mutex> lockClass(taskLock);
 	taskList.push_back(task);
 
 	taskSignal.notify_one();


### PR DESCRIPTION
All but those 2 instances of lock guards are called lockClass, I refactored them to be named equally for better searchability.