### PR TITLE
Fix #1611

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -1131,7 +1131,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 			bool force = false;
 
 			if ((attr = summonNode.attribute("speed")) || (attr = summonNode.attribute("interval"))) {
-				speed = pugi::cast<int32_t>(attr.value());
+				speed = std::max<int32_t>(1, pugi::cast<int32_t>(attr.value()));
 			}
 
 			if ((attr = summonNode.attribute("chance"))) {


### PR DESCRIPTION
Now, it has the same behaviour as the other intervals of monster.
The problem was dividing by 0 in:
```cpp
if (defenseTicks % summonBlock.speed >= interval) {
    //already used this spell for this round
    continue;
}
```
At https://github.com/otland/forgottenserver/blob/master/src/monster.cpp#L922