### PR TITLE
avoid debug assertions from specific param ids

### DIFF
--- a/data/talkactions/scripts/create_item.lua
+++ b/data/talkactions/scripts/create_item.lua
@@ -1,3 +1,5 @@
+local debugAssertionIds = {1, 2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15, 19, 21, 26, 27, 28, 35, 43}
+
 function onSay(player, words, param)
 	if not player:getGroup():getAccess() then
 		return true
@@ -16,6 +18,10 @@ function onSay(player, words, param)
 			player:sendCancelMessage("There is no item with that id or name.")
 			return false
 		end
+	end
+
+	if isInArray(debugAssertionIds, itemType:getId()) then
+		return false
 	end
 
 	local count = tonumber(split[2])

--- a/data/talkactions/scripts/create_item.lua
+++ b/data/talkactions/scripts/create_item.lua
@@ -1,4 +1,6 @@
-local debugAssertionIds = {1, 2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15, 19, 21, 26, 27, 28, 35, 43}
+local invalidIds = {
+	1, 2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15, 19, 21, 26, 27, 28, 35, 43
+}
 
 function onSay(player, words, param)
 	if not player:getGroup():getAccess() then
@@ -20,7 +22,7 @@ function onSay(player, words, param)
 		end
 	end
 
-	if isInArray(debugAssertionIds, itemType:getId()) then
+	if isInArray(invalidIds, itemType:getId()) then
 		return false
 	end
 


### PR DESCRIPTION
Executing the command `/i` with any of these number ids will cause debug assertion to all connected clients, and also to any new login try, forcing the user to restart the server.
