### PR TITLE
Improve ConfigManager class

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -132,11 +132,13 @@ bool ConfigManager::reload()
 	return result;
 }
 
+static std::string dummy;
+
 const std::string& ConfigManager::getString(string_config_t what) const
 {
 	if (what >= LAST_STRING_CONFIG) {
 		std::cout << "[Warning - ConfigManager::getString] Accessing invalid index: " << what << std::endl;
-		return string[DUMMY_STR];
+		return dummy;
 	}
 	return string[what];
 }

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -19,6 +19,8 @@
 
 #include "otpch.h"
 
+#include <lua.hpp>
+
 #include "configmanager.h"
 #include "game.h"
 
@@ -28,6 +30,50 @@
 #endif
 
 extern Game g_game;
+
+std::string getGlobalString(lua_State* L, const char* identifier, const char* defaultValue)
+{
+	lua_getglobal(L, identifier);
+	if (!lua_isstring(L, -1)) {
+		return defaultValue;
+	}
+
+	size_t len = lua_strlen(L, -1);
+	std::string ret(lua_tostring(L, -1), len);
+	lua_pop(L, 1);
+	return ret;
+}
+
+int32_t getGlobalNumber(lua_State* L, const char* identifier, const int32_t defaultValue = 0)
+{
+	lua_getglobal(L, identifier);
+	if (!lua_isnumber(L, -1)) {
+		return defaultValue;
+	}
+
+	int32_t val = lua_tonumber(L, -1);
+	lua_pop(L, 1);
+	return val;
+}
+
+bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultValue)
+{
+	lua_getglobal(L, identifier);
+	if (!lua_isboolean(L, -1)) {
+		if (!lua_isstring(L, -1)) {
+			return defaultValue;
+		}
+
+		size_t len = lua_strlen(L, -1);
+		std::string ret(lua_tostring(L, -1), len);
+		lua_pop(L, 1);
+		return booleanString(ret);
+	}
+
+	int val = lua_toboolean(L, -1);
+	lua_pop(L, 1);
+	return val != 0;
+}
 
 bool ConfigManager::load()
 {
@@ -159,48 +205,4 @@ bool ConfigManager::getBoolean(boolean_config_t what) const
 		return false;
 	}
 	return boolean[what];
-}
-
-std::string ConfigManager::getGlobalString(lua_State* L, const char* identifier, const char* defaultValue)
-{
-	lua_getglobal(L, identifier);
-	if (!lua_isstring(L, -1)) {
-		return defaultValue;
-	}
-
-	size_t len = lua_strlen(L, -1);
-	std::string ret(lua_tostring(L, -1), len);
-	lua_pop(L, 1);
-	return ret;
-}
-
-int32_t ConfigManager::getGlobalNumber(lua_State* L, const char* identifier, const int32_t defaultValue)
-{
-	lua_getglobal(L, identifier);
-	if (!lua_isnumber(L, -1)) {
-		return defaultValue;
-	}
-
-	int32_t val = lua_tonumber(L, -1);
-	lua_pop(L, 1);
-	return val;
-}
-
-bool ConfigManager::getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultValue)
-{
-	lua_getglobal(L, identifier);
-	if (!lua_isboolean(L, -1)) {
-		if (!lua_isstring(L, -1)) {
-			return defaultValue;
-		}
-
-		size_t len = lua_strlen(L, -1);
-		std::string ret(lua_tostring(L, -1), len);
-		lua_pop(L, 1);
-		return booleanString(ret);
-	}
-
-	int val = lua_toboolean(L, -1);
-	lua_pop(L, 1);
-	return val != 0;
 }

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -31,6 +31,8 @@
 
 extern Game g_game;
 
+namespace {
+
 std::string getGlobalString(lua_State* L, const char* identifier, const char* defaultValue)
 {
 	lua_getglobal(L, identifier);
@@ -73,6 +75,8 @@ bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultVa
 	int val = lua_toboolean(L, -1);
 	lua_pop(L, 1);
 	return val != 0;
+}
+
 }
 
 bool ConfigManager::load()

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -20,8 +20,6 @@
 #ifndef FS_CONFIGMANAGER_H_6BDD23BD0B8344F4B7C40E8BE6AF6F39
 #define FS_CONFIGMANAGER_H_6BDD23BD0B8344F4B7C40E8BE6AF6F39
 
-#include <lua.hpp>
-
 class ConfigManager
 {
 	public:
@@ -112,10 +110,6 @@ class ConfigManager
 		bool getBoolean(boolean_config_t what) const;
 
 	private:
-		static std::string getGlobalString(lua_State* L, const char* identifier, const char* defaultValue);
-		static int32_t getGlobalNumber(lua_State* L, const char* identifier, const int32_t defaultValue = 0);
-		static bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultValue);
-
 		std::string string[LAST_STRING_CONFIG] = {};
 		int32_t integer[LAST_INTEGER_CONFIG] = {};
 		bool boolean[LAST_BOOLEAN_CONFIG] = {};

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -47,7 +47,6 @@ class ConfigManager
 		};
 
 		enum string_config_t {
-			DUMMY_STR,
 			MAP_NAME,
 			HOUSE_RENT_PERIOD,
 			SERVER_NAME,


### PR DESCRIPTION
This moves the static functions to the source file (.cpp) and scopes them inside a namespace, as they are only needed for that single translation unit. This moves a `#include` from a header that is included in a lot of files to a cpp file, potentially improving compilation times.

For optimized buils, this also allows for more aggressive optimizations, even inlining entirely all those functions if the compiler decides to.

Also it moves a string from the string list to the translation unit, this is personal.