### PR TITLE
Fileloader refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     packages:
       - libboost-dev
       - libboost-system-dev
+      - libboost-iostreams-dev
       - liblua5.2-dev
       - libluajit-5.1-dev
       - libmysqlclient-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
     find_package(Lua)
 endif()
 
-find_package(Boost 1.53.0 COMPONENTS system REQUIRED)
+find_package(Boost 1.53.0 COMPONENTS system iostreams REQUIRED)
 
 include(src/CMakeLists.txt)
 add_executable(tfs ${tfs_SRC})

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -107,24 +107,22 @@ Attr_ReadValue Container::readAttr(AttrTypes_t attr, PropStream& propStream)
 	return Item::readAttr(attr, propStream);
 }
 
-bool Container::unserializeItemNode(FileLoader& f, NODE node, PropStream& propStream)
+bool Container::unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, PropStream& propStream)
 {
-	bool ret = Item::unserializeItemNode(f, node, propStream);
+	bool ret = Item::unserializeItemNode(loader, node, propStream);
 	if (!ret) {
 		return false;
 	}
 
-	uint32_t type;
-	NODE nodeItem = f.getChildNode(node, type);
-	while (nodeItem) {
+	for (auto& itemNode : node.children) {
 		//load container items
-		if (type != OTBM_ITEM) {
+		if (itemNode.type != OTBM_ITEM) {
 			// unknown type
 			return false;
 		}
 
 		PropStream itemPropStream;
-		if (!f.getProps(nodeItem, itemPropStream)) {
+		if (!loader.getProps(itemNode, itemPropStream)) {
 			return false;
 		}
 
@@ -133,14 +131,12 @@ bool Container::unserializeItemNode(FileLoader& f, NODE node, PropStream& propSt
 			return false;
 		}
 
-		if (!item->unserializeItemNode(f, nodeItem, itemPropStream)) {
+		if (!item->unserializeItemNode(loader, itemNode, itemPropStream)) {
 			return false;
 		}
 
 		addItem(item);
 		updateItemWeight(item->getWeight());
-
-		nodeItem = f.getNextNode(nodeItem, type);
 	}
 	return true;
 }

--- a/src/container.h
+++ b/src/container.h
@@ -75,7 +75,7 @@ class Container : public Item, public Cylinder
 		}
 
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
-		bool unserializeItemNode(FileLoader& f, NODE node, PropStream& propStream) override;
+		bool unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, PropStream& propStream) override;
 		std::string getContentDescription() const;
 
 		size_t size() const {

--- a/src/fileloader.cpp
+++ b/src/fileloader.cpp
@@ -19,387 +19,106 @@
 
 #include "otpch.h"
 
+#include <stack>
 #include "fileloader.h"
 
-FileLoader::~FileLoader()
+
+namespace OTB {
+
+constexpr Identifier wildcard = {{'\0', '\0', '\0', '\0'}};
+
+Loader::Loader(const std::string& fileName, const Identifier& acceptedIdentifier):
+	fileContents(fileName)
 {
-	if (file) {
-		fclose(file);
-		file = nullptr;
+	constexpr auto minimalSize = sizeof(Identifier) + sizeof(Node::START) + sizeof(Node::type) + sizeof(Node::END);
+	if (fileContents.size() <= minimalSize) {
+		throw InvalidOTBFormat{};
 	}
 
-	NodeStruct::clearNet(root);
-	delete[] buffer;
-
-	for (auto& i : cached_data) {
-		delete[] i.data;
+	Identifier fileIdentifier;
+	std::copy(fileContents.begin(), fileContents.begin() + fileIdentifier.size(), fileIdentifier.begin());
+	if (fileIdentifier != acceptedIdentifier && fileIdentifier != wildcard) {
+		throw InvalidOTBFormat{};
 	}
 }
 
-bool FileLoader::openFile(const char* filename, const char* accept_identifier)
-{
-	file = fopen(filename, "rb");
-	if (!file) {
-		lastError = ERROR_CAN_NOT_OPEN;
-		return false;
+using NodeStack = std::stack<Node*, std::vector<Node*>>;
+static Node& getCurrentNode(const NodeStack& nodeStack) {
+	if (nodeStack.empty()) {
+		throw InvalidOTBFormat{};
 	}
-
-	char identifier[4];
-	if (fread(identifier, 1, 4, file) < 4) {
-		fclose(file);
-		file = nullptr;
-		lastError = ERROR_EOF;
-		return false;
-	}
-
-	// The first four bytes must either match the accept identifier or be 0x00000000 (wildcard)
-	if (memcmp(identifier, accept_identifier, 4) != 0 && memcmp(identifier, "\0\0\0\0", 4) != 0) {
-		fclose(file);
-		file = nullptr;
-		lastError = ERROR_INVALID_FILE_VERSION;
-		return false;
-	}
-
-	fseek(file, 0, SEEK_END);
-	int32_t file_size = ftell(file);
-	cache_size = std::min<uint32_t>(32768, std::max<uint32_t>(file_size / 20, 8192)) & ~0x1FFF;
-
-	if (!safeSeek(4)) {
-		lastError = ERROR_INVALID_FORMAT;
-		return false;
-	}
-
-	delete root;
-	root = new NodeStruct();
-	root->start = 4;
-
-	int32_t byte;
-	if (safeSeek(4) && readByte(byte) && byte == NODE_START) {
-		return parseNode(root);
-	}
-
-	return false;
+	return *nodeStack.top();
 }
 
-bool FileLoader::parseNode(NODE node)
+const Node& Loader::parseTree()
 {
-	int32_t byte, pos;
-	NODE currentNode = node;
+	auto it = fileContents.begin() + sizeof(Identifier);
+	if (static_cast<uint8_t>(*it) != Node::START) {
+		throw InvalidOTBFormat{};
+	}
+	root.type = *(++it);
+	root.propsBegin = ++it;
+	NodeStack parseStack;
+	parseStack.push(&root);
 
-	while (readByte(byte)) {
-		currentNode->type = byte;
-		bool setPropsSize = false;
-
-		while (true) {
-			if (!readByte(byte)) {
-				return false;
+	for (; it != fileContents.end(); ++it) {
+		switch(static_cast<uint8_t>(*it)) {
+			case Node::START: {
+				auto& currentNode = getCurrentNode(parseStack);
+				if (currentNode.children.empty()) {
+					currentNode.propsEnd = it;
+				}
+				currentNode.children.emplace_back();
+				auto& child = currentNode.children.back();
+				if (++it == fileContents.end()) {
+					throw InvalidOTBFormat{};
+				}
+				child.type = *it;
+				child.propsBegin = it + sizeof(Node::type);
+				parseStack.push(&child);
+				break;
 			}
-
-			bool skipNode = false;
-
-			switch (byte) {
-				case NODE_START: {
-					//child node start
-					if (!safeTell(pos)) {
-						return false;
-					}
-
-					NODE childNode = new NodeStruct();
-					childNode->start = pos;
-					currentNode->propsSize = pos - currentNode->start - 2;
-					currentNode->child = childNode;
-
-					setPropsSize = true;
-
-					if (!parseNode(childNode)) {
-						return false;
-					}
-
-					break;
+			case Node::END: {
+				auto& currentNode = getCurrentNode(parseStack);
+				if (currentNode.children.empty()) {
+					currentNode.propsEnd = it;
 				}
-
-				case NODE_END: {
-					//current node end
-					if (!setPropsSize) {
-						if (!safeTell(pos)) {
-							return false;
-						}
-
-						currentNode->propsSize = pos - currentNode->start - 2;
-					}
-
-					if (!readByte(byte)) {
-						return true;
-					}
-
-					switch (byte) {
-						case NODE_START: {
-							//starts next node
-							if (!safeTell(pos)) {
-								return false;
-							}
-
-							skipNode = true;
-							NODE nextNode = new NodeStruct();
-							nextNode->start = pos;
-							currentNode->next = nextNode;
-							currentNode = nextNode;
-							break;
-						}
-
-						case NODE_END:
-							return safeTell(pos) && safeSeek(pos);
-
-						default:
-							lastError = ERROR_INVALID_FORMAT;
-							return false;
-					}
-
-					break;
-				}
-
-				case ESCAPE_CHAR: {
-					if (!readByte(byte)) {
-						return false;
-					}
-
-					break;
-				}
-
-				default:
-					break;
+				parseStack.pop();
+				break;
 			}
-
-			if (skipNode) {
+			case Node::ESCAPE: {
+				if (++it == fileContents.end()) {
+					throw InvalidOTBFormat{};
+				}
+				break;
+			}
+			default: {
 				break;
 			}
 		}
 	}
-	return false;
-}
-
-const uint8_t* FileLoader::getProps(const NODE node, size_t& size)
-{
-	if (!node) {
-		return nullptr;
+	if (!parseStack.empty()) {
+		throw InvalidOTBFormat{};
 	}
 
-	if (node->propsSize >= buffer_size) {
-		delete[] buffer;
-
-		while (node->propsSize >= buffer_size) {
-			buffer_size *= 2;
-		}
-
-		buffer = new uint8_t[buffer_size];
-	}
-
-	//get buffer
-	if (!readBytes(node->propsSize, node->start + 2)) {
-		return nullptr;
-	}
-
-	//unscape buffer
-	size_t j = 0;
-	bool escaped = false;
-	for (uint32_t i = 0; i < node->propsSize; ++i, ++j) {
-		if (buffer[i] == ESCAPE_CHAR) {
-			//escape char found, skip it and write next
-			buffer[j] = buffer[++i];
-			//is neede a displacement for next bytes
-			escaped = true;
-		} else if (escaped) {
-			//perform that displacement
-			buffer[j] = buffer[i];
-		}
-	}
-
-	size = j;
-	return buffer;
-}
-
-bool FileLoader::getProps(const NODE node, PropStream& props)
-{
-	size_t size;
-	if (const uint8_t* a = getProps(node, size)) {
-		props.init(reinterpret_cast<const char*>(a), size); // does not break strict aliasing
-		return true;
-	}
-
-	props.init(nullptr, 0);
-	return false;
-}
-
-NODE FileLoader::getChildNode(const NODE parent, uint32_t& type)
-{
-	if (parent) {
-		NODE child = parent->child;
-		if (child) {
-			type = child->type;
-		}
-
-		return child;
-	}
-
-	type = root->type;
 	return root;
 }
 
-NODE FileLoader::getNextNode(const NODE prev, uint32_t& type)
+bool Loader::getProps(const Node& node, PropStream& props)
 {
-	if (!prev) {
-		return NO_NODE;
-	}
-
-	NODE next = prev->next;
-	if (next) {
-		type = next->type;
-	}
-	return next;
-}
-
-inline bool FileLoader::readByte(int32_t& value)
-{
-	if (cache_index == NO_VALID_CACHE) {
-		lastError = ERROR_CACHE_ERROR;
+	auto size = std::distance(node.propsBegin, node.propsEnd);
+	if (size == 0) {
 		return false;
 	}
+	propBuffer.resize(size);
+	bool lastEscaped = false;
 
-	if (cache_offset >= cached_data[cache_index].size) {
-		int32_t pos = cache_offset + cached_data[cache_index].base;
-		int32_t tmp = getCacheBlock(pos);
-		if (tmp < 0) {
-			return false;
-		}
-
-		cache_index = tmp;
-		cache_offset = pos - cached_data[cache_index].base;
-		if (cache_offset >= cached_data[cache_index].size) {
-			return false;
-		}
-	}
-
-	value = cached_data[cache_index].data[cache_offset++];
+	auto escapedPropEnd = std::copy_if(node.propsBegin, node.propsEnd, propBuffer.begin(), [&lastEscaped](const char& byte) {
+		lastEscaped = byte == static_cast<char>(Node::ESCAPE) && !lastEscaped;
+		return !lastEscaped;
+	});
+	props.init(&propBuffer[0], std::distance(propBuffer.begin(), escapedPropEnd));
 	return true;
 }
 
-inline bool FileLoader::readBytes(uint32_t size, int32_t pos)
-{
-	//seek at pos
-	uint32_t remain = size;
-	uint8_t* buf = this->buffer;
-	do {
-		//prepare cache
-		uint32_t i = getCacheBlock(pos);
-		if (i == NO_VALID_CACHE) {
-			return false;
-		}
-
-		cache_index = i;
-		cache_offset = pos - cached_data[i].base;
-
-		//get maximum read block size and calculate remaining bytes
-		uint32_t reading = std::min<int32_t>(remain, cached_data[i].size - cache_offset);
-		remain -= reading;
-
-		//read it
-		memcpy(buf, cached_data[cache_index].data + cache_offset, reading);
-
-		//update variables
-		cache_offset += reading;
-		buf += reading;
-		pos += reading;
-	} while (remain > 0);
-	return true;
-}
-
-inline bool FileLoader::safeSeek(uint32_t pos)
-{
-	uint32_t i = getCacheBlock(pos);
-	if (i == NO_VALID_CACHE) {
-		return false;
-	}
-
-	cache_index = i;
-	cache_offset = pos - cached_data[i].base;
-	return true;
-}
-
-inline bool FileLoader::safeTell(int32_t& pos)
-{
-	if (cache_index == NO_VALID_CACHE) {
-		lastError = ERROR_CACHE_ERROR;
-		return false;
-	}
-
-	pos = cached_data[cache_index].base + cache_offset - 1;
-	return true;
-}
-
-inline uint32_t FileLoader::getCacheBlock(uint32_t pos)
-{
-	bool found = false;
-	uint32_t i, base_pos = pos & ~(cache_size - 1);
-
-	for (i = 0; i < CACHE_BLOCKS; i++) {
-		if (cached_data[i].loaded) {
-			if (cached_data[i].base == base_pos) {
-				found = true;
-				break;
-			}
-		}
-	}
-
-	if (!found) {
-		i = loadCacheBlock(pos);
-	}
-
-	return i;
-}
-
-int32_t FileLoader::loadCacheBlock(uint32_t pos)
-{
-	int32_t i, loading_cache = -1, base_pos = pos & ~(cache_size - 1);
-
-	for (i = 0; i < CACHE_BLOCKS; i++) {
-		if (!cached_data[i].loaded) {
-			loading_cache = i;
-			break;
-		}
-	}
-
-	if (loading_cache == -1) {
-		for (i = 0; i < CACHE_BLOCKS; i++) {
-			if (std::abs(static_cast<long>(cached_data[i].base) - base_pos) > static_cast<long>(2 * cache_size)) {
-				loading_cache = i;
-				break;
-			}
-		}
-
-		if (loading_cache == -1) {
-			loading_cache = 0;
-		}
-	}
-
-	if (cached_data[loading_cache].data == nullptr) {
-		cached_data[loading_cache].data = new uint8_t[cache_size];
-	}
-
-	cached_data[loading_cache].base = base_pos;
-
-	if (fseek(file, cached_data[loading_cache].base, SEEK_SET) != 0) {
-		lastError = ERROR_SEEK_ERROR;
-		return -1;
-	}
-
-	uint32_t size = fread(cached_data[loading_cache].data, 1, cache_size, file);
-	cached_data[loading_cache].size = size;
-
-	if (size < (pos - cached_data[loading_cache].base)) {
-		lastError = ERROR_SEEK_ERROR;
-		return -1;
-	}
-
-	cached_data[loading_cache].loaded = 1;
-	return loading_cache;
-}
+} //namespace OTB

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -22,54 +22,58 @@
 
 #include <limits>
 #include <vector>
+#include <boost/iostreams/device/mapped_file.hpp>
 
-struct NodeStruct;
+class PropStream;
 
-typedef NodeStruct* NODE;
+namespace OTB {
+using MappedFile = boost::iostreams::mapped_file_source;
+using ContentIt  = MappedFile::iterator;
+using Identifier = std::array<char, 4>;
 
-struct NodeStruct {
-	uint32_t start = 0;
-	uint32_t propsSize = 0;
-	uint32_t type = 0;
-	NodeStruct* next = nullptr;
-	NodeStruct* child = nullptr;
+struct Node
+{
+	Node() = default;
+	Node(Node&&) = default;
+	Node& operator=(Node&&) = default;
+	Node(const Node&) = delete;
+	Node& operator=(const Node&) = delete;
 
-	static void clearNet(NodeStruct* root) {
-		if (root) {
-			clearChild(root);
-		}
-	}
+	using ChildrenVector = std::vector<Node>;
 
-	private:
-		static void clearNext(NodeStruct* node) {
-			NodeStruct* deleteNode = node;
-			NodeStruct* nextNode;
-
-			while (deleteNode) {
-				if (deleteNode->child) {
-					clearChild(deleteNode->child);
-				}
-
-				nextNode = deleteNode->next;
-				delete deleteNode;
-				deleteNode = nextNode;
-			}
-		}
-
-		static void clearChild(NodeStruct* node) {
-			if (node->child) {
-				clearChild(node->child);
-			}
-
-			if (node->next) {
-				clearNext(node->next);
-			}
-
-			delete node;
-		}
+	ChildrenVector children;
+	ContentIt      propsBegin;
+	ContentIt      propsEnd;
+	uint8_t           type;
+	enum NodeChar: uint8_t
+	{
+		ESCAPE = 0xFD,
+		START  = 0xFE,
+		END    = 0xFF,
+	};
 };
 
-static constexpr auto NO_NODE = nullptr;
+struct LoadError : std::exception {
+	const char* what() const noexcept = 0;
+};
+
+struct InvalidOTBFormat : LoadError {
+	const char* what() const noexcept final {
+		return "Invalid OTBM file format";
+	}
+};
+
+class Loader {
+	MappedFile     fileContents;
+	Node              root;
+	std::vector<char> propBuffer;
+public:
+	Loader(const std::string& fileName, const Identifier& acceptedIdentifier);
+	bool getProps(const Node& node, PropStream& props);
+	const Node& parseTree();
+};
+
+} //namespace OTB
 
 enum FILELOADER_ERRORS {
 	ERROR_NONE,
@@ -81,72 +85,6 @@ enum FILELOADER_ERRORS {
 	ERROR_NOT_OPEN,
 	ERROR_INVALID_NODE,
 	ERROR_INVALID_FORMAT,
-	ERROR_TELL_ERROR,
-	ERROR_COULDNOTWRITE,
-	ERROR_CACHE_ERROR,
-};
-
-class PropStream;
-
-class FileLoader
-{
-	public:
-		FileLoader() = default;
-		~FileLoader();
-
-		// non-copyable
-		FileLoader(const FileLoader&) = delete;
-		FileLoader& operator=(const FileLoader&) = delete;
-
-		bool openFile(const char* filename, const char* identifier);
-		const uint8_t* getProps(const NODE, size_t& size);
-		bool getProps(const NODE, PropStream& props);
-		NODE getChildNode(const NODE parent, uint32_t& type);
-		NODE getNextNode(const NODE prev, uint32_t& type);
-
-		FILELOADER_ERRORS getError() const {
-			return lastError;
-		}
-
-	protected:
-		enum SPECIAL_BYTES {
-			ESCAPE_CHAR = 0xFD,
-			NODE_START = 0xFE,
-			NODE_END = 0xFF,
-		};
-
-		bool parseNode(NODE node);
-
-		inline bool readByte(int32_t& value);
-		inline bool readBytes(uint32_t size, int32_t pos);
-		inline bool safeSeek(uint32_t pos);
-		inline bool safeTell(int32_t& pos);
-
-	protected:
-		struct cache {
-			uint8_t* data;
-			uint32_t loaded;
-			uint32_t base;
-			uint32_t size;
-		};
-
-		static constexpr int32_t CACHE_BLOCKS = 3;
-		cache cached_data[CACHE_BLOCKS] = {};
-
-		uint8_t* buffer = new uint8_t[1024];
-		NODE root = nullptr;
-		FILE* file = nullptr;
-
-		FILELOADER_ERRORS lastError = ERROR_NONE;
-		uint32_t buffer_size = 1024;
-
-		uint32_t cache_size = 0;
-		static constexpr uint32_t NO_VALID_CACHE = std::numeric_limits<uint32_t>::max();
-		uint32_t cache_index = NO_VALID_CACHE;
-		uint32_t cache_offset = NO_VALID_CACHE;
-
-		inline uint32_t getCacheBlock(uint32_t pos);
-		int32_t loadCacheBlock(uint32_t pos);
 };
 
 class PropStream

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -66,23 +66,14 @@ Tile* IOMap::createTile(Item*& ground, Item* item, uint16_t x, uint16_t y, uint8
 	return tile;
 }
 
-bool IOMap::loadMap(Map* map, const std::string& identifier)
+bool IOMap::loadMap(Map* map, const std::string& fileName)
 {
 	int64_t start = OTSYS_TIME();
+	OTB::Loader loader{fileName, OTB::Identifier{{'O', 'T', 'B', 'M'}}};
+	auto& root = loader.parseTree();
 
-	FileLoader f;
-	if (!f.openFile(identifier.c_str(), "OTBM")) {
-		std::ostringstream ss;
-		ss << "Could not open the file " << identifier << '.';
-		setLastErrorString(ss.str());
-		return false;
-	}
-
-	uint32_t type;
 	PropStream propStream;
-
-	NODE root = f.getChildNode(nullptr, type);
-	if (!f.getProps(root, propStream)) {
+	if (!loader.getProps(root, propStream)) {
 		setLastErrorString("Could not read root property.");
 		return false;
 	}
@@ -130,13 +121,43 @@ bool IOMap::loadMap(Map* map, const std::string& identifier)
 	map->width = root_header.width;
 	map->height = root_header.height;
 
-	NODE nodeMap = f.getChildNode(root, type);
-	if (type != OTBM_MAP_DATA) {
+	if (root.children.size() != 1 || root.children[0].type != OTBM_MAP_DATA) {
 		setLastErrorString("Could not read data node.");
 		return false;
 	}
 
-	if (!f.getProps(nodeMap, propStream)) {
+	auto& mapNode = root.children[0];
+	if (!parseMapDataAttributes(loader, mapNode, *map, fileName)) {
+		return false;
+	}
+
+	for (auto& mapDataNode : mapNode.children) {
+		if (mapDataNode.type == OTBM_TILE_AREA) {
+			if (!parseTileArea(loader, mapDataNode, *map)) {
+				return false;
+			}
+		} else if (mapDataNode.type == OTBM_TOWNS) {
+			if (!parseTowns(loader, mapDataNode, *map)) {
+				return false;
+			}
+		} else if (mapDataNode.type == OTBM_WAYPOINTS && headerVersion > 1) {
+			if (!parseWaypoints(loader, mapDataNode, *map)) {
+				return false;
+			}
+		} else {
+			setLastErrorString("Unknown map node.");
+			return false;
+		}
+	}
+
+	std::cout << "> Map loading time: " << (OTSYS_TIME() - start) / (1000.) << " seconds." << std::endl;
+	return true;
+}
+
+bool IOMap::parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map, const std::string& fileName)
+{
+	PropStream propStream;
+	if (!loader.getProps(mapNode, propStream)) {
 		setLastErrorString("Could not read map data attributes.");
 		return false;
 	}
@@ -160,8 +181,8 @@ bool IOMap::loadMap(Map* map, const std::string& identifier)
 					return false;
 				}
 
-				map->spawnfile = identifier.substr(0, identifier.rfind('/') + 1);
-				map->spawnfile += tmp;
+				map.spawnfile = fileName.substr(0, fileName.rfind('/') + 1);
+				map.spawnfile += tmp;
 				break;
 
 			case OTBM_ATTR_EXT_HOUSE_FILE:
@@ -170,8 +191,8 @@ bool IOMap::loadMap(Map* map, const std::string& identifier)
 					return false;
 				}
 
-				map->housefile = identifier.substr(0, identifier.rfind('/') + 1);
-				map->housefile += tmp;
+				map.housefile = fileName.substr(0, fileName.rfind('/') + 1);
+				map.housefile += tmp;
 				break;
 
 			default:
@@ -179,180 +200,108 @@ bool IOMap::loadMap(Map* map, const std::string& identifier)
 				return false;
 		}
 	}
+	return true;
+}
 
-	NODE nodeMapData = f.getChildNode(nodeMap, type);
-	while (nodeMapData != NO_NODE) {
-		if (f.getError() != ERROR_NONE) {
-			setLastErrorString("Invalid map node.");
+bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Map& map)
+{
+	PropStream propStream;
+	if (!loader.getProps(tileAreaNode, propStream)) {
+		setLastErrorString("Invalid map node.");
+		return false;
+	}
+
+	OTBM_Destination_coords area_coord;
+	if (!propStream.read(area_coord)) {
+		setLastErrorString("Invalid map node.");
+		return false;
+	}
+
+	uint16_t base_x = area_coord.x;
+	uint16_t base_y = area_coord.y;
+	uint16_t z = area_coord.z;
+
+	for (auto& tileNode : tileAreaNode.children) {
+		if (tileNode.type != OTBM_TILE && tileNode.type != OTBM_HOUSETILE) {
+			setLastErrorString("Unknown tile node.");
 			return false;
 		}
 
-		if (type == OTBM_TILE_AREA) {
-			if (!f.getProps(nodeMapData, propStream)) {
-				setLastErrorString("Invalid map node.");
+		if (!loader.getProps(tileNode, propStream)) {
+			setLastErrorString("Could not read node data.");
+			return false;
+		}
+
+		OTBM_Tile_coords tile_coord;
+		if (!propStream.read(tile_coord)) {
+			setLastErrorString("Could not read tile position.");
+			return false;
+		}
+
+		uint16_t x = base_x + tile_coord.x;
+		uint16_t y = base_y + tile_coord.y;
+
+		bool isHouseTile = false;
+		House* house = nullptr;
+		Tile* tile = nullptr;
+		Item* ground_item = nullptr;
+		uint32_t tileflags = TILESTATE_NONE;
+
+		if (tileNode.type == OTBM_HOUSETILE) {
+			uint32_t houseId;
+			if (!propStream.read<uint32_t>(houseId)) {
+				std::ostringstream ss;
+				ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Could not read house id.";
+				setLastErrorString(ss.str());
 				return false;
 			}
 
-			OTBM_Destination_coords area_coord;
-			if (!propStream.read(area_coord)) {
-				setLastErrorString("Invalid map node.");
+			house = map.houses.addHouse(houseId);
+			if (!house) {
+				std::ostringstream ss;
+				ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Could not create house id: " << houseId;
+				setLastErrorString(ss.str());
 				return false;
 			}
 
-			uint16_t base_x = area_coord.x;
-			uint16_t base_y = area_coord.y;
-			uint16_t z = area_coord.z;
+			tile = new HouseTile(x, y, z, house);
+			house->addTile(static_cast<HouseTile*>(tile));
+			isHouseTile = true;
+		}
 
-			NODE nodeTile = f.getChildNode(nodeMapData, type);
-			while (nodeTile != NO_NODE) {
-				if (f.getError() != ERROR_NONE) {
-					setLastErrorString("Could not read node data.");
-					return false;
-				}
-
-				if (type != OTBM_TILE && type != OTBM_HOUSETILE) {
-					setLastErrorString("Unknown tile node.");
-					return false;
-				}
-
-				if (!f.getProps(nodeTile, propStream)) {
-					setLastErrorString("Could not read node data.");
-					return false;
-				}
-
-				OTBM_Tile_coords tile_coord;
-				if (!propStream.read(tile_coord)) {
-					setLastErrorString("Could not read tile position.");
-					return false;
-				}
-
-				uint16_t x = base_x + tile_coord.x;
-				uint16_t y = base_y + tile_coord.y;
-
-				bool isHouseTile = false;
-				House* house = nullptr;
-				Tile* tile = nullptr;
-				Item* ground_item = nullptr;
-				uint32_t tileflags = TILESTATE_NONE;
-
-				if (type == OTBM_HOUSETILE) {
-					uint32_t houseId;
-					if (!propStream.read<uint32_t>(houseId)) {
+		uint8_t attribute;
+		//read tile attributes
+		while (propStream.read<uint8_t>(attribute)) {
+			switch (attribute) {
+				case OTBM_ATTR_TILE_FLAGS: {
+					uint32_t flags;
+					if (!propStream.read<uint32_t>(flags)) {
 						std::ostringstream ss;
-						ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Could not read house id.";
+						ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to read tile flags.";
 						setLastErrorString(ss.str());
 						return false;
 					}
 
-					house = map->houses.addHouse(houseId);
-					if (!house) {
-						std::ostringstream ss;
-						ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Could not create house id: " << houseId;
-						setLastErrorString(ss.str());
-						return false;
+					if ((flags & OTBM_TILEFLAG_PROTECTIONZONE) != 0) {
+						tileflags |= TILESTATE_PROTECTIONZONE;
+					} else if ((flags & OTBM_TILEFLAG_NOPVPZONE) != 0) {
+						tileflags |= TILESTATE_NOPVPZONE;
+					} else if ((flags & OTBM_TILEFLAG_PVPZONE) != 0) {
+						tileflags |= TILESTATE_PVPZONE;
 					}
 
-					tile = new HouseTile(x, y, z, house);
-					house->addTile(static_cast<HouseTile*>(tile));
-					isHouseTile = true;
+					if ((flags & OTBM_TILEFLAG_NOLOGOUT) != 0) {
+						tileflags |= TILESTATE_NOLOGOUT;
+					}
+					break;
 				}
 
-				//read tile attributes
-				while (propStream.read<uint8_t>(attribute)) {
-					switch (attribute) {
-						case OTBM_ATTR_TILE_FLAGS: {
-							uint32_t flags;
-							if (!propStream.read<uint32_t>(flags)) {
-								std::ostringstream ss;
-								ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to read tile flags.";
-								setLastErrorString(ss.str());
-								return false;
-							}
-
-							if ((flags & OTBM_TILEFLAG_PROTECTIONZONE) != 0) {
-								tileflags |= TILESTATE_PROTECTIONZONE;
-							} else if ((flags & OTBM_TILEFLAG_NOPVPZONE) != 0) {
-								tileflags |= TILESTATE_NOPVPZONE;
-							} else if ((flags & OTBM_TILEFLAG_PVPZONE) != 0) {
-								tileflags |= TILESTATE_PVPZONE;
-							}
-
-							if ((flags & OTBM_TILEFLAG_NOLOGOUT) != 0) {
-								tileflags |= TILESTATE_NOLOGOUT;
-							}
-							break;
-						}
-
-						case OTBM_ATTR_ITEM: {
-							Item* item = Item::CreateItem(propStream);
-							if (!item) {
-								std::ostringstream ss;
-								ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to create item.";
-								setLastErrorString(ss.str());
-								return false;
-							}
-
-							if (isHouseTile && item->isMoveable()) {
-								std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID() << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y << ", z: " << z << "]." << std::endl;
-								delete item;
-							} else {
-								if (item->getItemCount() <= 0) {
-									item->setItemCount(1);
-								}
-
-								if (tile) {
-									tile->internalAddThing(item);
-									item->startDecaying();
-									item->setLoadedFromMap(true);
-								} else if (item->isGroundTile()) {
-									delete ground_item;
-									ground_item = item;
-								} else {
-									tile = createTile(ground_item, item, x, y, z);
-									tile->internalAddThing(item);
-									item->startDecaying();
-									item->setLoadedFromMap(true);
-								}
-							}
-							break;
-						}
-
-						default:
-							std::ostringstream ss;
-							ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Unknown tile attribute.";
-							setLastErrorString(ss.str());
-							return false;
-					}
-				}
-
-				NODE nodeItem = f.getChildNode(nodeTile, type);
-				while (nodeItem) {
-					if (type != OTBM_ITEM) {
-						std::ostringstream ss;
-						ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Unknown node type.";
-						setLastErrorString(ss.str());
-						return false;
-					}
-
-					PropStream stream;
-					if (!f.getProps(nodeItem, stream)) {
-						setLastErrorString("Invalid item node.");
-						return false;
-					}
-
-					Item* item = Item::CreateItem(stream);
+				case OTBM_ATTR_ITEM: {
+					Item* item = Item::CreateItem(propStream);
 					if (!item) {
 						std::ostringstream ss;
 						ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to create item.";
 						setLastErrorString(ss.str());
-						return false;
-					}
-
-					if (!item->unserializeItemNode(f, nodeItem, stream)) {
-						std::ostringstream ss;
-						ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to load item " << item->getID() << '.';
-						setLastErrorString(ss.str());
-						delete item;
 						return false;
 					}
 
@@ -378,100 +327,156 @@ bool IOMap::loadMap(Map* map, const std::string& identifier)
 							item->setLoadedFromMap(true);
 						}
 					}
-
-					nodeItem = f.getNextNode(nodeItem, type);
+					break;
 				}
 
-				if (!tile) {
-					tile = createTile(ground_item, nullptr, x, y, z);
-				}
-
-				tile->setFlag(static_cast<tileflags_t>(tileflags));
-
-				map->setTile(x, y, z, tile);
-
-				nodeTile = f.getNextNode(nodeTile, type);
+				default:
+					std::ostringstream ss;
+					ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Unknown tile attribute.";
+					setLastErrorString(ss.str());
+					return false;
 			}
-		} else if (type == OTBM_TOWNS) {
-			NODE nodeTown = f.getChildNode(nodeMapData, type);
-			while (nodeTown != NO_NODE) {
-				if (type != OTBM_TOWN) {
-					setLastErrorString("Unknown town node.");
-					return false;
-				}
+		}
 
-				if (!f.getProps(nodeTown, propStream)) {
-					setLastErrorString("Could not read town data.");
-					return false;
-				}
-
-				uint32_t townId;
-				if (!propStream.read<uint32_t>(townId)) {
-					setLastErrorString("Could not read town id.");
-					return false;
-				}
-
-				Town* town = map->towns.getTown(townId);
-				if (!town) {
-					town = new Town(townId);
-					map->towns.addTown(townId, town);
-				}
-
-				std::string townName;
-				if (!propStream.readString(townName)) {
-					setLastErrorString("Could not read town name.");
-					return false;
-				}
-
-				town->setName(townName);
-
-				OTBM_Destination_coords town_coords;
-				if (!propStream.read(town_coords)) {
-					setLastErrorString("Could not read town coordinates.");
-					return false;
-				}
-
-				town->setTemplePos(Position(town_coords.x, town_coords.y, town_coords.z));
-
-				nodeTown = f.getNextNode(nodeTown, type);
+		for (auto& itemNode : tileNode.children) {
+			if (itemNode.type != OTBM_ITEM) {
+				std::ostringstream ss;
+				ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Unknown node type.";
+				setLastErrorString(ss.str());
+				return false;
 			}
-		} else if (type == OTBM_WAYPOINTS && headerVersion > 1) {
-			NODE nodeWaypoint = f.getChildNode(nodeMapData, type);
-			while (nodeWaypoint != NO_NODE) {
-				if (type != OTBM_WAYPOINT) {
-					setLastErrorString("Unknown waypoint node.");
-					return false;
-				}
 
-				if (!f.getProps(nodeWaypoint, propStream)) {
-					setLastErrorString("Could not read waypoint data.");
-					return false;
-				}
-
-				std::string name;
-				if (!propStream.readString(name)) {
-					setLastErrorString("Could not read waypoint name.");
-					return false;
-				}
-
-				OTBM_Destination_coords waypoint_coords;
-				if (!propStream.read(waypoint_coords)) {
-					setLastErrorString("Could not read waypoint coordinates.");
-					return false;
-				}
-
-				map->waypoints[name] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
-
-				nodeWaypoint = f.getNextNode(nodeWaypoint, type);
+			PropStream stream;
+			if (!loader.getProps(itemNode, stream)) {
+				setLastErrorString("Invalid item node.");
+				return false;
 			}
-		} else {
-			setLastErrorString("Unknown map node.");
+
+			Item* item = Item::CreateItem(stream);
+			if (!item) {
+				std::ostringstream ss;
+				ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to create item.";
+				setLastErrorString(ss.str());
+				return false;
+			}
+
+			if (!item->unserializeItemNode(loader, itemNode, stream)) {
+				std::ostringstream ss;
+				ss << "[x:" << x << ", y:" << y << ", z:" << z << "] Failed to load item " << item->getID() << '.';
+				setLastErrorString(ss.str());
+				delete item;
+				return false;
+			}
+
+			if (isHouseTile && item->isMoveable()) {
+				std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID() << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y << ", z: " << z << "]." << std::endl;
+				delete item;
+			} else {
+				if (item->getItemCount() <= 0) {
+					item->setItemCount(1);
+				}
+
+				if (tile) {
+					tile->internalAddThing(item);
+					item->startDecaying();
+					item->setLoadedFromMap(true);
+				} else if (item->isGroundTile()) {
+					delete ground_item;
+					ground_item = item;
+				} else {
+					tile = createTile(ground_item, item, x, y, z);
+					tile->internalAddThing(item);
+					item->startDecaying();
+					item->setLoadedFromMap(true);
+				}
+			}
+		}
+
+		if (!tile) {
+			tile = createTile(ground_item, nullptr, x, y, z);
+		}
+
+		tile->setFlag(static_cast<tileflags_t>(tileflags));
+
+		map.setTile(x, y, z, tile);
+	}
+	return true;
+}
+
+bool IOMap::parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map)
+{
+	for (auto& townNode : townsNode.children) {
+		PropStream propStream;
+		if (townNode.type != OTBM_TOWN) {
+			setLastErrorString("Unknown town node.");
 			return false;
 		}
 
-		nodeMapData = f.getNextNode(nodeMapData, type);
-	}
+		if (!loader.getProps(townNode, propStream)) {
+			setLastErrorString("Could not read town data.");
+			return false;
+		}
 
-	std::cout << "> Map loading time: " << (OTSYS_TIME() - start) / (1000.) << " seconds." << std::endl;
+		uint32_t townId;
+		if (!propStream.read<uint32_t>(townId)) {
+			setLastErrorString("Could not read town id.");
+			return false;
+		}
+
+		Town* town = map.towns.getTown(townId);
+		if (!town) {
+			town = new Town(townId);
+			map.towns.addTown(townId, town);
+		}
+
+		std::string townName;
+		if (!propStream.readString(townName)) {
+			setLastErrorString("Could not read town name.");
+			return false;
+		}
+
+		town->setName(townName);
+
+		OTBM_Destination_coords town_coords;
+		if (!propStream.read(town_coords)) {
+			setLastErrorString("Could not read town coordinates.");
+			return false;
+		}
+
+		town->setTemplePos(Position(town_coords.x, town_coords.y, town_coords.z));
+	}
 	return true;
 }
+
+
+bool IOMap::parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map)
+{
+	PropStream propStream;
+	for (auto& node : waypointsNode.children) {
+		if (node.type != OTBM_WAYPOINT) {
+			setLastErrorString("Unknown waypoint node.");
+			return false;
+		}
+
+		if (!loader.getProps(node, propStream)) {
+			setLastErrorString("Could not read waypoint data.");
+			return false;
+		}
+
+		std::string name;
+		if (!propStream.readString(name)) {
+			setLastErrorString("Could not read waypoint name.");
+			return false;
+		}
+
+		OTBM_Destination_coords waypoint_coords;
+		if (!propStream.read(waypoint_coords)) {
+			setLastErrorString("Could not read waypoint coordinates.");
+			return false;
+		}
+
+		map.waypoints[name] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
+	}
+	return true;
+}
+

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -148,6 +148,10 @@ class IOMap
 		}
 
 	protected:
+		bool parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map, const std::string& fileName);
+		bool parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map);
+		bool parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map);
+		bool parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Map& map);
 		std::string errorString;
 };
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -638,7 +638,7 @@ bool Item::unserializeAttr(PropStream& propStream)
 	return true;
 }
 
-bool Item::unserializeItemNode(FileLoader&, NODE, PropStream& propStream)
+bool Item::unserializeItemNode(OTB::Loader&, const OTB::Node&, PropStream& propStream)
 {
 	return unserializeAttr(propStream);
 }

--- a/src/item.h
+++ b/src/item.h
@@ -528,7 +528,7 @@ class Item : virtual public Thing
 		//serialization
 		virtual Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream);
 		bool unserializeAttr(PropStream& propStream);
-		virtual bool unserializeItemNode(FileLoader& f, NODE node, PropStream& propStream);
+		virtual bool unserializeItemNode(OTB::Loader&, const OTB::Node&, PropStream& propStream);
 
 		virtual void serializeAttr(PropWriteStream& propWriteStream) const;
 

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -57,18 +57,16 @@ bool Items::reload()
 	return true;
 }
 
+constexpr auto OTBI = OTB::Identifier{{'O','T', 'B', 'I'}};
+
 FILELOADER_ERRORS Items::loadFromOtb(const std::string& file)
 {
-	FileLoader f;
-	if (!f.openFile(file.c_str(), "OTBI")) {
-		return f.getError();
-	}
+	OTB::Loader loader{file, OTBI};
 
-	uint32_t type;
-	NODE node = f.getChildNode(NO_NODE, type);
+	auto& root = loader.parseTree();
 
 	PropStream props;
-	if (f.getProps(node, props)) {
+	if (loader.getProps(root, props)) {
 		//4 byte flags
 		//attributes
 		//0x01 = version data
@@ -113,11 +111,10 @@ FILELOADER_ERRORS Items::loadFromOtb(const std::string& file)
 		return ERROR_INVALID_FORMAT;
 	}
 
-	node = f.getChildNode(node, type);
-	while (node != NO_NODE) {
+	for(auto & itemNode : root.children) {
 		PropStream stream;
-		if (!f.getProps(node, stream)) {
-			return f.getError();
+		if (!loader.getProps(itemNode, stream)) {
+			return ERROR_INVALID_FORMAT;
 		}
 
 		uint32_t flags;
@@ -233,8 +230,8 @@ FILELOADER_ERRORS Items::loadFromOtb(const std::string& file)
 		}
 		ItemType& iType = items[serverId];
 
-		iType.group = static_cast<itemgroup_t>(type);
-		switch (type) {
+		iType.group = static_cast<itemgroup_t>(itemNode.type);
+		switch (itemNode.type) {
 			case ITEM_GROUP_CONTAINER:
 				iType.type = ITEM_TYPE_CONTAINER;
 				break;
@@ -289,8 +286,6 @@ FILELOADER_ERRORS Items::loadFromOtb(const std::string& file)
 		iType.lightColor = lightColor;
 		iType.wareId = wareId;
 		iType.alwaysOnTopOrder = alwaysOnTopOrder;
-
-		node = f.getNextNode(node, type);
 	}
 
 	items.shrink_to_fit();


### PR DESCRIPTION
The map loading function will now use the new simplified loader. It has also been split into multiple functions to make it easier to read. Use mmap to load the OTB file. This improves load time slightly by mmaping the loaded map file into memory to reduce unnecessary copying. Moved OTB loader related code to the OTB namespace which makes it clearer that the OTB submodule is mostly indepenent from the rest of the application.

I've tested the map loading code both with the default and the ORTS maps. The load times were about the same.

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>