### PR TITLE
Fixing shared experience

### DIFF
--- a/src/party.cpp
+++ b/src/party.cpp
@@ -412,7 +412,7 @@ bool Party::setSharedExperience(Player* player, bool sharedExpActive)
 
 void Party::shareExperience(uint64_t experience, Creature* source/* = nullptr*/)
 {
-	uint64_t shareExperience = static_cast<uint64_t>(std::ceil((static_cast<double>(experience) * extraExpRate) / (memberList.size() + 1)));
+	uint64_t shareExperience = static_cast<uint64_t>(std::ceil((static_cast<double>(experience) * (extraExpRate + 1)) / (memberList.size() + 1)));
 	for (Player* member : memberList) {
 		member->onGainSharedExperience(shareExperience, source);
 	}

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -412,7 +412,7 @@ bool Party::setSharedExperience(Player* player, bool sharedExpActive)
 
 void Party::shareExperience(uint64_t experience, Creature* source/* = nullptr*/)
 {
-	uint32_t shareExperience = static_cast<uint64_t>(std::ceil(((static_cast<double>(experience) / (memberList.size() + 1)) + (static_cast<double>(experience) * extraExpRate))));
+	uint64_t shareExperience = static_cast<uint64_t>(std::ceil((static_cast<double>(experience) * extraExpRate) / (memberList.size() + 1)));
 	for (Player* member : memberList) {
 		member->onGainSharedExperience(shareExperience, source);
 	}


### PR DESCRIPTION
According to http://tibia.wikia.com/wiki/Party the correct formula for shared experience is (M * S) / P * C where,
-     M = Monster EXP
-     S = shared experience bonus (e.g. 30% = 1.3)
-     P = Party size
-     C = Character specific bonuses (e.g. 50% stamina bonus => 1.5, no bonus => 1)

As stamina modifier is calculated in player.lua event onGainExperience it should be adding (M * (S + 1)) / P and it was adding M / P + M * S.
(As S in wiki's formula is 100% + bonus and the extraExpRate is only the bonus, the correct formula would be M / P + (M * S) / P or (M * (S + 1)) / P).

Also the type was wrong.