### PR TITLE
Use default constructors where possible, else simplify them

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -26,12 +26,12 @@ struct Account {
 	std::vector<std::string> characters;
 	std::string name;
 	std::string key;
-	time_t lastDay;
-	uint32_t id;
-	uint16_t premiumDays;
-	AccountType_t accountType;
+	time_t lastDay = 0;
+	uint32_t id = 0;
+	uint16_t premiumDays = 0;
+	AccountType_t accountType = ACCOUNT_TYPE_NORMAL;
 
-	Account() : lastDay(0), id(0), premiumDays(0), accountType(ACCOUNT_TYPE_NORMAL) {}
+	Account() = default;
 };
 
 #endif

--- a/src/ban.h
+++ b/src/ban.h
@@ -27,8 +27,8 @@ struct BanInfo {
 };
 
 struct ConnectBlock {
-	ConnectBlock(uint64_t lastAttempt, uint64_t blockTime, uint32_t count)
-		: lastAttempt(lastAttempt), blockTime(blockTime), count(count) {}
+	constexpr ConnectBlock(uint64_t lastAttempt, uint64_t blockTime, uint32_t count) :
+		lastAttempt(lastAttempt), blockTime(blockTime), count(count) {}
 
 	uint64_t lastAttempt;
 	uint64_t blockTime;

--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -86,8 +86,7 @@ bool BaseEvents::reload()
 	return loadFromXml();
 }
 
-Event::Event(LuaScriptInterface* interface) :
-	scripted(false), scriptId(0), scriptInterface(interface) {}
+Event::Event(LuaScriptInterface* interface) : scriptInterface(interface) {}
 
 Event::Event(const Event* copy) :
 	scripted(copy->scripted), scriptId(copy->scriptId), scriptInterface(copy->scriptInterface) {}

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -44,15 +44,15 @@ class Event
 	protected:
 		virtual std::string getScriptEventName() const = 0;
 
-		bool scripted;
-		int32_t scriptId;
-		LuaScriptInterface* scriptInterface;
+		bool scripted = false;
+		int32_t scriptId = 0;
+		LuaScriptInterface* scriptInterface = nullptr;
 };
 
 class BaseEvents
 {
 	public:
- 		BaseEvents() = default;
+ 		constexpr BaseEvents() = default;
 		virtual ~BaseEvents() = default;
 
 		bool loadFromXml();

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -28,7 +28,6 @@ extern Game g_game;
 
 BedItem::BedItem(uint16_t id) : Item(id)
 {
-	house = nullptr;
 	internalRemoveSleeper();
 }
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -69,7 +69,7 @@ class BedItem final : public Item
 		void internalSetSleeper(const Player* player);
 		void internalRemoveSleeper();
 
-		House* house;
+		House* house = nullptr;
 		uint64_t sleepStart;
 		uint32_t sleeperGUID;
 };

--- a/src/chat.h
+++ b/src/chat.h
@@ -35,12 +35,7 @@ class ChatChannel
 		ChatChannel() = default;
 		ChatChannel(uint16_t channelId, std::string channelName):
 			name(channelName),
-			canJoinEvent(-1),
-			onJoinEvent(-1),
-			onLeaveEvent(-1),
-			onSpeakEvent(-1),
-			id(channelId),
-			publicChannel(false) {}
+			id(channelId) {}
 
 		virtual ~ChatChannel() = default;
 
@@ -79,13 +74,13 @@ class ChatChannel
 
 		std::string name;
 
-		int32_t canJoinEvent;
-		int32_t onJoinEvent;
-		int32_t onLeaveEvent;
-		int32_t onSpeakEvent;
+		int32_t canJoinEvent = -1;
+		int32_t onJoinEvent = -1;
+		int32_t onLeaveEvent = -1;
+		int32_t onSpeakEvent = -1;
 
 		uint16_t id;
-		bool publicChannel;
+		bool publicChannel = false;
 
 	friend class Chat;
 };
@@ -93,7 +88,7 @@ class ChatChannel
 class PrivateChatChannel final : public ChatChannel
 {
 	public:
-		PrivateChatChannel(uint16_t channelId, std::string channelName) : ChatChannel(channelId, channelName), owner(0) {}
+		PrivateChatChannel(uint16_t channelId, std::string channelName) : ChatChannel(channelId, channelName) {}
 
 		uint32_t getOwner() const final {
 			return owner;
@@ -117,7 +112,7 @@ class PrivateChatChannel final : public ChatChannel
 
 	protected:
 		InvitedMap invites;
-		uint32_t owner;
+		uint32_t owner = 0;
 };
 
 typedef std::list<ChatChannel*> ChannelList;

--- a/src/combat.h
+++ b/src/combat.h
@@ -73,7 +73,7 @@ struct CombatParams {
 	CombatType_t combatType = COMBAT_NONE;
 	CombatOrigin origin = ORIGIN_SPELL;
 
-	uint8_t impactEffect = CONST_ANI_NONE;
+	uint8_t impactEffect = CONST_ME_NONE;
 	uint8_t distanceEffect = CONST_ANI_NONE;
 
 	bool blockedByArmor = false;
@@ -88,13 +88,7 @@ typedef void (*COMBATFUNC)(Creature*, Creature*, const CombatParams&, CombatDama
 class MatrixArea
 {
 	public:
-		MatrixArea(uint32_t rows, uint32_t cols) {
-			centerX = 0;
-			centerY = 0;
-
-			this->rows = rows;
-			this->cols = cols;
-
+		MatrixArea(uint32_t rows, uint32_t cols): centerX(0), centerY(0), rows(rows), cols(cols) {
 			data_ = new bool*[rows];
 
 			for (uint32_t row = 0; row < rows; ++row) {
@@ -335,9 +329,7 @@ class Combat
 class MagicField final : public Item
 {
 	public:
-		explicit MagicField(uint16_t type) : Item(type) {
-			createTime = OTSYS_TIME();
-		}
+		explicit MagicField(uint16_t type) : Item(type), createTime(OTSYS_TIME()) {}
 
 		MagicField* getMagicField() final {
 			return this;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -24,15 +24,6 @@
 
 extern Game g_game;
 
-Condition::Condition(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	endTime(ticks == -1 ? std::numeric_limits<int64_t>::max() : 0),
-	subId(subId),
-	ticks(ticks),
-	conditionType(type),
-	id(id),
-	isBuff(buff)
-{}
-
 bool Condition::setParam(ConditionParam_t param, int32_t value)
 {
 	switch (param) {
@@ -304,9 +295,6 @@ bool Condition::updateCondition(const Condition* addCondition)
 	return true;
 }
 
-ConditionGeneric::ConditionGeneric(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	Condition(id, type, ticks, buff, subId) {}
-
 bool ConditionGeneric::startCondition(Creature* creature)
 {
 	return Condition::startCondition(creature);
@@ -352,16 +340,6 @@ uint32_t ConditionGeneric::getIcons() const
 
 	return icons;
 }
-
-ConditionAttributes::ConditionAttributes(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	ConditionGeneric(id, type, ticks, buff, subId),
-	skills(),
-	skillsPercent(),
-	stats(),
-	statsPercent(),
-	currentSkill(0),
-	currentStat(0)
-{}
 
 void ConditionAttributes::addCondition(Creature* creature, const Condition* addCondition)
 {
@@ -656,16 +634,6 @@ bool ConditionAttributes::setParam(ConditionParam_t param, int32_t value)
 	}
 }
 
-ConditionRegeneration::ConditionRegeneration(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	ConditionGeneric(id, type, ticks, buff, subId),
-	internalHealthTicks(0),
-	internalManaTicks(0),
-	healthTicks(1000),
-	manaTicks(1000),
-	healthGain(0),
-	manaGain(0)
-{}
-
 void ConditionRegeneration::addCondition(Creature*, const Condition* addCondition)
 {
 	if (updateCondition(addCondition)) {
@@ -785,13 +753,6 @@ bool ConditionRegeneration::setParam(ConditionParam_t param, int32_t value)
 	}
 }
 
-ConditionSoul::ConditionSoul(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	ConditionGeneric(id, type, ticks, buff, subId),
-	internalSoulTicks(0),
-	soulTicks(0),
-	soulGain(0)
-{}
-
 void ConditionSoul::addCondition(Creature*, const Condition* addCondition)
 {
 	if (updateCondition(addCondition)) {
@@ -857,20 +818,6 @@ bool ConditionSoul::setParam(ConditionParam_t param, int32_t value)
 			return ret;
 	}
 }
-
-ConditionDamage::ConditionDamage(ConditionId_t id, ConditionType_t type, bool buff, uint32_t subId) :
-	Condition(id, type, 0, buff, subId),
-	maxDamage(0),
-	minDamage(0),
-	startDamage(0),
-	periodDamage(0),
-	periodDamageTick(0),
-	tickInterval(2000),
-	forceUpdate(false),
-	delayed(false),
-	field(false),
-	owner(0)
-{}
 
 bool ConditionDamage::setParam(ConditionParam_t param, int32_t value)
 {
@@ -1269,15 +1216,6 @@ void ConditionDamage::generateDamageList(int32_t amount, int32_t start, std::lis
 	}
 }
 
-ConditionSpeed::ConditionSpeed(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, int32_t changeSpeed) :
-	Condition(id, type, ticks, buff, subId),
-	speedDelta(changeSpeed),
-	mina(0.0f),
-	minb(0.0f),
-	maxa(0.0f),
-	maxb(0.0f)
-{}
-
 void ConditionSpeed::setFormulaVars(float mina, float minb, float maxa, float maxb)
 {
 	this->mina = mina;
@@ -1422,9 +1360,6 @@ uint32_t ConditionSpeed::getIcons() const
 	return icons;
 }
 
-ConditionInvisible::ConditionInvisible(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	ConditionGeneric(id, type, ticks, buff, subId) {}
-
 bool ConditionInvisible::startCondition(Creature* creature)
 {
 	if (!Condition::startCondition(creature)) {
@@ -1441,9 +1376,6 @@ void ConditionInvisible::endCondition(Creature* creature)
 		g_game.internalCreatureChangeVisible(creature, true);
 	}
 }
-
-ConditionOutfit::ConditionOutfit(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	Condition(id, type, ticks, buff, subId) {}
 
 void ConditionOutfit::setOutfit(const Outfit_t& outfit)
 {
@@ -1497,13 +1429,6 @@ void ConditionOutfit::addCondition(Creature* creature, const Condition* addCondi
 		g_game.internalCreatureChangeOutfit(creature, outfit);
 	}
 }
-
-ConditionLight::ConditionLight(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, uint8_t lightlevel, uint8_t lightcolor) :
-	Condition(id, type, ticks, buff, subId),
-	lightInfo(lightlevel, lightcolor),
-	internalLightTicks(0),
-	lightChangeInterval(0)
-{}
 
 bool ConditionLight::startCondition(Creature* creature)
 {
@@ -1625,9 +1550,6 @@ void ConditionLight::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<uint32_t>(lightChangeInterval);
 }
 
-ConditionSpellCooldown::ConditionSpellCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	ConditionGeneric(id, type, ticks, buff, subId) {}
-
 void ConditionSpellCooldown::addCondition(Creature* creature, const Condition* addCondition)
 {
 	if (updateCondition(addCondition)) {
@@ -1656,9 +1578,6 @@ bool ConditionSpellCooldown::startCondition(Creature* creature)
 	}
 	return true;
 }
-
-ConditionSpellGroupCooldown::ConditionSpellGroupCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId) :
-	ConditionGeneric(id, type, ticks, buff, subId) {}
 
 void ConditionSpellGroupCooldown::addCondition(Creature* creature, const Condition* addCondition)
 {

--- a/src/condition.h
+++ b/src/condition.h
@@ -70,7 +70,9 @@ class Condition
 {
 	public:
 		Condition() = default;
-		Condition(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		Condition(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			endTime(ticks == -1 ? std::numeric_limits<int64_t>::max() : 0),
+			subId(subId), ticks(ticks),	conditionType(type), id(id), isBuff(buff) {}
 		virtual ~Condition() = default;
 
 		virtual bool startCondition(Creature* creature);
@@ -124,7 +126,8 @@ class Condition
 class ConditionGeneric : public Condition
 {
 	public:
-		ConditionGeneric(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionGeneric(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0):
+			Condition(id, type, ticks, buff, subId) {}
 
 		bool startCondition(Creature* creature) override;
 		bool executeCondition(Creature* creature, int32_t interval) override;
@@ -140,7 +143,8 @@ class ConditionGeneric : public Condition
 class ConditionAttributes final : public ConditionGeneric
 {
 	public:
-		ConditionAttributes(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionAttributes(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			ConditionGeneric(id, type, ticks, buff, subId) {}
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -158,12 +162,12 @@ class ConditionAttributes final : public ConditionGeneric
 		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
 
 	protected:
-		int32_t skills[SKILL_LAST + 1];
-		int32_t skillsPercent[SKILL_LAST + 1];
-		int32_t stats[STAT_LAST + 1];
-		int32_t statsPercent[STAT_LAST + 1];
-		int32_t currentSkill;
-		int32_t currentStat;
+		int32_t skills[SKILL_LAST + 1] = {};
+		int32_t skillsPercent[SKILL_LAST + 1] = {};
+		int32_t stats[STAT_LAST + 1] = {};
+		int32_t statsPercent[STAT_LAST + 1] = {};
+		int32_t currentSkill = 0;
+		int32_t currentStat = 0;
 
 		void updatePercentStats(Player* player);
 		void updateStats(Player* player);
@@ -174,7 +178,8 @@ class ConditionAttributes final : public ConditionGeneric
 class ConditionRegeneration final : public ConditionGeneric
 {
 	public:
-		ConditionRegeneration(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionRegeneration(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0):
+			ConditionGeneric(id, type, ticks, buff, subId) {}
 
 		void addCondition(Creature* creature, const Condition* addCondition) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -190,19 +195,20 @@ class ConditionRegeneration final : public ConditionGeneric
  		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
 
 	protected:
-		uint32_t internalHealthTicks;
-		uint32_t internalManaTicks;
+		uint32_t internalHealthTicks = 0;
+		uint32_t internalManaTicks = 0;
 
-		uint32_t healthTicks;
-		uint32_t manaTicks;
-		uint32_t healthGain;
-		uint32_t manaGain;
+		uint32_t healthTicks = 1000;
+		uint32_t manaTicks = 1000;
+		uint32_t healthGain = 0;
+		uint32_t manaGain = 0;
 };
 
 class ConditionSoul final : public ConditionGeneric
 {
 	public:
-		ConditionSoul(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionSoul(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			ConditionGeneric(id, type, ticks, buff, subId) {}
 
 		void addCondition(Creature* creature, const Condition* addCondition) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -218,15 +224,16 @@ class ConditionSoul final : public ConditionGeneric
 		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
 
 	protected:
-		uint32_t internalSoulTicks;
-		uint32_t soulTicks;
-		uint32_t soulGain;
+		uint32_t internalSoulTicks = 0;
+		uint32_t soulTicks = 0;
+		uint32_t soulGain = 0;
 };
 
 class ConditionInvisible final : public ConditionGeneric
 {
 	public:
-		ConditionInvisible(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionInvisible(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			ConditionGeneric(id, type, ticks, buff, subId) {}
 
 		bool startCondition(Creature* creature) final;
 		void endCondition(Creature* creature) final;
@@ -240,7 +247,8 @@ class ConditionDamage final : public Condition
 {
 	public:
 		ConditionDamage() = default;
-		ConditionDamage(ConditionId_t id, ConditionType_t type, bool buff = false, uint32_t subId = 0);
+		ConditionDamage(ConditionId_t id, ConditionType_t type, bool buff = false, uint32_t subId = 0) :
+			Condition(id, type, 0, buff, subId) {}
 
 		static void generateDamageList(int32_t amount, int32_t start, std::list<int32_t>& list);
 
@@ -267,17 +275,17 @@ class ConditionDamage final : public Condition
 		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
 
 	protected:
-		int32_t maxDamage;
-		int32_t minDamage;
-		int32_t startDamage;
-		int32_t periodDamage;
-		int32_t periodDamageTick;
-		int32_t tickInterval;
+		int32_t maxDamage = 0;
+		int32_t minDamage = 0;
+		int32_t startDamage = 0;
+		int32_t periodDamage = 0;
+		int32_t periodDamageTick = 0;
+		int32_t tickInterval = 2000;
 
-		bool forceUpdate;
-		bool delayed;
-		bool field;
-		uint32_t owner;
+		bool forceUpdate = false;
+		bool delayed = false;
+		bool field = false;
+		uint32_t owner = 0;
 
 		bool init();
 
@@ -292,7 +300,8 @@ class ConditionDamage final : public Condition
 class ConditionSpeed final : public Condition
 {
 	public:
-		ConditionSpeed(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, int32_t changeSpeed);
+		ConditionSpeed(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, int32_t changeSpeed) :
+			Condition(id, type, ticks, buff, subId), speedDelta(changeSpeed) {}
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -318,16 +327,17 @@ class ConditionSpeed final : public Condition
 		int32_t speedDelta;
 
 		//formula variables
-		float mina;
-		float minb;
-		float maxa;
-		float maxb;
+		float mina = 0.0f;
+		float minb = 0.0f;
+		float maxa = 0.0f;
+		float maxb = 0.0f;
 };
 
 class ConditionOutfit final : public Condition
 {
 	public:
-		ConditionOutfit(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionOutfit(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			Condition(id, type, ticks, buff, subId) {}
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -351,7 +361,8 @@ class ConditionOutfit final : public Condition
 class ConditionLight final : public Condition
 {
 	public:
-		ConditionLight(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, uint8_t lightlevel, uint8_t lightcolor);
+		ConditionLight(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, uint8_t lightlevel, uint8_t lightcolor) :
+			Condition(id, type, ticks, buff, subId), lightInfo(lightlevel, lightcolor) {}
 
 		bool startCondition(Creature* creature) final;
 		bool executeCondition(Creature* creature, int32_t interval) final;
@@ -370,14 +381,15 @@ class ConditionLight final : public Condition
 
 	protected:
 		LightInfo lightInfo;
-		uint32_t internalLightTicks;
-		uint32_t lightChangeInterval;
+		uint32_t internalLightTicks = 0;
+		uint32_t lightChangeInterval = 0;
 };
 
 class ConditionSpellCooldown final : public ConditionGeneric
 {
 	public:
-		ConditionSpellCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionSpellCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			ConditionGeneric(id, type, ticks, buff, subId) {}
 
 		bool startCondition(Creature* creature) final;
 		void addCondition(Creature* creature, const Condition* condition) final;
@@ -390,7 +402,8 @@ class ConditionSpellCooldown final : public ConditionGeneric
 class ConditionSpellGroupCooldown final : public ConditionGeneric
 {
 	public:
-		ConditionSpellGroupCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0);
+		ConditionSpellGroupCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
+			ConditionGeneric(id, type, ticks, buff, subId) {}
 
 		bool startCondition(Creature* creature) final;
 		void addCondition(Creature* creature, const Condition* condition) final;

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -117,9 +117,9 @@ class ConfigManager
 		static int32_t getGlobalNumber(lua_State* L, const char* identifier, const int32_t defaultValue = 0);
 		static bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultValue);
 
-		std::string string[LAST_STRING_CONFIG];
-		int32_t integer[LAST_INTEGER_CONFIG] = { 0 };
-		bool boolean[LAST_BOOLEAN_CONFIG] = { false };
+		std::string string[LAST_STRING_CONFIG] = {};
+		int32_t integer[LAST_INTEGER_CONFIG] = {};
+		bool boolean[LAST_BOOLEAN_CONFIG] = {};
 
 		bool loaded = false;
 };

--- a/src/creature.h
+++ b/src/creature.h
@@ -49,23 +49,13 @@ enum slots_t : uint8_t {
 };
 
 struct FindPathParams {
-	bool fullPathSearch;
-	bool clearSight;
-	bool allowDiagonal;
-	bool keepDistance;
-	int32_t maxSearchDist;
-	int32_t minTargetDist;
-	int32_t maxTargetDist;
-
-	FindPathParams() {
-		fullPathSearch = true;
-		clearSight = true;
-		allowDiagonal = true;
-		keepDistance = false;
-		maxSearchDist = 0;
-		minTargetDist = -1;
-		maxTargetDist = -1;
-	}
+	bool fullPathSearch = true;
+	bool clearSight = true;
+	bool allowDiagonal = true;
+	bool keepDistance = false;
+	int32_t maxSearchDist = 0;
+	int32_t minTargetDist = -1;
+	int32_t maxTargetDist = -1;
 };
 
 class Map;
@@ -84,7 +74,7 @@ class Tile;
 class FrozenPathingConditionCall
 {
 	public:
-		explicit FrozenPathingConditionCall(Position targetPos) : targetPos(targetPos) {}
+		explicit constexpr FrozenPathingConditionCall(Position targetPos) : targetPos(std::move(targetPos)) {}
 
 		bool operator()(const Position& startPos, const Position& testPos,
 		                const FindPathParams& fpp, int32_t& bestMatchDist) const;

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -239,7 +239,7 @@ class VirtualCylinder final : public Cylinder
 			return 1;
 		}
 		std::string getDescription(int32_t) const override {
-			return std::string();
+			return {};
 		}
 		bool isRemoved() const override {
 			return false;

--- a/src/database.h
+++ b/src/database.h
@@ -204,9 +204,7 @@ class DBInsert
 class DBTransaction
 {
 	public:
-		DBTransaction() {
-			state = STATE_NO_START;
-		}
+		constexpr DBTransaction() = default;
 
 		~DBTransaction() {
 			if (state == STATE_START) {
@@ -239,7 +237,7 @@ class DBTransaction
 			STEATE_COMMIT,
 		};
 
-		TransactionStates_t state;
+		TransactionStates_t state = STATE_NO_START;
 };
 
 #endif

--- a/src/enums.h
+++ b/src/enums.h
@@ -425,36 +425,21 @@ enum MapMark_t
 };
 
 struct Outfit_t {
-	Outfit_t() {
-		reset();
-	}
-
-	void reset() {
-		lookType = 0;
-		lookTypeEx = 0;
-		lookMount = 0;
-		lookHead = 0;
-		lookBody = 0;
-		lookLegs = 0;
-		lookFeet = 0;
-		lookAddons = 0;
-	}
-
-	uint16_t lookType;
-	uint16_t lookTypeEx;
-	uint16_t lookMount;
-	uint8_t lookHead;
-	uint8_t lookBody;
-	uint8_t lookLegs;
-	uint8_t lookFeet;
-	uint8_t lookAddons;
+	uint16_t lookType = 0;
+	uint16_t lookTypeEx = 0;
+	uint16_t lookMount = 0;
+	uint8_t lookHead = 0;
+	uint8_t lookBody = 0;
+	uint8_t lookLegs = 0;
+	uint8_t lookFeet = 0;
+	uint8_t lookAddons = 0;
 };
 
 struct LightInfo {
 	uint8_t level = 0;
 	uint8_t color = 0;
-	LightInfo() = default;
-	LightInfo(uint8_t level, uint8_t color) : level(level), color(color) {}
+	constexpr LightInfo() = default;
+	constexpr LightInfo(uint8_t level, uint8_t color) : level(level), color(color) {}
 };
 
 struct ShopInfo {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -29,36 +29,7 @@
 Events::Events() :
 	scriptInterface("Event Interface")
 {
-	clear();
 	scriptInterface.initState();
-}
-
-void Events::clear()
-{
-	// Creature
-	creatureOnChangeOutfit = -1;
-	creatureOnAreaCombat = -1;
-	creatureOnTargetCombat = -1;
-
-	// Party
-	partyOnJoin = -1;
-	partyOnLeave = -1;
-	partyOnDisband = -1;
-
-	// Player
-	playerOnBrowseField = -1;
-	playerOnLook = -1;
-	playerOnLookInBattleList = -1;
-	playerOnLookInTrade = -1;
-	playerOnLookInShop = -1;
-	playerOnMoveItem = -1;
-	playerOnMoveCreature = -1;
-	playerOnTurn = -1;
-	playerOnTradeRequest = -1;
-	playerOnTradeAccept = -1;
-	playerOnGainExperience = -1;
-	playerOnLoseExperience = -1;
-	playerOnGainSkillTries = -1;
 }
 
 bool Events::load()
@@ -70,7 +41,7 @@ bool Events::load()
 		return false;
 	}
 
-	clear();
+	info = {};
 
 	std::set<std::string> classes;
 	for (auto eventNode : doc.child("events").children()) {
@@ -92,51 +63,51 @@ bool Events::load()
 		const int32_t event = scriptInterface.getMetaEvent(className, methodName);
 		if (className == "Creature") {
 			if (methodName == "onChangeOutfit") {
-				creatureOnChangeOutfit = event;
+				info.creatureOnChangeOutfit = event;
 			} else if (methodName == "onAreaCombat") {
-				creatureOnAreaCombat = event;
+				info.creatureOnAreaCombat = event;
 			} else if (methodName == "onTargetCombat") {
-				creatureOnTargetCombat = event;
+				info.creatureOnTargetCombat = event;
 			} else {
 				std::cout << "[Warning - Events::load] Unknown creature method: " << methodName << std::endl;
 			}
 		} else if (className == "Party") {
 			if (methodName == "onJoin") {
-				partyOnJoin = event;
+				info.partyOnJoin = event;
 			} else if (methodName == "onLeave") {
-				partyOnLeave = event;
+				info.partyOnLeave = event;
 			} else if (methodName == "onDisband") {
-				partyOnDisband = event;
+				info.partyOnDisband = event;
 			} else {
 				std::cout << "[Warning - Events::load] Unknown party method: " << methodName << std::endl;
 			}
 		} else if (className == "Player") {
 			if (methodName == "onBrowseField") {
-				playerOnBrowseField = event;
+				info.playerOnBrowseField = event;
 			} else if (methodName == "onLook") {
-				playerOnLook = event;
+				info.playerOnLook = event;
 			} else if (methodName == "onLookInBattleList") {
-				playerOnLookInBattleList = event;
+				info.playerOnLookInBattleList = event;
 			} else if (methodName == "onLookInTrade") {
-				playerOnLookInTrade = event;
+				info.playerOnLookInTrade = event;
 			} else if (methodName == "onLookInShop") {
-				playerOnLookInShop = event;
+				info.playerOnLookInShop = event;
 			} else if (methodName == "onTradeRequest") {
-				playerOnTradeRequest = event;
+				info.playerOnTradeRequest = event;
 			} else if (methodName == "onTradeAccept") {
-				playerOnTradeAccept = event;
+				info.playerOnTradeAccept = event;
 			} else if (methodName == "onMoveItem") {
-				playerOnMoveItem = event;
+				info.playerOnMoveItem = event;
 			} else if (methodName == "onMoveCreature") {
-				playerOnMoveCreature = event;
+				info.playerOnMoveCreature = event;
 			} else if (methodName == "onTurn") {
-				playerOnTurn = event;
+				info.playerOnTurn = event;
 			} else if (methodName == "onGainExperience") {
-				playerOnGainExperience = event;
+				info.playerOnGainExperience = event;
 			} else if (methodName == "onLoseExperience") {
-				playerOnLoseExperience = event;
+				info.playerOnLoseExperience = event;
 			} else if (methodName == "onGainSkillTries") {
-				playerOnGainSkillTries = event;
+				info.playerOnGainSkillTries = event;
 			} else {
 				std::cout << "[Warning - Events::load] Unknown player method: " << methodName << std::endl;
 			}
@@ -151,7 +122,7 @@ bool Events::load()
 bool Events::eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& outfit)
 {
 	// Creature:onChangeOutfit(outfit) or Creature.onChangeOutfit(self, outfit)
-	if (creatureOnChangeOutfit == -1) {
+	if (info.creatureOnChangeOutfit == -1) {
 		return true;
 	}
 
@@ -161,10 +132,10 @@ bool Events::eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& out
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(creatureOnChangeOutfit, &scriptInterface);
+	env->setScriptId(info.creatureOnChangeOutfit, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(creatureOnChangeOutfit);
+	scriptInterface.pushFunction(info.creatureOnChangeOutfit);
 
 	LuaScriptInterface::pushUserdata<Creature>(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
@@ -177,7 +148,7 @@ bool Events::eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& out
 ReturnValue Events::eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bool aggressive)
 {
 	// Creature:onAreaCombat(tile, aggressive) or Creature.onAreaCombat(self, tile, aggressive)
-	if (creatureOnAreaCombat == -1) {
+	if (info.creatureOnAreaCombat == -1) {
 		return RETURNVALUE_NOERROR;
 	}
 
@@ -187,10 +158,10 @@ ReturnValue Events::eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bo
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(creatureOnAreaCombat, &scriptInterface);
+	env->setScriptId(info.creatureOnAreaCombat, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(creatureOnAreaCombat);
+	scriptInterface.pushFunction(info.creatureOnAreaCombat);
 
 	if (creature) {
 		LuaScriptInterface::pushUserdata<Creature>(L, creature);
@@ -220,7 +191,7 @@ ReturnValue Events::eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bo
 ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* target)
 {
 	// Creature:onTargetCombat(target) or Creature.onTargetCombat(self, target)
-	if (creatureOnTargetCombat == -1) {
+	if (info.creatureOnTargetCombat == -1) {
 		return RETURNVALUE_NOERROR;
 	}
 
@@ -230,10 +201,10 @@ ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* ta
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(creatureOnTargetCombat, &scriptInterface);
+	env->setScriptId(info.creatureOnTargetCombat, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(creatureOnTargetCombat);
+	scriptInterface.pushFunction(info.creatureOnTargetCombat);
 
 	if (creature) {
 		LuaScriptInterface::pushUserdata<Creature>(L, creature);
@@ -262,7 +233,7 @@ ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* ta
 bool Events::eventPartyOnJoin(Party* party, Player* player)
 {
 	// Party:onJoin(player) or Party.onJoin(self, player)
-	if (partyOnJoin == -1) {
+	if (info.partyOnJoin == -1) {
 		return true;
 	}
 
@@ -272,10 +243,10 @@ bool Events::eventPartyOnJoin(Party* party, Player* player)
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(partyOnJoin, &scriptInterface);
+	env->setScriptId(info.partyOnJoin, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(partyOnJoin);
+	scriptInterface.pushFunction(info.partyOnJoin);
 
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
@@ -289,7 +260,7 @@ bool Events::eventPartyOnJoin(Party* party, Player* player)
 bool Events::eventPartyOnLeave(Party* party, Player* player)
 {
 	// Party:onLeave(player) or Party.onLeave(self, player)
-	if (partyOnLeave == -1) {
+	if (info.partyOnLeave == -1) {
 		return true;
 	}
 
@@ -299,10 +270,10 @@ bool Events::eventPartyOnLeave(Party* party, Player* player)
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(partyOnLeave, &scriptInterface);
+	env->setScriptId(info.partyOnLeave, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(partyOnLeave);
+	scriptInterface.pushFunction(info.partyOnLeave);
 
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
@@ -316,7 +287,7 @@ bool Events::eventPartyOnLeave(Party* party, Player* player)
 bool Events::eventPartyOnDisband(Party* party)
 {
 	// Party:onDisband() or Party.onDisband(self)
-	if (partyOnDisband == -1) {
+	if (info.partyOnDisband == -1) {
 		return true;
 	}
 
@@ -326,10 +297,10 @@ bool Events::eventPartyOnDisband(Party* party)
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(partyOnDisband, &scriptInterface);
+	env->setScriptId(info.partyOnDisband, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(partyOnDisband);
+	scriptInterface.pushFunction(info.partyOnDisband);
 
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
@@ -341,7 +312,7 @@ bool Events::eventPartyOnDisband(Party* party)
 bool Events::eventPlayerOnBrowseField(Player* player, const Position& position)
 {
 	// Player:onBrowseField(position) or Player.onBrowseField(self, position)
-	if (playerOnBrowseField == -1) {
+	if (info.playerOnBrowseField == -1) {
 		return true;
 	}
 
@@ -351,10 +322,10 @@ bool Events::eventPlayerOnBrowseField(Player* player, const Position& position)
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnBrowseField, &scriptInterface);
+	env->setScriptId(info.playerOnBrowseField, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnBrowseField);
+	scriptInterface.pushFunction(info.playerOnBrowseField);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -367,7 +338,7 @@ bool Events::eventPlayerOnBrowseField(Player* player, const Position& position)
 void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* thing, uint8_t stackpos, int32_t lookDistance)
 {
 	// Player:onLook(thing, position, distance) or Player.onLook(self, thing, position, distance)
-	if (playerOnLook == -1) {
+	if (info.playerOnLook == -1) {
 		return;
 	}
 
@@ -377,10 +348,10 @@ void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* 
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnLook, &scriptInterface);
+	env->setScriptId(info.playerOnLook, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnLook);
+	scriptInterface.pushFunction(info.playerOnLook);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -404,7 +375,7 @@ void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* 
 void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, int32_t lookDistance)
 {
 	// Player:onLookInBattleList(creature, position, distance) or Player.onLookInBattleList(self, creature, position, distance)
-	if (playerOnLookInBattleList == -1) {
+	if (info.playerOnLookInBattleList == -1) {
 		return;
 	}
 
@@ -414,10 +385,10 @@ void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, i
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnLookInBattleList, &scriptInterface);
+	env->setScriptId(info.playerOnLookInBattleList, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnLookInBattleList);
+	scriptInterface.pushFunction(info.playerOnLookInBattleList);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -433,7 +404,7 @@ void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, i
 void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDistance)
 {
 	// Player:onLookInTrade(partner, item, distance) or Player.onLookInTrade(self, partner, item, distance)
-	if (playerOnLookInTrade == -1) {
+	if (info.playerOnLookInTrade == -1) {
 		return;
 	}
 
@@ -443,10 +414,10 @@ void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* ite
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnLookInTrade, &scriptInterface);
+	env->setScriptId(info.playerOnLookInTrade, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnLookInTrade);
+	scriptInterface.pushFunction(info.playerOnLookInTrade);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -465,7 +436,7 @@ void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* ite
 bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, uint8_t count)
 {
 	// Player:onLookInShop(itemType, count) or Player.onLookInShop(self, itemType, count)
-	if (playerOnLookInShop == -1) {
+	if (info.playerOnLookInShop == -1) {
 		return true;
 	}
 
@@ -475,10 +446,10 @@ bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, u
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnLookInShop, &scriptInterface);
+	env->setScriptId(info.playerOnLookInShop, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnLookInShop);
+	scriptInterface.pushFunction(info.playerOnLookInShop);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -494,7 +465,7 @@ bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, u
 bool Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition, Cylinder* fromCylinder, Cylinder* toCylinder)
 {
 	// Player:onMoveItem(item, count, fromPosition, toPosition) or Player.onMoveItem(self, item, count, fromPosition, toPosition, fromCylinder, toCylinder)
-	if (playerOnMoveItem == -1) {
+	if (info.playerOnMoveItem == -1) {
 		return true;
 	}
 
@@ -504,10 +475,10 @@ bool Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t count, c
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnMoveItem, &scriptInterface);
+	env->setScriptId(info.playerOnMoveItem, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnMoveItem);
+	scriptInterface.pushFunction(info.playerOnMoveItem);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -518,7 +489,7 @@ bool Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t count, c
 	lua_pushnumber(L, count);
 	LuaScriptInterface::pushPosition(L, fromPosition);
 	LuaScriptInterface::pushPosition(L, toPosition);
-	
+
 	LuaScriptInterface::pushCylinder(L, fromCylinder);
 	LuaScriptInterface::pushCylinder(L, toCylinder);
 
@@ -528,7 +499,7 @@ bool Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t count, c
 bool Events::eventPlayerOnMoveCreature(Player* player, Creature* creature, const Position& fromPosition, const Position& toPosition)
 {
 	// Player:onMoveCreature(creature, fromPosition, toPosition) or Player.onMoveCreature(self, creature, fromPosition, toPosition)
-	if (playerOnMoveCreature == -1) {
+	if (info.playerOnMoveCreature == -1) {
 		return true;
 	}
 
@@ -538,10 +509,10 @@ bool Events::eventPlayerOnMoveCreature(Player* player, Creature* creature, const
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnMoveCreature, &scriptInterface);
+	env->setScriptId(info.playerOnMoveCreature, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnMoveCreature);
+	scriptInterface.pushFunction(info.playerOnMoveCreature);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -558,7 +529,7 @@ bool Events::eventPlayerOnMoveCreature(Player* player, Creature* creature, const
 bool Events::eventPlayerOnTurn(Player* player, Direction direction)
 {
 	// Player:onTurn(direction) or Player.onTurn(self, direction)
-	if (playerOnTurn == -1) {
+	if (info.playerOnTurn == -1) {
 		return true;
 	}
 
@@ -568,10 +539,10 @@ bool Events::eventPlayerOnTurn(Player* player, Direction direction)
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnTurn, &scriptInterface);
+	env->setScriptId(info.playerOnTurn, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnTurn);
+	scriptInterface.pushFunction(info.playerOnTurn);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -584,7 +555,7 @@ bool Events::eventPlayerOnTurn(Player* player, Direction direction)
 bool Events::eventPlayerOnTradeRequest(Player* player, Player* target, Item* item)
 {
 	// Player:onTradeRequest(target, item)
-	if (playerOnTradeRequest == -1) {
+	if (info.playerOnTradeRequest == -1) {
 		return true;
 	}
 
@@ -594,10 +565,10 @@ bool Events::eventPlayerOnTradeRequest(Player* player, Player* target, Item* ite
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnTradeRequest, &scriptInterface);
+	env->setScriptId(info.playerOnTradeRequest, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnTradeRequest);
+	scriptInterface.pushFunction(info.playerOnTradeRequest);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -614,7 +585,7 @@ bool Events::eventPlayerOnTradeRequest(Player* player, Player* target, Item* ite
 bool Events::eventPlayerOnTradeAccept(Player* player, Player* target, Item* item, Item* targetItem)
 {
 	// Player:onTradeAccept(target, item, targetItem)
-	if (playerOnTradeAccept == -1) {
+	if (info.playerOnTradeAccept == -1) {
 		return true;
 	}
 
@@ -624,10 +595,10 @@ bool Events::eventPlayerOnTradeAccept(Player* player, Player* target, Item* item
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnTradeAccept, &scriptInterface);
+	env->setScriptId(info.playerOnTradeAccept, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnTradeAccept);
+	scriptInterface.pushFunction(info.playerOnTradeAccept);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -648,7 +619,7 @@ void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint6
 {
 	// Player:onGainExperience(source, exp, rawExp)
 	// rawExp gives the original exp which is not multiplied
-	if (playerOnGainExperience == -1) {
+	if (info.playerOnGainExperience == -1) {
 		return;
 	}
 
@@ -658,10 +629,10 @@ void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint6
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnGainExperience, &scriptInterface);
+	env->setScriptId(info.playerOnGainExperience, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnGainExperience);
+	scriptInterface.pushFunction(info.playerOnGainExperience);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -689,7 +660,7 @@ void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint6
 void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
 {
 	// Player:onLoseExperience(exp)
-	if (playerOnLoseExperience == -1) {
+	if (info.playerOnLoseExperience == -1) {
 		return;
 	}
 
@@ -699,10 +670,10 @@ void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnLoseExperience, &scriptInterface);
+	env->setScriptId(info.playerOnLoseExperience, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnLoseExperience);
+	scriptInterface.pushFunction(info.playerOnLoseExperience);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
@@ -722,7 +693,7 @@ void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
 void Events::eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_t& tries)
 {
 	// Player:onGainSkillTries(skill, tries)
-	if (playerOnGainSkillTries == -1) {
+	if (info.playerOnGainSkillTries == -1) {
 		return;
 	}
 
@@ -732,10 +703,10 @@ void Events::eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
-	env->setScriptId(playerOnGainSkillTries, &scriptInterface);
+	env->setScriptId(info.playerOnGainSkillTries, &scriptInterface);
 
 	lua_State* L = scriptInterface.getLuaState();
-	scriptInterface.pushFunction(playerOnGainSkillTries);
+	scriptInterface.pushFunction(info.playerOnGainSkillTries);
 
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");

--- a/src/events.h
+++ b/src/events.h
@@ -28,10 +28,36 @@ class Tile;
 
 class Events
 {
+	struct EventsInfo {
+		// Creature
+		int32_t creatureOnChangeOutfit = -1;
+		int32_t creatureOnAreaCombat = -1;
+		int32_t creatureOnTargetCombat = -1;
+
+		// Party
+		int32_t partyOnJoin = -1;
+		int32_t partyOnLeave = -1;
+		int32_t partyOnDisband = -1;
+
+		// Player
+		int32_t playerOnBrowseField = -1;
+		int32_t playerOnLook = -1;
+		int32_t playerOnLookInBattleList = -1;
+		int32_t playerOnLookInTrade = -1;
+		int32_t playerOnLookInShop = -1;
+		int32_t playerOnMoveItem = -1;
+		int32_t playerOnMoveCreature = -1;
+		int32_t playerOnTurn = -1;
+		int32_t playerOnTradeRequest = -1;
+		int32_t playerOnTradeAccept = -1;
+		int32_t playerOnGainExperience = -1;
+		int32_t playerOnLoseExperience = -1;
+		int32_t playerOnGainSkillTries = -1;
+	};
+
 	public:
 		Events();
 
-		void clear();
 		bool load();
 
 		// Creature
@@ -61,31 +87,7 @@ class Events
 
 	private:
 		LuaScriptInterface scriptInterface;
-
-		// Creature
-		int32_t creatureOnChangeOutfit;
-		int32_t creatureOnAreaCombat;
-		int32_t creatureOnTargetCombat;
-
-		// Party
-		int32_t partyOnJoin;
-		int32_t partyOnLeave;
-		int32_t partyOnDisband;
-
-		// Player
-		int32_t playerOnBrowseField;
-		int32_t playerOnLook;
-		int32_t playerOnLookInBattleList;
-		int32_t playerOnLookInTrade;
-		int32_t playerOnLookInShop;
-		int32_t playerOnMoveItem;
-		int32_t playerOnMoveCreature;
-		int32_t playerOnTurn;
-		int32_t playerOnTradeRequest;
-		int32_t playerOnTradeAccept;
-		int32_t playerOnGainExperience;
-		int32_t playerOnLoseExperience;
-		int32_t playerOnGainSkillTries;
+		EventsInfo info;
 };
 
 #endif

--- a/src/fileloader.cpp
+++ b/src/fileloader.cpp
@@ -21,20 +21,6 @@
 
 #include "fileloader.h"
 
-FileLoader::FileLoader() : cached_data()
-{
-	file = nullptr;
-	root = nullptr;
-	buffer = new uint8_t[1024];
-	buffer_size = 1024;
-	lastError = ERROR_NONE;
-
-	//cache
-	cache_size = 0;
-	cache_index = NO_VALID_CACHE;
-	cache_offset = NO_VALID_CACHE;
-}
-
 FileLoader::~FileLoader()
 {
 	if (file) {

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -91,7 +91,7 @@ class PropStream;
 class FileLoader
 {
 	public:
-		FileLoader();
+		constexpr FileLoader() = default;
 		~FileLoader();
 
 		// non-copyable
@@ -131,19 +131,19 @@ class FileLoader
 		};
 
 #define CACHE_BLOCKS 3
-		cache cached_data[CACHE_BLOCKS];
+		cache cached_data[CACHE_BLOCKS] = {};
 
-		uint8_t* buffer;
-		NODE root;
-		FILE* file;
+		uint8_t* buffer = new uint8_t[1024];
+		NODE root = nullptr;
+		FILE* file = nullptr;
 
-		FILELOADER_ERRORS lastError;
-		uint32_t buffer_size;
+		FILELOADER_ERRORS lastError = ERROR_NONE;
+		uint32_t buffer_size = 1024;
 
-		uint32_t cache_size;
+		uint32_t cache_size = 0;
 #define NO_VALID_CACHE 0xFFFFFFFF
-		uint32_t cache_index;
-		uint32_t cache_offset;
+		uint32_t cache_index = NO_VALID_CACHE;
+		uint32_t cache_offset = NO_VALID_CACHE;
 
 		inline uint32_t getCacheBlock(uint32_t pos);
 		int32_t loadCacheBlock(uint32_t pos);

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -31,8 +31,6 @@ GlobalEvents::GlobalEvents() :
 	scriptInterface("GlobalEvent Interface")
 {
 	scriptInterface.initState();
-	thinkEventId = 0;
-	timerEventId = 0;
 }
 
 GlobalEvents::~GlobalEvents()
@@ -209,8 +207,7 @@ GlobalEventMap GlobalEvents::getEventMap(GlobalEvent_t type)
 	}
 }
 
-GlobalEvent::GlobalEvent(LuaScriptInterface* interface):
-	Event(interface), eventType(GLOBALEVENT_NONE), nextExecution(0), interval(0) {}
+GlobalEvent::GlobalEvent(LuaScriptInterface* interface) : Event(interface) {}
 
 bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 {

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -69,7 +69,7 @@ class GlobalEvents final : public BaseEvents
 		LuaScriptInterface scriptInterface;
 
 		GlobalEventMap thinkMap, serverMap, timerMap;
-		int32_t thinkEventId, timerEventId;
+		int32_t thinkEventId = 0, timerEventId = 0;
 };
 
 class GlobalEvent final : public Event
@@ -85,7 +85,8 @@ class GlobalEvent final : public Event
 		GlobalEvent_t getEventType() const {
 			return eventType;
 		}
-		std::string getName() const {
+
+		const std::string& getName() const {
 			return name;
 		}
 
@@ -101,13 +102,13 @@ class GlobalEvent final : public Event
 		}
 
 	protected:
-		GlobalEvent_t eventType;
+		GlobalEvent_t eventType = GLOBALEVENT_NONE;
 
 		std::string getScriptEventName() const final;
 
 		std::string name;
-		int64_t nextExecution;
-		uint32_t interval;
+		int64_t nextExecution = 0;
+		uint32_t interval = 0;
 };
 
 #endif

--- a/src/guild.h
+++ b/src/guild.h
@@ -27,13 +27,14 @@ struct GuildRank {
 	std::string name;
 	uint8_t level;
 
-	GuildRank(uint32_t id, std::string name, uint8_t level) : id(id), name(name), level(level) {}
+	GuildRank(uint32_t id, std::string name, uint8_t level) :
+		id(id), name(std::move(name)), level(level) {}
 };
 
 class Guild
 {
 	public:
-		Guild(uint32_t id, std::string name) : name(name), id(id), memberCount(0) {}
+		Guild(uint32_t id, std::string name) : name(std::move(name)), id(id) {}
 
 		void addMember(Player* player);
 		void removeMember(Player* player);
@@ -71,7 +72,7 @@ class Guild
 		std::string name;
 		std::string motd;
 		uint32_t id;
-		uint32_t memberCount;
+		uint32_t memberCount = 0;
 };
 
 #endif

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -30,8 +30,7 @@
 extern ConfigManager g_config;
 extern Game g_game;
 
-House::House(uint32_t houseId) : id(houseId)
-{}
+House::House(uint32_t houseId) : id(houseId) {}
 
 void House::addTile(HouseTile* tile)
 {
@@ -510,13 +509,7 @@ void AccessList::getList(std::string& list) const
 	list = this->list;
 }
 
-Door::Door(uint16_t type) :
-	Item(type), house(nullptr), accessList(nullptr) {}
-
-Door::~Door()
-{
-	delete accessList;
-}
+Door::Door(uint16_t type) :	Item(type) {}
 
 Attr_ReadValue Door::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
@@ -541,7 +534,7 @@ void Door::setHouse(House* house)
 	this->house = house;
 
 	if (!accessList) {
-		accessList = new AccessList();
+		accessList.reset(new AccessList());
 	}
 }
 
@@ -561,7 +554,7 @@ bool Door::canUse(const Player* player)
 void Door::setAccessList(const std::string& textlist)
 {
 	if (!accessList) {
-		accessList = new AccessList();
+		accessList.reset(new AccessList());
 	}
 
 	accessList->parseList(textlist);

--- a/src/house.h
+++ b/src/house.h
@@ -54,7 +54,6 @@ class Door final : public Item
 {
 	public:
 		explicit Door(uint16_t type);
-		~Door();
 
 		// non-copyable
 		Door(const Door&) = delete;
@@ -93,8 +92,8 @@ class Door final : public Item
 		void setHouse(House* house);
 
 	private:
-		House* house;
-		AccessList* accessList;
+		House* house = nullptr;
+		std::unique_ptr<AccessList> accessList;
 		friend class House;
 };
 
@@ -232,7 +231,7 @@ class House
 		AccessList guestList;
 		AccessList subOwnerList;
 
-		Container transfer_container { ITEM_LOCKER1 };
+		Container transfer_container{ITEM_LOCKER1};
 
 		HouseTileList houseTiles;
 		std::list<Door*> doorList;
@@ -251,7 +250,7 @@ class House
 		uint32_t rent = 0;
 		uint32_t townId = 0;
 
-		Position posEntry {};
+		Position posEntry = {};
 
 		bool isLoaded = false;
 };

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -144,17 +144,10 @@ Item* Item::CreateItem(PropStream& propStream)
 	return Item::CreateItem(id, 0);
 }
 
-Item::Item(const uint16_t type, uint16_t count /*= 0*/)
+Item::Item(const uint16_t type, uint16_t count /*= 0*/) :
+	id(type)
 {
-	parent = nullptr;
-	referenceCounter = 0;
-
-	id = type;
-	attributes = nullptr;
-
 	const ItemType& it = items[id];
-
-	setItemCount(1);
 
 	if (it.isFluidContainer() || it.isSplash()) {
 		setFluidType(count);
@@ -172,24 +165,14 @@ Item::Item(const uint16_t type, uint16_t count /*= 0*/)
 		}
 	}
 
-	loadedFromMap = false;
 	setDefaultDuration();
 }
 
 Item::Item(const Item& i) :
-	Thing()
+	Thing(), id(i.id), count(i.count), loadedFromMap(i.loadedFromMap)
 {
-	parent = nullptr;
-	referenceCounter = 0;
-
-	id = i.id;
-	count = i.count;
-	loadedFromMap = i.loadedFromMap;
-
 	if (i.attributes) {
-		attributes = new ItemAttributes(*i.attributes);
-	} else {
-		attributes = nullptr;
+		attributes.reset(new ItemAttributes(*i.attributes));
 	}
 }
 
@@ -197,14 +180,9 @@ Item* Item::clone() const
 {
 	Item* item = Item::CreateItem(id, count);
 	if (attributes) {
-		item->attributes = new ItemAttributes(*attributes);
+		item->attributes.reset(new ItemAttributes(*attributes));
 	}
 	return item;
-}
-
-Item::~Item()
-{
-	delete attributes;
 }
 
 bool Item::equals(const Item* otherItem) const
@@ -217,7 +195,7 @@ bool Item::equals(const Item* otherItem) const
 		return !otherItem->attributes;
 	}
 
-	const ItemAttributes* otherAttributes = otherItem->attributes;
+	const auto& otherAttributes = otherItem->attributes;
 	if (!otherAttributes || attributes->attributeBits != otherAttributes->attributeBits) {
 		return false;
 	}

--- a/src/item.h
+++ b/src/item.h
@@ -108,7 +108,7 @@ enum Attr_ReadValue {
 class ItemAttributes
 {
 	public:
-		ItemAttributes() : attributeBits(0) {}
+		ItemAttributes() = default;
 
 		void setSpecialDescription(const std::string& desc) {
 			setStrAttr(ITEM_ATTRIBUTE_DESCRIPTION, desc);
@@ -270,7 +270,7 @@ class ItemAttributes
 		};
 
 		std::forward_list<Attribute> attributes;
-		uint32_t attributeBits;
+		uint32_t attributeBits = 0;
 
 		const std::string& getStrAttr(itemAttrTypes type) const;
 		void setStrAttr(itemAttrTypes type, const std::string& value);
@@ -311,7 +311,7 @@ class Item : virtual public Thing
 		Item(const Item& i);
 		virtual Item* clone() const;
 
-		virtual ~Item();
+		virtual ~Item() = default;
 
 		// non-assignable
 		Item& operator=(const Item&) = delete;
@@ -709,9 +709,9 @@ class Item : virtual public Thing
 
 		bool hasMarketAttributes() const;
 
-		ItemAttributes* getAttributes() {
+		std::unique_ptr<ItemAttributes>& getAttributes() {
 			if (!attributes) {
-				attributes = new ItemAttributes();
+				attributes.reset(new ItemAttributes());
 			}
 			return attributes;
 		}
@@ -742,15 +742,15 @@ class Item : virtual public Thing
 	protected:
 		std::string getWeightDescription(uint32_t weight) const;
 
-		Cylinder* parent;
-		ItemAttributes* attributes;
+		Cylinder* parent = nullptr;
+		std::unique_ptr<ItemAttributes> attributes;
 
-		uint32_t referenceCounter;
+		uint32_t referenceCounter = 0;
 
 		uint16_t id;  // the same id as in ItemType
-		uint8_t count; // number of stacked items
+		uint8_t count = 1; // number of stacked items
 
-		bool loadedFromMap;
+		bool loadedFromMap = false;
 
 		//Don't add variables here, use the ItemAttribute class.
 };

--- a/src/items.h
+++ b/src/items.h
@@ -207,7 +207,7 @@ class ItemType
 
 		CombatType_t combatType = COMBAT_NONE;
 
-		uint16_t transformToOnUse[2] = { 0 };
+		uint16_t transformToOnUse[2] = {0, 0};
 		uint16_t transformToFree = 0;
 		uint16_t destroyTo = 0;
 		uint16_t maxTextLen = 0;

--- a/src/lockfree.h
+++ b/src/lockfree.h
@@ -21,7 +21,7 @@
 #define FS_LOCKFREE_H_8C707AEB7C7235A2FBC5D4EDDF03B008
 
 #if _MSC_FULL_VER >= 190023918 // Workaround for VS2015 Update 2. Boost.Lockfree is a header-only library, so this should be safe to do.
-#define _ENABLE_ATOMIC_ALIGNMENT_FIX 
+#define _ENABLE_ATOMIC_ALIGNMENT_FIX
 #endif
 
 #include <boost/lockfree/stack.hpp>
@@ -31,7 +31,7 @@ class LockfreePoolingAllocator : public std::allocator<T>
 {
 	public:
 		template <typename U>
-		explicit LockfreePoolingAllocator(const U&) {}
+		explicit constexpr LockfreePoolingAllocator(const U&) {}
 		typedef T value_type;
 
 		T* allocate(size_t) const {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -43,11 +43,6 @@ extern ConfigManager g_config;
 extern Vocations g_vocations;
 extern Spells* g_spells;
 
-enum {
-	EVENT_ID_LOADING = 1,
-	EVENT_ID_USER = 1000,
-};
-
 ScriptEnvironment::DBResultMap ScriptEnvironment::tempResults;
 uint32_t ScriptEnvironment::lastResultId = 0;
 
@@ -261,8 +256,7 @@ std::string LuaScriptInterface::getErrorDesc(ErrorCode_t code)
 ScriptEnvironment LuaScriptInterface::scriptEnv[16];
 int32_t LuaScriptInterface::scriptEnvIndex = -1;
 
-LuaScriptInterface::LuaScriptInterface(std::string interfaceName)
-	: luaState(nullptr), interfaceName(interfaceName), eventTableRef(-1), runningEventId(EVENT_ID_USER)
+LuaScriptInterface::LuaScriptInterface(std::string interfaceName) : interfaceName(std::move(interfaceName))
 {
 	if (!g_luaEnvironment.getLuaState()) {
 		g_luaEnvironment.initState();
@@ -11358,7 +11352,7 @@ int LuaScriptInterface::luaMonsterTypeIsAttackable(lua_State* L)
 	// monsterType:isAttackable()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->isAttackable);
+		pushBoolean(L, monsterType->info.isAttackable);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11370,7 +11364,7 @@ int LuaScriptInterface::luaMonsterTypeIsConvinceable(lua_State* L)
 	// monsterType:isConvinceable()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->isConvinceable);
+		pushBoolean(L, monsterType->info.isConvinceable);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11382,7 +11376,7 @@ int LuaScriptInterface::luaMonsterTypeIsSummonable(lua_State* L)
 	// monsterType:isSummonable()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->isSummonable);
+		pushBoolean(L, monsterType->info.isSummonable);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11394,7 +11388,7 @@ int LuaScriptInterface::luaMonsterTypeIsIllusionable(lua_State* L)
 	// monsterType:isIllusionable()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->isIllusionable);
+		pushBoolean(L, monsterType->info.isIllusionable);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11406,7 +11400,7 @@ int LuaScriptInterface::luaMonsterTypeIsHostile(lua_State* L)
 	// monsterType:isHostile()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->isHostile);
+		pushBoolean(L, monsterType->info.isHostile);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11418,7 +11412,7 @@ int LuaScriptInterface::luaMonsterTypeIsPushable(lua_State* L)
 	// monsterType:isPushable()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->pushable);
+		pushBoolean(L, monsterType->info.pushable);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11430,7 +11424,7 @@ int LuaScriptInterface::luaMonsterTypeIsHealthShown(lua_State* L)
 	// monsterType:isHealthShown()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, !monsterType->hiddenHealth);
+		pushBoolean(L, !monsterType->info.hiddenHealth);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11442,7 +11436,7 @@ int LuaScriptInterface::luaMonsterTypeCanPushItems(lua_State* L)
 	// monsterType:canPushItems()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->canPushItems);
+		pushBoolean(L, monsterType->info.canPushItems);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11454,7 +11448,7 @@ int LuaScriptInterface::luaMonsterTypeCanPushCreatures(lua_State* L)
 	// monsterType:canPushCreatures()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushBoolean(L, monsterType->canPushCreatures);
+		pushBoolean(L, monsterType->info.canPushCreatures);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11490,7 +11484,7 @@ int LuaScriptInterface::luaMonsterTypeGetHealth(lua_State* L)
 	// monsterType:getHealth()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->health);
+		lua_pushnumber(L, monsterType->info.health);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11502,7 +11496,7 @@ int LuaScriptInterface::luaMonsterTypeGetMaxHealth(lua_State* L)
 	// monsterType:getMaxHealth()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->healthMax);
+		lua_pushnumber(L, monsterType->info.healthMax);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11514,7 +11508,7 @@ int LuaScriptInterface::luaMonsterTypeGetRunHealth(lua_State* L)
 	// monsterType:getRunHealth()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->runAwayHealth);
+		lua_pushnumber(L, monsterType->info.runAwayHealth);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11526,7 +11520,7 @@ int LuaScriptInterface::luaMonsterTypeGetExperience(lua_State* L)
 	// monsterType:getExperience()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->experience);
+		lua_pushnumber(L, monsterType->info.experience);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11538,7 +11532,7 @@ int LuaScriptInterface::luaMonsterTypeGetCombatImmunities(lua_State* L)
 	// monsterType:getCombatImmunities()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->damageImmunities);
+		lua_pushnumber(L, monsterType->info.damageImmunities);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11550,7 +11544,7 @@ int LuaScriptInterface::luaMonsterTypeGetConditionImmunities(lua_State* L)
 	// monsterType:getConditionImmunities()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->conditionImmunities);
+		lua_pushnumber(L, monsterType->info.conditionImmunities);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11566,10 +11560,10 @@ int LuaScriptInterface::luaMonsterTypeGetAttackList(lua_State* L)
 		return 1;
 	}
 
-	lua_createtable(L, monsterType->attackSpells.size(), 0);
+	lua_createtable(L, monsterType->info.attackSpells.size(), 0);
 
 	int index = 0;
-	for (const auto& spellBlock : monsterType->attackSpells) {
+	for (const auto& spellBlock : monsterType->info.attackSpells) {
 		lua_createtable(L, 0, 8);
 
 		setField(L, "chance", spellBlock.chance);
@@ -11596,11 +11590,11 @@ int LuaScriptInterface::luaMonsterTypeGetDefenseList(lua_State* L)
 		return 1;
 	}
 
-	lua_createtable(L, monsterType->defenseSpells.size(), 0);
+	lua_createtable(L, monsterType->info.defenseSpells.size(), 0);
 
 
 	int index = 0;
-	for (const auto& spellBlock : monsterType->defenseSpells) {
+	for (const auto& spellBlock : monsterType->info.defenseSpells) {
 		lua_createtable(L, 0, 8);
 
 		setField(L, "chance", spellBlock.chance);
@@ -11627,8 +11621,8 @@ int LuaScriptInterface::luaMonsterTypeGetElementList(lua_State* L)
 		return 1;
 	}
 
-	lua_createtable(L, monsterType->elementMap.size(), 0);
-	for (const auto& elementEntry : monsterType->elementMap) {
+	lua_createtable(L, monsterType->info.elementMap.size(), 0);
+	for (const auto& elementEntry : monsterType->info.elementMap) {
 		lua_pushnumber(L, elementEntry.second);
 		lua_rawseti(L, -2, elementEntry.first);
 	}
@@ -11645,8 +11639,8 @@ int LuaScriptInterface::luaMonsterTypeGetVoices(lua_State* L)
 	}
 
 	int index = 0;
-	lua_createtable(L, monsterType->voiceVector.size(), 0);
-	for (const auto& voiceBlock : monsterType->voiceVector) {
+	lua_createtable(L, monsterType->info.voiceVector.size(), 0);
+	for (const auto& voiceBlock : monsterType->info.voiceVector) {
 		lua_createtable(L, 0, 2);
 		setField(L, "text", voiceBlock.text);
 		setField(L, "yellText", voiceBlock.yellText);
@@ -11684,7 +11678,7 @@ int LuaScriptInterface::luaMonsterTypeGetLoot(lua_State* L)
 			lua_rawseti(L, -2, ++index);
 		}
 	};
-	parseLoot(monsterType->lootItems);
+	parseLoot(monsterType->info.lootItems);
 	return 1;
 }
 
@@ -11698,8 +11692,8 @@ int LuaScriptInterface::luaMonsterTypeGetCreatureEvents(lua_State* L)
 	}
 
 	int index = 0;
-	lua_createtable(L, monsterType->scripts.size(), 0);
-	for (const std::string& creatureEvent : monsterType->scripts) {
+	lua_createtable(L, monsterType->info.scripts.size(), 0);
+	for (const std::string& creatureEvent : monsterType->info.scripts) {
 		pushString(L, creatureEvent);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -11716,8 +11710,8 @@ int LuaScriptInterface::luaMonsterTypeGetSummonList(lua_State* L)
 	}
 
 	int index = 0;
-	lua_createtable(L, monsterType->summons.size(), 0);
-	for (const auto& summonBlock : monsterType->summons) {
+	lua_createtable(L, monsterType->info.summons.size(), 0);
+	for (const auto& summonBlock : monsterType->info.summons) {
 		lua_createtable(L, 0, 3);
 		setField(L, "name", summonBlock.name);
 		setField(L, "speed", summonBlock.speed);
@@ -11732,7 +11726,7 @@ int LuaScriptInterface::luaMonsterTypeGetMaxSummons(lua_State* L)
 	// monsterType:getMaxSummons()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->maxSummons);
+		lua_pushnumber(L, monsterType->info.maxSummons);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11744,7 +11738,7 @@ int LuaScriptInterface::luaMonsterTypeGetArmor(lua_State* L)
 	// monsterType:getArmor()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->armor);
+		lua_pushnumber(L, monsterType->info.armor);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11756,7 +11750,7 @@ int LuaScriptInterface::luaMonsterTypeGetDefense(lua_State* L)
 	// monsterType:getDefense()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->defense);
+		lua_pushnumber(L, monsterType->info.defense);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11768,7 +11762,7 @@ int LuaScriptInterface::luaMonsterTypeGetOutfit(lua_State* L)
 	// monsterType:getOutfit()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		pushOutfit(L, monsterType->outfit);
+		pushOutfit(L, monsterType->info.outfit);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11780,7 +11774,7 @@ int LuaScriptInterface::luaMonsterTypeGetRace(lua_State* L)
 	// monsterType:getRace()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->race);
+		lua_pushnumber(L, monsterType->info.race);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11792,7 +11786,7 @@ int LuaScriptInterface::luaMonsterTypeGetCorpseId(lua_State* L)
 	// monsterType:getCorpseId()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->lookcorpse);
+		lua_pushnumber(L, monsterType->info.lookcorpse);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11804,7 +11798,7 @@ int LuaScriptInterface::luaMonsterTypeGetManaCost(lua_State* L)
 	// monsterType:getManaCost()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->manaCost);
+		lua_pushnumber(L, monsterType->info.manaCost);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11816,7 +11810,7 @@ int LuaScriptInterface::luaMonsterTypeGetBaseSpeed(lua_State* L)
 	// monsterType:getBaseSpeed()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->baseSpeed);
+		lua_pushnumber(L, monsterType->info.baseSpeed);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11832,8 +11826,8 @@ int LuaScriptInterface::luaMonsterTypeGetLight(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, monsterType->lightLevel);
-	lua_pushnumber(L, monsterType->lightColor);
+	lua_pushnumber(L, monsterType->info.light.level);
+	lua_pushnumber(L, monsterType->info.light.color);
 	return 2;
 }
 
@@ -11842,7 +11836,7 @@ int LuaScriptInterface::luaMonsterTypeGetStaticAttackChance(lua_State* L)
 	// monsterType:getStaticAttackChance()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->staticAttackChance);
+		lua_pushnumber(L, monsterType->info.staticAttackChance);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11854,7 +11848,7 @@ int LuaScriptInterface::luaMonsterTypeGetTargetDistance(lua_State* L)
 	// monsterType:getTargetDistance()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->targetDistance);
+		lua_pushnumber(L, monsterType->info.targetDistance);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11866,7 +11860,7 @@ int LuaScriptInterface::luaMonsterTypeGetYellChance(lua_State* L)
 	// monsterType:getYellChance()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->yellChance);
+		lua_pushnumber(L, monsterType->info.yellChance);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11878,7 +11872,7 @@ int LuaScriptInterface::luaMonsterTypeGetYellSpeedTicks(lua_State* L)
 	// monsterType:getYellSpeedTicks()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->yellSpeedTicks);
+		lua_pushnumber(L, monsterType->info.yellSpeedTicks);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11890,7 +11884,7 @@ int LuaScriptInterface::luaMonsterTypeGetChangeTargetChance(lua_State* L)
 	// monsterType:getChangeTargetChance()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->changeTargetChance);
+		lua_pushnumber(L, monsterType->info.changeTargetChance);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11902,7 +11896,7 @@ int LuaScriptInterface::luaMonsterTypeGetChangeTargetSpeed(lua_State* L)
 	// monsterType:getChangeTargetSpeed()
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
-		lua_pushnumber(L, monsterType->changeTargetSpeed);
+		lua_pushnumber(L, monsterType->info.changeTargetSpeed);
 	} else {
 		lua_pushnil(L);
 	}
@@ -12123,12 +12117,7 @@ int LuaScriptInterface::luaPartySetSharedExperience(lua_State* L)
 }
 
 //
-LuaEnvironment::LuaEnvironment() :
-	LuaScriptInterface("Main Interface"), testInterface(nullptr),
-	lastEventTimerId(1), lastCombatId(0), lastAreaId(0)
-{
-	//
-}
+LuaEnvironment::LuaEnvironment() : LuaScriptInterface("Main Interface") {}
 
 LuaEnvironment::~LuaEnvironment()
 {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -47,6 +47,11 @@ class Condition;
 class Npc;
 class Monster;
 
+enum {
+	EVENT_ID_LOADING = 1,
+	EVENT_ID_USER = 1000,
+};
+
 enum LuaVariantType_t {
 	VARIANT_NONE,
 
@@ -69,29 +74,20 @@ enum LuaDataType {
 };
 
 struct LuaVariant {
-	LuaVariant() {
-		type = VARIANT_NONE;
-		number = 0;
-	}
-
-	LuaVariantType_t type;
+	LuaVariantType_t type = VARIANT_NONE;
 	std::string text;
 	Position pos;
-	uint32_t number;
+	uint32_t number = 0;
 };
 
 struct LuaTimerEventDesc {
-	int32_t scriptId;
-	int32_t function;
+	int32_t scriptId = -1;
+	int32_t function = -1;
 	std::list<int32_t> parameters;
-	uint32_t eventId;
+	uint32_t eventId = 0;
 
-	LuaTimerEventDesc() :
-		scriptId(-1), function(-1), eventId(0) {}
-
-	LuaTimerEventDesc(LuaTimerEventDesc&& other) :
-		scriptId(other.scriptId), function(other.function),
-		parameters(std::move(other.parameters)), eventId(other.eventId) {}
+	LuaTimerEventDesc() = default;
+	LuaTimerEventDesc(LuaTimerEventDesc&& other) = default;
 };
 
 class LuaScriptInterface;
@@ -1244,16 +1240,16 @@ class LuaScriptInterface
 		static int luaPartySetSharedExperience(lua_State* L);
 
 		//
-		lua_State* luaState;
+		lua_State* luaState = nullptr;
 		std::string lastLuaError;
 
 		std::string interfaceName;
-		int32_t eventTableRef;
+		int32_t eventTableRef = -1;
 
 		static ScriptEnvironment scriptEnv[16];
 		static int32_t scriptEnvIndex;
 
-		int32_t runningEventId;
+		int32_t runningEventId = EVENT_ID_USER;
 		std::string loadingFile;
 
 		//script file cache
@@ -1287,7 +1283,6 @@ class LuaEnvironment : public LuaScriptInterface
 	private:
 		void executeTimerEvent(uint32_t eventIndex);
 
-		//
 		std::unordered_map<uint32_t, LuaTimerEventDesc> timerEvents;
 		std::unordered_map<uint32_t, Combat*> combatMap;
 		std::unordered_map<uint32_t, AreaCombat*> areaMap;
@@ -1295,13 +1290,12 @@ class LuaEnvironment : public LuaScriptInterface
 		std::unordered_map<LuaScriptInterface*, std::vector<uint32_t>> combatIdMap;
 		std::unordered_map<LuaScriptInterface*, std::vector<uint32_t>> areaIdMap;
 
-		LuaScriptInterface* testInterface;
+		LuaScriptInterface* testInterface = nullptr;
 
-		uint32_t lastEventTimerId;
-		uint32_t lastCombatId;
-		uint32_t lastAreaId;
+		uint32_t lastEventTimerId = 1;
+		uint32_t lastCombatId = 0;
+		uint32_t lastAreaId = 0;
 
-		//
 		friend class LuaScriptInterface;
 		friend class CombatSpell;
 };

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -861,21 +861,11 @@ Floor::~Floor()
 }
 
 // QTreeNode
-QTreeNode::QTreeNode()
-{
-	leaf = false;
-	child[0] = nullptr;
-	child[1] = nullptr;
-	child[2] = nullptr;
-	child[3] = nullptr;
-}
-
 QTreeNode::~QTreeNode()
 {
-	delete child[0];
-	delete child[1];
-	delete child[2];
-	delete child[3];
+	for (auto* ptr : child) {
+		delete ptr;
+	}
 }
 
 QTreeLeafNode* QTreeNode::getLeaf(uint32_t x, uint32_t y)
@@ -910,21 +900,11 @@ QTreeLeafNode* QTreeNode::createLeaf(uint32_t x, uint32_t y, uint32_t level)
 
 // QTreeLeafNode
 bool QTreeLeafNode::newLeaf = false;
-QTreeLeafNode::QTreeLeafNode()
-{
-	for (uint32_t i = 0; i < MAP_MAX_LAYERS; ++i) {
-		array[i] = nullptr;
-	}
-
-	leaf = true;
-	leafS = nullptr;
-	leafE = nullptr;
-}
 
 QTreeLeafNode::~QTreeLeafNode()
 {
-	for (uint32_t i = 0; i < MAP_MAX_LAYERS; ++i) {
-		delete array[i];
+	for (auto* ptr : array) {
+		delete ptr;
 	}
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -80,14 +80,14 @@ typedef std::map<Position, SpectatorVec> SpectatorCache;
 #define FLOOR_MASK (FLOOR_SIZE - 1)
 
 struct Floor {
-	Floor() = default;
+	constexpr Floor() = default;
 	~Floor();
 
 	// non-copyable
 	Floor(const Floor&) = delete;
 	Floor& operator=(const Floor&) = delete;
 
-	Tile* tiles[FLOOR_SIZE][FLOOR_SIZE] = {{ nullptr }};
+	Tile* tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
 };
 
 class FrozenPathingConditionCall;
@@ -96,7 +96,7 @@ class QTreeLeafNode;
 class QTreeNode
 {
 	public:
-		QTreeNode();
+		constexpr QTreeNode() = default;
 		virtual ~QTreeNode();
 
 		// non-copyable
@@ -127,9 +127,9 @@ class QTreeNode
 		QTreeLeafNode* createLeaf(uint32_t x, uint32_t y, uint32_t level);
 
 	protected:
-		QTreeNode* child[4];
+		QTreeNode* child[4] = {};
 
-		bool leaf;
+		bool leaf = false;
 
 		friend class Map;
 };
@@ -137,7 +137,7 @@ class QTreeNode
 class QTreeLeafNode final : public QTreeNode
 {
 	public:
-		QTreeLeafNode();
+		QTreeLeafNode() { leaf = true; newLeaf = true; }
 		~QTreeLeafNode();
 
 		// non-copyable
@@ -154,9 +154,9 @@ class QTreeLeafNode final : public QTreeNode
 
 	protected:
 		static bool newLeaf;
-		QTreeLeafNode* leafS;
-		QTreeLeafNode* leafE;
-		Floor* array[MAP_MAX_LAYERS];
+		QTreeLeafNode* leafS = nullptr;
+		QTreeLeafNode* leafE = nullptr;
+		Floor* array[MAP_MAX_LAYERS] = {};
 		CreatureVector creature_list;
 		CreatureVector player_list;
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -41,27 +41,21 @@ Monster* Monster::createMonster(const std::string& name)
 }
 
 Monster::Monster(MonsterType* mtype) :
-	Creature()
+	Creature(),
+	strDescription(asLowerCaseString(mtype->nameDescription)),
+	mType(mtype)
 {
-	mType = mtype;
-	defaultOutfit = mType->outfit;
-	currentOutfit = mType->outfit;
-
-	skull = mType->skull;
-
-	health = mType->health;
-	healthMax = mType->healthMax;
-	baseSpeed = mType->baseSpeed;
-	internalLight.level = mType->lightLevel;
-	internalLight.color = mType->lightColor;
-
-	hiddenHealth = mType->hiddenHealth;
-
-	strDescription = mType->nameDescription;
-	toLowerCaseString(strDescription);
+	defaultOutfit = mType->info.outfit;
+	currentOutfit = mType->info.outfit;
+	skull = mType->info.skull;
+	health = mType->info.health;
+	healthMax = mType->info.healthMax;
+	baseSpeed = mType->info.baseSpeed;
+	internalLight = mType->info.light;
+	hiddenHealth = mType->info.hiddenHealth;
 
 	// register creature events
-	for (const std::string& scriptName : mType->scripts) {
+	for (const std::string& scriptName : mType->info.scripts) {
 		if (!registerCreatureEvent(scriptName)) {
 			std::cout << "[Warning - Monster::Monster] Unknown event name: " << scriptName << std::endl;
 		}
@@ -99,19 +93,19 @@ void Monster::onCreatureAppear(Creature* creature, bool isLogin)
 {
 	Creature::onCreatureAppear(creature, isLogin);
 
-	if (mType->creatureAppearEvent != -1) {
+	if (mType->info.creatureAppearEvent != -1) {
 		// onCreatureAppear(self, creature)
-		LuaScriptInterface* scriptInterface = mType->scriptInterface;
+		LuaScriptInterface* scriptInterface = mType->info.scriptInterface;
 		if (!scriptInterface->reserveScriptEnv()) {
 			std::cout << "[Error - Monster::onCreatureAppear] Call stack overflow" << std::endl;
 			return;
 		}
 
 		ScriptEnvironment* env = scriptInterface->getScriptEnv();
-		env->setScriptId(mType->creatureAppearEvent, scriptInterface);
+		env->setScriptId(mType->info.creatureAppearEvent, scriptInterface);
 
 		lua_State* L = scriptInterface->getLuaState();
-		scriptInterface->pushFunction(mType->creatureAppearEvent);
+		scriptInterface->pushFunction(mType->info.creatureAppearEvent);
 
 		LuaScriptInterface::pushUserdata<Monster>(L, this);
 		LuaScriptInterface::setMetatable(L, -1, "Monster");
@@ -141,19 +135,19 @@ void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
-	if (mType->creatureDisappearEvent != -1) {
+	if (mType->info.creatureDisappearEvent != -1) {
 		// onCreatureDisappear(self, creature)
-		LuaScriptInterface* scriptInterface = mType->scriptInterface;
+		LuaScriptInterface* scriptInterface = mType->info.scriptInterface;
 		if (!scriptInterface->reserveScriptEnv()) {
 			std::cout << "[Error - Monster::onCreatureDisappear] Call stack overflow" << std::endl;
 			return;
 		}
 
 		ScriptEnvironment* env = scriptInterface->getScriptEnv();
-		env->setScriptId(mType->creatureDisappearEvent, scriptInterface);
+		env->setScriptId(mType->info.creatureDisappearEvent, scriptInterface);
 
 		lua_State* L = scriptInterface->getLuaState();
-		scriptInterface->pushFunction(mType->creatureDisappearEvent);
+		scriptInterface->pushFunction(mType->info.creatureDisappearEvent);
 
 		LuaScriptInterface::pushUserdata<Monster>(L, this);
 		LuaScriptInterface::setMetatable(L, -1, "Monster");
@@ -182,19 +176,19 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
-	if (mType->creatureMoveEvent != -1) {
+	if (mType->info.creatureMoveEvent != -1) {
 		// onCreatureMove(self, creature, oldPosition, newPosition)
-		LuaScriptInterface* scriptInterface = mType->scriptInterface;
+		LuaScriptInterface* scriptInterface = mType->info.scriptInterface;
 		if (!scriptInterface->reserveScriptEnv()) {
 			std::cout << "[Error - Monster::onCreatureMove] Call stack overflow" << std::endl;
 			return;
 		}
 
 		ScriptEnvironment* env = scriptInterface->getScriptEnv();
-		env->setScriptId(mType->creatureMoveEvent, scriptInterface);
+		env->setScriptId(mType->info.creatureMoveEvent, scriptInterface);
 
 		lua_State* L = scriptInterface->getLuaState();
-		scriptInterface->pushFunction(mType->creatureMoveEvent);
+		scriptInterface->pushFunction(mType->info.creatureMoveEvent);
 
 		LuaScriptInterface::pushUserdata<Monster>(L, this);
 		LuaScriptInterface::setMetatable(L, -1, "Monster");
@@ -240,7 +234,7 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 
 				int32_t offset_x = Position::getDistanceX(followPosition, position);
 				int32_t offset_y = Position::getDistanceY(followPosition, position);
-				if ((offset_x > 1 || offset_y > 1) && mType->changeTargetChance > 0) {
+				if ((offset_x > 1 || offset_y > 1) && mType->info.changeTargetChance > 0) {
 					Direction dir = getDirectionTo(position, followPosition);
 					const Position& checkPosition = getNextPosition(dir, position);
 
@@ -264,19 +258,19 @@ void Monster::onCreatureSay(Creature* creature, SpeakClasses type, const std::st
 {
 	Creature::onCreatureSay(creature, type, text);
 
-	if (mType->creatureSayEvent != -1) {
+	if (mType->info.creatureSayEvent != -1) {
 		// onCreatureSay(self, creature, type, message)
-		LuaScriptInterface* scriptInterface = mType->scriptInterface;
+		LuaScriptInterface* scriptInterface = mType->info.scriptInterface;
 		if (!scriptInterface->reserveScriptEnv()) {
 			std::cout << "[Error - Monster::onCreatureSay] Call stack overflow" << std::endl;
 			return;
 		}
 
 		ScriptEnvironment* env = scriptInterface->getScriptEnv();
-		env->setScriptId(mType->creatureSayEvent, scriptInterface);
+		env->setScriptId(mType->info.creatureSayEvent, scriptInterface);
 
 		lua_State* L = scriptInterface->getLuaState();
-		scriptInterface->pushFunction(mType->creatureSayEvent);
+		scriptInterface->pushFunction(mType->info.creatureSayEvent);
 
 		LuaScriptInterface::pushUserdata<Monster>(L, this);
 		LuaScriptInterface::setMetatable(L, -1, "Monster");
@@ -579,8 +573,8 @@ BlockType_t Monster::blockHit(Creature* attacker, CombatType_t combatType, int32
 
 	if (damage != 0) {
 		int32_t elementMod = 0;
-		auto it = mType->elementMap.find(combatType);
-		if (it != mType->elementMap.end()) {
+		auto it = mType->info.elementMap.find(combatType);
+		if (it != mType->info.elementMap.end()) {
 			elementMod = it->second;
 		}
 
@@ -683,19 +677,19 @@ void Monster::onThink(uint32_t interval)
 {
 	Creature::onThink(interval);
 
-	if (mType->thinkEvent != -1) {
+	if (mType->info.thinkEvent != -1) {
 		// onThink(self, interval)
-		LuaScriptInterface* scriptInterface = mType->scriptInterface;
+		LuaScriptInterface* scriptInterface = mType->info.scriptInterface;
 		if (!scriptInterface->reserveScriptEnv()) {
 			std::cout << "[Error - Monster::onThink] Call stack overflow" << std::endl;
 			return;
 		}
 
 		ScriptEnvironment* env = scriptInterface->getScriptEnv();
-		env->setScriptId(mType->thinkEvent, scriptInterface);
+		env->setScriptId(mType->info.thinkEvent, scriptInterface);
 
 		lua_State* L = scriptInterface->getLuaState();
-		scriptInterface->pushFunction(mType->thinkEvent);
+		scriptInterface->pushFunction(mType->info.thinkEvent);
 
 		LuaScriptInterface::pushUserdata<Monster>(L, this);
 		LuaScriptInterface::setMetatable(L, -1, "Monster");
@@ -761,7 +755,7 @@ void Monster::doAttacking(uint32_t interval)
 	const Position& myPos = getPosition();
 	const Position& targetPos = attackedCreature->getPosition();
 
-	for (const spellBlock_t& spellBlock : mType->attackSpells) {
+	for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
 		bool inRange = false;
 
 		if (canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
@@ -804,7 +798,7 @@ bool Monster::canUseAttack(const Position& pos, const Creature* target) const
 	if (isHostile()) {
 		const Position& targetPos = target->getPosition();
 		uint32_t distance = std::max<uint32_t>(Position::getDistanceX(pos, targetPos), Position::getDistanceY(pos, targetPos));
-		for (const spellBlock_t& spellBlock : mType->attackSpells) {
+		for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
 			if (spellBlock.range != 0 && distance <= spellBlock.range) {
 				return g_game.isSightClear(pos, targetPos, true);
 			}
@@ -851,7 +845,7 @@ bool Monster::canUseSpell(const Position& pos, const Position& targetPos,
 void Monster::onThinkTarget(uint32_t interval)
 {
 	if (!isSummon()) {
-		if (mType->changeTargetSpeed != 0) {
+		if (mType->info.changeTargetSpeed != 0) {
 			bool canChangeTarget = true;
 
 			if (targetChangeCooldown > 0) {
@@ -859,7 +853,7 @@ void Monster::onThinkTarget(uint32_t interval)
 
 				if (targetChangeCooldown <= 0) {
 					targetChangeCooldown = 0;
-					targetChangeTicks = mType->changeTargetSpeed;
+					targetChangeTicks = mType->info.changeTargetSpeed;
 				} else {
 					canChangeTarget = false;
 				}
@@ -868,12 +862,12 @@ void Monster::onThinkTarget(uint32_t interval)
 			if (canChangeTarget) {
 				targetChangeTicks += interval;
 
-				if (targetChangeTicks >= mType->changeTargetSpeed) {
+				if (targetChangeTicks >= mType->info.changeTargetSpeed) {
 					targetChangeTicks = 0;
-					targetChangeCooldown = mType->changeTargetSpeed;
+					targetChangeCooldown = mType->info.changeTargetSpeed;
 
-					if (mType->changeTargetChance >= uniform_random(1, 100)) {
-						if (mType->targetDistance <= 1) {
+					if (mType->info.changeTargetChance >= uniform_random(1, 100)) {
+						if (mType->info.targetDistance <= 1) {
 							searchTarget(TARGETSEARCH_RANDOM);
 						} else {
 							searchTarget(TARGETSEARCH_NEAREST);
@@ -890,7 +884,7 @@ void Monster::onThinkDefense(uint32_t interval)
 	bool resetTicks = true;
 	defenseTicks += interval;
 
-	for (const spellBlock_t& spellBlock : mType->defenseSpells) {
+	for (const spellBlock_t& spellBlock : mType->info.defenseSpells) {
 		if (spellBlock.speed > defenseTicks) {
 			resetTicks = false;
 			continue;
@@ -908,14 +902,14 @@ void Monster::onThinkDefense(uint32_t interval)
 		}
 	}
 
-	if (!isSummon() && summons.size() < mType->maxSummons && hasFollowPath) {
-		for (const summonBlock_t& summonBlock : mType->summons) {
+	if (!isSummon() && summons.size() < mType->info.maxSummons && hasFollowPath) {
+		for (const summonBlock_t& summonBlock : mType->info.summons) {
 			if (summonBlock.speed > defenseTicks) {
 				resetTicks = false;
 				continue;
 			}
 
-			if (summons.size() >= mType->maxSummons) {
+			if (summons.size() >= mType->info.maxSummons) {
 				continue;
 			}
 
@@ -962,17 +956,17 @@ void Monster::onThinkDefense(uint32_t interval)
 
 void Monster::onThinkYell(uint32_t interval)
 {
-	if (mType->yellSpeedTicks == 0) {
+	if (mType->info.yellSpeedTicks == 0) {
 		return;
 	}
 
 	yellTicks += interval;
-	if (yellTicks >= mType->yellSpeedTicks) {
+	if (yellTicks >= mType->info.yellSpeedTicks) {
 		yellTicks = 0;
 
-		if (!mType->voiceVector.empty() && (mType->yellChance >= static_cast<uint32_t>(uniform_random(1, 100)))) {
-			uint32_t index = uniform_random(0, mType->voiceVector.size() - 1);
-			const voiceBlock_t& vb = mType->voiceVector[index];
+		if (!mType->info.voiceVector.empty() && (mType->info.yellChance >= static_cast<uint32_t>(uniform_random(1, 100)))) {
+			uint32_t index = uniform_random(0, mType->info.voiceVector.size() - 1);
+			const voiceBlock_t& vb = mType->info.voiceVector[index];
 
 			if (vb.yellText) {
 				g_game.internalCreatureSay(this, TALKTYPE_MONSTER_YELL, vb.text, false);
@@ -1114,7 +1108,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 			if (attackedCreature && attackedCreature == followCreature) {
 				if (isFleeing()) {
 					result = getDanceStep(getPosition(), direction, false, false);
-				} else if (mType->staticAttackChance < static_cast<uint32_t>(uniform_random(1, 100))) {
+				} else if (mType->info.staticAttackChance < static_cast<uint32_t>(uniform_random(1, 100))) {
 					result = getDanceStep(getPosition(), direction);
 				}
 			}
@@ -1251,9 +1245,9 @@ bool Monster::getDistanceStep(const Position& targetPos, Direction& direction, b
 
 	int32_t distance = std::max<int32_t>(dx, dy);
 
-	if (!flee && (distance > mType->targetDistance || !g_game.isSightClear(creaturePos, targetPos, true))) {
+	if (!flee && (distance > mType->info.targetDistance || !g_game.isSightClear(creaturePos, targetPos, true))) {
 		return false; // let the A* calculate it
-	} else if (!flee && distance == mType->targetDistance) {
+	} else if (!flee && distance == mType->info.targetDistance) {
 		return true; // we don't really care here, since it's what we wanted to reach (a dancestep will take of dancing in that position)
 	}
 
@@ -1891,8 +1885,7 @@ void Monster::dropLoot(Container* corpse, Creature*)
 
 void Monster::setNormalCreatureLight()
 {
-	internalLight.level = mType->lightLevel;
-	internalLight.color = mType->lightColor;
+	internalLight = mType->info.light;
 }
 
 void Monster::drainHealth(Creature* attacker, int32_t damage)
@@ -1928,7 +1921,7 @@ bool Monster::convinceCreature(Creature* creature)
 {
 	Player* player = creature->getPlayer();
 	if (player && !player->hasFlag(PlayerFlag_CanConvinceAll)) {
-		if (!mType->isConvinceable) {
+		if (!mType->info.isConvinceable) {
 			return false;
 		}
 	}
@@ -1989,13 +1982,13 @@ void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp)
 	Creature::getPathSearchParams(creature, fpp);
 
 	fpp.minTargetDist = 1;
-	fpp.maxTargetDist = mType->targetDistance;
+	fpp.maxTargetDist = mType->info.targetDistance;
 
 	if (isSummon()) {
 		if (getMaster() == creature) {
 			fpp.maxTargetDist = 2;
 			fpp.fullPathSearch = true;
-		} else if (mType->targetDistance <= 1) {
+		} else if (mType->info.targetDistance <= 1) {
 			fpp.fullPathSearch = true;
 		} else {
 			fpp.fullPathSearch = !canUseAttack(getPosition(), creature);
@@ -2006,7 +1999,7 @@ void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp)
 		fpp.clearSight = false;
 		fpp.keepDistance = true;
 		fpp.fullPathSearch = false;
-	} else if (mType->targetDistance <= 1) {
+	} else if (mType->info.targetDistance <= 1) {
 		fpp.fullPathSearch = true;
 	} else {
 		fpp.fullPathSearch = !canUseAttack(getPosition(), creature);

--- a/src/monster.h
+++ b/src/monster.h
@@ -89,36 +89,36 @@ class Monster final : public Creature
 		}
 
 		RaceType_t getRace() const final {
-			return mType->race;
+			return mType->info.race;
 		}
 		int32_t getArmor() const final {
-			return mType->armor;
+			return mType->info.armor;
 		}
 		int32_t getDefense() const final {
-			return mType->defense;
+			return mType->info.defense;
 		}
 		bool isPushable() const final {
-			return mType->pushable && baseSpeed != 0;
+			return mType->info.pushable && baseSpeed != 0;
 		}
 		bool isAttackable() const final {
-			return mType->isAttackable;
+			return mType->info.isAttackable;
 		}
 
 		bool canPushItems() const {
-			return mType->canPushItems;
+			return mType->info.canPushItems;
 		}
 		bool canPushCreatures() const {
-			return mType->canPushCreatures;
+			return mType->info.canPushCreatures;
 		}
 		bool isHostile() const {
-			return mType->isHostile;
+			return mType->info.isHostile;
 		}
 		bool canSee(const Position& pos) const final;
 		bool canSeeInvisibility() const final {
 			return isImmune(CONDITION_INVISIBLE);
 		}
 		uint32_t getManaCost() const {
-			return mType->manaCost;
+			return mType->info.manaCost;
 		}
 		void setSpawn(Spawn* spawn) {
 			this->spawn = spawn;
@@ -162,7 +162,7 @@ class Monster final : public Creature
 
 		bool isTarget(const Creature* creature) const;
 		bool isFleeing() const {
-			return !isSummon() && getHealth() <= mType->runAwayHealth;
+			return !isSummon() && getHealth() <= mType->info.runAwayHealth;
 		}
 
 		bool getDistanceStep(const Position& targetPos, Direction& direction, bool flee = false);
@@ -252,17 +252,17 @@ class Monster final : public Creature
 		bool isOpponent(const Creature* creature) const;
 
 		uint64_t getLostExperience() const final {
-			return skillLoss ? mType->experience : 0;
+			return skillLoss ? mType->info.experience : 0;
 		}
 		uint16_t getLookCorpse() const final {
-			return mType->lookcorpse;
+			return mType->info.lookcorpse;
 		}
 		void dropLoot(Container* corpse, Creature* lastHitCreature) final;
 		uint32_t getDamageImmunities() const final {
-			return mType->damageImmunities;
+			return mType->info.damageImmunities;
 		}
 		uint32_t getConditionImmunities() const final {
-			return mType->conditionImmunities;
+			return mType->info.conditionImmunities;
 		}
 		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const final;
 		bool useCacheMap() const final {

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -41,73 +41,6 @@ spellBlock_t::~spellBlock_t()
 	}
 }
 
-MonsterType::MonsterType()
-{
-	reset();
-}
-
-void MonsterType::reset()
-{
-	experience = 0;
-
-	defense = 0;
-	armor = 0;
-
-	hiddenHealth = false;
-
-	canPushItems = false;
-	canPushCreatures = false;
-	staticAttackChance = 95;
-	maxSummons = 0;
-	targetDistance = 1;
-	runAwayHealth = 0;
-	pushable = true;
-	baseSpeed = 200;
-	health = 100;
-	healthMax = 100;
-
-	outfit.reset();
-	lookcorpse = 0;
-
-	skull = SKULL_NONE;
-
-	conditionImmunities = 0;
-	damageImmunities = 0;
-	race = RACE_BLOOD;
-	isSummonable = false;
-	isIllusionable = false;
-	isConvinceable = false;
-	isAttackable = true;
-	isHostile = true;
-
-	lightLevel = 0;
-	lightColor = 0;
-
-	manaCost = 0;
-	summons.clear();
-	lootItems.clear();
-	elementMap.clear();
-
-	attackSpells.clear();
-	defenseSpells.clear();
-
-	yellSpeedTicks = 0;
-	yellChance = 0;
-	voiceVector.clear();
-
-	changeTargetSpeed = 0;
-	changeTargetChance = 0;
-
-	scriptInterface = nullptr;
-	creatureAppearEvent = -1;
-	creatureDisappearEvent = -1;
-	creatureMoveEvent = -1;
-	creatureSayEvent = -1;
-	thinkEvent = -1;
-
-	scripts.clear();
-}
-
 uint32_t Monsters::getLootRandom()
 {
 	return uniform_random(0, MAX_LOOTCHANCE) / g_config.getNumber(ConfigManager::RATE_LOOT);
@@ -122,7 +55,7 @@ void MonsterType::createLoot(Container* corpse)
 
 	Player* owner = g_game.getPlayerByID(corpse->getCorpseOwner());
 	if (!owner || owner->getStaminaMinutes() > 840) {
-		for (auto it = lootItems.rbegin(), end = lootItems.rend(); it != end; ++it) {
+		for (auto it = info.lootItems.rbegin(), end = info.lootItems.rend(); it != end; ++it) {
 			auto itemList = createLootItem(*it);
 			if (itemList.empty()) {
 				continue;
@@ -231,11 +164,6 @@ bool MonsterType::createLootContainer(Container* parent, const LootBlock& lootbl
 	return !parent->empty();
 }
 
-Monsters::Monsters()
-{
-	loaded = false;
-}
-
 bool Monsters::loadFromXml(bool reloading /*= false*/)
 {
 	pugi::xml_document doc;
@@ -261,12 +189,12 @@ bool Monsters::loadFromXml(bool reloading /*= false*/)
 		for (const auto& scriptEntry : monsterScriptList) {
 			MonsterType* mType = scriptEntry.first;
 			if (scriptInterface->loadFile("data/monster/scripts/" + scriptEntry.second) == 0) {
-				mType->scriptInterface = scriptInterface.get();
-				mType->creatureAppearEvent = scriptInterface->getEvent("onCreatureAppear");
-				mType->creatureDisappearEvent = scriptInterface->getEvent("onCreatureDisappear");
-				mType->creatureMoveEvent = scriptInterface->getEvent("onCreatureMove");
-				mType->creatureSayEvent = scriptInterface->getEvent("onCreatureSay");
-				mType->thinkEvent = scriptInterface->getEvent("onThink");
+				mType->info.scriptInterface = scriptInterface.get();
+				mType->info.creatureAppearEvent = scriptInterface->getEvent("onCreatureAppear");
+				mType->info.creatureDisappearEvent = scriptInterface->getEvent("onCreatureDisappear");
+				mType->info.creatureMoveEvent = scriptInterface->getEvent("onCreatureMove");
+				mType->info.creatureSayEvent = scriptInterface->getEvent("onCreatureSay");
+				mType->info.thinkEvent = scriptInterface->getEvent("onThink");
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Can not load script: " << scriptEntry.second << std::endl;
 				std::cout << scriptInterface->getLastLuaError() << std::endl;
@@ -556,7 +484,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 				MonsterType* mType = g_monsters.getMonsterType(attr.as_string());
 				if (mType) {
 					ConditionOutfit* condition = static_cast<ConditionOutfit*>(Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0));
-					condition->setOutfit(mType->outfit);
+					condition->setOutfit(mType->info.outfit);
 					combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
 					combat->setCondition(condition);
 				}
@@ -726,7 +654,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 		mType = getMonsterType(monsterName);
 		if (mType != nullptr) {
 			new_mType = false;
-			mType->reset();
+			mType->info = {};
 		}
 	}
 
@@ -739,42 +667,41 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	if ((attr = monsterNode.attribute("nameDescription"))) {
 		mType->nameDescription = attr.as_string();
 	} else {
-		mType->nameDescription = "a " + mType->name;
-		toLowerCaseString(mType->nameDescription);
+		mType->nameDescription = "a " + asLowerCaseString(mType->name);
 	}
 
 	if ((attr = monsterNode.attribute("race"))) {
 		std::string tmpStrValue = asLowerCaseString(attr.as_string());
 		uint16_t tmpInt = pugi::cast<uint16_t>(attr.value());
 		if (tmpStrValue == "venom" || tmpInt == 1) {
-			mType->race = RACE_VENOM;
+			mType->info.race = RACE_VENOM;
 		} else if (tmpStrValue == "blood" || tmpInt == 2) {
-			mType->race = RACE_BLOOD;
+			mType->info.race = RACE_BLOOD;
 		} else if (tmpStrValue == "undead" || tmpInt == 3) {
-			mType->race = RACE_UNDEAD;
+			mType->info.race = RACE_UNDEAD;
 		} else if (tmpStrValue == "fire" || tmpInt == 4) {
-			mType->race = RACE_FIRE;
+			mType->info.race = RACE_FIRE;
 		} else if (tmpStrValue == "energy" || tmpInt == 5) {
-			mType->race = RACE_ENERGY;
+			mType->info.race = RACE_ENERGY;
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Unknown race type " << attr.as_string() << ". " << file << std::endl;
 		}
 	}
 
 	if ((attr = monsterNode.attribute("experience"))) {
-		mType->experience = pugi::cast<uint64_t>(attr.value());
+		mType->info.experience = pugi::cast<uint64_t>(attr.value());
 	}
 
 	if ((attr = monsterNode.attribute("speed"))) {
-		mType->baseSpeed = pugi::cast<int32_t>(attr.value());
+		mType->info.baseSpeed = pugi::cast<int32_t>(attr.value());
 	}
 
 	if ((attr = monsterNode.attribute("manacost"))) {
-		mType->manaCost = pugi::cast<uint32_t>(attr.value());
+		mType->info.manaCost = pugi::cast<uint32_t>(attr.value());
 	}
 
 	if ((attr = monsterNode.attribute("skull"))) {
-		mType->skull = getSkullType(attr.as_string());
+		mType->info.skull = getSkullType(attr.as_string());
 	}
 
 	if ((attr = monsterNode.attribute("script"))) {
@@ -784,13 +711,13 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	pugi::xml_node node;
 	if ((node = monsterNode.child("health"))) {
 		if ((attr = node.attribute("now"))) {
-			mType->health = pugi::cast<int32_t>(attr.value());
+			mType->info.health = pugi::cast<int32_t>(attr.value());
 		} else {
 			std::cout << "[Error - Monsters::loadMonster] Missing health now. " << file << std::endl;
 		}
 
 		if ((attr = node.attribute("max"))) {
-			mType->healthMax = pugi::cast<int32_t>(attr.value());
+			mType->info.healthMax = pugi::cast<int32_t>(attr.value());
 		} else {
 			std::cout << "[Error - Monsters::loadMonster] Missing health max. " << file << std::endl;
 		}
@@ -801,21 +728,21 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 			attr = flagNode.first_attribute();
 			const char* attrName = attr.name();
 			if (strcasecmp(attrName, "summonable") == 0) {
-				mType->isSummonable = attr.as_bool();
+				mType->info.isSummonable = attr.as_bool();
 			} else if (strcasecmp(attrName, "attackable") == 0) {
-				mType->isAttackable = attr.as_bool();
+				mType->info.isAttackable = attr.as_bool();
 			} else if (strcasecmp(attrName, "hostile") == 0) {
-				mType->isHostile = attr.as_bool();
+				mType->info.isHostile = attr.as_bool();
 			} else if (strcasecmp(attrName, "illusionable") == 0) {
-				mType->isIllusionable = attr.as_bool();
+				mType->info.isIllusionable = attr.as_bool();
 			} else if (strcasecmp(attrName, "convinceable") == 0) {
-				mType->isConvinceable = attr.as_bool();
+				mType->info.isConvinceable = attr.as_bool();
 			} else if (strcasecmp(attrName, "pushable") == 0) {
-				mType->pushable = attr.as_bool();
+				mType->info.pushable = attr.as_bool();
 			} else if (strcasecmp(attrName, "canpushitems") == 0) {
-				mType->canPushItems = attr.as_bool();
+				mType->info.canPushItems = attr.as_bool();
 			} else if (strcasecmp(attrName, "canpushcreatures") == 0) {
-				mType->canPushCreatures = attr.as_bool();
+				mType->info.canPushCreatures = attr.as_bool();
 			} else if (strcasecmp(attrName, "staticattack") == 0) {
 				uint32_t staticAttack = pugi::cast<uint32_t>(attr.value());
 				if (staticAttack > 100) {
@@ -823,17 +750,17 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 					staticAttack = 100;
 				}
 
-				mType->staticAttackChance = staticAttack;
+				mType->info.staticAttackChance = staticAttack;
 			} else if (strcasecmp(attrName, "lightlevel") == 0) {
-				mType->lightLevel = pugi::cast<uint16_t>(attr.value());
+				mType->info.light.level = pugi::cast<uint16_t>(attr.value());
 			} else if (strcasecmp(attrName, "lightcolor") == 0) {
-				mType->lightColor = pugi::cast<uint16_t>(attr.value());
+				mType->info.light.color = pugi::cast<uint16_t>(attr.value());
 			} else if (strcasecmp(attrName, "targetdistance") == 0) {
-				mType->targetDistance = std::max<int32_t>(1, pugi::cast<int32_t>(attr.value()));
+				mType->info.targetDistance = std::max<int32_t>(1, pugi::cast<int32_t>(attr.value()));
 			} else if (strcasecmp(attrName, "runonhealth") == 0) {
-				mType->runAwayHealth = pugi::cast<int32_t>(attr.value());
+				mType->info.runAwayHealth = pugi::cast<int32_t>(attr.value());
 			} else if (strcasecmp(attrName, "hidehealth") == 0) {
-				mType->hiddenHealth = attr.as_bool();
+				mType->info.hiddenHealth = attr.as_bool();
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Unknown flag attribute: " << attrName << ". " << file << std::endl;
 			}
@@ -841,20 +768,20 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 
 		//if a monster can push creatures,
 		// it should not be pushable
-		if (mType->canPushCreatures && mType->pushable) {
-			mType->pushable = false;
+		if (mType->info.canPushCreatures) {
+			mType->info.pushable = false;
 		}
 	}
 
 	if ((node = monsterNode.child("targetchange"))) {
 		if ((attr = node.attribute("speed")) || (attr = node.attribute("interval"))) {
-			mType->changeTargetSpeed = pugi::cast<uint32_t>(attr.value());
+			mType->info.changeTargetSpeed = pugi::cast<uint32_t>(attr.value());
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Missing targetchange speed. " << file << std::endl;
 		}
 
 		if ((attr = node.attribute("chance"))) {
-			mType->changeTargetChance = pugi::cast<int32_t>(attr.value());
+			mType->info.changeTargetChance = pugi::cast<int32_t>(attr.value());
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Missing targetchange chance. " << file << std::endl;
 		}
@@ -862,39 +789,39 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 
 	if ((node = monsterNode.child("look"))) {
 		if ((attr = node.attribute("type"))) {
-			mType->outfit.lookType = pugi::cast<uint16_t>(attr.value());
+			mType->info.outfit.lookType = pugi::cast<uint16_t>(attr.value());
 
 			if ((attr = node.attribute("head"))) {
-				mType->outfit.lookHead = pugi::cast<uint16_t>(attr.value());
+				mType->info.outfit.lookHead = pugi::cast<uint16_t>(attr.value());
 			}
 
 			if ((attr = node.attribute("body"))) {
-				mType->outfit.lookBody = pugi::cast<uint16_t>(attr.value());
+				mType->info.outfit.lookBody = pugi::cast<uint16_t>(attr.value());
 			}
 
 			if ((attr = node.attribute("legs"))) {
-				mType->outfit.lookLegs = pugi::cast<uint16_t>(attr.value());
+				mType->info.outfit.lookLegs = pugi::cast<uint16_t>(attr.value());
 			}
 
 			if ((attr = node.attribute("feet"))) {
-				mType->outfit.lookFeet = pugi::cast<uint16_t>(attr.value());
+				mType->info.outfit.lookFeet = pugi::cast<uint16_t>(attr.value());
 			}
 
 			if ((attr = node.attribute("addons"))) {
-				mType->outfit.lookAddons = pugi::cast<uint16_t>(attr.value());
+				mType->info.outfit.lookAddons = pugi::cast<uint16_t>(attr.value());
 			}
 		} else if ((attr = node.attribute("typeex"))) {
-			mType->outfit.lookTypeEx = pugi::cast<uint16_t>(attr.value());
+			mType->info.outfit.lookTypeEx = pugi::cast<uint16_t>(attr.value());
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Missing look type/typeex. " << file << std::endl;
 		}
 
 		if ((attr = node.attribute("mount"))) {
-			mType->outfit.lookMount = pugi::cast<uint16_t>(attr.value());
+			mType->info.outfit.lookMount = pugi::cast<uint16_t>(attr.value());
 		}
 
 		if ((attr = node.attribute("corpse"))) {
-			mType->lookcorpse = pugi::cast<uint16_t>(attr.value());
+			mType->info.lookcorpse = pugi::cast<uint16_t>(attr.value());
 		}
 	}
 
@@ -902,7 +829,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 		for (auto attackNode : node.children()) {
 			spellBlock_t sb;
 			if (deserializeSpell(attackNode, sb, monsterName)) {
-				mType->attackSpells.emplace_back(std::move(sb));
+				mType->info.attackSpells.emplace_back(std::move(sb));
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Cant load spell. " << file << std::endl;
 			}
@@ -911,17 +838,17 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 
 	if ((node = monsterNode.child("defenses"))) {
 		if ((attr = node.attribute("defense"))) {
-			mType->defense = pugi::cast<int32_t>(attr.value());
+			mType->info.defense = pugi::cast<int32_t>(attr.value());
 		}
 
 		if ((attr = node.attribute("armor"))) {
-			mType->armor = pugi::cast<int32_t>(attr.value());
+			mType->info.armor = pugi::cast<int32_t>(attr.value());
 		}
 
 		for (auto defenseNode : node.children()) {
 			spellBlock_t sb;
 			if (deserializeSpell(defenseNode, sb, monsterName)) {
-				mType->defenseSpells.emplace_back(std::move(sb));
+				mType->info.defenseSpells.emplace_back(std::move(sb));
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Cant load spell. " << file << std::endl;
 			}
@@ -933,114 +860,114 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 			if ((attr = immunityNode.attribute("name"))) {
 				std::string tmpStrValue = asLowerCaseString(attr.as_string());
 				if (tmpStrValue == "physical") {
-					mType->damageImmunities |= COMBAT_PHYSICALDAMAGE;
-					mType->conditionImmunities |= CONDITION_BLEEDING;
+					mType->info.damageImmunities |= COMBAT_PHYSICALDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_BLEEDING;
 				} else if (tmpStrValue == "energy") {
-					mType->damageImmunities |= COMBAT_ENERGYDAMAGE;
-					mType->conditionImmunities |= CONDITION_ENERGY;
+					mType->info.damageImmunities |= COMBAT_ENERGYDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_ENERGY;
 				} else if (tmpStrValue == "fire") {
-					mType->damageImmunities |= COMBAT_FIREDAMAGE;
-					mType->conditionImmunities |= CONDITION_FIRE;
+					mType->info.damageImmunities |= COMBAT_FIREDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_FIRE;
 				} else if (tmpStrValue == "poison" ||
 							tmpStrValue == "earth") {
-					mType->damageImmunities |= COMBAT_EARTHDAMAGE;
-					mType->conditionImmunities |= CONDITION_POISON;
+					mType->info.damageImmunities |= COMBAT_EARTHDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_POISON;
 				} else if (tmpStrValue == "drown") {
-					mType->damageImmunities |= COMBAT_DROWNDAMAGE;
-					mType->conditionImmunities |= CONDITION_DROWN;
+					mType->info.damageImmunities |= COMBAT_DROWNDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_DROWN;
 				} else if (tmpStrValue == "ice") {
-					mType->damageImmunities |= COMBAT_ICEDAMAGE;
-					mType->conditionImmunities |= CONDITION_FREEZING;
+					mType->info.damageImmunities |= COMBAT_ICEDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_FREEZING;
 				} else if (tmpStrValue == "holy") {
-					mType->damageImmunities |= COMBAT_HOLYDAMAGE;
-					mType->conditionImmunities |= CONDITION_DAZZLED;
+					mType->info.damageImmunities |= COMBAT_HOLYDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_DAZZLED;
 				} else if (tmpStrValue == "death") {
-					mType->damageImmunities |= COMBAT_DEATHDAMAGE;
-					mType->conditionImmunities |= CONDITION_CURSED;
+					mType->info.damageImmunities |= COMBAT_DEATHDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_CURSED;
 				} else if (tmpStrValue == "lifedrain") {
-					mType->damageImmunities |= COMBAT_LIFEDRAIN;
+					mType->info.damageImmunities |= COMBAT_LIFEDRAIN;
 				} else if (tmpStrValue == "manadrain") {
-					mType->damageImmunities |= COMBAT_MANADRAIN;
+					mType->info.damageImmunities |= COMBAT_MANADRAIN;
 				} else if (tmpStrValue == "paralyze") {
-					mType->conditionImmunities |= CONDITION_PARALYZE;
+					mType->info.conditionImmunities |= CONDITION_PARALYZE;
 				} else if (tmpStrValue == "outfit") {
-					mType->conditionImmunities |= CONDITION_OUTFIT;
+					mType->info.conditionImmunities |= CONDITION_OUTFIT;
 				} else if (tmpStrValue == "drunk") {
-					mType->conditionImmunities |= CONDITION_DRUNK;
+					mType->info.conditionImmunities |= CONDITION_DRUNK;
 				} else if (tmpStrValue == "invisible" || tmpStrValue == "invisibility") {
-					mType->conditionImmunities |= CONDITION_INVISIBLE;
+					mType->info.conditionImmunities |= CONDITION_INVISIBLE;
 				} else if (tmpStrValue == "bleed") {
-					mType->conditionImmunities |= CONDITION_BLEEDING;
+					mType->info.conditionImmunities |= CONDITION_BLEEDING;
 				} else {
 					std::cout << "[Warning - Monsters::loadMonster] Unknown immunity name " << attr.as_string() << ". " << file << std::endl;
 				}
 			} else if ((attr = immunityNode.attribute("physical"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_PHYSICALDAMAGE;
-					mType->conditionImmunities |= CONDITION_BLEEDING;
+					mType->info.damageImmunities |= COMBAT_PHYSICALDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_BLEEDING;
 				}
 			} else if ((attr = immunityNode.attribute("energy"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_ENERGYDAMAGE;
-					mType->conditionImmunities |= CONDITION_ENERGY;
+					mType->info.damageImmunities |= COMBAT_ENERGYDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_ENERGY;
 				}
 			} else if ((attr = immunityNode.attribute("fire"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_FIREDAMAGE;
-					mType->conditionImmunities |= CONDITION_FIRE;
+					mType->info.damageImmunities |= COMBAT_FIREDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_FIRE;
 				}
 			} else if ((attr = immunityNode.attribute("poison")) || (attr = immunityNode.attribute("earth"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_EARTHDAMAGE;
-					mType->conditionImmunities |= CONDITION_POISON;
+					mType->info.damageImmunities |= COMBAT_EARTHDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_POISON;
 				}
 			} else if ((attr = immunityNode.attribute("drown"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_DROWNDAMAGE;
-					mType->conditionImmunities |= CONDITION_DROWN;
+					mType->info.damageImmunities |= COMBAT_DROWNDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_DROWN;
 				}
 			} else if ((attr = immunityNode.attribute("ice"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_ICEDAMAGE;
-					mType->conditionImmunities |= CONDITION_FREEZING;
+					mType->info.damageImmunities |= COMBAT_ICEDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_FREEZING;
 				}
 			} else if ((attr = immunityNode.attribute("holy"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_HOLYDAMAGE;
-					mType->conditionImmunities |= CONDITION_DAZZLED;
+					mType->info.damageImmunities |= COMBAT_HOLYDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_DAZZLED;
 				}
 			} else if ((attr = immunityNode.attribute("death"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_DEATHDAMAGE;
-					mType->conditionImmunities |= CONDITION_CURSED;
+					mType->info.damageImmunities |= COMBAT_DEATHDAMAGE;
+					mType->info.conditionImmunities |= CONDITION_CURSED;
 				}
 			} else if ((attr = immunityNode.attribute("lifedrain"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_LIFEDRAIN;
+					mType->info.damageImmunities |= COMBAT_LIFEDRAIN;
 				}
 			} else if ((attr = immunityNode.attribute("manadrain"))) {
 				if (attr.as_bool()) {
-					mType->damageImmunities |= COMBAT_MANADRAIN;
+					mType->info.damageImmunities |= COMBAT_MANADRAIN;
 				}
 			} else if ((attr = immunityNode.attribute("paralyze"))) {
 				if (attr.as_bool()) {
-					mType->conditionImmunities |= CONDITION_PARALYZE;
+					mType->info.conditionImmunities |= CONDITION_PARALYZE;
 				}
 			} else if ((attr = immunityNode.attribute("outfit"))) {
 				if (attr.as_bool()) {
-					mType->conditionImmunities |= CONDITION_OUTFIT;
+					mType->info.conditionImmunities |= CONDITION_OUTFIT;
 				}
 			} else if ((attr = immunityNode.attribute("bleed"))) {
 				if (attr.as_bool()) {
-					mType->conditionImmunities |= CONDITION_BLEEDING;
+					mType->info.conditionImmunities |= CONDITION_BLEEDING;
 				}
 			} else if ((attr = immunityNode.attribute("drunk"))) {
 				if (attr.as_bool()) {
-					mType->conditionImmunities |= CONDITION_DRUNK;
+					mType->info.conditionImmunities |= CONDITION_DRUNK;
 				}
 			} else if ((attr = immunityNode.attribute("invisible")) || (attr = immunityNode.attribute("invisibility"))) {
 				if (attr.as_bool()) {
-					mType->conditionImmunities |= CONDITION_INVISIBLE;
+					mType->info.conditionImmunities |= CONDITION_INVISIBLE;
 				}
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Unknown immunity. " << file << std::endl;
@@ -1050,13 +977,13 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 
 	if ((node = monsterNode.child("voices"))) {
 		if ((attr = node.attribute("speed")) || (attr = node.attribute("interval"))) {
-			mType->yellSpeedTicks = pugi::cast<uint32_t>(attr.value());
+			mType->info.yellSpeedTicks = pugi::cast<uint32_t>(attr.value());
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Missing voices speed. " << file << std::endl;
 		}
 
 		if ((attr = node.attribute("chance"))) {
-			mType->yellChance = pugi::cast<uint32_t>(attr.value());
+			mType->info.yellChance = pugi::cast<uint32_t>(attr.value());
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Missing voices chance. " << file << std::endl;
 		}
@@ -1074,7 +1001,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 			} else {
 				vb.yellText = false;
 			}
-			mType->voiceVector.emplace_back(vb);
+			mType->info.voiceVector.emplace_back(vb);
 		}
 	}
 
@@ -1082,7 +1009,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 		for (auto lootNode : node.children()) {
 			LootBlock lootBlock;
 			if (loadLootItem(lootNode, lootBlock)) {
-				mType->lootItems.emplace_back(std::move(lootBlock));
+				mType->info.lootItems.emplace_back(std::move(lootBlock));
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Cant load loot. " << file << std::endl;
 			}
@@ -1092,25 +1019,25 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	if ((node = monsterNode.child("elements"))) {
 		for (auto elementNode : node.children()) {
 			if ((attr = elementNode.attribute("physicalPercent"))) {
-				mType->elementMap[COMBAT_PHYSICALDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_PHYSICALDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("icePercent"))) {
-				mType->elementMap[COMBAT_ICEDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_ICEDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("poisonPercent")) || (attr = elementNode.attribute("earthPercent"))) {
-				mType->elementMap[COMBAT_EARTHDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_EARTHDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("firePercent"))) {
-				mType->elementMap[COMBAT_FIREDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_FIREDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("energyPercent"))) {
-				mType->elementMap[COMBAT_ENERGYDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_ENERGYDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("holyPercent"))) {
-				mType->elementMap[COMBAT_HOLYDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_HOLYDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("deathPercent"))) {
-				mType->elementMap[COMBAT_DEATHDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_DEATHDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("drownPercent"))) {
-				mType->elementMap[COMBAT_DROWNDAMAGE] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_DROWNDAMAGE] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("lifedrainPercent"))) {
-				mType->elementMap[COMBAT_LIFEDRAIN] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_LIFEDRAIN] = pugi::cast<int32_t>(attr.value());
 			} else if ((attr = elementNode.attribute("manadrainPercent"))) {
-				mType->elementMap[COMBAT_MANADRAIN] = pugi::cast<int32_t>(attr.value());
+				mType->info.elementMap[COMBAT_MANADRAIN] = pugi::cast<int32_t>(attr.value());
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Unknown element percent. " << file << std::endl;
 			}
@@ -1119,7 +1046,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 
 	if ((node = monsterNode.child("summons"))) {
 		if ((attr = node.attribute("maxSummons"))) {
-			mType->maxSummons = std::min<uint32_t>(pugi::cast<uint32_t>(attr.value()), 100);
+			mType->info.maxSummons = std::min<uint32_t>(pugi::cast<uint32_t>(attr.value()), 100);
 		} else {
 			std::cout << "[Warning - Monsters::loadMonster] Missing summons maxSummons. " << file << std::endl;
 		}
@@ -1127,7 +1054,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 		for (auto summonNode : node.children()) {
 			int32_t chance = 100;
 			int32_t speed = 1000;
-			int32_t max = mType->maxSummons;
+			int32_t max = mType->info.maxSummons;
 			bool force = false;
 
 			if ((attr = summonNode.attribute("speed")) || (attr = summonNode.attribute("interval"))) {
@@ -1153,7 +1080,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 				sb.chance = chance;
 				sb.max = max;
 				sb.force = force;
-				mType->summons.emplace_back(sb);
+				mType->info.summons.emplace_back(sb);
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Missing summon name. " << file << std::endl;
 			}
@@ -1163,19 +1090,19 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	if ((node = monsterNode.child("script"))) {
 		for (auto eventNode : node.children()) {
 			if ((attr = eventNode.attribute("name"))) {
-				mType->scripts.emplace_back(attr.as_string());
+				mType->info.scripts.emplace_back(attr.as_string());
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Missing name for script event. " << file << std::endl;
 			}
 		}
 	}
 
-	mType->summons.shrink_to_fit();
-	mType->lootItems.shrink_to_fit();
-	mType->attackSpells.shrink_to_fit();
-	mType->defenseSpells.shrink_to_fit();
-	mType->voiceVector.shrink_to_fit();
-	mType->scripts.shrink_to_fit();
+	mType->info.summons.shrink_to_fit();
+	mType->info.lootItems.shrink_to_fit();
+	mType->info.attackSpells.shrink_to_fit();
+	mType->info.defenseSpells.shrink_to_fit();
+	mType->info.voiceVector.shrink_to_fit();
+	mType->info.scripts.shrink_to_fit();
 	return true;
 }
 

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -57,11 +57,11 @@ struct summonBlock_t {
 
 class BaseSpell;
 struct spellBlock_t {
-	spellBlock_t() = default;
+	constexpr spellBlock_t() = default;
 	~spellBlock_t();
 	spellBlock_t(const spellBlock_t& other) = delete;
 	spellBlock_t& operator=(const spellBlock_t& other) = delete;
-	spellBlock_t(spellBlock_t&& other):
+	spellBlock_t(spellBlock_t&& other) :
 		spell(other.spell),
 		chance(other.chance),
 		speed(other.speed),
@@ -90,15 +90,8 @@ struct voiceBlock_t {
 
 class MonsterType
 {
-	public:
-		MonsterType();
-		~MonsterType() = default;
-
-		// non-copyable
-		MonsterType(const MonsterType&) = delete;
-		MonsterType& operator=(const MonsterType&) = delete;
-
-		void reset();
+	struct MonsterInfo {
+		LuaScriptInterface* scriptInterface;
 
 		std::map<CombatType_t, int32_t> elementMap;
 
@@ -110,55 +103,60 @@ class MonsterType
 		std::vector<spellBlock_t> defenseSpells;
 		std::vector<summonBlock_t> summons;
 
+		Skulls_t skull = SKULL_NONE;
+		Outfit_t outfit = {};
+		RaceType_t race = RACE_BLOOD;
+
+		LightInfo light = {};
+		uint16_t lookcorpse = 0;
+
+		uint64_t experience = 0;
+
+		uint32_t manaCost = 0;
+		uint32_t yellChance = 0;
+		uint32_t yellSpeedTicks = 0;
+		uint32_t staticAttackChance = 95;
+		uint32_t maxSummons = 0;
+		uint32_t changeTargetSpeed = 0;
+		uint32_t conditionImmunities = 0;
+		uint32_t damageImmunities = 0;
+		uint32_t baseSpeed = 200;
+
+		int32_t creatureAppearEvent = -1;
+		int32_t creatureDisappearEvent = -1;
+		int32_t creatureMoveEvent = -1;
+		int32_t creatureSayEvent = -1;
+		int32_t thinkEvent = -1;
+		int32_t targetDistance = 1;
+		int32_t runAwayHealth = 0;
+		int32_t health = 100;
+		int32_t healthMax = 100;
+		int32_t changeTargetChance =0;
+		int32_t defense = 0;
+		int32_t armor = 0;
+
+		bool canPushItems = false;
+		bool canPushCreatures = false;
+		bool pushable = true;
+		bool isSummonable = false;
+		bool isIllusionable = false;
+		bool isConvinceable = false;
+		bool isAttackable = true;
+		bool isHostile = true;
+		bool hiddenHealth = false;
+	};
+
+	public:
+		MonsterType() = default;
+
+		// non-copyable
+		MonsterType(const MonsterType&) = delete;
+		MonsterType& operator=(const MonsterType&) = delete;
+
 		std::string name;
 		std::string nameDescription;
 
-		LuaScriptInterface* scriptInterface;
-
-		uint64_t experience;
-
-		Outfit_t outfit;
-
-		uint32_t manaCost;
-		uint32_t yellChance;
-		uint32_t yellSpeedTicks;
-		uint32_t staticAttackChance;
-		uint32_t maxSummons;
-		uint32_t changeTargetSpeed;
-		uint32_t conditionImmunities;
-		uint32_t damageImmunities;
-		uint32_t baseSpeed;
-
-		int32_t creatureAppearEvent;
-		int32_t creatureDisappearEvent;
-		int32_t creatureMoveEvent;
-		int32_t creatureSayEvent;
-		int32_t thinkEvent;
-		int32_t targetDistance;
-		int32_t runAwayHealth;
-		int32_t health;
-		int32_t healthMax;
-		int32_t changeTargetChance;
-		int32_t defense;
-		int32_t armor;
-
-		RaceType_t race;
-
-		uint16_t lookcorpse;
-
-		Skulls_t skull;
-		uint8_t lightLevel;
-		uint8_t lightColor;
-
-		bool canPushItems;
-		bool canPushCreatures;
-		bool pushable;
-		bool isSummonable;
-		bool isIllusionable;
-		bool isConvinceable;
-		bool isAttackable;
-		bool isHostile;
-		bool hiddenHealth;
+		MonsterInfo info;
 
 		void createLoot(Container* corpse);
 		bool createLootContainer(Container* parent, const LootBlock& lootblock);
@@ -168,8 +166,7 @@ class MonsterType
 class Monsters
 {
 	public:
-		Monsters();
-		~Monsters() = default;
+		Monsters() = default;
 		// non-copyable
 		Monsters(const Monsters&) = delete;
 		Monsters& operator=(const Monsters&) = delete;
@@ -197,7 +194,7 @@ class Monsters
 		std::map<std::string, MonsterType> monsters;
 		std::unique_ptr<LuaScriptInterface> scriptInterface;
 
-		bool loaded;
+		bool loaded = false;
 };
 
 #endif

--- a/src/mounts.h
+++ b/src/mounts.h
@@ -22,8 +22,8 @@
 
 struct Mount
 {
-	Mount(uint8_t id, uint16_t clientId, std::string name, int32_t speed, bool premium)
-		: name(name), speed(speed), clientId(clientId), id(id), premium(premium) {}
+	Mount(uint8_t id, uint16_t clientId, std::string name, int32_t speed, bool premium) :
+		name(std::move(name)), speed(speed), clientId(clientId), id(id), premium(premium) {}
 
 	std::string name;
 	int32_t speed;

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -384,37 +384,21 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 	return ret;
 }
 
-MoveEvent::MoveEvent(LuaScriptInterface* interface) :
-	Event(interface),
-	eventType(MOVE_EVENT_NONE),
-	stepFunction(nullptr),
-	moveFunction(nullptr),
-	equipFunction(nullptr),
-	slot(SLOTP_WHEREEVER),
-	reqLevel(0),
-	reqMagLevel(0),
-	premium(false),
-	wieldInfo(0)
-{}
+MoveEvent::MoveEvent(LuaScriptInterface* interface) : Event(interface) {}
 
 MoveEvent::MoveEvent(const MoveEvent* copy) :
-	Event(copy)
-{
-	eventType = copy->eventType;
-	stepFunction = copy->stepFunction;
-	moveFunction = copy->moveFunction;
-	equipFunction = copy->equipFunction;
-	slot = copy->slot;
-
-	if (copy->eventType == MOVE_EVENT_EQUIP) {
-		wieldInfo = copy->wieldInfo;
-		reqLevel = copy->reqLevel;
-		reqMagLevel = copy->reqMagLevel;
-		vocationString = copy->vocationString;
-		premium = copy->premium;
-		vocEquipMap = copy->vocEquipMap;
-	}
-}
+	Event(copy),
+	eventType(copy->eventType),
+	stepFunction(copy->stepFunction),
+	moveFunction(copy->moveFunction),
+	equipFunction(copy->equipFunction),
+	slot(copy->slot),
+	reqLevel(copy->reqLevel),
+	reqMagLevel(copy->reqMagLevel),
+	premium(copy->premium),
+	vocationString(copy->vocationString),
+	wieldInfo(copy->wieldInfo),
+	vocEquipMap(copy->vocEquipMap) {}
 
 std::string MoveEvent::getScriptEventName() const
 {

--- a/src/movement.h
+++ b/src/movement.h
@@ -150,18 +150,18 @@ class MoveEvent final : public Event
 		static EquipFunction EquipItem;
 		static EquipFunction DeEquipItem;
 
-		MoveEvent_t eventType;
-		StepFunction* stepFunction;
-		MoveFunction* moveFunction;
-		EquipFunction* equipFunction;
-		uint32_t slot;
+		MoveEvent_t eventType = MOVE_EVENT_NONE;
+		StepFunction* stepFunction = nullptr;
+		MoveFunction* moveFunction = nullptr;
+		EquipFunction* equipFunction = nullptr;
+		uint32_t slot = SLOTP_WHEREEVER;
 
 		//onEquip information
-		uint32_t reqLevel;
-		uint32_t reqMagLevel;
-		bool premium;
+		uint32_t reqLevel = 0;
+		uint32_t reqMagLevel = 0;
+		bool premium = false;
 		std::string vocationString;
-		uint32_t wieldInfo;
+		uint32_t wieldInfo = 0;
 		VocEquipMap vocEquipMap;
 };
 

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -34,8 +34,8 @@ std::string NetworkMessage::getString(uint16_t stringLen/* = 0*/)
 		return std::string();
 	}
 
-	char* v = reinterpret_cast<char*>(buffer) + position; //does not break strict aliasing
-	position += stringLen;
+	char* v = reinterpret_cast<char*>(buffer) + info.position; //does not break strict aliasing
+	info.position += stringLen;
 	return std::string(v, stringLen);
 }
 
@@ -56,9 +56,9 @@ void NetworkMessage::addString(const std::string& value)
 	}
 
 	add<uint16_t>(stringLen);
-	memcpy(buffer + position, value.c_str(), stringLen);
-	position += stringLen;
-	length += stringLen;
+	memcpy(buffer + info.position, value.c_str(), stringLen);
+	info.position += stringLen;
+	info.length += stringLen;
 }
 
 void NetworkMessage::addDouble(double value, uint8_t precision/* = 2*/)
@@ -73,9 +73,9 @@ void NetworkMessage::addBytes(const char* bytes, size_t size)
 		return;
 	}
 
-	memcpy(buffer + position, bytes, size);
-	position += size;
-	length += size;
+	memcpy(buffer + info.position, bytes, size);
+	info.position += size;
+	info.length += size;
 }
 
 void NetworkMessage::addPaddingBytes(size_t n)
@@ -84,8 +84,8 @@ void NetworkMessage::addPaddingBytes(size_t n)
 		return;
 	}
 
-	memset(buffer + position, 0x33, n);
-	length += n;
+	memset(buffer + info.position, 0x33, n);
+	info.length += n;
 }
 
 void NetworkMessage::addPosition(const Position& pos)

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -26,11 +26,6 @@
 extern Game g_game;
 extern LuaEnvironment g_luaEnvironment;
 
-enum {
-	EVENT_ID_LOADING = 1,
-	EVENT_ID_USER = 1000,
-};
-
 uint32_t Npc::npcAutoID = 0x80000000;
 NpcScriptInterface* Npc::scriptInterface = nullptr;
 
@@ -1046,21 +1041,13 @@ int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 	return 1;
 }
 
-NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc)
+NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc) :
+	npc(npc), scriptInterface(npc->getScriptInterface())
 {
-	this->npc = npc;
-	scriptInterface = npc->getScriptInterface();
 	loaded = scriptInterface->loadFile("data/npc/scripts/" + file, npc) == 0;
 	if (!loaded) {
 		std::cout << "[Warning - NpcScript::NpcScript] Can not load script: " << file << std::endl;
 		std::cout << scriptInterface->getLastLuaError() << std::endl;
-		creatureSayEvent = -1;
-		creatureDisappearEvent = -1;
-		creatureAppearEvent = -1;
-		creatureMoveEvent = -1;
-		playerCloseChannelEvent = -1;
-		playerEndTradeEvent = -1;
-		thinkEvent = -1;
 	} else {
 		creatureSayEvent = scriptInterface->getEvent("onCreatureSay");
 		creatureDisappearEvent = scriptInterface->getEvent("onCreatureDisappear");

--- a/src/npc.h
+++ b/src/npc.h
@@ -91,14 +91,14 @@ class NpcEventsHandler
 		Npc* npc;
 		NpcScriptInterface* scriptInterface;
 
-		int32_t creatureAppearEvent;
-		int32_t creatureDisappearEvent;
-		int32_t creatureMoveEvent;
-		int32_t creatureSayEvent;
-		int32_t playerCloseChannelEvent;
-		int32_t playerEndTradeEvent;
-		int32_t thinkEvent;
-		bool loaded;
+		int32_t creatureAppearEvent = -1;
+		int32_t creatureDisappearEvent = -1;
+		int32_t creatureMoveEvent = -1;
+		int32_t creatureSayEvent = -1;
+		int32_t playerCloseChannelEvent = -1;
+		int32_t playerEndTradeEvent = -1;
+		int32_t thinkEvent = -1;
+		bool loaded = false;
 };
 
 class Npc final : public Creature

--- a/src/outfit.h
+++ b/src/outfit.h
@@ -23,7 +23,8 @@
 #include "enums.h"
 
 struct Outfit {
-	Outfit(std::string name, uint16_t lookType, bool premium, bool unlocked) : name(name), lookType(lookType), premium(premium), unlocked(unlocked) {}
+	Outfit(std::string name, uint16_t lookType, bool premium, bool unlocked) :
+		name(std::move(name)), lookType(lookType), premium(premium), unlocked(unlocked) {}
 
 	std::string name;
 	uint16_t lookType;
@@ -32,9 +33,10 @@ struct Outfit {
 };
 
 struct ProtocolOutfit {
-	ProtocolOutfit(const std::string* name, uint16_t lookType, uint8_t addons) : name(name), lookType(lookType), addons(addons) {}
+	ProtocolOutfit(const std::string& name, uint16_t lookType, uint8_t addons) :
+		name(name), lookType(lookType), addons(addons) {}
 
-	const std::string* name;
+	const std::string& name;
 	uint16_t lookType;
 	uint8_t addons;
 };

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -29,8 +29,7 @@ class Protocol;
 class OutputMessage : public NetworkMessage
 {
 	public:
-		OutputMessage():
-			outputBufferStart(INITIAL_BUFFER_POSITION) {}
+		OutputMessage() = default;
 
 		// non-copyable
 		OutputMessage(const OutputMessage&) = delete;
@@ -41,12 +40,12 @@ class OutputMessage : public NetworkMessage
 		}
 
 		void writeMessageLength() {
-			add_header(length);
+			add_header(info.length);
 		}
 
 		void addCryptoHeader(bool addChecksum) {
 			if (addChecksum) {
-				add_header(adlerChecksum(buffer + outputBufferStart, length));
+				add_header(adlerChecksum(buffer + outputBufferStart, info.length));
 			}
 
 			writeMessageLength();
@@ -54,16 +53,16 @@ class OutputMessage : public NetworkMessage
 
 		inline void append(const NetworkMessage& msg) {
 			auto msgLen = msg.getLength();
-			memcpy(buffer + position, msg.getBuffer() + 8, msgLen);
-			length += msgLen;
-			position += msgLen;
+			memcpy(buffer + info.position, msg.getBuffer() + 8, msgLen);
+			info.length += msgLen;
+			info.position += msgLen;
 		}
 
 		inline void append(const OutputMessage_ptr& msg) {
 			auto msgLen = msg->getLength();
-			memcpy(buffer + position, msg->getBuffer() + 8, msgLen);
-			length += msgLen;
-			position += msgLen;
+			memcpy(buffer + info.position, msg->getBuffer() + 8, msgLen);
+			info.length += msgLen;
+			info.position += msgLen;
 		}
 
 	protected:
@@ -73,10 +72,10 @@ class OutputMessage : public NetworkMessage
 			outputBufferStart -= sizeof(T);
 			memcpy(buffer + outputBufferStart, &add, sizeof(T));
 			//added header size to the message size
-			length += sizeof(T);
+			info.length += sizeof(T);
 		}
 
-		MsgSize_t outputBufferStart;
+		MsgSize_t outputBufferStart = INITIAL_BUFFER_POSITION;
 };
 
 class OutputMessagePool

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -28,9 +28,8 @@ extern Game g_game;
 extern ConfigManager g_config;
 extern Events* g_events;
 
-Party::Party(Player* leader)
+Party::Party(Player* leader) : leader(leader)
 {
-	this->leader = leader;
 	leader->setParty(this);
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -48,12 +48,8 @@ MuteCountMap Player::muteCountMap;
 uint32_t Player::playerAutoID = 0x10000000;
 
 Player::Player(ProtocolGame_ptr p) :
-	Creature(), client(p)
+	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), inbox(new Inbox(ITEM_INBOX)), client(p)
 {
-	lastPing = OTSYS_TIME();
-	lastPong = lastPing;
-
-	inbox = new Inbox(ITEM_INBOX);
 	inbox->incrementReferenceCounter();
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -90,8 +90,8 @@ enum tradestate_t : uint8_t {
 };
 
 struct VIPEntry {
-	VIPEntry(uint32_t guid, std::string name, const std::string& description, uint32_t icon, bool notify)
-		: guid(guid), name(name), description(description), icon(icon), notify(notify) {}
+	VIPEntry(uint32_t guid, std::string name, std::string description, uint32_t icon, bool notify) :
+		guid(guid), name(std::move(name)), description(std::move(description)), icon(icon), notify(notify) {}
 
 	uint32_t guid;
 	std::string name;
@@ -106,17 +106,16 @@ struct OpenContainer {
 };
 
 struct OutfitEntry {
-	OutfitEntry(uint16_t lookType, uint8_t addons) : lookType(lookType), addons(addons) {}
+	constexpr OutfitEntry(uint16_t lookType, uint8_t addons) : lookType(lookType), addons(addons) {}
 
 	uint16_t lookType;
 	uint8_t addons;
 };
 
 struct Skill {
-	Skill() : tries(0), level(10), percent(0) {}
-	uint64_t tries;
-	uint16_t level;
-	uint8_t percent;
+	uint64_t tries = 0;
+	uint16_t level = 10;
+	uint8_t percent = 0;
 };
 
 typedef std::map<uint32_t, uint32_t> MuteCountMap;
@@ -153,7 +152,7 @@ class Player final : public Creature, public Cylinder
 			return name;
 		}
 		void setName(std::string name) {
-			this->name = name;
+			this->name = std::move(name);
 		}
 		const std::string& getNameDescription() const final {
 			return name;

--- a/src/position.h
+++ b/src/position.h
@@ -38,8 +38,8 @@ enum Direction : uint8_t {
 
 struct Position
 {
-	Position() = default;
-	Position(uint16_t x, uint16_t y, uint8_t z) : x(x), y(y), z(z) {}
+	constexpr Position() = default;
+	constexpr Position(uint16_t x, uint16_t y, uint8_t z) : x(x), y(y), z(z) {}
 
 	template<int_fast32_t deltax, int_fast32_t deltay>
 	inline static bool areInRange(const Position& p1, const Position& p2) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -92,7 +92,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		OutputMessage_ptr outputBuffer;
 	private:
 		const ConnectionWeak_ptr connection;
-		uint32_t key[4] = { 0 };
+		uint32_t key[4] = {};
 		bool encryptionEnabled = false;
 		bool checksumEnabled = true;
 		bool rawMessages = false;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -41,19 +41,6 @@ extern Actions actions;
 extern CreatureEvents* g_creatureEvents;
 extern Chat* g_chat;
 
-ProtocolGame::ProtocolGame(Connection_ptr connection) :
-	Protocol(connection),
-	player(nullptr),
-	eventConnect(0),
-	challengeTimestamp(0),
-	version(CLIENT_VERSION_MIN),
-	challengeRandom(0),
-	debugAssertSent(false),
-	acceptPackets(false)
-{
-	//
-}
-
 void ProtocolGame::release()
 {
 	//dispatcher thread
@@ -2639,11 +2626,7 @@ void ProtocolGame::sendOutfitWindow()
 	std::vector<ProtocolOutfit> protocolOutfits;
 	if (player->isAccessPlayer()) {
 		static const std::string gamemasterOutfitName = "Gamemaster";
-		protocolOutfits.emplace_back(
-			&gamemasterOutfitName,
-			75,
-			0
-		);
+		protocolOutfits.emplace_back(gamemasterOutfitName, 75, 0);
 	}
 
 	const auto& outfits = Outfits::getInstance()->getOutfits(player->getSex());
@@ -2654,11 +2637,7 @@ void ProtocolGame::sendOutfitWindow()
 			continue;
 		}
 
-		protocolOutfits.emplace_back(
-			&outfit.name,
-			outfit.lookType,
-			addons
-		);
+		protocolOutfits.emplace_back(outfit.name, outfit.lookType, addons);
 		if (protocolOutfits.size() == 50) { // Game client doesn't allow more than 50 outfits
 			break;
 		}
@@ -2667,7 +2646,7 @@ void ProtocolGame::sendOutfitWindow()
 	msg.addByte(protocolOutfits.size());
 	for (const ProtocolOutfit& outfit : protocolOutfits) {
 		msg.add<uint16_t>(outfit.lookType);
-		msg.addString(*outfit.name);
+		msg.addString(outfit.name);
 		msg.addByte(outfit.addons);
 	}
 

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -40,23 +40,16 @@ extern Game g_game;
 
 struct TextMessage
 {
-	MessageClasses type;
+	MessageClasses type = MESSAGE_STATUS_DEFAULT;
 	std::string text;
 	Position position;
 	struct {
-		int32_t value;
+		int32_t value = 0;
 		TextColor_t color;
 	} primary, secondary;
 
-	TextMessage() {
-		type = MESSAGE_STATUS_DEFAULT;
-		primary.value = 0;
-		secondary.value = 0;
-	}
-	TextMessage(MessageClasses type, std::string text) : type(type), text(text) {
-		primary.value = 0;
-		secondary.value = 0;
-	}
+	TextMessage() = default;
+	TextMessage(MessageClasses type, std::string text) : type(type), text(text) {}
 };
 
 class ProtocolGame final : public Protocol
@@ -70,7 +63,7 @@ class ProtocolGame final : public Protocol
 			return "gameworld protocol";
 		}
 
-		explicit ProtocolGame(Connection_ptr connection);
+		explicit ProtocolGame(Connection_ptr connection) : Protocol(connection) {}
 
 		void login(const std::string& name, uint32_t accnumber, OperatingSystem_t operatingSystem);
 		void logout(bool displayEffect, bool forced);
@@ -317,16 +310,16 @@ class ProtocolGame final : public Protocol
 		}
 
 		std::unordered_set<uint32_t> knownCreatureSet;
-		Player* player;
+		Player* player = nullptr;
 
-		uint32_t eventConnect;
-		uint32_t challengeTimestamp;
-		uint16_t version;
+		uint32_t eventConnect = 0;
+		uint32_t challengeTimestamp = 0;
+		uint16_t version = CLIENT_VERSION_MIN;
 
-		uint8_t challengeRandom;
+		uint8_t challengeRandom = 0;
 
-		bool debugAssertSent;
-		bool acceptPackets;
+		bool debugAssertSent = false;
+		bool acceptPackets = false;
 };
 
 #endif

--- a/src/quests.h
+++ b/src/quests.h
@@ -32,8 +32,8 @@ typedef std::list<Quest> QuestsList;
 class Mission
 {
 	public:
-		Mission(std::string name, int32_t storageID, int32_t startValue, int32_t endValue, bool ignoreEndValue)
-			: name(name), storageID(storageID), startValue(startValue), endValue(endValue), ignoreEndValue(ignoreEndValue) {}
+		Mission(std::string name, int32_t storageID, int32_t startValue, int32_t endValue, bool ignoreEndValue) :
+			name(std::move(name)), storageID(storageID), startValue(startValue), endValue(endValue), ignoreEndValue(ignoreEndValue) {}
 
 		bool isCompleted(Player* player) const;
 		bool isStarted(Player* player) const;
@@ -63,8 +63,8 @@ class Mission
 class Quest
 {
 	public:
-		Quest(std::string name, uint16_t id, int32_t startStorageID, int32_t startStorageValue)
-			: name(name), startStorageID(startStorageID), startStorageValue(startStorageValue), id(id) {}
+		Quest(std::string name, uint16_t id, int32_t startStorageID, int32_t startStorageValue) :
+			name(std::move(name)), startStorageID(startStorageID), startStorageValue(startStorageValue), id(id) {}
 
 		bool isCompleted(Player* player) const;
 		bool isStarted(Player* player) const;

--- a/src/raids.cpp
+++ b/src/raids.cpp
@@ -546,8 +546,6 @@ bool AreaSpawnEvent::executeEvent()
 	return true;
 }
 
-ScriptEvent::ScriptEvent(LuaScriptInterface* interface) : Event(interface) {}
-
 bool ScriptEvent::configureRaidEvent(const pugi::xml_node& eventNode)
 {
 	if (!RaidEvent::configureRaidEvent(eventNode)) {

--- a/src/raids.h
+++ b/src/raids.h
@@ -30,7 +30,8 @@ enum RaidState_t {
 };
 
 struct MonsterSpawn {
-	MonsterSpawn(const char* name, uint32_t minAmount, uint32_t maxAmount) : name(name), minAmount(minAmount), maxAmount(maxAmount) {}
+	MonsterSpawn(std::string name, uint32_t minAmount, uint32_t maxAmount) :
+		name(std::move(name)), minAmount(minAmount), maxAmount(maxAmount) {}
 
 	std::string name;
 	uint32_t minAmount;
@@ -91,7 +92,7 @@ class Raids
 		}
 
 	private:
-		LuaScriptInterface scriptInterface { "Raid Interface" };
+		LuaScriptInterface scriptInterface{"Raid Interface"};
 
 		std::list<Raid*> raidList;
 		Raid* running = nullptr;
@@ -104,8 +105,8 @@ class Raids
 class Raid
 {
 	public:
-		Raid(std::string name, uint32_t interval, uint32_t marginTime, bool repeat)
-			: name(name), interval(interval), nextEvent(0), margin(marginTime), state(RAIDSTATE_IDLE), nextEventEvent(0), loaded(false), repeat(repeat) {}
+		Raid(std::string name, uint32_t interval, uint32_t marginTime, bool repeat) :
+			name(std::move(name)), interval(interval), margin(marginTime), repeat(repeat) {}
 		~Raid();
 
 		// non-copyable
@@ -123,7 +124,7 @@ class Raid
 		void setState(RaidState_t newState) {
 			state = newState;
 		}
-		std::string getName() const {
+		const std::string& getName() const {
 			return name;
 		}
 
@@ -146,11 +147,11 @@ class Raid
 		std::vector<RaidEvent*> raidEvents;
 		std::string name;
 		uint32_t interval;
-		uint32_t nextEvent;
+		uint32_t nextEvent = 0;
 		uint64_t margin;
-		RaidState_t state;
-		uint32_t nextEventEvent;
-		bool loaded;
+		RaidState_t state = RAIDSTATE_IDLE;
+		uint32_t nextEventEvent = 0;
+		bool loaded = false;
 		bool repeat;
 };
 
@@ -177,7 +178,7 @@ class RaidEvent
 class AnnounceEvent final : public RaidEvent
 {
 	public:
-		AnnounceEvent() : messageType(MESSAGE_EVENT_ADVANCE) {}
+		AnnounceEvent() = default;
 
 		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
 
@@ -185,7 +186,7 @@ class AnnounceEvent final : public RaidEvent
 
 	private:
 		std::string message;
-		MessageClasses messageType;
+		MessageClasses messageType = MESSAGE_EVENT_ADVANCE;
 };
 
 class SingleSpawnEvent final : public RaidEvent
@@ -215,7 +216,7 @@ class AreaSpawnEvent final : public RaidEvent
 class ScriptEvent final : public RaidEvent, public Event
 {
 	public:
-		explicit ScriptEvent(LuaScriptInterface* interface);
+		explicit ScriptEvent(LuaScriptInterface* interface) : Event(interface) {}
 
 		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
 		bool configureEvent(const pugi::xml_node&) final {

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -45,11 +45,9 @@ class SchedulerTask : public Task
 		}
 
 	protected:
-		SchedulerTask(uint32_t delay, const std::function<void (void)>& f) : Task(delay, f) {
-			eventId = 0;
-		}
+		SchedulerTask(uint32_t delay, const std::function<void (void)>& f) : Task(delay, f) {}
 
-		uint32_t eventId;
+		uint32_t eventId = 0;
 
 		friend SchedulerTask* createSchedulerTask(uint32_t, const std::function<void (void)>&);
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -67,10 +67,6 @@ void ServiceManager::stop()
 	death_timer.async_wait(std::bind(&ServiceManager::die, this));
 }
 
-ServicePort::ServicePort(boost::asio::io_service& io_service) :
-	io_service(io_service)
-{}
-
 ServicePort::~ServicePort()
 {
 	close();

--- a/src/server.h
+++ b/src/server.h
@@ -61,7 +61,7 @@ class Service final : public ServiceBase
 class ServicePort : public std::enable_shared_from_this<ServicePort>
 {
 	public:
-		explicit ServicePort(boost::asio::io_service& io_service);
+		explicit ServicePort(boost::asio::io_service& io_service) : io_service(io_service) {}
 		~ServicePort();
 
 		// non-copyable

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -38,7 +38,7 @@ struct spawnBlock_t {
 class Spawn
 {
 	public:
-		Spawn(const Position& pos, int32_t radius) : centerPos(pos), radius(radius), interval(60000), checkSpawnEvent() {}
+		Spawn(Position pos, int32_t radius) : centerPos(std::move(pos)), radius(radius) {}
 		~Spawn();
 
 		// non-copyable
@@ -71,8 +71,8 @@ class Spawn
 		Position centerPos;
 		int32_t radius;
 
-		uint32_t interval;
-		uint32_t checkSpawnEvent;
+		uint32_t interval = 60000;
+		uint32_t checkSpawnEvent = 0;
 
 		static bool findPlayer(const Position& pos);
 		bool spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& pos, Direction dir, bool startup = false);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -367,31 +367,6 @@ bool CombatSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 	return scriptInterface->callFunction(2);
 }
 
-Spell::Spell()
-{
-	spellId = 0;
-	level = 0;
-	magLevel = 0;
-	mana = 0;
-	manaPercent = 0;
-	soul = 0;
-	range = -1;
-	cooldown = 1000;
-	needTarget = false;
-	needWeapon = false;
-	selfTarget = false;
-	blockingSolid = false;
-	blockingCreature = false;
-	premium = false;
-	enabled = true;
-	aggressive = true;
-	learnable = false;
-	group = SPELLGROUP_NONE;
-	groupCooldown = 1000;
-	secondaryGroup = SPELLGROUP_NONE;
-	secondaryGroupCooldown = 0;
-}
-
 bool Spell::configureSpell(const pugi::xml_node& node)
 {
 	pugi::xml_attribute nameAttribute = node.attribute("name");
@@ -858,12 +833,12 @@ ReturnValue Spell::CreateIllusion(Creature* creature, const std::string& name, i
 
 	Player* player = creature->getPlayer();
 	if (player && !player->hasFlag(PlayerFlag_CanIllusionAll)) {
-		if (!mType->isIllusionable) {
+		if (!mType->info.isIllusionable) {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 	}
 
-	return CreateIllusion(creature, mType->outfit, time);
+	return CreateIllusion(creature, mType->info.outfit, time);
 }
 
 ReturnValue Spell::CreateIllusion(Creature* creature, uint32_t itemId, int32_t time)
@@ -878,16 +853,6 @@ ReturnValue Spell::CreateIllusion(Creature* creature, uint32_t itemId, int32_t t
 
 	return CreateIllusion(creature, outfit, time);
 }
-
-InstantSpell::InstantSpell(LuaScriptInterface* interface) :
-	TalkAction(interface),
-	function(nullptr),
-	needDirection(false),
-	hasParam(false),
-	hasPlayerNameParam(false),
-	checkLineOfSight(true),
-	casterTargetOrDirection(false)
-{}
 
 std::string InstantSpell::getScriptEventName() const
 {
@@ -1476,13 +1441,13 @@ bool InstantSpell::SummonMonster(const InstantSpell* spell, Creature* creature, 
 	}
 
 	if (!player->hasFlag(PlayerFlag_CanSummonAll)) {
-		if (!mType->isSummonable) {
+		if (!mType->info.isSummonable) {
 			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
 			return false;
 		}
 
-		if (player->getMana() < mType->manaCost) {
+		if (player->getMana() < mType->info.manaCost) {
 			player->sendCancelMessage(RETURNVALUE_NOTENOUGHMANA);
 			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
 			return false;
@@ -1512,7 +1477,7 @@ bool InstantSpell::SummonMonster(const InstantSpell* spell, Creature* creature, 
 		return false;
 	}
 
-	Spell::postCastSpell(player, mType->manaCost, spell->getSoulCost());
+	Spell::postCastSpell(player, mType->info.manaCost, spell->getSoulCost());
 	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_BLUE);
 	g_game.addMagicEffect(monster->getPosition(), CONST_ME_TELEPORT);
 	return true;
@@ -1603,14 +1568,6 @@ bool InstantSpell::canCast(const Player* player) const
 	return false;
 }
 
-
-ConjureSpell::ConjureSpell(LuaScriptInterface* interface) :
-	InstantSpell(interface),
-	conjureId(0),
-	conjureCount(1),
-	reagentId(0)
-{}
-
 std::string ConjureSpell::getScriptEventName() const
 {
 	return "onCastSpell";
@@ -1697,13 +1654,6 @@ bool ConjureSpell::playerCastInstant(Player* player, std::string& param)
 	}
 	return conjureItem(player);
 }
-
-RuneSpell::RuneSpell(LuaScriptInterface* interface) :
-	Action(interface),
-	runeFunction(nullptr),
-	runeId(0),
-	hasCharges(true)
-{}
 
 std::string RuneSpell::getScriptEventName() const
 {

--- a/src/spells.h
+++ b/src/spells.h
@@ -77,7 +77,7 @@ typedef bool (RuneSpellFunction)(const RuneSpell* spell, Player* player, const P
 class BaseSpell
 {
 	public:
-		BaseSpell() = default;
+		constexpr BaseSpell() = default;
 		virtual ~BaseSpell() = default;
 
 		virtual bool castSpell(Creature* creature) = 0;
@@ -122,7 +122,7 @@ class CombatSpell final : public Event, public BaseSpell
 class Spell : public BaseSpell
 {
 	public:
-		Spell();
+		Spell() = default;
 
 		bool configureSpell(const pugi::xml_node& node);
 		const std::string& getName() const {
@@ -167,29 +167,29 @@ class Spell : public BaseSpell
 		bool playerInstantSpellCheck(Player* player, const Position& toPos);
 		bool playerRuneSpellCheck(Player* player, const Position& toPos);
 
-		uint8_t spellId;
-		SpellGroup_t group;
-		uint32_t groupCooldown;
-		SpellGroup_t secondaryGroup;
-		uint32_t secondaryGroupCooldown;
+		uint8_t spellId = 0;
+		SpellGroup_t group = SPELLGROUP_NONE;
+		uint32_t groupCooldown = 1000;
+		SpellGroup_t secondaryGroup = SPELLGROUP_NONE;
+		uint32_t secondaryGroupCooldown = 0;
 
-		uint32_t mana;
-		uint32_t manaPercent;
-		uint32_t soul;
-		uint32_t cooldown;
-		uint32_t level;
-		uint32_t magLevel;
-		int32_t range;
+		uint32_t mana = 0;
+		uint32_t manaPercent = 0;
+		uint32_t soul = 0;
+		uint32_t cooldown = 1000;
+		uint32_t level = 0;
+		uint32_t magLevel = 0;
+		int32_t range = -1;
 
-		bool needTarget;
-		bool needWeapon;
-		bool selfTarget;
-		bool blockingSolid;
-		bool blockingCreature;
-		bool aggressive;
-		bool learnable;
-		bool enabled;
-		bool premium;
+		bool needTarget = false;
+		bool needWeapon = false;
+		bool selfTarget = false;
+		bool blockingSolid = false;
+		bool blockingCreature = false;
+		bool aggressive = true;
+		bool learnable = false;
+		bool enabled = true;
+		bool premium = false;
 
 		VocSpellMap vocSpellMap;
 
@@ -200,7 +200,7 @@ class Spell : public BaseSpell
 class InstantSpell : public TalkAction, public Spell
 {
 	public:
-		explicit InstantSpell(LuaScriptInterface* interface);
+		explicit InstantSpell(LuaScriptInterface* interface) : TalkAction(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) override;
 		bool loadFunction(const pugi::xml_attribute& attr) override;
@@ -241,19 +241,19 @@ class InstantSpell : public TalkAction, public Spell
 
 		bool internalCastSpell(Creature* creature, const LuaVariant& var);
 
-		InstantSpellFunction* function;
+		InstantSpellFunction* function = nullptr;
 
-		bool needDirection;
-		bool hasParam;
-		bool hasPlayerNameParam;
-		bool checkLineOfSight;
-		bool casterTargetOrDirection;
+		bool needDirection = false;
+		bool hasParam = false;
+		bool hasPlayerNameParam = false;
+		bool checkLineOfSight = true;
+		bool casterTargetOrDirection = false;
 };
 
 class ConjureSpell final : public InstantSpell
 {
 	public:
-		explicit ConjureSpell(LuaScriptInterface* interface);
+		explicit ConjureSpell(LuaScriptInterface* interface) : InstantSpell(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) final;
 		bool loadFunction(const pugi::xml_attribute& attr) final;
@@ -272,15 +272,15 @@ class ConjureSpell final : public InstantSpell
 
 		bool conjureItem(Creature* creature) const;
 
-		uint32_t conjureId;
-		uint32_t conjureCount;
-		uint32_t reagentId;
+		uint32_t conjureId = 0;
+		uint32_t conjureCount = 1;
+		uint32_t reagentId = 0;
 };
 
 class RuneSpell final : public Action, public Spell
 {
 	public:
-		explicit RuneSpell(LuaScriptInterface* interface);
+		explicit RuneSpell(LuaScriptInterface* interface) : Action(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) final;
 		bool loadFunction(const pugi::xml_attribute& attr) final;
@@ -316,9 +316,9 @@ class RuneSpell final : public Action, public Spell
 
 		bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
 
-		RuneSpellFunction* runeFunction;
-		uint16_t runeId;
-		bool hasCharges;
+		RuneSpellFunction* runeFunction = nullptr;
+		uint16_t runeId = 0;
+		bool hasCharges = true;
 };
 
 #endif

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -107,9 +107,6 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 	return TALKACTION_CONTINUE;
 }
 
-TalkAction::TalkAction(LuaScriptInterface* interface) :
-	Event(interface), separator('"') {}
-
 bool TalkAction::configureEvent(const pugi::xml_node& node)
 {
 	pugi::xml_attribute wordsAttribute = node.attribute("words");

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -60,11 +60,11 @@ class TalkActions : public BaseEvents
 class TalkAction : public Event
 {
 	public:
-		explicit TalkAction(LuaScriptInterface* interface);
+		explicit TalkAction(LuaScriptInterface* interface) : Event(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) override;
 
-		std::string getWords() const {
+		const std::string& getWords() const {
 			return words;
 		}
 		char getSeparator() const {
@@ -79,7 +79,7 @@ class TalkAction : public Event
 		std::string getScriptEventName() const override;
 
 		std::string words;
-		char separator;
+		char separator = '"';
 };
 
 #endif

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -31,11 +31,8 @@ class Task
 {
 	public:
 		// DO NOT allocate this class on the stack
-		Task(uint32_t ms, const std::function<void (void)>& f) : func(f) {
-			expiration = std::chrono::system_clock::now() + std::chrono::milliseconds(ms);
-		}
-		explicit Task(const std::function<void (void)>& f)
-			: expiration(SYSTEM_TIME_ZERO), func(f) {}
+		explicit Task(const std::function<void (void)>& f) : func(f) {}
+		Task(uint32_t ms, const std::function<void (void)>& f) : expiration(std::chrono::system_clock::now() + std::chrono::milliseconds(ms)), func(f) {}
 
 		virtual ~Task() = default;
 		void operator()() {
@@ -57,7 +54,7 @@ class Task
 		// Expiration has another meaning for scheduler tasks,
 		// then it is the time the task should be added to the
 		// dispatcher
-		std::chrono::system_clock::time_point expiration;
+		std::chrono::system_clock::time_point expiration = SYSTEM_TIME_ZERO;
 		std::function<void (void)> func;
 };
 
@@ -71,23 +68,25 @@ inline Task* createTask(uint32_t expiration, const std::function<void (void)>& f
 	return new Task(expiration, f);
 }
 
-class Dispatcher : public ThreadHolder<Dispatcher>
-{
+class Dispatcher : public ThreadHolder<Dispatcher> {
 	public:
 		void addTask(Task* task, bool push_front = false);
+
 		void shutdown();
 
 		uint64_t getDispatcherCycle() const {
 			return dispatcherCycle;
 		}
+
 		void threadMain();
+
 	protected:
 		std::thread thread;
 		std::mutex taskLock;
 		std::condition_variable taskSignal;
 
 		std::list<Task*> taskList;
-		uint64_t dispatcherCycle {0};
+		uint64_t dispatcherCycle = 0;
 };
 
 extern Dispatcher g_dispatcher;

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -24,8 +24,6 @@
 
 extern Game g_game;
 
-Teleport::Teleport(uint16_t type) : Item(type) {}
-
 Attr_ReadValue Teleport::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	if (attr == ATTR_TELE_DEST) {

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -25,7 +25,7 @@
 class Teleport final : public Item, public Cylinder
 {
 	public:
-		explicit Teleport(uint16_t type);
+		explicit Teleport(uint16_t type) : Item(type) {};
 
 		Teleport* getTeleport() final {
 			return this;
@@ -42,7 +42,7 @@ class Teleport final : public Item, public Cylinder
 			return destPos;
 		}
 		void setDestPos(Position pos) {
-			destPos = pos;
+			destPos = std::move(pos);
 		}
 
 		//cylinder implementations

--- a/src/thing.h
+++ b/src/thing.h
@@ -31,7 +31,7 @@ class Container;
 class Thing
 {
 	protected:
-		Thing() = default;
+		constexpr Thing() = default;
 		~Thing() = default;
 
 	public:

--- a/src/thread_holder_base.h
+++ b/src/thread_holder_base.h
@@ -28,7 +28,7 @@ template <typename Derived>
 class ThreadHolder
 {
 	public:
-		ThreadHolder(): threadState(THREAD_STATE_TERMINATED) {}
+		ThreadHolder() {}
 		void start() {
 			setState(THREAD_STATE_RUNNING);
 			thread = std::thread(&Derived::threadMain, static_cast<Derived*>(this));
@@ -52,7 +52,7 @@ class ThreadHolder
 			return threadState.load(std::memory_order_relaxed);
 		}
 	private:
-		std::atomic<ThreadState> threadState;
+		std::atomic<ThreadState> threadState{THREAD_STATE_TERMINATED};
 		std::thread thread;
 };
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -144,14 +144,14 @@ class TileItemVector : private ItemVector
 		}
 
 	private:
-		uint16_t downItemCount {0};
+		uint16_t downItemCount = 0;
 };
 
 class Tile : public Cylinder
 {
 	public:
 		static Tile& nullptr_tile;
-		Tile(uint16_t x, uint16_t y, uint8_t z);
+		Tile(uint16_t x, uint16_t y, uint8_t z) : tilePos(x, y, z) {}
 		virtual ~Tile();
 
 		// non-copyable
@@ -292,9 +292,9 @@ class Tile : public Cylinder
 		void resetTileFlags(const Item* item);
 
 	protected:
-		Item* ground;
+		Item* ground = nullptr;
 		Position tilePos;
-		uint32_t flags;
+		uint32_t flags = 0;
 };
 
 // Used for walkable tiles, where there is high likeliness of
@@ -306,7 +306,7 @@ class DynamicTile : public Tile
 		CreatureVector creatures;
 
 	public:
-		DynamicTile(uint16_t x, uint16_t y, uint8_t z);
+		DynamicTile(uint16_t x, uint16_t y, uint8_t z) : Tile(x, y, z) {}
 		~DynamicTile();
 
 		// non-copyable
@@ -342,7 +342,7 @@ class StaticTile final : public Tile
 	std::unique_ptr<CreatureVector> creatures;
 
 	public:
-		StaticTile(uint16_t x, uint16_t y, uint8_t z);
+		StaticTile(uint16_t x, uint16_t y, uint8_t z) : Tile(x, y, z) {}
 		~StaticTile();
 
 		// non-copyable
@@ -376,23 +376,9 @@ class StaticTile final : public Tile
 		}
 };
 
-inline Tile::Tile(uint16_t x, uint16_t y, uint8_t z) :
-	ground(nullptr),
-	tilePos(x, y, z),
-	flags(0)
-{
-}
-
 inline Tile::~Tile()
 {
 	delete ground;
-}
-
-inline StaticTile::StaticTile(uint16_t x, uint16_t y, uint8_t z) :
-	Tile(x, y, z),
-	items(nullptr),
-	creatures(nullptr)
-{
 }
 
 inline StaticTile::~StaticTile()
@@ -402,11 +388,6 @@ inline StaticTile::~StaticTile()
 			item->decrementReferenceCounter();
 		}
 	}
-}
-
-inline DynamicTile::DynamicTile(uint16_t x, uint16_t y, uint8_t z) :
-	Tile(x, y, z)
-{
 }
 
 inline DynamicTile::~DynamicTile()

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -259,18 +259,16 @@ void toLowerCaseString(std::string& source)
 	std::transform(source.begin(), source.end(), source.begin(), tolower);
 }
 
-std::string asLowerCaseString(const std::string& source)
+std::string asLowerCaseString(std::string source)
 {
-	std::string s = source;
-	toLowerCaseString(s);
-	return s;
+	toLowerCaseString(source);
+	return source;
 }
 
-std::string asUpperCaseString(const std::string& source)
+std::string asUpperCaseString(std::string source)
 {
-	std::string s = source;
-	std::transform(s.begin(), s.end(), s.begin(), toupper);
-	return s;
+	std::transform(source.begin(), source.end(), source.begin(), toupper);
+	return source;
 }
 
 StringVec explodeString(const std::string& inString, const std::string& separator, int32_t limit/* = -1*/)
@@ -354,7 +352,7 @@ std::string convertIPToString(uint32_t ip)
 
 	int res = sprintf(buffer, "%u.%u.%u.%u", ip & 0xFF, (ip >> 8) & 0xFF, (ip >> 16) & 0xFF, (ip >> 24));
 	if (res < 0) {
-		return std::string();
+		return {};
 	}
 
 	return buffer;
@@ -364,30 +362,30 @@ std::string formatDate(time_t time)
 {
 	const tm* tms = localtime(&time);
 	if (!tms) {
-		return std::string();
+		return {};
 	}
 
 	char buffer[20];
 	int res = sprintf(buffer, "%02d/%02d/%04d %02d:%02d:%02d", tms->tm_mday, tms->tm_mon + 1, tms->tm_year + 1900, tms->tm_hour, tms->tm_min, tms->tm_sec);
 	if (res < 0) {
-		return std::string();
+		return {};
 	}
-	return std::string(buffer, 19);
+	return {buffer, 19};
 }
 
 std::string formatDateShort(time_t time)
 {
 	const tm* tms = localtime(&time);
 	if (!tms) {
-		return std::string();
+		return {};
 	}
 
 	char buffer[12];
 	size_t res = strftime(buffer, 12, "%d %b %Y", tms);
 	if (res == 0) {
-		return std::string();
+		return {};
 	}
-	return std::string(buffer, 11);
+	return {buffer, 11};
 }
 
 Direction getDirection(const std::string& string)

--- a/src/tools.h
+++ b/src/tools.h
@@ -35,8 +35,8 @@ void replaceString(std::string& str, const std::string& sought, const std::strin
 void trim_right(std::string& source, char t);
 void trim_left(std::string& source, char t);
 void toLowerCaseString(std::string& source);
-std::string asLowerCaseString(const std::string& source);
-std::string asUpperCaseString(const std::string& source);
+std::string asLowerCaseString(std::string source);
+std::string asUpperCaseString(std::string source);
 
 typedef std::vector<std::string> StringVec;
 typedef std::vector<int32_t> IntegerVec;

--- a/src/town.h
+++ b/src/town.h
@@ -38,7 +38,7 @@ class Town
 			templePosition = pos;
 		}
 		void setName(std::string name) {
-			this->name = name;
+			this->name = std::move(name);
 		}
 		uint32_t getID() const {
 			return id;

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -181,10 +181,6 @@ uint16_t Vocations::getPromotedVocation(uint16_t vocationId) const
 
 uint32_t Vocation::skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
 
-Vocation::Vocation(uint16_t id)
-	: id(id)
-{}
-
 uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 {
 	if (skill > SKILL_LAST) {

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -26,7 +26,7 @@
 class Vocation
 {
 	public:
-		explicit Vocation(uint16_t id);
+		explicit Vocation(uint16_t id) : id(id) {}
 
 		const std::string& getVocName() const {
 			return name;
@@ -97,7 +97,7 @@ class Vocation
 		std::map<uint32_t, uint64_t> cacheMana;
 		std::map<uint32_t, uint32_t> cacheSkill[SKILL_LAST + 1];
 
-		std::string name {"none"};
+		std::string name = "none";
 		std::string description;
 
 		float skillMultipliers[SKILL_LAST + 1] = {1.5f, 2.0f, 2.0f, 2.0f, 2.0f, 1.5f, 1.1f};

--- a/src/waitlist.h
+++ b/src/waitlist.h
@@ -23,7 +23,7 @@
 #include "player.h"
 
 struct Wait {
-	Wait(int64_t timeout, uint32_t playerGUID) :
+	constexpr Wait(int64_t timeout, uint32_t playerGUID) :
 		timeout(timeout), playerGUID(playerGUID) {}
 
 	int64_t timeout;

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -144,23 +144,6 @@ int32_t Weapons::getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t
 	return static_cast<int32_t>(std::round((level / 5) + (((((attackSkill / 4.) + 1) * (attackValue / 3.)) * 1.03) / attackFactor)));
 }
 
-Weapon::Weapon(LuaScriptInterface* interface) :
-	Event(interface)
-{
-	scripted = false;
-	id = 0;
-	level = 0;
-	magLevel = 0;
-	mana = 0;
-	manaPercent = 0;
-	soul = 0;
-	premium = false;
-	enabled = true;
-	wieldUnproperly = false;
-	breakChance = 0;
-	action = WEAPONACTION_NONE;
-}
-
 bool Weapon::configureEvent(const pugi::xml_node& node)
 {
 	pugi::xml_attribute attr;
@@ -509,7 +492,7 @@ void Weapon::decrementItemCount(Item* item)
 }
 
 WeaponMelee::WeaponMelee(LuaScriptInterface* interface) :
-	Weapon(interface), elementType(COMBAT_NONE), elementDamage(0)
+	Weapon(interface)
 {
 	params.blockedByArmor = true;
 	params.blockedByShield = true;
@@ -602,7 +585,7 @@ int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, cons
 }
 
 WeaponDistance::WeaponDistance(LuaScriptInterface* interface) :
-	Weapon(interface), elementType(COMBAT_NONE), elementDamage(0)
+	Weapon(interface)
 {
 	params.blockedByArmor = true;
 	params.combatType = COMBAT_PHYSICALDAMAGE;
@@ -871,13 +854,6 @@ bool WeaponDistance::getSkillType(const Player* player, const Item*, skills_t& s
 		skillpoint = 0;
 	}
 	return true;
-}
-
-WeaponWand::WeaponWand(LuaScriptInterface* interface) :
-	Weapon(interface)
-{
-	minChange = 0;
-	maxChange = 0;
 }
 
 bool WeaponWand::configureEvent(const pugi::xml_node& node)

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -62,7 +62,7 @@ class Weapons final : public BaseEvents
 class Weapon : public Event
 {
 	public:
-		explicit Weapon(LuaScriptInterface* interface);
+		explicit Weapon(LuaScriptInterface* interface) : Event(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) override;
 		bool loadFunction(const pugi::xml_attribute&) final {
@@ -114,17 +114,17 @@ class Weapon : public Event
 
 		CombatParams params;
 
-		uint32_t level;
-		uint32_t magLevel;
-		uint32_t mana;
-		uint32_t manaPercent;
-		uint32_t soul;
-		uint16_t id;
-		WeaponAction_t action;
-		uint8_t breakChance;
-		bool enabled;
-		bool premium;
-		bool wieldUnproperly;
+		uint32_t level = 0;
+		uint32_t magLevel = 0;
+		uint32_t mana = 0;
+		uint32_t manaPercent = 0;
+		uint32_t soul = 0;
+		uint16_t id = 0;
+		WeaponAction_t action = WEAPONACTION_NONE;
+		uint8_t breakChance = 0;
+		bool enabled = true;
+		bool premium = false;
+		bool wieldUnproperly = false;
 
 	private:
 		static void decrementItemCount(Item* item);
@@ -149,8 +149,8 @@ class WeaponMelee final : public Weapon
 	protected:
 		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const final;
 
-		CombatType_t elementType;
-		uint16_t elementDamage;
+		CombatType_t elementType = COMBAT_NONE;
+		uint16_t elementDamage = 0;
 };
 
 class WeaponDistance final : public Weapon
@@ -172,14 +172,14 @@ class WeaponDistance final : public Weapon
 	protected:
 		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const final;
 
-		CombatType_t elementType;
-		uint16_t elementDamage;
+		CombatType_t elementType = COMBAT_NONE;
+		uint16_t elementDamage = 0;
 };
 
 class WeaponWand final : public Weapon
 {
 	public:
-		explicit WeaponWand(LuaScriptInterface* interface);
+		explicit WeaponWand(LuaScriptInterface* interface) : Weapon(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) final;
 		void configureWeapon(const ItemType& it) final;
@@ -193,8 +193,8 @@ class WeaponWand final : public Weapon
 			return false;
 		}
 
-		int32_t minChange;
-		int32_t maxChange;
+		int32_t minChange = 0;
+		int32_t maxChange = 0;
 };
 
 #endif

--- a/src/wildcardtree.h
+++ b/src/wildcardtree.h
@@ -26,7 +26,7 @@ class WildcardTreeNode
 {
 	public:
 		explicit WildcardTreeNode(bool breakpoint) : breakpoint(breakpoint) {}
-		WildcardTreeNode(WildcardTreeNode&& other) : children(std::move(other.children)), breakpoint(other.breakpoint) {}
+		WildcardTreeNode(WildcardTreeNode&& other) = default;
 
 		// non-copyable
 		WildcardTreeNode(const WildcardTreeNode&) = delete;


### PR DESCRIPTION
This PR aims to use default constructors as much as possible, as they hint the compiler to optimize as much as possible and lead to cleaner and shorter code, as is seen on line delta. Also, some constructors can be `constexpr`d which can lead to more optimizations, notably `QTreeNode` is probably the most used one that was marked as `constexpr`.

Three major changes in classes were splitting information attributes for `Events`, `MonsterType` and `NetworkMessage` in a pimpl-like manner for cleaner `clear`/`reset` methods. In fact, now only `NetworkMessage` keeps a `reset` method and the others are not needed anymore.

Last, for some classes where the destructor was only used to delete a pointer, I changed it to unique_ptr which does the job automatically and implies no overhead.

There might be some non-consistent default attributes and unrelated changes because I've been working on this commit for a few weeks now, please point out anything strange.

