### PR TITLE
Replace arrays with maps for search

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -564,19 +564,19 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 				std::cout << "[Warning - Items::parseItemNode] Unknown slotType: " << valueAttribute.as_string() << std::endl;
 			}
 		} else if (tmpStrValue == "ammotype") {
-			it.ammoType = getAmmoType(valueAttribute.as_string());
+			it.ammoType = getAmmoType(asLowerCaseString(valueAttribute.as_string()));
 			if (it.ammoType == AMMO_NONE) {
 				std::cout << "[Warning - Items::parseItemNode] Unknown ammoType: " << valueAttribute.as_string() << std::endl;
 			}
 		} else if (tmpStrValue == "shoottype") {
-			ShootType_t shoot = getShootType(valueAttribute.as_string());
+			ShootType_t shoot = getShootType(asLowerCaseString(valueAttribute.as_string()));
 			if (shoot != CONST_ANI_NONE) {
 				it.shootType = shoot;
 			} else {
 				std::cout << "[Warning - Items::parseItemNode] Unknown shootType: " << valueAttribute.as_string() << std::endl;
 			}
 		} else if (tmpStrValue == "effect") {
-			MagicEffectClasses effect = getMagicEffect(valueAttribute.as_string());
+			MagicEffectClasses effect = getMagicEffect(asLowerCaseString(valueAttribute.as_string()));
 			if (effect != CONST_ME_NONE) {
 				it.magicEffect = effect;
 			} else {

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -596,7 +596,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 				const char* value = attr.value();
 				if (strcasecmp(value, "shooteffect") == 0) {
 					if ((attr = attributeNode.attribute("value"))) {
-						ShootType_t shoot = getShootType(attr.as_string());
+						ShootType_t shoot = getShootType(asLowerCaseString(attr.as_string()));
 						if (shoot != CONST_ANI_NONE) {
 							combat->setParam(COMBAT_PARAM_DISTANCEEFFECT, shoot);
 						} else {
@@ -605,7 +605,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 					}
 				} else if (strcasecmp(value, "areaeffect") == 0) {
 					if ((attr = attributeNode.attribute("value"))) {
-						MagicEffectClasses effect = getMagicEffect(attr.as_string());
+						MagicEffectClasses effect = getMagicEffect(asLowerCaseString(attr.as_string()));
 						if (effect != CONST_ME_NONE) {
 							combat->setParam(COMBAT_PARAM_EFFECT, effect);
 						} else {
@@ -701,7 +701,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	}
 
 	if ((attr = monsterNode.attribute("skull"))) {
-		mType->info.skull = getSkullType(attr.as_string());
+		mType->info.skull = getSkullType(asLowerCaseString(attr.as_string()));
 	}
 
 	if ((attr = monsterNode.attribute("script"))) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -170,7 +170,7 @@ bool Npc::loadFromXml()
 	}
 
 	if ((attr = npcNode.attribute("skull"))) {
-		setSkull(getSkullType(attr.as_string()));
+		setSkull(getSkullType(asLowerCaseString(attr.as_string())));
 	}
 
 	pugi::xml_node healthNode = npcNode.child("health");

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -497,37 +497,14 @@ Direction getDirectionTo(const Position& from, const Position& to)
 	return dir;
 }
 
-struct MagicEffectNames {
-	const char* name;
-	MagicEffectClasses effect;
-};
+using MagicEffectNames = std::unordered_map<std::string, MagicEffectClasses>;
+using ShootTypeNames = std::unordered_map<std::string, ShootType_t>;
+using CombatTypeNames = std::unordered_map<CombatType_t, std::string, std::hash<int32_t>>;
+using AmmoTypeNames = std::unordered_map<std::string, Ammo_t>;
+using WeaponActionNames = std::unordered_map<std::string, WeaponAction_t>;
+using SkullNames = std::unordered_map<std::string, Skulls_t>;
 
-struct ShootTypeNames {
-	const char* name;
-	ShootType_t shoot;
-};
-
-struct CombatTypeNames {
-	const char* name;
-	CombatType_t combat;
-};
-
-struct AmmoTypeNames {
-	const char* name;
-	Ammo_t ammoType;
-};
-
-struct WeaponActionNames {
-	const char* name;
-	WeaponAction_t weaponAction;
-};
-
-struct SkullNames {
-	const char* name;
-	Skulls_t skull;
-};
-
-MagicEffectNames magicEffectNames[] = {
+MagicEffectNames magicEffectNames = {
 	{"redspark",		CONST_ME_DRAWBLOOD},
 	{"bluebubble",		CONST_ME_LOSEENERGY},
 	{"poff",		CONST_ME_POFF},
@@ -611,7 +588,7 @@ MagicEffectNames magicEffectNames[] = {
 	{"purplesmoke",		CONST_ME_PURPLESMOKE},
 };
 
-ShootTypeNames shootTypeNames[] = {
+ShootTypeNames shootTypeNames = {
 	{"spear",		CONST_ANI_SPEAR},
 	{"bolt",		CONST_ANI_BOLT},
 	{"arrow",		CONST_ANI_ARROW},
@@ -664,22 +641,22 @@ ShootTypeNames shootTypeNames[] = {
 	{"simplearrow",		CONST_ANI_SIMPLEARROW},
 };
 
-CombatTypeNames combatTypeNames[] = {
-	{"physical",		COMBAT_PHYSICALDAMAGE},
-	{"energy",		COMBAT_ENERGYDAMAGE},
-	{"earth",		COMBAT_EARTHDAMAGE},
-	{"fire",		COMBAT_FIREDAMAGE},
-	{"undefined",		COMBAT_UNDEFINEDDAMAGE},
-	{"lifedrain",		COMBAT_LIFEDRAIN},
-	{"manadrain",		COMBAT_MANADRAIN},
-	{"healing",		COMBAT_HEALING},
-	{"drown",		COMBAT_DROWNDAMAGE},
-	{"ice",			COMBAT_ICEDAMAGE},
-	{"holy",		COMBAT_HOLYDAMAGE},
-	{"death",		COMBAT_DEATHDAMAGE},
+CombatTypeNames combatTypeNames = {
+	{COMBAT_PHYSICALDAMAGE, 	"physical"},
+	{COMBAT_ENERGYDAMAGE, 		"energy"},
+	{COMBAT_EARTHDAMAGE, 		"earth"},
+	{COMBAT_FIREDAMAGE, 		"fire"},
+	{COMBAT_UNDEFINEDDAMAGE, 	"undefined"},
+	{COMBAT_LIFEDRAIN, 		"lifedrain"},
+	{COMBAT_MANADRAIN, 		"manadrain"},
+	{COMBAT_HEALING, 		"healing"},
+	{COMBAT_DROWNDAMAGE, 		"drown"},
+	{COMBAT_ICEDAMAGE, 		"ice"},
+	{COMBAT_HOLYDAMAGE, 		"holy"},
+	{COMBAT_DEATHDAMAGE, 		"death"},
 };
 
-AmmoTypeNames ammoTypeNames[] = {
+AmmoTypeNames ammoTypeNames = {
 	{"spear",		AMMO_SPEAR},
 	{"bolt",		AMMO_BOLT},
 	{"arrow",		AMMO_ARROW},
@@ -705,13 +682,13 @@ AmmoTypeNames ammoTypeNames[] = {
 	{"eartharrow",		AMMO_ARROW},
 };
 
-WeaponActionNames weaponActionNames[] = {
+WeaponActionNames weaponActionNames = {
 	{"move",		WEAPONACTION_MOVE},
 	{"removecharge",	WEAPONACTION_REMOVECHARGE},
 	{"removecount",		WEAPONACTION_REMOVECOUNT},
 };
 
-SkullNames skullNames[] = {
+SkullNames skullNames = {
 	{"none",	SKULL_NONE},
 	{"yellow",	SKULL_YELLOW},
 	{"green",	SKULL_GREEN},
@@ -723,70 +700,54 @@ SkullNames skullNames[] = {
 
 MagicEffectClasses getMagicEffect(const std::string& strValue)
 {
-	for (auto& magicEffectName : magicEffectNames) {
-		if (strcasecmp(strValue.c_str(), magicEffectName.name) == 0) {
-			return magicEffectName.effect;
-		}
+	auto magicEffect = magicEffectNames.find(strValue);
+	if (magicEffect != magicEffectNames.end()) {
+		return magicEffect->second;
 	}
 	return CONST_ME_NONE;
 }
 
 ShootType_t getShootType(const std::string& strValue)
 {
-	for (size_t i = 0, size = sizeof(shootTypeNames) / sizeof(ShootTypeNames); i < size; ++i) {
-		if (strcasecmp(strValue.c_str(), shootTypeNames[i].name) == 0) {
-			return shootTypeNames[i].shoot;
-		}
+	auto shootType = shootTypeNames.find(strValue);
+	if (shootType != shootTypeNames.end()) {
+		return shootType->second;
 	}
 	return CONST_ANI_NONE;
 }
 
-CombatType_t getCombatType(const std::string& strValue)
-{
-	for (size_t i = 0, size = sizeof(combatTypeNames) / sizeof(CombatTypeNames); i < size; ++i) {
-		if (strcasecmp(strValue.c_str(), combatTypeNames[i].name) == 0) {
-			return combatTypeNames[i].combat;
-		}
-	}
-	return COMBAT_NONE;
-}
-
 std::string getCombatName(CombatType_t combatType)
 {
-	for (size_t i = 0, size = sizeof(combatTypeNames) / sizeof(CombatTypeNames); i < size; ++i) {
-		if (combatTypeNames[i].combat == combatType) {
-			return combatTypeNames[i].name;
-		}
+	auto combatName = combatTypeNames.find(combatType);
+	if (combatName != combatTypeNames.end()) {
+		return combatName->second;
 	}
 	return "unknown";
 }
 
 Ammo_t getAmmoType(const std::string& strValue)
 {
-	for (size_t i = 0, size = sizeof(ammoTypeNames) / sizeof(AmmoTypeNames); i < size; ++i) {
-		if (strcasecmp(strValue.c_str(), ammoTypeNames[i].name) == 0) {
-			return ammoTypeNames[i].ammoType;
-		}
+	auto ammoType = ammoTypeNames.find(strValue);
+	if (ammoType != ammoTypeNames.end()) {
+		return ammoType->second;
 	}
 	return AMMO_NONE;
 }
 
 WeaponAction_t getWeaponAction(const std::string& strValue)
 {
-	for (size_t i = 0, size = sizeof(weaponActionNames) / sizeof(WeaponActionNames); i < size; ++i) {
-		if (strcasecmp(strValue.c_str(), weaponActionNames[i].name) == 0) {
-			return weaponActionNames[i].weaponAction;
-		}
+	auto weaponAction = weaponActionNames.find(strValue);
+	if (weaponAction != weaponActionNames.end()) {
+		return weaponAction->second;
 	}
 	return WEAPONACTION_NONE;
 }
 
 Skulls_t getSkullType(const std::string& strValue)
 {
-	for (size_t i = 0, size = sizeof(skullNames) / sizeof(SkullNames); i < size; ++i) {
-		if (strcasecmp(strValue.c_str(), skullNames[i].name) == 0) {
-			return skullNames[i].skull;
-		}
+	auto skullType = skullNames.find(strValue);
+	if (skullType != skullNames.end()) {
+		return skullType->second;
 	}
 	return SKULL_NONE;
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -68,7 +68,6 @@ MagicEffectClasses getMagicEffect(const std::string& strValue);
 ShootType_t getShootType(const std::string& strValue);
 Ammo_t getAmmoType(const std::string& strValue);
 WeaponAction_t getWeaponAction(const std::string& strValue);
-CombatType_t getCombatType(const std::string& strValue);
 Skulls_t getSkullType(const std::string& strValue);
 std::string getCombatName(CombatType_t combatType);
 

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -182,7 +182,7 @@ bool Weapon::configureEvent(const pugi::xml_node& node)
 	}
 
 	if ((attr = node.attribute("action"))) {
-		action = getWeaponAction(attr.as_string());
+		action = getWeaponAction(asLowerCaseString(attr.as_string()));
 		if (action == WEAPONACTION_NONE) {
 			std::cout << "[Warning - Weapon::configureEvent] Unknown action " << attr.as_string() << std::endl;
 		}


### PR DESCRIPTION
Replaces some arrays that map names to enum values (and one vice-versa) to drop search complexity from O(n) to O(1) and reduce a lot of code since structs are not needed.