### PR TITLE
do not create blood splashes on pz tiles

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3687,7 +3687,11 @@ void Game::combatGetTypeInfo(CombatType_t combatType, Creature* target, TextColo
 				case RACE_BLOOD:
 					color = TEXTCOLOR_RED;
 					effect = CONST_ME_DRAWBLOOD;
-					splash = Item::CreateItem(ITEM_SMALLSPLASH, FLUID_BLOOD);
+					if (const Tile* tile = target->getTile()) {
+						if (!tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+							splash = Item::CreateItem(ITEM_SMALLSPLASH, FLUID_BLOOD);
+						}
+					}
 					break;
 				case RACE_UNDEAD:
 					color = TEXTCOLOR_LIGHTGREY;


### PR DESCRIPTION
Example: 
![blood_splash_pz_tiles](https://cloud.githubusercontent.com/assets/6445979/21074518/c14b21f6-bed9-11e6-9703-d1b8ab45b325.gif)

