### PR TITLE
fix seek in container to be able to move back after changing page

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2392,7 +2392,7 @@ void Game::playerSeekInContainer(uint32_t playerId, uint8_t containerId, uint16_
 	}
 
 	player->setContainerIndex(containerId, index);
-	player->sendContainer(containerId, container, false, index);
+	player->sendContainer(containerId, container, container->hasParent(), index);
 }
 
 void Game::playerUpdateHouseWindow(uint32_t playerId, uint8_t listId, uint32_t windowTextId, const std::string& text)


### PR DESCRIPTION
If you have more pages in Inbox or you use global depot and change panges than it should be possible to go back to previous container too.