### PR TITLE
Update potions script

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -190,16 +190,14 @@
 	<action fromid="2031" toid="2034" script="other/fluids.lua" />
 	<action fromid="2574" toid="2577" script="other/fluids.lua" />
 	<action fromid="5792" toid="5797" script="other/die.lua" />
-	<action itemid="7588" script="other/potions.lua" />
-	<action itemid="7589" script="other/potions.lua" />
-	<action itemid="7590" script="other/potions.lua" />
-	<action itemid="7591" script="other/potions.lua" />
+	<action fromid="7439" toid="7440" script="other/potions.lua"/>
+	<action itemid="7443" script="other/potions.lua"/>
+	<action fromid="7588" toid="7591" script="other/potions.lua" />
 	<action itemid="7618" script="other/potions.lua" />
 	<action itemid="7620" script="other/potions.lua" />
-	<action itemid="8472" script="other/potions.lua" />
-	<action itemid="8473" script="other/potions.lua" />
-	<action itemid="8474" script="other/potions.lua" />
+	<action fromid="8472" toid="8474" script="other/potions.lua" />
 	<action itemid="8704" script="other/potions.lua" />
+	<action fromid="26029" toid="26031" script="other/potions.lua" />
 	<action itemid="2692" script="other/createbread.lua" />
 	<action itemid="2694" script="other/createbread.lua" />
 	<action fromid="6436" toid="6447" script="other/windows.lua" />

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -1,158 +1,113 @@
-local ultimateHealthPot = 8473
-local greatHealthPot = 7591
-local greatManaPot = 7590
-local greatSpiritPot = 8472
-local strongHealthPot = 7588
-local strongManaPot = 7589
-local healthPot = 7618
-local manaPot = 7620
-local smallHealthPot = 8704
-local antidotePot = 8474
-local greatEmptyPot = 7635
-local strongEmptyPot = 7634
-local emptyPot = 7636
+local berserk = Condition(CONDITION_ATTRIBUTES)
+berserk:setParameter(CONDITION_PARAM_SUBID, 7)
+berserk:setParameter(CONDITION_PARAM_TICKS, 10 * 60 * 1000)
+berserk:setParameter(CONDITION_PARAM_SKILL_MELEE, 5)
+berserk:setParameter(CONDITION_PARAM_SKILL_SHIELD, -10)
+berserk:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
+
+local mastermind = Condition(CONDITION_ATTRIBUTES)
+mastermind:setParameter(CONDITION_PARAM_SUBID, 8)
+mastermind:setParameter(CONDITION_PARAM_TICKS, 10 * 60 * 1000)
+mastermind:setParameter(CONDITION_PARAM_STAT_MAGICPOINTS, 3)
+mastermind:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
+
+local bullseye = Condition(CONDITION_ATTRIBUTES)
+bullseye:setParameter(CONDITION_PARAM_SUBID, 9)
+bullseye:setParameter(CONDITION_PARAM_TICKS, 10 * 60 * 1000)
+bullseye:setParameter(CONDITION_PARAM_SKILL_DISTANCE, 5)
+bullseye:setParameter(CONDITION_PARAM_SKILL_SHIELD, -10)
+bullseye:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
 local antidote = Combat()
 antidote:setParameter(COMBAT_PARAM_TYPE, COMBAT_HEALING)
 antidote:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
-antidote:setParameter(COMBAT_PARAM_TARGETCASTERORTOPMOST, true)
-antidote:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 antidote:setParameter(COMBAT_PARAM_DISPEL, CONDITION_POISON)
+antidote:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
+antidote:setParameter(COMBAT_PARAM_TARGETCASTERORTOPMOST, true)
 
-local exhaust = Condition(CONDITION_EXHAUST_HEAL)
-exhaust:setParameter(CONDITION_PARAM_TICKS, (configManager.getNumber(configKeys.EX_ACTIONS_DELAY_INTERVAL) - 100))
--- 1000 - 100 due to exact condition timing. -100 doesn't hurt us, and players don't have reminding ~50ms exhaustion.
+local potions = {
+	[6558] = {transform = {id = {7588, 7589}}, effect = CONST_ME_DRAWBLOOD},
+	[7439] = {condition = berserk, vocations = {4, 8}, effect = CONST_ME_MAGIC_RED,
+			description = "Only knights may drink this potion.", text = "You feel stronger."},
+
+	[7440] = {condition = mastermind, vocations = {1, 2, 5, 6}, effect = CONST_ME_MAGIC_BLUE,
+			description = "Only sorcerers and druids may drink this potion.", text = "You feel smarter."},
+
+	[7443] = {condition = bullseye, vocations = {3, 7}, effect = CONST_ME_MAGIC_GREEN,
+			description = "Only paladins may drink this potion.", text = "You feel more accurate."},
+
+	[7588] = {health = {250, 350}, vocations = {3, 4, 7, 8}, level = 50, flask = 7634,
+			description = "Only knights and paladins of level 50 or above may drink this fluid."},
+
+	[7589] = {mana = {115, 185}, vocations = {1, 2, 3, 5, 6, 7}, level = 50, flask = 7634,
+			description = "Only sorcerers, druids and paladins of level 50 or above may drink this fluid."},
+
+	[7590] = {mana = {150, 250}, vocations = {1, 2, 5, 6}, level = 80, flask = 7635,
+			description = "Only druids and sorcerers of level 80 or above may drink this fluid."},
+
+	[7591] = {health = {425, 575}, vocations = {4, 8}, level = 80, flask = 7635,
+			description = "Only knights of level 80 or above may drink this fluid."},
+
+	[7618] = {health = {125, 175}, flask = 7636},
+	[7620] = {mana = {75, 125}, flask = 7636},
+	[8472] = {health = {250, 350}, mana = {100, 200}, vocations = {3, 7}, level = 80, flask = 7635,
+			description = "Only paladins of level 80 or above may drink this fluid."},
+
+	[8473] = {health = {650, 850}, vocations = {4, 8}, level = 130, flask = 7635,
+			description = "Only knights of level 130 or above may drink this fluid."},
+
+	[8474] = {combat = antidote, flask = 7636},
+	[8704] = {health = {60, 90}, flask = 7636},
+	[26029] = {mana = {425, 575}, vocations = {1, 2, 5, 6}, level = 130, flask = 7635,
+			description = "Only druids and sorcerers of level 130 or above may drink this fluid."},
+
+	[26030] = {health = {420, 580}, mana = {250, 350}, vocations = {3, 7}, level = 130, flask = 7635,
+			description = "Only paladins of level 130 or above may drink this fluid."},
+
+	[26031] = {health = {875, 1125}, vocations = {4, 8}, level = 200, flask = 7635,
+			description = "Only knights of level 200 or above may drink this fluid."},
+}
 
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if target == nil or not target:isPlayer() then
+	if type(target) == "userdata" and not target:isPlayer() then
+		return false
+	end
+
+	local potion = potions[item:getId()]
+	if potion.level and player:getLevel() < potion.level or potion.vocations and not isInArray(potion.vocations, player:getVocation():getId()) then
+		player:say(potion.description, TALKTYPE_MONSTER_SAY)
 		return true
 	end
 
-	if player:getCondition(CONDITION_EXHAUST_HEAL) then
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, Game.getReturnMessage(RETURNVALUE_YOUAREEXHAUSTED))
+	if potion.health or potion.mana or potion.combat then
+		if potion.health then
+			doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2], CONST_ME_MAGIC_BLUE)
+		end
+
+		if potion.mana then
+			doTargetCombatMana(0, target, potion.mana[1], potion.mana[2], CONST_ME_MAGIC_BLUE)
+		end
+
+		if potion.combat then
+			potion.combat:execute(target, Variant(target:getId()))
+		end
+
+		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
+		player:addItem(potion.flask, 1)
+	end
+
+	if potion.condition then
+		player:addCondition(potion.condition)
+		player:say(potion.text, TALKTYPE_MONSTER_SAY)
+		player:getPosition():sendMagicEffect(potion.effect)
+	end
+
+	if potion.transform then
+		item:transform(math.random(potion.transform.id[1], potion.transform.id[2]))
+		item:getPosition():sendMagicEffect(potion.effect)
 		return true
 	end
 
-	local itemId = item:getId()
-	if itemId == antidotePot then
-		if not antidote:execute(target, numberToVariant(target:getId())) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(emptyPot, 1)
-	elseif itemId == smallHealthPot then
-		if not doTargetCombatHealth(0, target, COMBAT_HEALING, 60, 90, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(emptyPot, 1)
-	elseif itemId == healthPot then
-		if not doTargetCombatHealth(0, target, COMBAT_HEALING, 125, 175, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(emptyPot, 1)
-	elseif itemId == manaPot then
-		if not doTargetCombatMana(0, target, 75, 125, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(emptyPot, 1)
-	elseif itemId == strongHealthPot then
-		if (not isInArray({3, 4, 7, 8}, target:getVocation():getId()) or target:getLevel() < 50) and not getPlayerFlagValue(player, PlayerFlag_IgnoreSpellCheck) then
-			player:say("This potion can only be consumed by paladins and knights of level 50 or higher.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		if not doTargetCombatHealth(0, target, COMBAT_HEALING, 250, 350, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(strongEmptyPot, 1)
-	elseif itemId == strongManaPot then
-		if (not isInArray({1, 2, 3, 5, 6, 7}, target:getVocation():getId()) or target:getLevel() < 50) and not getPlayerFlagValue(player, PlayerFlag_IgnoreSpellCheck) then
-			player:say("This potion can only be consumed by sorcerers, druids and paladins of level 50 or higher.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		if not doTargetCombatMana(0, target, 115, 185, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(strongEmptyPot, 1)
-	elseif itemId == greatSpiritPot then
-		if (not isInArray({3, 7}, target:getVocation():getId()) or target:getLevel() < 80) and not getPlayerFlagValue(player, PlayerFlag_IgnoreSpellCheck) then
-			player:say("This potion can only be consumed by paladins of level 80 or higher.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		if not doTargetCombatHealth(0, target, COMBAT_HEALING, 250, 350, CONST_ME_MAGIC_BLUE) or not doTargetCombatMana(0, target, 100, 200, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(greatEmptyPot, 1)
-	elseif itemId == greatHealthPot then
-		if (not isInArray({4, 8}, target:getVocation():getId()) or target:getLevel() < 80) and not getPlayerFlagValue(player, PlayerFlag_IgnoreSpellCheck) then
-			player:say("This potion can only be consumed by knights of level 80 or higher.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		if not doTargetCombatHealth(0, target, COMBAT_HEALING, 425, 575, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(greatEmptyPot, 1)
-	elseif itemId == greatManaPot then
-		if (not isInArray({1,2,5,6}, target:getVocation():getId()) or target:getLevel() < 80) and not getPlayerFlagValue(player, PlayerFlag_IgnoreSpellCheck) then
-			player:say("This potion can only be consumed by sorcerers and druids of level 80 or higher.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		if not doTargetCombatMana(0, target, 150, 250, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(greatEmptyPot, 1)
-	elseif itemId == ultimateHealthPot then
-		if (not isInArray({4, 8}, target:getVocation():getId()) or target:getLevel() < 130) and not getPlayerFlagValue(player, PlayerFlag_IgnoreSpellCheck) then
-			player:say("This potion can only be consumed by knights of level 130 or higher.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		if not doTargetCombatHealth(0, target, COMBAT_HEALING, 650, 850, CONST_ME_MAGIC_BLUE) then
-			return false
-		end
-
-		player:addCondition(exhaust)
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		item:remove(1)
-		player:addItem(greatEmptyPot, 1)
-	end
+	item:remove(1)
 	return true
 end


### PR DESCRIPTION
I have updated potions script to look more cleaner, added buff potions, etc.

Aside from that, I removed the ``CONDITION_EXAUST_HEAL" because as it is stated in the source code (enum.h) it not used anymore (also not used in vanilla, though there is still a delay, around 1-2s), atleast it doesn't work anymore (getCondition always return nil/false).

I have also added 3 buff potions.
Also using a potion on another player is now permitted (as in vanilla) if his requirements (the player's) are met (vocation, level).

I tried to do a simpler and maybe cleaner version of #1795.
