### PR TITLE
fix group cooldowns of spell sharpshooter

### DIFF
--- a/data/spells/scripts/support/sharpshooter.lua
+++ b/data/spells/scripts/support/sharpshooter.lua
@@ -14,16 +14,6 @@ speed:setParameter(CONDITION_PARAM_TICKS, 10000)
 speed:setFormula(-0.7, 56, -0.7, 56)
 combat:setCondition(speed)
 
-local cooldownHealingGroup = Condition(CONDITION_SPELLGROUPCOOLDOWN)
-cooldownHealingGroup:setParameter(CONDITION_PARAM_TICKS, 10000)
-cooldownHealingGroup:setParameter(CONDITION_PARAM_SUBID, 2)
-combat:setCondition(cooldownHealingGroup)
-
-local cooldownSupportGroup = Condition(CONDITION_SPELLGROUPCOOLDOWN)
-cooldownSupportGroup:setParameter(CONDITION_PARAM_TICKS, 10000)
-cooldownSupportGroup:setParameter(CONDITION_PARAM_SUBID, 3)
-combat:setCondition(cooldownSupportGroup)
-
 function onCastSpell(creature, variant)
 	return combat:execute(creature, variant)
 end

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -351,7 +351,7 @@
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>
-	<instant group="support" spellid="135" name="Sharpshooter" words="utito tempo san" lvl="60" mana="450" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="support/sharpshooter.lua">
+	<instant group="support" secondarygroup="healing" spellid="135" name="Sharpshooter" words="utito tempo san" lvl="60" mana="450" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="10000" secondarygroupcooldown="10000" needlearn="0" script="support/sharpshooter.lua">
 		<vocation name="Paladin" />
 		<vocation name="Royal Paladin" />
 	</instant>


### PR DESCRIPTION
Currently, it is:
![current](https://cloud.githubusercontent.com/assets/6445979/18588998/18f570dc-7bff-11e6-9463-caba0bdc6902.png)

But it should be:
![fixed](https://cloud.githubusercontent.com/assets/6445979/18589016/2a8377fe-7bff-11e6-8afc-50680cc924a1.png) *(both support/healing group cooldowns (10 s) ends at the same time)*

