### PR TITLE
new function added to itemtype.lua

### DIFF
--- a/data/lib/core/itemtype.lua
+++ b/data/lib/core/itemtype.lua
@@ -11,6 +11,24 @@ local slotBits = {
 	[CONST_SLOT_AMMO] = SLOTP_AMMO
 }
 
+local slotPositions = {
+	[16] = SLOTP_RIGHT, -- 16
+	[32] = SLOTP_LEFT, -- 32
+	[49] = SLOTP_HEAD, -- 1
+	[50] = SLOTP_NECKLACE, -- 2
+	[52] = SLOTP_BACKPACK, -- 4
+	[56] = SLOTP_ARMOR, -- 8
+	[112] = SLOTP_LEGS, -- 64
+	[176] = SLOTP_FEET, -- 128
+	[304] = SLOTP_RING, -- 256
+	[560] = SLOTP_AMMO, -- 512
+	[2096] = SLOTP_TWO_HAND, -- 2048
+}
+
 function ItemType.usesSlot(self, slot)
 	return bit.band(self:getSlotPosition(), slotBits[slot] or 0) ~= 0
+end
+
+function ItemType.getRealSlotPosition(self)
+	return slotPositions[self:getSlotPosition()]
 end


### PR DESCRIPTION
This new function is needed in #2020.

I had to create this function so I wouldn't have to use any workarounds to work with slot positions constants (because some constants gives different values due to bitwise operations in items.cpp)