### PR TITLE
fixed debug when more then 7 players are on tile

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -516,20 +516,53 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 		}
 	}
 
-	const CreatureVector* creatures = tile->getCreatures();
-	if (creatures) {
-		for (const Creature* creature : boost::adaptors::reverse(*creatures)) {
-			if (!player->canSeeCreature(creature)) {
-				continue;
+	if (tileLogin && tile->getPosition() == player->getPosition()) {
+		bool playerSpawned = false;
+		const CreatureVector *creatures = tile->getCreatures();
+		if (creatures) {
+			for (const Creature *creature : boost::adaptors::reverse(*creatures)) {
+				if (!player->canSeeCreature(creature)) {
+					continue;
+				}
+
+				if (creature == player) {
+					playerSpawned = true;
+				}
+
+				bool known;
+				uint32_t removedKnown;
+				checkCreatureAsKnown(creature->getID(), known, removedKnown);
+				AddCreature(msg, creature, known, removedKnown);
+
+				if (count == 8 && playerSpawned == false) {
+					bool known;
+					uint32_t removedKnown;
+					checkCreatureAsKnown(player->getID(), known, removedKnown);
+					AddCreature(msg, player, known, removedKnown);
+					++count;
+				}
+
+				if (++count == 10) {
+					return;
+				}
 			}
+		}
+	} else {
+		const CreatureVector *creatures = tile->getCreatures();
+		if (creatures) {
+			for (const Creature *creature : boost::adaptors::reverse(*creatures)) {
+				if (!player->canSeeCreature(creature)) {
+					continue;
+				}
 
-			bool known;
-			uint32_t removedKnown;
-			checkCreatureAsKnown(creature->getID(), known, removedKnown);
-			AddCreature(msg, creature, known, removedKnown);
+				bool known;
+				uint32_t removedKnown;
+				checkCreatureAsKnown(creature->getID(), known, removedKnown);
+				AddCreature(msg, creature, known, removedKnown);
 
-			if (++count == 10) {
-				return;
+				if (++count == 10) {
+					return;
+				}
 			}
 		}
 	}
@@ -2389,7 +2422,9 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 
 	sendPendingStateEntered();
 	sendEnterWorld();
+	tileLogin = true;
 	sendMapDescription(pos);
+	tileLogin = false;
 
 	if (isLogin) {
 		sendMagicEffect(pos, CONST_ME_TELEPORT);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -516,7 +516,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 		}
 	}
 
-	if (tileLogin && tile->getPosition() == player->getPosition()) {
+	if (!loggedIn && tile->getPosition() == player->getPosition()) {
 		bool playerSpawned = false;
 		const CreatureVector *creatures = tile->getCreatures();
 		if (creatures) {
@@ -534,9 +534,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 				checkCreatureAsKnown(creature->getID(), known, removedKnown);
 				AddCreature(msg, creature, known, removedKnown);
 
-				if (count == 8 && playerSpawned == false) {
-					bool known;
-					uint32_t removedKnown;
+				if (count == 8 && playerSpawned == false) { // player still not spawned and we need to send him too
 					checkCreatureAsKnown(player->getID(), known, removedKnown);
 					AddCreature(msg, player, known, removedKnown);
 					++count;
@@ -2422,9 +2420,8 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 
 	sendPendingStateEntered();
 	sendEnterWorld();
-	tileLogin = true;
 	sendMapDescription(pos);
-	tileLogin = false;
+	loggedIn = true;
 
 	if (isLogin) {
 		sendMagicEffect(pos, CONST_ME_TELEPORT);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -534,7 +534,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 				checkCreatureAsKnown(creature->getID(), known, removedKnown);
 				AddCreature(msg, creature, known, removedKnown);
 
-				if (count == 8 && playerSpawned == false) { // player still not spawned and we need to send him too
+				if (count == 8 && !playerSpawned) { // player still not spawned and we need to send him too
 					checkCreatureAsKnown(player->getID(), known, removedKnown);
 					AddCreature(msg, player, known, removedKnown);
 					++count;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -320,7 +320,7 @@ class ProtocolGame final : public Protocol
 
 		bool debugAssertSent = false;
 		bool acceptPackets = false;
-		bool tileLogin = true;
+		bool loggedIn = false;
 };
 
 #endif

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -320,6 +320,7 @@ class ProtocolGame final : public Protocol
 
 		bool debugAssertSent = false;
 		bool acceptPackets = false;
+		bool tileLogin = true;
 };
 
 #endif


### PR DESCRIPTION
Problem explantation:
If player tries to login and the tile has more than 7-8 players on it, player got debug. The logging player should be always part of the tile after logging in game. 

I've experienced this issue since TFS 1.0. After some investigation I managed to fix.

Please correct my typo.
