### PR TITLE
Use constexpr for compile time constants and defines

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -20,7 +20,7 @@
 #ifndef FS_CONST_H_0A49B5996F074465BF44B90F4F780E8B
 #define FS_CONST_H_0A49B5996F074465BF44B90F4F780E8B
 
-#define NETWORKMESSAGE_MAXSIZE 24590
+static constexpr int32_t NETWORKMESSAGE_MAXSIZE = 24590;
 
 enum MagicEffectClasses : uint8_t {
 	CONST_ME_NONE,
@@ -517,21 +517,21 @@ enum PlayerFlags : uint64_t {
 	PlayerFlag_IsAlwaysPremium = static_cast<uint64_t>(1) << 37,
 };
 
-#define CHANNEL_GUILD 0x00
-#define CHANNEL_PARTY 0x01
-#define CHANNEL_PRIVATE 0xFFFF
+static constexpr int32_t CHANNEL_GUILD = 0x00;
+static constexpr int32_t CHANNEL_PARTY = 0x01;
+static constexpr int32_t CHANNEL_PRIVATE = 0xFFFF;
 
-//Reserved player storage key ranges
-//[10000000 - 20000000]
-#define PSTRG_RESERVED_RANGE_START 10000000
-#define PSTRG_RESERVED_RANGE_SIZE 10000000
-//[1000 - 1500]
-#define PSTRG_OUTFITS_RANGE_START (PSTRG_RESERVED_RANGE_START + 1000)
-#define PSTRG_OUTFITS_RANGE_SIZE 500
-//[2001 - 2011]
-#define PSTRG_MOUNTS_RANGE_START (PSTRG_RESERVED_RANGE_START + 2001)
-#define PSTRG_MOUNTS_RANGE_SIZE 10
-#define PSTRG_MOUNTS_CURRENTMOUNT (PSTRG_MOUNTS_RANGE_START + 10)
+//Reserved player storage key ranges;
+//[10000000 - 20000000];
+static constexpr int32_t PSTRG_RESERVED_RANGE_START = 10000000;
+static constexpr int32_t PSTRG_RESERVED_RANGE_SIZE = 10000000;
+//[1000 - 1500];
+static constexpr int32_t PSTRG_OUTFITS_RANGE_START = (PSTRG_RESERVED_RANGE_START + 1000);
+static constexpr int32_t PSTRG_OUTFITS_RANGE_SIZE = 500;
+//[2001 - 2011];
+static constexpr int32_t PSTRG_MOUNTS_RANGE_START = (PSTRG_RESERVED_RANGE_START + 2001);
+static constexpr int32_t PSTRG_MOUNTS_RANGE_SIZE = 10;
+static constexpr int32_t PSTRG_MOUNTS_CURRENTMOUNT = (PSTRG_MOUNTS_RANGE_START + 10);
 
 #define IS_IN_KEYRANGE(key, range) (key >= PSTRG_##range##_START && ((key - PSTRG_##range##_START) <= PSTRG_##range##_SIZE))
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -67,9 +67,9 @@ class Npc;
 class Item;
 class Tile;
 
-#define EVENT_CREATURECOUNT 10
-#define EVENT_CREATURE_THINK_INTERVAL 1000
-#define EVENT_CHECK_CREATURE_INTERVAL (EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT)
+static constexpr int32_t EVENT_CREATURECOUNT = 10;
+static constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 1000;
+static constexpr int32_t EVENT_CHECK_CREATURE_INTERVAL = (EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT);
 
 class FrozenPathingConditionCall
 {
@@ -474,10 +474,10 @@ class Creature : virtual public Thing
 			int64_t ticks;
 		};
 
-		static const int32_t mapWalkWidth = Map::maxViewportX * 2 + 1;
-		static const int32_t mapWalkHeight = Map::maxViewportY * 2 + 1;
-		static const int32_t maxWalkCacheWidth = (mapWalkWidth - 1) / 2;
-		static const int32_t maxWalkCacheHeight = (mapWalkHeight - 1) / 2;
+		static constexpr int32_t mapWalkWidth = Map::maxViewportX * 2 + 1;
+		static constexpr int32_t mapWalkHeight = Map::maxViewportY * 2 + 1;
+		static constexpr int32_t maxWalkCacheWidth = (mapWalkWidth - 1) / 2;
+		static constexpr int32_t maxWalkCacheHeight = (mapWalkHeight - 1) / 2;
 
 		Position position;
 

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -26,7 +26,7 @@
 class Item;
 class Creature;
 
-#define INDEX_WHEREEVER -1
+static constexpr int32_t INDEX_WHEREEVER = -1;
 
 enum cylinderflags_t {
 	FLAG_NOLIMIT = 1 << 0, //Bypass limits like capacity/container limits, blocking items/creatures etc.

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -20,16 +20,16 @@
 #ifndef FS_DEFINITIONS_H_877452FEC245450C9F96B8FD268D8963
 #define FS_DEFINITIONS_H_877452FEC245450C9F96B8FD268D8963
 
-#define STATUS_SERVER_NAME "The Forgotten Server"
-#define STATUS_SERVER_VERSION "1.2"
-#define STATUS_SERVER_DEVELOPERS "Mark Samman"
+static constexpr auto STATUS_SERVER_NAME = "The Forgotten Server";
+static constexpr auto STATUS_SERVER_VERSION = "1.2";
+static constexpr auto STATUS_SERVER_DEVELOPERS = "Mark Samman";
 
-#define CLIENT_VERSION_MIN 1097
-#define CLIENT_VERSION_MAX 1098
-#define CLIENT_VERSION_STR "10.98"
+static constexpr auto CLIENT_VERSION_MIN = 1097;
+static constexpr auto CLIENT_VERSION_MAX = 1098;
+static constexpr auto CLIENT_VERSION_STR = "10.98";
 
-#define AUTHENTICATOR_DIGITS 6U
-#define AUTHENTICATOR_PERIOD 30U
+static constexpr auto AUTHENTICATOR_DIGITS = 6U;
+static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 
 #ifndef __FUNCTION__
 #define __FUNCTION__ __func__

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -69,7 +69,7 @@ struct NodeStruct {
 		}
 };
 
-#define NO_NODE 0
+static constexpr auto NO_NODE = nullptr;
 
 enum FILELOADER_ERRORS {
 	ERROR_NONE,
@@ -130,7 +130,7 @@ class FileLoader
 			uint32_t size;
 		};
 
-#define CACHE_BLOCKS 3
+		static constexpr int32_t CACHE_BLOCKS = 3;
 		cache cached_data[CACHE_BLOCKS] = {};
 
 		uint8_t* buffer = new uint8_t[1024];
@@ -141,7 +141,7 @@ class FileLoader
 		uint32_t buffer_size = 1024;
 
 		uint32_t cache_size = 0;
-#define NO_VALID_CACHE 0xFFFFFFFF
+		static constexpr uint32_t NO_VALID_CACHE = std::numeric_limits<uint32_t>::max();
 		uint32_t cache_index = NO_VALID_CACHE;
 		uint32_t cache_offset = NO_VALID_CACHE;
 

--- a/src/game.h
+++ b/src/game.h
@@ -71,9 +71,9 @@ enum LightState_t {
 	LIGHT_STATE_SUNRISE,
 };
 
-#define EVENT_LIGHTINTERVAL 10000
-#define EVENT_DECAYINTERVAL 250
-#define EVENT_DECAY_BUCKETS 4
+static constexpr int32_t EVENT_LIGHTINTERVAL = 10000;
+static constexpr int32_t EVENT_DECAYINTERVAL = 250;
+static constexpr int32_t EVENT_DECAY_BUCKETS = 4;
 
 /**
   * Main Game class.
@@ -545,10 +545,10 @@ class Game
 		ModalWindow offlineTrainingWindow { std::numeric_limits<uint32_t>::max(), "Choose a Skill", "Please choose a skill:" };
 		Commands commands;
 
-		static const int32_t LIGHT_LEVEL_DAY = 250;
-		static const int32_t LIGHT_LEVEL_NIGHT = 40;
-		static const int32_t SUNSET = 1305;
-		static const int32_t SUNRISE = 430;
+		static constexpr int32_t LIGHT_LEVEL_DAY = 250;
+		static constexpr int32_t LIGHT_LEVEL_NIGHT = 40;
+		static constexpr int32_t SUNSET = 1305;
+		static constexpr int32_t SUNRISE = 430;
 
 		GameState_t gameState = GAME_STATE_NORMAL;
 		WorldType_t worldType = WORLD_TYPE_PVP;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -373,7 +373,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	static const std::string skillNames[] = {"skill_fist", "skill_club", "skill_sword", "skill_axe", "skill_dist", "skill_shielding", "skill_fishing"};
 	static const std::string skillNameTries[] = {"skill_fist_tries", "skill_club_tries", "skill_sword_tries", "skill_axe_tries", "skill_dist_tries", "skill_shielding_tries", "skill_fishing_tries"};
-	static const size_t size = sizeof(skillNames) / sizeof(std::string);
+	static constexpr size_t size = sizeof(skillNames) / sizeof(std::string);
 	for (uint8_t i = 0; i < size; ++i) {
 		uint16_t skillLevel = result->getNumber<uint16_t>(skillNames[i]);
 		uint64_t skillTries = result->getNumber<uint64_t>(skillNameTries[i]);

--- a/src/map.h
+++ b/src/map.h
@@ -36,7 +36,7 @@ class Game;
 class Tile;
 class Map;
 
-#define MAP_MAX_LAYERS 16
+static constexpr int32_t MAP_MAX_LAYERS = 16;
 
 struct FindPathParams;
 struct AStarNode {
@@ -45,10 +45,10 @@ struct AStarNode {
 	uint16_t x, y;
 };
 
-#define MAX_NODES 512
+static constexpr int32_t MAX_NODES = 512;
 
-#define MAP_NORMALWALKCOST 10
-#define MAP_DIAGONALWALKCOST 25
+static constexpr int32_t MAP_NORMALWALKCOST = 10;
+static constexpr int32_t MAP_DIAGONALWALKCOST = 25;
 
 class AStarNodes
 {
@@ -75,9 +75,9 @@ class AStarNodes
 
 typedef std::map<Position, SpectatorVec> SpectatorCache;
 
-#define FLOOR_BITS 3
-#define FLOOR_SIZE (1 << FLOOR_BITS)
-#define FLOOR_MASK (FLOOR_SIZE - 1)
+static constexpr int32_t FLOOR_BITS = 3;
+static constexpr int32_t FLOOR_SIZE = (1 << FLOOR_BITS);
+static constexpr int32_t FLOOR_MASK = (FLOOR_SIZE - 1);
 
 struct Floor {
 	constexpr Floor() = default;
@@ -172,10 +172,10 @@ class QTreeLeafNode final : public QTreeNode
 class Map
 {
 	public:
-		static const int32_t maxViewportX = 11; //min value: maxClientViewportX + 1
-		static const int32_t maxViewportY = 11; //min value: maxClientViewportY + 1
-		static const int32_t maxClientViewportX = 8;
-		static const int32_t maxClientViewportY = 6;
+		static constexpr int32_t maxViewportX = 11; //min value: maxClientViewportX + 1
+		static constexpr int32_t maxViewportY = 11; //min value: maxClientViewportY + 1
+		static constexpr int32_t maxClientViewportX = 8;
+		static constexpr int32_t maxClientViewportY = 6;
 
 		uint32_t clean() const;
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -36,7 +36,7 @@ class NetworkMessage
 		// 2 bytes for unencrypted message size
 		// 4 bytes for checksum
 		// 2 bytes for encrypted message size
-		static const MsgSize_t INITIAL_BUFFER_POSITION = 8;
+		static constexpr MsgSize_t INITIAL_BUFFER_POSITION = 8;
 		enum { HEADER_LENGTH = 2 };
 		enum { CHECKSUM_LENGTH = 4 };
 		enum { XTEA_MULTIPLE = 8 };

--- a/src/player.h
+++ b/src/player.h
@@ -120,8 +120,8 @@ struct Skill {
 
 typedef std::map<uint32_t, uint32_t> MuteCountMap;
 
-#define PLAYER_MAX_SPEED 1500
-#define PLAYER_MIN_SPEED 10
+static constexpr int32_t PLAYER_MAX_SPEED = 1500;
+static constexpr int32_t PLAYER_MIN_SPEED = 10;
 
 class Player final : public Creature, public Cylinder
 {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -294,7 +294,9 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {
-		disconnectClient("Only clients with protocol " CLIENT_VERSION_STR " allowed!");
+		std::ostringstream ss;
+		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
+		disconnectClient(ss.str());
 		return;
 	}
 

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -138,7 +138,9 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	 */
 
 	if (version <= 760) {
-		disconnectClient("Only clients with protocol " CLIENT_VERSION_STR " allowed!", version);
+		std::ostringstream ss;
+		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
+		disconnectClient(ss.str(), version);
 		return;
 	}
 
@@ -156,7 +158,9 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	setXTEAKey(key);
 
 	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {
-		disconnectClient("Only clients with protocol " CLIENT_VERSION_STR " allowed!", version);
+		std::ostringstream ss;
+		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
+		disconnectClient(ss.str(), version);
 		return;
 	}
 

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -48,7 +48,9 @@ void ProtocolOld::onRecvFirstMessage(NetworkMessage& msg)
 	msg.skipBytes(12);
 
 	if (version <= 760) {
-		disconnectClient("Only clients with protocol " CLIENT_VERSION_STR " allowed!");
+		std::ostringstream ss;
+		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
+		disconnectClient(ss.str());
 		return;
 	}
 
@@ -69,5 +71,7 @@ void ProtocolOld::onRecvFirstMessage(NetworkMessage& msg)
 		disableChecksum();
 	}
 
-	disconnectClient("Only clients with protocol " CLIENT_VERSION_STR " allowed!");
+	std::ostringstream ss;
+	ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
+	disconnectClient(ss.str());
 }

--- a/src/raids.cpp
+++ b/src/raids.cpp
@@ -110,7 +110,7 @@ bool Raids::loadFromXml()
 	return true;
 }
 
-#define MAX_RAND_RANGE 10000000
+static constexpr int32_t MAX_RAND_RANGE = 10000000;
 
 bool Raids::startup()
 {

--- a/src/raids.h
+++ b/src/raids.h
@@ -39,9 +39,9 @@ struct MonsterSpawn {
 };
 
 //How many times it will try to find a tile to add the monster to before giving up
-#define MAXIMUM_TRIES_PER_MONSTER 10
-#define CHECK_RAIDS_INTERVAL 60
-#define RAID_MINTICKS 1000
+static constexpr int32_t MAXIMUM_TRIES_PER_MONSTER = 10;
+static constexpr int32_t CHECK_RAIDS_INTERVAL = 60;
+static constexpr int32_t RAID_MINTICKS = 1000;
 
 class Raid;
 class RaidEvent;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -24,11 +24,9 @@
 #include <unordered_set>
 #include <queue>
 
-
 #include "thread_holder_base.h"
 
-
-#define SCHEDULER_MINTICKS 50
+static constexpr int32_t SCHEDULER_MINTICKS = 50;
 
 class SchedulerTask : public Task
 {

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -31,7 +31,7 @@ extern ConfigManager g_config;
 extern Monsters g_monsters;
 extern Game g_game;
 
-#define MINSPAWN_INTERVAL 1000
+static constexpr int32_t MINSPAWN_INTERVAL = 1000;
 
 bool Spawns::loadFromXml(const std::string& filename)
 {


### PR DESCRIPTION
`#define` macros for constant values usually mask errors, e.g. if you accidentally type a macro name in the middle of the code (I once run into this problem with NodeJS that has a `#define THIS`...). Also, it's a preprocessor directive and not exactly a language feature.

`constexpr` instead of just `const` is better explained [here](https://stackoverflow.com/questions/13346879/const-vs-constexpr-on-variables).

(crossing fingers hoping clang behaves properly)