### PR TITLE
Fix build error with AppleClang 8.0

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -74,7 +74,7 @@ class Tile;
 class FrozenPathingConditionCall
 {
 	public:
-		explicit constexpr FrozenPathingConditionCall(Position targetPos) : targetPos(std::move(targetPos)) {}
+		explicit FrozenPathingConditionCall(Position targetPos) : targetPos(std::move(targetPos)) {}
 
 		bool operator()(const Position& startPos, const Position& testPos,
 		                const FindPathParams& fpp, int32_t& bestMatchDist) const;


### PR DESCRIPTION
Error:
```
In file included from ~/Projects/forgottenserver/src/actions.cpp:26:
In file included from ~/Projects/forgottenserver/src/game.h:31:
In file included from ~/Projects/forgottenserver/src/player.h:23:
~/Projects/forgottenserver/src/creature.h:77:22: error: constexpr constructor never produces a constant
      expression [-Winvalid-constexpr]
                explicit constexpr FrozenPathingConditionCall(Position targetPos) : targetPos(std::move(targetPos)) {}
                                   ^
~/Projects/forgottenserver/src/creature.h:77:81: note: non-constexpr function 'move<Position &>' cannot
      be used in a constant expression
                explicit constexpr FrozenPathingConditionCall(Position targetPos) : targetPos(std::move(targetPos)) {}
                                                                                              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:1666:1: note: 
      declared here
move(_Tp&& __t) _NOEXCEPT
^
1 error generated.
make[2]: *** [CMakeFiles/tfs.dir/src/actions.cpp.o] Error 1
```