### PR TITLE
Added attack speed to Weapons

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -59,6 +59,7 @@ enum itemAttrTypes : uint32_t {
 	ITEM_ATTRIBUTE_CHARGES = 1 << 20,
 	ITEM_ATTRIBUTE_FLUIDTYPE = 1 << 21,
 	ITEM_ATTRIBUTE_DOORID = 1 << 22,
+	ITEM_ATTRIBUTE_ATTACKSPEED = 1 << 23,
 };
 
 enum VipStatus_t : uint8_t {

--- a/src/item.h
+++ b/src/item.h
@@ -603,6 +603,13 @@ class Item : virtual public Thing
 			}
 			return items[id].hitChance;
 		}
+		
+		uint32_t getAttackSpeed() const {
+			if (hasAttribute(ITEM_ATTRIBUTE_ATTACKSPEED)) {
+				return getIntAttr(ITEM_ATTRIBUTE_ATTACKSPEED);
+			}
+			return items[id].attackspeed;
+		}
 
 		uint32_t getWorth() const;
 		void getLight(LightInfo& lightInfo) const;

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -583,7 +583,9 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 			it.stopTime = valueAttribute.as_bool();
 		} else if (tmpStrValue == "decayto") {
 			it.decayTo = pugi::cast<int32_t>(valueAttribute.value());
-		} else if (tmpStrValue == "transformequipto") {
+		} else if (tmpStrValue == "attackspeed") {
+			it.attackspeed = pugi::cast<uint32_t>(valueAttribute.value());
+		}else if (tmpStrValue == "transformequipto") {
 			it.transformEquipTo = pugi::cast<uint16_t>(valueAttribute.value());
 		} else if (tmpStrValue == "transformdeequipto") {
 			it.transformDeEquipTo = pugi::cast<uint16_t>(valueAttribute.value());

--- a/src/items.h
+++ b/src/items.h
@@ -195,6 +195,7 @@ class ItemType
 		uint32_t minReqLevel = 0;
 		uint32_t minReqMagicLevel = 0;
 		uint32_t charges = 0;
+		uint32_t attackspeed = 0;
 		int32_t maxHitChance = -1;
 		int32_t decayTo = -1;
 		int32_t attack = 0;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2412,6 +2412,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("ItemType", "getShootRange", LuaScriptInterface::luaItemTypeGetShootRange);
 
 	registerMethod("ItemType", "getAttack", LuaScriptInterface::luaItemTypeGetAttack);
+	registerMethod("ItemType", "getAttackSpeed", LuaScriptInterface::luaItemTypeGetAttackSpeed);
 	registerMethod("ItemType", "getDefense", LuaScriptInterface::luaItemTypeGetDefense);
 	registerMethod("ItemType", "getExtraDefense", LuaScriptInterface::luaItemTypeGetExtraDefense);
 	registerMethod("ItemType", "getArmor", LuaScriptInterface::luaItemTypeGetArmor);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -10773,6 +10773,19 @@ int LuaScriptInterface::luaItemTypeGetAttack(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaItemTypeGetAttackSpeed(lua_State* L)
+{
+	// itemType:getAttackSpeed()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		lua_pushnumber(L, itemType->attackspeed);
+	}
+	else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int LuaScriptInterface::luaItemTypeGetDefense(lua_State* L)
 {
 	// itemType:getDefense()

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1113,6 +1113,7 @@ class LuaScriptInterface
 		static int luaItemTypeGetHitChance(lua_State* L);
 		static int luaItemTypeGetShootRange(lua_State* L);
 		static int luaItemTypeGetAttack(lua_State* L);
+		static int luaItemTypeGetAttackSpeed(lua_State* L);
 		static int luaItemTypeGetDefense(lua_State* L);
 		static int luaItemTypeGetExtraDefense(lua_State* L);
 		static int luaItemTypeGetArmor(lua_State* L);

--- a/src/player.h
+++ b/src/player.h
@@ -1305,6 +1305,20 @@ class Player final : public Creature, public Cylinder
 		bool isPromoted() const;
 
 		uint32_t getAttackSpeed() const {
+			if (auto left = getInventoryItem(CONST_SLOT_LEFT)) {
+				if (left->getWeaponType()) {
+					if (auto wleft = left->getAttackSpeed()) {
+						return wleft;
+					}
+				}
+			}
+			else if (auto right = getInventoryItem(CONST_SLOT_RIGHT)) {
+				if (right->getWeaponType()) {
+					if (auto wright = right->getAttackSpeed()) {
+						return wright;
+					}
+				}
+			}
 			return vocation->getAttackSpeed();
 		}
 


### PR DESCRIPTION
This will override the vocations attack speed setting and use the item's attack speed instead. If there is no attack speed set on the item then attack speed will default to the vocation attack speed. The settings only apply to weapons and they must be in either the left or right hand.