### PR TITLE
Disallow setting mounts for unsupported outfits, fix #2028

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3141,6 +3141,11 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit)
 		return;
 	}
 
+	const Outfit* playerOutfit = Outfits::getInstance()->getOutfitByLookType(player->getSex(), outfit.lookType);
+	if (!playerOutfit) {
+		outfit.lookMount = 0;
+	}
+
 	if (outfit.lookMount != 0) {
 		Mount* mount = mounts.getMountByClientID(outfit.lookMount);
 		if (!mount) {


### PR DESCRIPTION
Fixes #2028 

It performs the same check that fixed mounting with Ctrl+R and marked #1334 as fixed, this time for the outfit window callback and it just unsets the mount instead of blocking the action.