### PR TITLE
Assorted code improvements

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -440,6 +440,32 @@ bool Action::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
+namespace {
+
+bool increaseItemId(Player*, Item* item, const Position&, Thing*, const Position&, bool)
+{
+	g_game.startDecay(g_game.transformItem(item, item->getID() + 1));
+	return true;
+}
+
+bool decreaseItemId(Player*, Item* item, const Position&, Thing*, const Position&, bool)
+{
+	g_game.startDecay(g_game.transformItem(item, item->getID() - 1));
+	return true;
+}
+
+bool enterMarket(Player* player, Item*, const Position&, Thing*, const Position&, bool)
+{
+	if (player->getLastDepotId() == -1) {
+		return false;
+	}
+
+	player->sendMarketEnter(player->getLastDepotId());
+	return true;
+}
+
+}
+
 bool Action::loadFunction(const pugi::xml_attribute& attr)
 {
 	const char* functionName = attr.as_string();
@@ -455,28 +481,6 @@ bool Action::loadFunction(const pugi::xml_attribute& attr)
 	}
 
 	scripted = false;
-	return true;
-}
-
-bool Action::increaseItemId(Player*, Item* item, const Position&, Thing*, const Position&, bool)
-{
-	g_game.startDecay(g_game.transformItem(item, item->getID() + 1));
-	return true;
-}
-
-bool Action::decreaseItemId(Player*, Item* item, const Position&, Thing*, const Position&, bool)
-{
-	g_game.startDecay(g_game.transformItem(item, item->getID() - 1));
-	return true;
-}
-
-bool Action::enterMarket(Player* player, Item*, const Position&, Thing*, const Position&, bool)
-{
-	if (player->getLastDepotId() == -1) {
-		return false;
-	}
-
-	player->sendMarketEnter(player->getLastDepotId());
 	return true;
 }
 

--- a/src/actions.h
+++ b/src/actions.h
@@ -24,7 +24,7 @@
 #include "enums.h"
 #include "luascript.h"
 
-typedef bool (ActionFunction)(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition, bool isHotkey);
+using ActionFunction = std::function<bool(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition, bool isHotkey)>;
 
 class Action : public Event
 {
@@ -67,14 +67,10 @@ class Action : public Event
 		}
 		virtual Thing* getTarget(Player* player, Creature* targetCreature, const Position& toPosition, uint8_t toStackPos) const;
 
-		ActionFunction* function;
+		ActionFunction function;
 
 	protected:
 		std::string getScriptEventName() const override;
-
-		static ActionFunction increaseItemId;
-		static ActionFunction decreaseItemId;
-		static ActionFunction enterMarket;
 
 		bool allowFarUse;
 		bool checkFloor;
@@ -108,7 +104,7 @@ class Actions final : public BaseEvents
 		Event* getEvent(const std::string& nodeName) final;
 		bool registerEvent(Event* event, const pugi::xml_node& node) final;
 
-		typedef std::map<uint16_t, Action*> ActionUseMap;
+		using ActionUseMap = std::map<uint16_t, Action*>;
 		ActionUseMap useItemMap;
 		ActionUseMap uniqueItemMap;
 		ActionUseMap actionItemMap;

--- a/src/ban.h
+++ b/src/ban.h
@@ -35,7 +35,7 @@ struct ConnectBlock {
 	uint32_t count;
 };
 
-typedef std::map<uint32_t, ConnectBlock> IpConnectMap;
+using IpConnectMap = std::map<uint32_t, ConnectBlock>;
 
 class Ban
 {

--- a/src/chat.h
+++ b/src/chat.h
@@ -26,8 +26,8 @@
 class Party;
 class Player;
 
-typedef std::map<uint32_t, Player*> UsersMap;
-typedef std::map<uint32_t, const Player*> InvitedMap;
+using UsersMap = std::map<uint32_t, Player*>;
+using InvitedMap = std::map<uint32_t, const Player*>;
 
 class ChatChannel
 {
@@ -115,7 +115,7 @@ class PrivateChatChannel final : public ChatChannel
 		uint32_t owner = 0;
 };
 
-typedef std::list<ChatChannel*> ChannelList;
+using ChannelList = std::list<ChatChannel*>;
 
 class Chat
 {

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -668,7 +668,7 @@ void Combat::addDistanceEffect(Creature* caster, const Position& fromPos, const 
 	}
 }
 
-void Combat::CombatFunc(Creature* caster, const Position& pos, const AreaCombat* area, const CombatParams& params, COMBATFUNC func, CombatDamage* data)
+void Combat::CombatFunc(Creature* caster, const Position& pos, const AreaCombat* area, const CombatParams& params, CombatFunction func, CombatDamage* data)
 {
 	std::forward_list<Tile*> tileList;
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -546,7 +546,7 @@ void Combat::CombatNullFunc(Creature* caster, Creature* target, const CombatPara
 	CombatDispelFunc(caster, target, params, nullptr);
 }
 
-void Combat::combatTileEffects(const SpectatorVec& list, Creature* caster, Tile* tile, const CombatParams& params)
+void Combat::combatTileEffects(const SpectatorHashSet& spectators, Creature* caster, Tile* tile, const CombatParams& params)
 {
 	if (params.itemId != 0) {
 		uint16_t itemId = params.itemId;
@@ -624,7 +624,7 @@ void Combat::combatTileEffects(const SpectatorVec& list, Creature* caster, Tile*
 	}
 
 	if (params.impactEffect != CONST_ME_NONE) {
-		Game::addMagicEffect(list, tile->getPosition(), params.impactEffect);
+		Game::addMagicEffect(spectators, tile->getPosition(), params.impactEffect);
 	}
 }
 
@@ -678,7 +678,7 @@ void Combat::CombatFunc(Creature* caster, const Position& pos, const AreaCombat*
 		getCombatArea(pos, pos, area, tileList);
 	}
 
-	SpectatorVec list;
+	SpectatorHashSet spectators;
 	uint32_t maxX = 0;
 	uint32_t maxY = 0;
 
@@ -699,7 +699,7 @@ void Combat::CombatFunc(Creature* caster, const Position& pos, const AreaCombat*
 
 	const int32_t rangeX = maxX + Map::maxViewportX;
 	const int32_t rangeY = maxY + Map::maxViewportY;
-	g_game.map.getSpectators(list, pos, true, true, rangeX, rangeX, rangeY, rangeY);
+	g_game.map.getSpectators(spectators, pos, true, true, rangeX, rangeX, rangeY, rangeY);
 
 	for (Tile* tile : tileList) {
 		if (canDoCombat(caster, tile, params.aggressive) != RETURNVALUE_NOERROR) {
@@ -731,7 +731,7 @@ void Combat::CombatFunc(Creature* caster, const Position& pos, const AreaCombat*
 				}
 			}
 		}
-		combatTileEffects(list, caster, tile, params);
+		combatTileEffects(spectators, caster, tile, params);
 	}
 	postCombatEffects(caster, pos, params);
 }
@@ -865,11 +865,11 @@ void Combat::doCombatDispel(Creature* caster, Creature* target, const CombatPara
 void Combat::doCombatDefault(Creature* caster, Creature* target, const CombatParams& params)
 {
 	if (!params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR)) {
-		SpectatorVec list;
-		g_game.map.getSpectators(list, target->getPosition(), true, true);
+		SpectatorHashSet spectators;
+		g_game.map.getSpectators(spectators, target->getPosition(), true, true);
 
 		CombatNullFunc(caster, target, params, nullptr);
-		combatTileEffects(list, caster, target->getTile(), params);
+		combatTileEffects(spectators, caster, target->getTile(), params);
 
 		if (params.targetCallback) {
 			params.targetCallback->onTargetCombat(caster, target);

--- a/src/combat.h
+++ b/src/combat.h
@@ -310,7 +310,7 @@ class Combat
 		static void CombatDispelFunc(Creature* caster, Creature* target, const CombatParams& params, CombatDamage* data);
 		static void CombatNullFunc(Creature* caster, Creature* target, const CombatParams& params, CombatDamage* data);
 
-		static void combatTileEffects(const SpectatorVec& list, Creature* caster, Tile* tile, const CombatParams& params);
+		static void combatTileEffects(const SpectatorHashSet& spectators, Creature* caster, Tile* tile, const CombatParams& params);
 		CombatDamage getCombatDamage(Creature* creature, Creature* target) const;
 
 		//configureable

--- a/src/combat.h
+++ b/src/combat.h
@@ -83,7 +83,7 @@ struct CombatParams {
 	bool useCharges = false;
 };
 
-typedef void (*COMBATFUNC)(Creature*, Creature*, const CombatParams&, CombatDamage*);
+using CombatFunction = std::function<void(Creature*, Creature*, const CombatParams&, CombatDamage*)>;
 
 class MatrixArea
 {
@@ -302,7 +302,7 @@ class Combat
 	protected:
 		static void doCombatDefault(Creature* caster, Creature* target, const CombatParams& params);
 
-		static void CombatFunc(Creature* caster, const Position& pos, const AreaCombat* area, const CombatParams& params, COMBATFUNC func, CombatDamage* data);
+		static void CombatFunc(Creature* caster, const Position& pos, const AreaCombat* area, const CombatParams& params, CombatFunction func, CombatDamage* data);
 
 		static void CombatHealthFunc(Creature* caster, Creature* target, const CombatParams& params, CombatDamage* data);
 		static void CombatManaFunc(Creature* caster, Creature* target, const CombatParams& params, CombatDamage* damage);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -52,22 +52,179 @@ extern Events* g_events;
 extern Chat* g_chat;
 extern LuaEnvironment g_luaEnvironment;
 
-s_defcommands Commands::defined_commands[] = {
+namespace {
+
+void reloadInfo(Player& player, const std::string& param)
+{
+	std::string tmpParam = asLowerCaseString(param);
+	if (tmpParam == "action" || tmpParam == "actions") {
+		g_actions->reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded actions.");
+	} else if (tmpParam == "config" || tmpParam == "configuration") {
+		g_config.reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded config.");
+	} else if (tmpParam == "command" || tmpParam == "commands") {
+		g_game.reloadCommands();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded commands.");
+	} else if (tmpParam == "creaturescript" || tmpParam == "creaturescripts") {
+		g_creatureEvents->reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded creature scripts.");
+	} else if (tmpParam == "monster" || tmpParam == "monsters") {
+		g_monsters.reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded monsters.");
+	} else if (tmpParam == "move" || tmpParam == "movement" || tmpParam == "movements"
+			   || tmpParam == "moveevents" || tmpParam == "moveevent") {
+		g_moveEvents->reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded movements.");
+	} else if (tmpParam == "npc" || tmpParam == "npcs") {
+		Npcs::reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded npcs.");
+	} else if (tmpParam == "raid" || tmpParam == "raids") {
+		g_game.raids.reload();
+		g_game.raids.startup();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded raids.");
+	} else if (tmpParam == "spell" || tmpParam == "spells") {
+		g_spells->reload();
+		g_monsters.reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded spells.");
+	} else if (tmpParam == "talk" || tmpParam == "talkaction" || tmpParam == "talkactions") {
+		g_talkActions->reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded talk actions.");
+	} else if (tmpParam == "items") {
+		Item::items.reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded items.");
+	} else if (tmpParam == "weapon" || tmpParam == "weapons") {
+		g_weapons->reload();
+		g_weapons->loadDefaults();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded weapons.");
+	} else if (tmpParam == "quest" || tmpParam == "quests") {
+		g_game.quests.reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded quests.");
+	} else if (tmpParam == "mount" || tmpParam == "mounts") {
+		g_game.mounts.reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded mounts.");
+	} else if (tmpParam == "globalevents" || tmpParam == "globalevent") {
+		g_globalEvents->reload();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded globalevents.");
+	} else if (tmpParam == "events") {
+		g_events->load();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded events.");
+	} else if (tmpParam == "chat" || tmpParam == "channel" || tmpParam == "chatchannels") {
+		g_chat->load();
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded chatchannels.");
+	} else if (tmpParam == "global") {
+		g_luaEnvironment.loadFile("data/global.lua");
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded global.lua.");
+	} else {
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reload type not found.");
+	}
+	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+}
+
+void forceRaid(Player& player, const std::string& param)
+{
+	Raid* raid = g_game.raids.getRaidByName(param);
+	if (!raid || !raid->isLoaded()) {
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "No such raid exists.");
+		return;
+	}
+
+	if (g_game.raids.getRunning()) {
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Another raid is already being executed.");
+		return;
+	}
+
+	g_game.raids.setRunning(raid);
+
+	RaidEvent* event = raid->getNextRaidEvent();
+	if (!event) {
+		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "The raid does not contain any data.");
+		return;
+	}
+
+	raid->setState(RAIDSTATE_EXECUTING);
+
+	uint32_t ticks = event->getDelay();
+	if (ticks > 0) {
+		g_scheduler.addEvent(createSchedulerTask(ticks, std::bind(&Raid::executeRaidEvent, raid, event)));
+	} else {
+		g_dispatcher.addTask(createTask(std::bind(&Raid::executeRaidEvent, raid, event)));
+	}
+
+	player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Raid started.");
+}
+
+void sellHouse(Player& player, const std::string& param)
+{
+	Player* tradePartner = g_game.getPlayerByName(param);
+	if (!tradePartner || tradePartner == &player) {
+		player.sendCancelMessage("Trade player not found.");
+		return;
+	}
+
+	if (!Position::areInRange<2, 2, 0>(tradePartner->getPosition(), player.getPosition())) {
+		player.sendCancelMessage("Trade player is too far away.");
+		return;
+	}
+
+	if (!tradePartner->isPremium()) {
+		player.sendCancelMessage("Trade player does not have a premium account.");
+		return;
+	}
+
+	HouseTile* houseTile = dynamic_cast<HouseTile*>(player.getTile());
+	if (!houseTile) {
+		player.sendCancelMessage("You must stand in your house to initiate the trade.");
+		return;
+	}
+
+	House* house = houseTile->getHouse();
+	if (!house || house->getOwner() != player.getGUID()) {
+		player.sendCancelMessage("You don't own this house.");
+		return;
+	}
+
+	if (g_game.map.houses.getHouseByPlayerId(tradePartner->getGUID())) {
+		player.sendCancelMessage("Trade player already owns a house.");
+		return;
+	}
+
+	if (IOLoginData::hasBiddedOnHouse(tradePartner->getGUID())) {
+		player.sendCancelMessage("Trade player is currently the highest bidder of an auctioned house.");
+		return;
+	}
+
+	Item* transferItem = house->getTransferItem();
+	if (!transferItem) {
+		player.sendCancelMessage("You can not trade this house.");
+		return;
+	}
+
+	transferItem->getParent()->setParent(&player);
+
+	if (!g_game.internalStartTrade(&player, tradePartner, transferItem)) {
+		house->resetTransferItem();
+	}
+}
+
+std::map<std::string, CommandFunction> defined_commands = {
 	// TODO: move all commands to talkactions
 
 	//admin commands
-	{"/reload", &Commands::reloadInfo},
-	{"/raid", &Commands::forceRaid},
+	{"/reload", reloadInfo},
+	{"/raid", forceRaid},
 
 	// player commands
-	{"!sellhouse", &Commands::sellHouse}
+	{"!sellhouse", sellHouse}
 };
+
+}
 
 Commands::Commands()
 {
 	// set up command map
 	for (auto& command : defined_commands) {
-		commandMap[command.name] = new Command(command.f, 1, ACCOUNT_TYPE_GOD, true);
+		commandMap[command.first] = new Command(command.second, 1, ACCOUNT_TYPE_GOD, true);
 	}
 }
 
@@ -169,8 +326,8 @@ bool Commands::exeCommand(Player& player, const std::string& cmd)
 	}
 
 	//execute command
-	CommandFunc cfunc = command->f;
-	(this->*cfunc)(player, str_param);
+	CommandFunction cfunc = command->f;
+	cfunc(player, str_param);
 
 	if (command->log) {
 		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_RED, cmd);
@@ -189,157 +346,4 @@ bool Commands::exeCommand(Player& player, const std::string& cmd)
 		}
 	}
 	return true;
-}
-
-void Commands::reloadInfo(Player& player, const std::string& param)
-{
-	std::string tmpParam = asLowerCaseString(param);
-	if (tmpParam == "action" || tmpParam == "actions") {
-		g_actions->reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded actions.");
-	} else if (tmpParam == "config" || tmpParam == "configuration") {
-		g_config.reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded config.");
-	} else if (tmpParam == "command" || tmpParam == "commands") {
-		reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded commands.");
-	} else if (tmpParam == "creaturescript" || tmpParam == "creaturescripts") {
-		g_creatureEvents->reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded creature scripts.");
-	} else if (tmpParam == "monster" || tmpParam == "monsters") {
-		g_monsters.reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded monsters.");
-	} else if (tmpParam == "move" || tmpParam == "movement" || tmpParam == "movements"
-	           || tmpParam == "moveevents" || tmpParam == "moveevent") {
-		g_moveEvents->reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded movements.");
-	} else if (tmpParam == "npc" || tmpParam == "npcs") {
-		Npcs::reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded npcs.");
-	} else if (tmpParam == "raid" || tmpParam == "raids") {
-		g_game.raids.reload();
-		g_game.raids.startup();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded raids.");
-	} else if (tmpParam == "spell" || tmpParam == "spells") {
-		g_spells->reload();
-		g_monsters.reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded spells.");
-	} else if (tmpParam == "talk" || tmpParam == "talkaction" || tmpParam == "talkactions") {
-		g_talkActions->reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded talk actions.");
-	} else if (tmpParam == "items") {
-		Item::items.reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded items.");
-	} else if (tmpParam == "weapon" || tmpParam == "weapons") {
-		g_weapons->reload();
-		g_weapons->loadDefaults();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded weapons.");
-	} else if (tmpParam == "quest" || tmpParam == "quests") {
-		g_game.quests.reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded quests.");
-	} else if (tmpParam == "mount" || tmpParam == "mounts") {
-		g_game.mounts.reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded mounts.");
-	} else if (tmpParam == "globalevents" || tmpParam == "globalevent") {
-		g_globalEvents->reload();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded globalevents.");
-	} else if (tmpParam == "events") {
-		g_events->load();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded events.");
-	} else if (tmpParam == "chat" || tmpParam == "channel" || tmpParam == "chatchannels") {
-		g_chat->load();
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded chatchannels.");
-	} else if (tmpParam == "global") {
-		g_luaEnvironment.loadFile("data/global.lua");
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reloaded global.lua.");
-	} else {
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Reload type not found.");
-	}
-	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
-}
-
-void Commands::sellHouse(Player& player, const std::string& param)
-{
-	Player* tradePartner = g_game.getPlayerByName(param);
-	if (!tradePartner || tradePartner == &player) {
-		player.sendCancelMessage("Trade player not found.");
-		return;
-	}
-
-	if (!Position::areInRange<2, 2, 0>(tradePartner->getPosition(), player.getPosition())) {
-		player.sendCancelMessage("Trade player is too far away.");
-		return;
-	}
-
-	if (!tradePartner->isPremium()) {
-		player.sendCancelMessage("Trade player does not have a premium account.");
-		return;
-	}
-
-	HouseTile* houseTile = dynamic_cast<HouseTile*>(player.getTile());
-	if (!houseTile) {
-		player.sendCancelMessage("You must stand in your house to initiate the trade.");
-		return;
-	}
-
-	House* house = houseTile->getHouse();
-	if (!house || house->getOwner() != player.getGUID()) {
-		player.sendCancelMessage("You don't own this house.");
-		return;
-	}
-
-	if (g_game.map.houses.getHouseByPlayerId(tradePartner->getGUID())) {
-		player.sendCancelMessage("Trade player already owns a house.");
-		return;
-	}
-
-	if (IOLoginData::hasBiddedOnHouse(tradePartner->getGUID())) {
-		player.sendCancelMessage("Trade player is currently the highest bidder of an auctioned house.");
-		return;
-	}
-
-	Item* transferItem = house->getTransferItem();
-	if (!transferItem) {
-		player.sendCancelMessage("You can not trade this house.");
-		return;
-	}
-
-	transferItem->getParent()->setParent(&player);
-
-	if (!g_game.internalStartTrade(&player, tradePartner, transferItem)) {
-		house->resetTransferItem();
-	}
-}
-
-void Commands::forceRaid(Player& player, const std::string& param)
-{
-	Raid* raid = g_game.raids.getRaidByName(param);
-	if (!raid || !raid->isLoaded()) {
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "No such raid exists.");
-		return;
-	}
-
-	if (g_game.raids.getRunning()) {
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Another raid is already being executed.");
-		return;
-	}
-
-	g_game.raids.setRunning(raid);
-
-	RaidEvent* event = raid->getNextRaidEvent();
-	if (!event) {
-		player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "The raid does not contain any data.");
-		return;
-	}
-
-	raid->setState(RAIDSTATE_EXECUTING);
-
-	uint32_t ticks = event->getDelay();
-	if (ticks > 0) {
-		g_scheduler.addEvent(createSchedulerTask(ticks, std::bind(&Raid::executeRaidEvent, raid, event)));
-	} else {
-		g_dispatcher.addTask(createTask(std::bind(&Raid::executeRaidEvent, raid, event)));
-	}
-
-	player.sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Raid started.");
 }

--- a/src/commands.h
+++ b/src/commands.h
@@ -43,32 +43,19 @@ class Commands
 		bool exeCommand(Player& player, const std::string& cmd);
 
 	protected:
-		//commands
-		void reloadInfo(Player& player, const std::string& param);
-		void sellHouse(Player& player, const std::string& param);
-		void forceRaid(Player& player, const std::string& param);
-
-		//table of commands
-		static s_defcommands defined_commands[];
-
 		std::map<std::string, Command*> commandMap;
 };
 
-typedef void (Commands::*CommandFunc)(Player&, const std::string&);
+using CommandFunction = std::function<void(Player&, const std::string&)>;
 
 struct Command {
-	Command(CommandFunc f, uint32_t groupId, AccountType_t accountType, bool log)
+	Command(CommandFunction f, uint32_t groupId, AccountType_t accountType, bool log)
 		: f(f), groupId(groupId), accountType(accountType), log(log) {}
 
-	CommandFunc f;
+	CommandFunction f;
 	uint32_t groupId;
 	AccountType_t accountType;
 	bool log;
-};
-
-struct s_defcommands {
-	const char* name;
-	CommandFunc f;
 };
 
 #endif

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -704,13 +704,13 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 					message.primary.color = TEXTCOLOR_MAYABLUE;
 					player->sendTextMessage(message);
 
-					SpectatorVec list;
-					g_game.map.getSpectators(list, player->getPosition(), false, true);
-					list.erase(player);
-					if (!list.empty()) {
+					SpectatorHashSet spectators;
+					g_game.map.getSpectators(spectators, player->getPosition(), false, true);
+					spectators.erase(player);
+					if (!spectators.empty()) {
 						message.type = MESSAGE_HEALED_OTHERS;
 						message.text = player->getName() + " was healed for " + healString;
-						for (Creature* spectator : list) {
+						for (Creature* spectator : spectators) {
 							spectator->getPlayer()->sendTextMessage(message);
 						}
 					}

--- a/src/connection.h
+++ b/src/connection.h
@@ -25,17 +25,17 @@
 #include "networkmessage.h"
 
 class Protocol;
-typedef std::shared_ptr<Protocol> Protocol_ptr;
+using Protocol_ptr = std::shared_ptr<Protocol>;
 class OutputMessage;
-typedef std::shared_ptr<OutputMessage> OutputMessage_ptr;
+using OutputMessage_ptr = std::shared_ptr<OutputMessage>;
 class Connection;
-typedef std::shared_ptr<Connection> Connection_ptr;
-typedef std::weak_ptr<Connection> ConnectionWeak_ptr;
+using Connection_ptr = std::shared_ptr<Connection> ;
+using ConnectionWeak_ptr = std::weak_ptr<Connection>;
 class ServiceBase;
-typedef std::shared_ptr<ServiceBase> Service_ptr;
+using Service_ptr = std::shared_ptr<ServiceBase>;
 class ServicePort;
-typedef std::shared_ptr<ServicePort> ServicePort_ptr;
-typedef std::shared_ptr<const ServicePort> ConstServicePort_ptr;
+using ServicePort_ptr = std::shared_ptr<ServicePort>;
+using ConstServicePort_ptr = std::shared_ptr<const ServicePort>;
 
 class ConnectionManager
 {

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -215,48 +215,48 @@ bool Container::isHoldingItem(const Item* item) const
 
 void Container::onAddContainerItem(Item* item)
 {
-	SpectatorVec list;
-	g_game.map.getSpectators(list, getPosition(), false, true, 2, 2, 2, 2);
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);
 
 	//send to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendAddContainerItem(this, item);
 	}
 
 	//event methods
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->onAddContainerItem(item);
 	}
 }
 
 void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem)
 {
-	SpectatorVec list;
-	g_game.map.getSpectators(list, getPosition(), false, true, 2, 2, 2, 2);
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);
 
 	//send to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendUpdateContainerItem(this, index, newItem);
 	}
 
 	//event methods
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->onUpdateContainerItem(this, oldItem, newItem);
 	}
 }
 
 void Container::onRemoveContainerItem(uint32_t index, Item* item)
 {
-	SpectatorVec list;
-	g_game.map.getSpectators(list, getPosition(), false, true, 2, 2, 2, 2);
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);
 
 	//send change to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendRemoveContainerItem(this, index);
 	}
 
 	//event methods
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->onRemoveContainerItem(this, item);
 	}
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1103,9 +1103,9 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 	gainExp /= 2;
 	master->onGainExperience(gainExp, target);
 
-	SpectatorVec list;
-	g_game.map.getSpectators(list, position, false, true);
-	if (list.empty()) {
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, position, false, true);
+	if (spectators.empty()) {
 		return;
 	}
 
@@ -1114,7 +1114,7 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 	message.primary.color = TEXTCOLOR_WHITE_EXP;
 	message.primary.value = gainExp;
 
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendTextMessage(message);
 	}
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -28,8 +28,8 @@
 #include "enums.h"
 #include "creatureevent.h"
 
-typedef std::list<Condition*> ConditionList;
-typedef std::list<CreatureEvent*> CreatureEventList;
+using ConditionList = std::list<Condition*>;
+using CreatureEventList = std::list<CreatureEvent*>;
 
 enum slots_t : uint8_t {
 	CONST_SLOT_WHEREEVER = 0,
@@ -481,7 +481,7 @@ class Creature : virtual public Thing
 
 		Position position;
 
-		typedef std::map<uint32_t, CountBlock_t> CountMap;
+		using CountMap = std::map<uint32_t, CountBlock_t>;
 		CountMap damageMap;
 
 		std::list<Creature*> summons;

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -67,7 +67,7 @@ class CreatureEvents final : public BaseEvents
 		void clear() final;
 
 		//creature events
-		typedef std::map<std::string, CreatureEvent*> CreatureEventList;
+		using CreatureEventList = std::map<std::string, CreatureEvent*>;
 		CreatureEventList creatureEvents;
 
 		LuaScriptInterface scriptInterface;

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -67,8 +67,8 @@ class CreatureEvents final : public BaseEvents
 		void clear() final;
 
 		//creature events
-		using CreatureEventList = std::map<std::string, CreatureEvent*>;
-		CreatureEventList creatureEvents;
+		using CreatureEventMap = std::map<std::string, CreatureEvent*>;
+		CreatureEventMap creatureEvents;
 
 		LuaScriptInterface scriptInterface;
 };

--- a/src/database.h
+++ b/src/database.h
@@ -25,7 +25,7 @@
 #include <mysql.h>
 
 class DBResult;
-typedef std::shared_ptr<DBResult> DBResult_ptr;
+using DBResult_ptr = std::shared_ptr<DBResult>;
 
 class Database
 {

--- a/src/enums.h
+++ b/src/enums.h
@@ -546,8 +546,8 @@ struct CombatDamage
 	}
 };
 
-typedef std::list<MarketOffer> MarketOfferList;
-typedef std::list<HistoryMarketOffer> HistoryMarketOfferList;
-typedef std::list<ShopInfo> ShopInfoList;
+using MarketOfferList = std::list<MarketOffer>;
+using HistoryMarketOfferList = std::list<HistoryMarketOffer>;
+using ShopInfoList = std::list<ShopInfo>;
 
 #endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -533,15 +533,15 @@ bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedP
 		return false;
 	}
 
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true);
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendCreatureAppear(creature, creature->getPosition(), true);
 		}
 	}
 
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onCreatureAppear(creature, true);
 	}
 
@@ -562,9 +562,9 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 
 	std::vector<int32_t> oldStackPosVector;
 
-	SpectatorVec list;
-	map.getSpectators(list, tile->getPosition(), true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, tile->getPosition(), true);
+	for (Creature* spectator : spectators) {
 		if (Player* player = spectator->getPlayer()) {
 			oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getStackposOfCreature(player, creature) : -1);
 		}
@@ -576,14 +576,14 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 
 	//send to client
 	size_t i = 0;
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* player = spectator->getPlayer()) {
 			player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
 		}
 	}
 
 	//event method
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onRemoveCreature(creature, isLogout);
 	}
 
@@ -1842,9 +1842,9 @@ void Game::playerCloseNpcChannel(uint32_t playerId)
 		return;
 	}
 
-	SpectatorVec list;
-	map.getSpectators(list, player->getPosition());
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, player->getPosition());
+	for (Creature* spectator : spectators) {
 		if (Npc* npc = spectator->getNpc()) {
 			npc->onPlayerCloseChannel(player);
 		}
@@ -3316,13 +3316,13 @@ bool Game::playerSaySpell(Player* player, SpeakClasses type, const std::string& 
 
 void Game::playerWhisper(Player* player, const std::string& text)
 {
-	SpectatorVec list;
-	map.getSpectators(list, player->getPosition(), false, false,
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, player->getPosition(), false, false,
 	              Map::maxClientViewportX, Map::maxClientViewportX,
 	              Map::maxClientViewportY, Map::maxClientViewportY);
 
 	//send to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* spectatorPlayer = spectator->getPlayer()) {
 			if (!Position::areInRange<1, 1>(player->getPosition(), spectatorPlayer->getPosition())) {
 				spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, "pspsps");
@@ -3333,7 +3333,7 @@ void Game::playerWhisper(Player* player, const std::string& text)
 	}
 
 	//event method
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onCreatureSay(player, TALKTYPE_WHISPER, text);
 	}
 }
@@ -3389,9 +3389,9 @@ bool Game::playerSpeakTo(Player* player, SpeakClasses type, const std::string& r
 
 void Game::playerSpeakToNpc(Player* player, const std::string& text)
 {
-	SpectatorVec list;
-	map.getSpectators(list, player->getPosition());
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, player->getPosition());
+	for (Creature* spectator : spectators) {
 		if (spectator->getNpc()) {
 			spectator->onCreatureSay(player, TALKTYPE_PRIVATE_PN, text);
 		}
@@ -3419,16 +3419,16 @@ bool Game::internalCreatureTurn(Creature* creature, Direction dir)
 	creature->setDirection(dir);
 
 	//send to client
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureTurn(creature);
 	}
 	return true;
 }
 
 bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std::string& text,
-                               bool ghostMode, SpectatorVec* listPtr/* = nullptr*/, const Position* pos/* = nullptr*/)
+                               bool ghostMode, SpectatorHashSet* spectatorsPtr/* = nullptr*/, const Position* pos/* = nullptr*/)
 {
 	if (text.empty()) {
 		return false;
@@ -3438,26 +3438,26 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 		pos = &creature->getPosition();
 	}
 
-	SpectatorVec list;
+	SpectatorHashSet spectators;
 
-	if (!listPtr || listPtr->empty()) {
-		// This somewhat complex construct ensures that the cached SpectatorVec
+	if (!spectatorsPtr || spectatorsPtr->empty()) {
+		// This somewhat complex construct ensures that the cached SpectatorHashSet
 		// is used if available and if it can be used, else a local vector is
 		// used (hopefully the compiler will optimize away the construction of
 		// the temporary when it's not used).
 		if (type != TALKTYPE_YELL && type != TALKTYPE_MONSTER_YELL) {
-			map.getSpectators(list, *pos, false, false,
+			map.getSpectators(spectators, *pos, false, false,
 			              Map::maxClientViewportX, Map::maxClientViewportX,
 			              Map::maxClientViewportY, Map::maxClientViewportY);
 		} else {
-			map.getSpectators(list, *pos, true, false, 18, 18, 14, 14);
+			map.getSpectators(spectators, *pos, true, false, 18, 18, 14, 14);
 		}
 	} else {
-		list = (*listPtr);
+		spectators = (*spectatorsPtr);
 	}
 
 	//send to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (!ghostMode || tmpPlayer->canSeeCreature(creature)) {
 				tmpPlayer->sendCreatureSay(creature, type, text, pos);
@@ -3466,7 +3466,7 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 	}
 
 	//event method
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onCreatureSay(creature, type, text);
 	}
 	return true;
@@ -3553,9 +3553,9 @@ void Game::changeSpeed(Creature* creature, int32_t varSpeedDelta)
 	creature->setSpeed(varSpeed);
 
 	//send to clients
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), false, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), false, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendChangeSpeed(creature, creature->getStepSpeed());
 	}
 }
@@ -3573,9 +3573,9 @@ void Game::internalCreatureChangeOutfit(Creature* creature, const Outfit_t& outf
 	}
 
 	//send to clients
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureChangeOutfit(creature, outfit);
 	}
 }
@@ -3583,9 +3583,9 @@ void Game::internalCreatureChangeOutfit(Creature* creature, const Outfit_t& outf
 void Game::internalCreatureChangeVisible(Creature* creature, bool visible)
 {
 	//send to clients
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureChangeVisible(creature, visible);
 	}
 }
@@ -3593,9 +3593,9 @@ void Game::internalCreatureChangeVisible(Creature* creature, bool visible)
 void Game::changeLight(const Creature* creature)
 {
 	//send to clients
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureLight(creature);
 	}
 }
@@ -3827,9 +3827,9 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			message.primary.value = realHealthChange;
 			message.primary.color = TEXTCOLOR_MAYABLUE;
 
-			SpectatorVec list;
-			map.getSpectators(list, targetPos, false, true);
-			for (Creature* spectator : list) {
+			SpectatorHashSet spectators;
+			map.getSpectators(spectators, targetPos, false, true);
+			for (Creature* spectator : spectators) {
 				Player* tmpPlayer = spectator->getPlayer();
 				if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 					message.type = MESSAGE_HEALED;
@@ -3881,7 +3881,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		TextMessage message;
 		message.position = targetPos;
 
-		SpectatorVec list;
+		SpectatorHashSet spectators;
 		if (target->hasCondition(CONDITION_MANASHIELD) && damage.primary.type != COMBAT_UNDEFINEDDAMAGE) {
 			int32_t manaDamage = std::min<int32_t>(target->getMana(), healthChange);
 			if (manaDamage != 0) {
@@ -3899,8 +3899,8 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 				}
 
 				target->drainMana(attacker, manaDamage);
-				map.getSpectators(list, targetPos, true, true);
-				addMagicEffect(list, targetPos, CONST_ME_LOSEENERGY);
+				map.getSpectators(spectators, targetPos, true, true);
+				addMagicEffect(spectators, targetPos, CONST_ME_LOSEENERGY);
 
 				std::string damageString = std::to_string(manaDamage);
 				std::string spectatorMessage = ucfirst(target->getNameDescription()) + " loses " + damageString + " mana";
@@ -3917,7 +3917,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 				message.primary.value = manaDamage;
 				message.primary.color = TEXTCOLOR_BLUE;
 
-				for (Creature* spectator : list) {
+				for (Creature* spectator : spectators) {
 					Player* tmpPlayer = spectator->getPlayer();
 					if (tmpPlayer->getPosition().z != targetPos.z) {
 						continue;
@@ -3986,10 +3986,10 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		}
 
 		target->drainHealth(attacker, realDamage);
-		if (list.empty()) {
-			map.getSpectators(list, targetPos, true, true);
+		if (spectators.empty()) {
+			map.getSpectators(spectators, targetPos, true, true);
 		}
-		addCreatureHealth(list, target);
+		addCreatureHealth(spectators, target);
 
 		message.primary.value = damage.primary.value;
 		message.secondary.value = damage.secondary.value;
@@ -3998,14 +3998,14 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		if (message.primary.value) {
 			combatGetTypeInfo(damage.primary.type, target, message.primary.color, hitEffect);
 			if (hitEffect != CONST_ME_NONE) {
-				addMagicEffect(list, targetPos, hitEffect);
+				addMagicEffect(spectators, targetPos, hitEffect);
 			}
 		}
 
 		if (message.secondary.value) {
 			combatGetTypeInfo(damage.secondary.type, target, message.secondary.color, hitEffect);
 			if (hitEffect != CONST_ME_NONE) {
-				addMagicEffect(list, targetPos, hitEffect);
+				addMagicEffect(spectators, targetPos, hitEffect);
 			}
 		}
 
@@ -4022,7 +4022,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			}
 			spectatorMessage += '.';
 
-			for (Creature* spectator : list) {
+			for (Creature* spectator : spectators) {
 				Player* tmpPlayer = spectator->getPlayer();
 				if (tmpPlayer->getPosition().z != targetPos.z) {
 					continue;
@@ -4135,9 +4135,9 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, int32_t manaCh
 		message.primary.value = manaLoss;
 		message.primary.color = TEXTCOLOR_BLUE;
 
-		SpectatorVec list;
-		map.getSpectators(list, targetPos, false, true);
-		for (Creature* spectator : list) {
+		SpectatorHashSet spectators;
+		map.getSpectators(spectators, targetPos, false, true);
+		for (Creature* spectator : spectators) {
 			Player* tmpPlayer = spectator->getPlayer();
 			if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 				message.type = MESSAGE_DAMAGE_DEALT;
@@ -4164,14 +4164,14 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, int32_t manaCh
 
 void Game::addCreatureHealth(const Creature* target)
 {
-	SpectatorVec list;
-	map.getSpectators(list, target->getPosition(), true, true);
-	addCreatureHealth(list, target);
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, target->getPosition(), true, true);
+	addCreatureHealth(spectators, target);
 }
 
-void Game::addCreatureHealth(const SpectatorVec& list, const Creature* target)
+void Game::addCreatureHealth(const SpectatorHashSet& spectators, const Creature* target)
 {
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendCreatureHealth(target);
 		}
@@ -4180,14 +4180,14 @@ void Game::addCreatureHealth(const SpectatorVec& list, const Creature* target)
 
 void Game::addMagicEffect(const Position& pos, uint8_t effect)
 {
-	SpectatorVec list;
-	map.getSpectators(list, pos, true, true);
-	addMagicEffect(list, pos, effect);
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, pos, true, true);
+	addMagicEffect(spectators, pos, effect);
 }
 
-void Game::addMagicEffect(const SpectatorVec& list, const Position& pos, uint8_t effect)
+void Game::addMagicEffect(const SpectatorHashSet& spectators, const Position& pos, uint8_t effect)
 {
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendMagicEffect(pos, effect);
 		}
@@ -4196,15 +4196,15 @@ void Game::addMagicEffect(const SpectatorVec& list, const Position& pos, uint8_t
 
 void Game::addDistanceEffect(const Position& fromPos, const Position& toPos, uint8_t effect)
 {
-	SpectatorVec list;
-	map.getSpectators(list, fromPos, false, true);
-	map.getSpectators(list, toPos, false, true);
-	addDistanceEffect(list, fromPos, toPos, effect);
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, fromPos, false, true);
+	map.getSpectators(spectators, toPos, false, true);
+	addDistanceEffect(spectators, fromPos, toPos, effect);
 }
 
-void Game::addDistanceEffect(const SpectatorVec& list, const Position& fromPos, const Position& toPos, uint8_t effect)
+void Game::addDistanceEffect(const SpectatorHashSet& spectators, const Position& fromPos, const Position& toPos, uint8_t effect)
 {
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendDistanceShoot(fromPos, toPos, effect);
 		}
@@ -4430,9 +4430,9 @@ void Game::broadcastMessage(const std::string& text, MessageClasses type) const
 void Game::updateCreatureWalkthrough(const Creature* creature)
 {
 	//send to clients
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		Player* tmpPlayer = spectator->getPlayer();
 		tmpPlayer->sendCreatureWalkthrough(creature, tmpPlayer->canWalkthroughEx(creature));
 	}
@@ -4444,18 +4444,18 @@ void Game::updateCreatureSkull(const Creature* creature)
 		return;
 	}
 
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureSkull(creature);
 	}
 }
 
 void Game::updatePlayerShield(Player* player)
 {
-	SpectatorVec list;
-	map.getSpectators(list, player->getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, player->getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureShield(player);
 	}
 }
@@ -4465,9 +4465,9 @@ void Game::updatePlayerHelpers(const Player& player)
 	uint32_t creatureId = player.getID();
 	uint16_t helpers = player.getHelpers();
 
-	SpectatorVec list;
-	map.getSpectators(list, player.getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, player.getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendCreatureHelpers(creatureId, helpers);
 	}
 }
@@ -4489,11 +4489,11 @@ void Game::updateCreatureType(Creature* creature)
 	}
 
 	//send to clients
-	SpectatorVec list;
-	map.getSpectators(list, creature->getPosition(), true, true);
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
 
 	if (creatureType == CREATURETYPE_SUMMON_OTHERS) {
-		for (Creature* spectator : list) {
+		for (Creature* spectator : spectators) {
 			Player* player = spectator->getPlayer();
 			if (masterPlayer == player) {
 				player->sendCreatureType(creatureId, CREATURETYPE_SUMMON_OWN);
@@ -4502,7 +4502,7 @@ void Game::updateCreatureType(Creature* creature)
 			}
 		}
 	} else {
-		for (Creature* spectator : list) {
+		for (Creature* spectator : spectators) {
 			spectator->getPlayer()->sendCreatureType(creatureId, creatureType);
 		}
 	}

--- a/src/game.h
+++ b/src/game.h
@@ -308,7 +308,7 @@ class Game
 		  * \param text The text to say
 		  */
 		bool internalCreatureSay(Creature* creature, SpeakClasses type, const std::string& text,
-		                         bool ghostMode, SpectatorVec* listPtr = nullptr, const Position* pos = nullptr);
+		                         bool ghostMode, SpectatorHashSet* spectatorsPtr = nullptr, const Position* pos = nullptr);
 
 		void loadPlayersRecord();
 		void checkPlayersRecord();
@@ -444,11 +444,11 @@ class Game
 
 		//animation help functions
 		void addCreatureHealth(const Creature* target);
-		static void addCreatureHealth(const SpectatorVec& list, const Creature* target);
+		static void addCreatureHealth(const SpectatorHashSet& spectators, const Creature* target);
 		void addMagicEffect(const Position& pos, uint8_t effect);
-		static void addMagicEffect(const SpectatorVec& list, const Position& pos, uint8_t effect);
+		static void addMagicEffect(const SpectatorHashSet& spectators, const Position& pos, uint8_t effect);
 		void addDistanceEffect(const Position& fromPos, const Position& toPos, uint8_t effect);
-		static void addDistanceEffect(const SpectatorVec& list, const Position& fromPos, const Position& toPos, uint8_t effect);
+		static void addDistanceEffect(const SpectatorHashSet& spectators, const Position& fromPos, const Position& toPos, uint8_t effect);
 
 		void addCommandTag(char tag);
 		void resetCommandTag();

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -33,7 +33,7 @@ enum GlobalEvent_t {
 };
 
 class GlobalEvent;
-typedef std::map<std::string, GlobalEvent*> GlobalEventMap;
+using GlobalEventMap = std::map<std::string, GlobalEvent*>;
 
 class GlobalEvents final : public BaseEvents
 {

--- a/src/house.h
+++ b/src/house.h
@@ -109,8 +109,8 @@ enum AccessHouseLevel_t {
 	HOUSE_OWNER = 3,
 };
 
-typedef std::list<HouseTile*> HouseTileList;
-typedef std::list<BedItem*> HouseBedItemList;
+using HouseTileList = std::list<HouseTile*>;
+using HouseBedItemList = std::list<BedItem*>;
 
 class HouseTransferItem final : public Item
 {
@@ -255,7 +255,7 @@ class House
 		bool isLoaded = false;
 };
 
-typedef std::map<uint32_t, House*> HouseMap;
+using HouseMap = std::map<uint32_t, House*>;
 
 enum RentPeriod_t {
 	RENTPERIOD_DAILY,

--- a/src/ioguild.cpp
+++ b/src/ioguild.cpp
@@ -36,7 +36,7 @@ uint32_t IOGuild::getGuildIdByName(const std::string& name)
 	return result->getNumber<uint32_t>("id");
 }
 
-void IOGuild::getWarList(uint32_t guildId, GuildWarList& guildWarList)
+void IOGuild::getWarList(uint32_t guildId, GuildWarVector& guildWarVector)
 {
 	std::ostringstream query;
 	query << "SELECT `guild1`, `guild2` FROM `guild_wars` WHERE (`guild1` = " << guildId << " OR `guild2` = " << guildId << ") AND `ended` = 0 AND `status` = 1";
@@ -49,9 +49,9 @@ void IOGuild::getWarList(uint32_t guildId, GuildWarList& guildWarList)
 	do {
 		uint32_t guild1 = result->getNumber<uint32_t>("guild1");
 		if (guildId != guild1) {
-			guildWarList.push_back(guild1);
+			guildWarVector.push_back(guild1);
 		} else {
-			guildWarList.push_back(result->getNumber<uint32_t>("guild2"));
+			guildWarVector.push_back(result->getNumber<uint32_t>("guild2"));
 		}
 	} while (result->next());
 }

--- a/src/ioguild.h
+++ b/src/ioguild.h
@@ -20,13 +20,13 @@
 #ifndef FS_IOGUILD_H_EF9ACEBA0B844C388B70FF52E69F1AFF
 #define FS_IOGUILD_H_EF9ACEBA0B844C388B70FF52E69F1AFF
 
-using GuildWarList = std::vector<uint32_t>;
+using GuildWarVector = std::vector<uint32_t>;
 
 class IOGuild
 {
 	public:
 		static uint32_t getGuildIdByName(const std::string& name);
-		static void getWarList(uint32_t guildId, GuildWarList& guildWarList);
+		static void getWarList(uint32_t guildId, GuildWarVector& guildWarVector);
 };
 
 #endif

--- a/src/ioguild.h
+++ b/src/ioguild.h
@@ -20,7 +20,7 @@
 #ifndef FS_IOGUILD_H_EF9ACEBA0B844C388B70FF52E69F1AFF
 #define FS_IOGUILD_H_EF9ACEBA0B844C388B70FF52E69F1AFF
 
-typedef std::vector<uint32_t> GuildWarList;
+using GuildWarList = std::vector<uint32_t>;
 
 class IOGuild
 {

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -444,7 +444,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 			player->guildRank = rank;
 
-			IOGuild::getWarList(guildId, player->guildWarList);
+			IOGuild::getWarList(guildId, player->guildWarVector);
 
 			query.str(std::string());
 			query << "SELECT COUNT(*) AS `members` FROM `guild_membership` WHERE `guild_id` = " << guildId;
@@ -580,8 +580,8 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 {
 	std::ostringstream ss;
 
-	using containerBlock = std::pair<Container*, int32_t>;
-	std::list<containerBlock> queue;
+	using ContainerBlock = std::pair<Container*, int32_t>;
+	std::list<ContainerBlock> queue;
 
 	int32_t runningId = 100;
 
@@ -608,7 +608,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 	}
 
 	while (!queue.empty()) {
-		const containerBlock& cb = queue.front();
+		const ContainerBlock& cb = queue.front();
 		Container* container = cb.first;
 		int32_t parentId = cb.second;
 		queue.pop_front();

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -580,7 +580,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 {
 	std::ostringstream ss;
 
-	typedef std::pair<Container*, int32_t> containerBlock;
+	using containerBlock = std::pair<Container*, int32_t>;
 	std::list<containerBlock> queue;
 
 	int32_t runningId = 100;

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -24,7 +24,7 @@
 #include "player.h"
 #include "database.h"
 
-typedef std::list<std::pair<int32_t, Item*>> ItemBlockList;
+using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
 
 class IOLoginData
 {
@@ -60,7 +60,7 @@ class IOLoginData
 		static void removePremiumDays(uint32_t accountId, int32_t removeDays);
 
 	protected:
-		typedef std::map<uint32_t, std::pair<Item*, uint32_t>> ItemMap;
+		using ItemMap = std::map<uint32_t, std::pair<Item*, uint32_t>>;
 
 		static void loadItems(ItemMap& itemMap, DBResult_ptr result);
 		static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert, PropWriteStream& stream);

--- a/src/item.h
+++ b/src/item.h
@@ -755,8 +755,8 @@ class Item : virtual public Thing
 		//Don't add variables here, use the ItemAttribute class.
 };
 
-typedef std::list<Item*> ItemList;
-typedef std::deque<Item*> ItemDeque;
+using ItemList = std::list<Item*>;
+using ItemDeque = std::deque<Item*>;
 
 inline uint32_t Item::countByType(const Item* i, int32_t subType)
 {

--- a/src/items.h
+++ b/src/items.h
@@ -265,7 +265,7 @@ class ItemType
 class Items
 {
 	public:
-		using nameMap = std::unordered_multimap<std::string, uint16_t>;
+		using NameMap = std::unordered_multimap<std::string, uint16_t>;
 
 		Items();
 
@@ -298,7 +298,7 @@ class Items
 			return items.size();
 		}
 
-		nameMap nameToItems;
+		NameMap nameToItems;
 
 	protected:
 		std::map<uint16_t, uint16_t> reverseItemMap;

--- a/src/lockfree.h
+++ b/src/lockfree.h
@@ -32,7 +32,7 @@ class LockfreePoolingAllocator : public std::allocator<T>
 	public:
 		template <typename U>
 		explicit constexpr LockfreePoolingAllocator(const U&) {}
-		typedef T value_type;
+		using value_type = T;
 
 		T* allocate(size_t) const {
 			T* p; // NOTE: p doesn't have to be initialized
@@ -52,7 +52,7 @@ class LockfreePoolingAllocator : public std::allocator<T>
 		}
 
 	private:
-		typedef boost::lockfree::stack<T*, boost::lockfree::capacity<CAPACITY>> FreeList;
+		using FreeList = boost::lockfree::stack<T*, boost::lockfree::capacity<CAPACITY>>;
 		static FreeList& getFreeList() {
 			static FreeList freeList;
 			return freeList;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4109,7 +4109,7 @@ int LuaScriptInterface::luaGameGetSpectators(lua_State* L)
 	int32_t minRangeY = getNumber<int32_t>(L, 6, 0);
 	int32_t maxRangeY = getNumber<int32_t>(L, 7, 0);
 
-	SpectatorVec spectators;
+	SpectatorHashSet spectators;
 	g_game.map.getSpectators(spectators, position, multifloor, onlyPlayers, minRangeX, maxRangeX, minRangeY, maxRangeY);
 
 	lua_createtable(L, spectators.size(), 0);
@@ -4578,18 +4578,18 @@ int LuaScriptInterface::luaPositionIsSightClear(lua_State* L)
 int LuaScriptInterface::luaPositionSendMagicEffect(lua_State* L)
 {
 	// position:sendMagicEffect(magicEffect[, player = nullptr])
-	SpectatorVec list;
+	SpectatorHashSet spectators;
 	if (lua_gettop(L) >= 3) {
 		Player* player = getPlayer(L, 3);
 		if (player) {
-			list.insert(player);
+			spectators.insert(player);
 		}
 	}
 
 	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 2);
 	const Position& position = getPosition(L, 1);
-	if (!list.empty()) {
-		Game::addMagicEffect(list, position, magicEffect);
+	if (!spectators.empty()) {
+		Game::addMagicEffect(spectators, position, magicEffect);
 	} else {
 		g_game.addMagicEffect(position, magicEffect);
 	}
@@ -4601,19 +4601,19 @@ int LuaScriptInterface::luaPositionSendMagicEffect(lua_State* L)
 int LuaScriptInterface::luaPositionSendDistanceEffect(lua_State* L)
 {
 	// position:sendDistanceEffect(positionEx, distanceEffect[, player = nullptr])
-	SpectatorVec list;
+	SpectatorHashSet spectators;
 	if (lua_gettop(L) >= 4) {
 		Player* player = getPlayer(L, 4);
 		if (player) {
-			list.insert(player);
+			spectators.insert(player);
 		}
 	}
 
 	ShootType_t distanceEffect = getNumber<ShootType_t>(L, 3);
 	const Position& positionEx = getPosition(L, 2);
 	const Position& position = getPosition(L, 1);
-	if (!list.empty()) {
-		Game::addDistanceEffect(list, position, positionEx, distanceEffect);
+	if (!spectators.empty()) {
+		Game::addDistanceEffect(spectators, position, positionEx, distanceEffect);
 	} else {
 		g_game.addDistanceEffect(position, positionEx, distanceEffect);
 	}
@@ -7345,15 +7345,15 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 		return 1;
 	}
 
-	SpectatorVec list;
+	SpectatorHashSet spectators;
 	if (target) {
-		list.insert(target);
+		spectators.insert(target);
 	}
 
 	if (position.x != 0) {
-		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &list, &position));
+		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators, &position));
 	} else {
-		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &list));
+		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators));
 	}
 	return 1;
 }
@@ -9205,9 +9205,9 @@ int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 	Tile* tile = player->getTile();
 	const Position& position = player->getPosition();
 
-	SpectatorVec list;
-	g_game.map.getSpectators(list, position, true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, position, true, true);
+	for (Creature* spectator : spectators) {
 		Player* tmpPlayer = spectator->getPlayer();
 		if (tmpPlayer != player && !tmpPlayer->isAccessPlayer()) {
 			if (enabled) {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -147,9 +147,9 @@ class ScriptEnvironment
 		void removeItemByUID(uint32_t uid);
 
 	private:
-		typedef std::vector<const LuaVariant*> VariantVector;
-		typedef std::map<uint32_t, int32_t> StorageMap;
-		typedef std::map<uint32_t, DBResult_ptr> DBResultMap;
+		using VariantVector = std::vector<const LuaVariant*>;
+		using StorageMap = std::map<uint32_t, int32_t>;
+		using DBResultMap = std::map<uint32_t, DBResult_ptr>;
 
 		LuaScriptInterface* interface;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -234,12 +234,12 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport/* =
 
 	bool teleport = forceTeleport || !newTile.getGround() || !Position::areInRange<1, 1, 0>(oldPos, newPos);
 
-	SpectatorVec list;
-	getSpectators(list, oldPos, true);
-	getSpectators(list, newPos, true);
+	SpectatorHashSet spectators;
+	getSpectators(spectators, oldPos, true);
+	getSpectators(spectators, newPos, true);
 
 	std::vector<int32_t> oldStackPosVector;
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (tmpPlayer->canSeeCreature(&creature)) {
 				oldStackPosVector.push_back(oldTile.getClientIndexOfCreature(tmpPlayer, &creature));
@@ -280,7 +280,7 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport/* =
 
 	//send to client
 	size_t i = 0;
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			//Use the correct stackpos
 			int32_t stackpos = oldStackPosVector[i++];
@@ -291,7 +291,7 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport/* =
 	}
 
 	//event method
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onCreatureMove(&creature, &newTile, newPos, &oldTile, oldPos, teleport);
 	}
 
@@ -299,7 +299,7 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport/* =
 	newTile.postAddNotification(&creature, &oldTile, 0);
 }
 
-void Map::getSpectatorsInternal(SpectatorVec& list, const Position& centerPos, int32_t minRangeX, int32_t maxRangeX, int32_t minRangeY, int32_t maxRangeY, int32_t minRangeZ, int32_t maxRangeZ, bool onlyPlayers) const
+void Map::getSpectatorsInternal(SpectatorHashSet& spectators, const Position& centerPos, int32_t minRangeX, int32_t maxRangeX, int32_t minRangeY, int32_t maxRangeY, int32_t minRangeZ, int32_t maxRangeZ, bool onlyPlayers) const
 {
 	int_fast16_t min_y = centerPos.y + minRangeY;
 	int_fast16_t min_x = centerPos.x + minRangeX;
@@ -339,7 +339,7 @@ void Map::getSpectatorsInternal(SpectatorVec& list, const Position& centerPos, i
 						continue;
 					}
 
-					list.insert(creature);
+					spectators.insert(creature);
 				}
 				leafE = leafE->leafE;
 			} else {
@@ -355,7 +355,7 @@ void Map::getSpectatorsInternal(SpectatorVec& list, const Position& centerPos, i
 	}
 }
 
-void Map::getSpectators(SpectatorVec& list, const Position& centerPos, bool multifloor /*= false*/, bool onlyPlayers /*= false*/, int32_t minRangeX /*= 0*/, int32_t maxRangeX /*= 0*/, int32_t minRangeY /*= 0*/, int32_t maxRangeY /*= 0*/)
+void Map::getSpectators(SpectatorHashSet& spectators, const Position& centerPos, bool multifloor /*= false*/, bool onlyPlayers /*= false*/, int32_t minRangeX /*= 0*/, int32_t maxRangeX /*= 0*/, int32_t minRangeY /*= 0*/, int32_t maxRangeY /*= 0*/)
 {
 	if (centerPos.z >= MAP_MAX_LAYERS) {
 		return;
@@ -373,11 +373,11 @@ void Map::getSpectators(SpectatorVec& list, const Position& centerPos, bool mult
 		if (onlyPlayers) {
 			auto it = playersSpectatorCache.find(centerPos);
 			if (it != playersSpectatorCache.end()) {
-				if (!list.empty()) {
-					const SpectatorVec& cachedList = it->second;
-					list.insert(cachedList.begin(), cachedList.end());
+				if (!spectators.empty()) {
+					const SpectatorHashSet& cachedSpectators = it->second;
+					spectators.insert(cachedSpectators.begin(), cachedSpectators.end());
 				} else {
-					list = it->second;
+					spectators = it->second;
 				}
 
 				foundCache = true;
@@ -388,17 +388,17 @@ void Map::getSpectators(SpectatorVec& list, const Position& centerPos, bool mult
 			auto it = spectatorCache.find(centerPos);
 			if (it != spectatorCache.end()) {
 				if (!onlyPlayers) {
-					if (!list.empty()) {
-						const SpectatorVec& cachedList = it->second;
-						list.insert(cachedList.begin(), cachedList.end());
+					if (!spectators.empty()) {
+						const SpectatorHashSet& cachedSpectators = it->second;
+						spectators.insert(cachedSpectators.begin(), cachedSpectators.end());
 					} else {
-						list = it->second;
+						spectators = it->second;
 					}
 				} else {
-					const SpectatorVec& cachedList = it->second;
-					for (Creature* spectator : cachedList) {
+					const SpectatorHashSet& cachedSpectators = it->second;
+					for (Creature* spectator : cachedSpectators) {
 						if (spectator->getPlayer()) {
-							list.insert(spectator);
+							spectators.insert(spectator);
 						}
 					}
 				}
@@ -436,13 +436,13 @@ void Map::getSpectators(SpectatorVec& list, const Position& centerPos, bool mult
 			maxRangeZ = centerPos.z;
 		}
 
-		getSpectatorsInternal(list, centerPos, minRangeX, maxRangeX, minRangeY, maxRangeY, minRangeZ, maxRangeZ, onlyPlayers);
+		getSpectatorsInternal(spectators, centerPos, minRangeX, maxRangeX, minRangeY, maxRangeY, minRangeZ, maxRangeZ, onlyPlayers);
 
 		if (cacheResult) {
 			if (onlyPlayers) {
-				playersSpectatorCache[centerPos] = list;
+				playersSpectatorCache[centerPos] = spectators;
 			} else {
-				spectatorCache[centerPos] = list;
+				spectatorCache[centerPos] = spectators;
 			}
 		}
 	}

--- a/src/map.h
+++ b/src/map.h
@@ -73,7 +73,7 @@ class AStarNodes
 		int_fast32_t closedNodes;
 };
 
-typedef std::map<Position, SpectatorVec> SpectatorCache;
+using SpectatorCache = std::map<Position, SpectatorVec>;
 
 static constexpr int32_t FLOOR_BITS = 3;
 static constexpr int32_t FLOOR_SIZE = (1 << FLOOR_BITS);

--- a/src/map.h
+++ b/src/map.h
@@ -73,7 +73,7 @@ class AStarNodes
 		int_fast32_t closedNodes;
 };
 
-using SpectatorCache = std::map<Position, SpectatorVec>;
+using SpectatorCache = std::map<Position, SpectatorHashSet>;
 
 static constexpr int32_t FLOOR_BITS = 3;
 static constexpr int32_t FLOOR_SIZE = (1 << FLOOR_BITS);
@@ -219,7 +219,7 @@ class Map
 
 		void moveCreature(Creature& creature, Tile& newTile, bool forceTeleport = false);
 
-		void getSpectators(SpectatorVec& list, const Position& centerPos, bool multifloor = false, bool onlyPlayers = false,
+		void getSpectators(SpectatorHashSet& spectators, const Position& centerPos, bool multifloor = false, bool onlyPlayers = false,
 		                   int32_t minRangeX = 0, int32_t maxRangeX = 0,
 		                   int32_t minRangeY = 0, int32_t maxRangeY = 0);
 
@@ -275,7 +275,7 @@ class Map
 		uint32_t height = 0;
 
 		// Actually scans the map for spectators
-		void getSpectatorsInternal(SpectatorVec& list, const Position& centerPos,
+		void getSpectatorsInternal(SpectatorHashSet& spectators, const Position& centerPos,
 		                           int32_t minRangeX, int32_t maxRangeX,
 		                           int32_t minRangeY, int32_t maxRangeY,
 		                           int32_t minRangeZ, int32_t maxRangeZ, bool onlyPlayers) const;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -349,10 +349,10 @@ void Monster::updateTargetList()
 		}
 	}
 
-	SpectatorVec list;
-	g_game.map.getSpectators(list, position, true);
-	list.erase(this);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, position, true);
+	spectators.erase(this);
+	for (Creature* spectator : spectators) {
 		if (canSee(spectator->getPosition())) {
 			onCreatureFound(spectator);
 		}
@@ -1952,10 +1952,10 @@ bool Monster::convinceCreature(Creature* creature)
 	updateIdleStatus();
 
 	//Notify surrounding about the change
-	SpectatorVec list;
-	g_game.map.getSpectators(list, getPosition(), true);
-	g_game.map.getSpectators(list, creature->getPosition(), true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, getPosition(), true);
+	g_game.map.getSpectators(spectators, creature->getPosition(), true);
+	for (Creature* spectator : spectators) {
 		spectator->onCreatureConvinced(creature, this);
 	}
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -27,8 +27,8 @@ class Creature;
 class Game;
 class Spawn;
 
-typedef std::unordered_set<Creature*> CreatureHashSet;
-typedef std::list<Creature*> CreatureList;
+using CreatureHashSet = std::unordered_set<Creature*>;
+using CreatureList = std::list<Creature*>;
 
 enum TargetSearchType_t {
 	TARGETSEARCH_DEFAULT,

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -536,41 +536,9 @@ bool MoveEvent::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-bool MoveEvent::loadFunction(const pugi::xml_attribute& attr)
-{
-	const char* functionName = attr.as_string();
-	if (strcasecmp(functionName, "onstepinfield") == 0) {
-		stepFunction = StepInField;
-	} else if (strcasecmp(functionName, "onstepoutfield") == 0) {
-		stepFunction = StepOutField;
-	} else if (strcasecmp(functionName, "onaddfield") == 0) {
-		moveFunction = AddItemField;
-	} else if (strcasecmp(functionName, "onremovefield") == 0) {
-		moveFunction = RemoveItemField;
-	} else if (strcasecmp(functionName, "onequipitem") == 0) {
-		equipFunction = EquipItem;
-	} else if (strcasecmp(functionName, "ondeequipitem") == 0) {
-		equipFunction = DeEquipItem;
-	} else {
-		std::cout << "[Warning - MoveEvent::loadFunction] Function \"" << functionName << "\" does not exist." << std::endl;
-		return false;
-	}
+namespace {
 
-	scripted = false;
-	return true;
-}
-
-MoveEvent_t MoveEvent::getEventType() const
-{
-	return eventType;
-}
-
-void MoveEvent::setEventType(MoveEvent_t type)
-{
-	eventType = type;
-}
-
-uint32_t MoveEvent::StepInField(Creature* creature, Item* item, const Position&)
+uint32_t StepInField(Creature* creature, Item* item, const Position&)
 {
 	MagicField* field = item->getMagicField();
 	if (field) {
@@ -581,12 +549,12 @@ uint32_t MoveEvent::StepInField(Creature* creature, Item* item, const Position&)
 	return LUA_ERROR_ITEM_NOT_FOUND;
 }
 
-uint32_t MoveEvent::StepOutField(Creature*, Item*, const Position&)
+uint32_t StepOutField(Creature*, Item*, const Position&)
 {
 	return 1;
 }
 
-uint32_t MoveEvent::AddItemField(Item* item, Item*, const Position&)
+uint32_t AddItemField(Item* item, Item*, const Position&)
 {
 	if (MagicField* field = item->getMagicField()) {
 		Tile* tile = item->getTile();
@@ -600,12 +568,12 @@ uint32_t MoveEvent::AddItemField(Item* item, Item*, const Position&)
 	return LUA_ERROR_ITEM_NOT_FOUND;
 }
 
-uint32_t MoveEvent::RemoveItemField(Item*, Item*, const Position&)
+uint32_t RemoveItemField(Item*, Item*, const Position&)
 {
 	return 1;
 }
 
-uint32_t MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool isCheck)
+uint32_t EquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool isCheck)
 {
 	if (player->isItemAbilityEnabled(slot)) {
 		return 1;
@@ -719,7 +687,7 @@ uint32_t MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, 
 	return 1;
 }
 
-uint32_t MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, slots_t slot, bool)
+uint32_t DeEquipItem(MoveEvent*, Player* player, Item* item, slots_t slot, bool)
 {
 	if (!player->isItemAbilityEnabled(slot)) {
 		return 1;
@@ -792,6 +760,42 @@ uint32_t MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, slots_t 
 	}
 
 	return 1;
+}
+
+}
+
+bool MoveEvent::loadFunction(const pugi::xml_attribute& attr)
+{
+	const char* functionName = attr.as_string();
+	if (strcasecmp(functionName, "onstepinfield") == 0) {
+		stepFunction = StepInField;
+	} else if (strcasecmp(functionName, "onstepoutfield") == 0) {
+		stepFunction = StepOutField;
+	} else if (strcasecmp(functionName, "onaddfield") == 0) {
+		moveFunction = AddItemField;
+	} else if (strcasecmp(functionName, "onremovefield") == 0) {
+		moveFunction = RemoveItemField;
+	} else if (strcasecmp(functionName, "onequipitem") == 0) {
+		equipFunction = EquipItem;
+	} else if (strcasecmp(functionName, "ondeequipitem") == 0) {
+		equipFunction = DeEquipItem;
+	} else {
+		std::cout << "[Warning - MoveEvent::loadFunction] Function \"" << functionName << "\" does not exist." << std::endl;
+		return false;
+	}
+
+	scripted = false;
+	return true;
+}
+
+MoveEvent_t MoveEvent::getEventType() const
+{
+	return eventType;
+}
+
+void MoveEvent::setEventType(MoveEvent_t type)
+{
+	eventType = type;
 }
 
 uint32_t MoveEvent::fireStepEvent(Creature* creature, Item* item, const Position& pos)

--- a/src/movement.h
+++ b/src/movement.h
@@ -44,7 +44,7 @@ struct MoveEventList {
 	std::list<MoveEvent*> moveEvent[MOVE_EVENT_LAST];
 };
 
-typedef std::map<uint16_t, bool> VocEquipMap;
+using VocEquipMap = std::map<uint16_t, bool>;
 
 class MoveEvents final : public BaseEvents
 {
@@ -64,10 +64,10 @@ class MoveEvents final : public BaseEvents
 		MoveEvent* getEvent(Item* item, MoveEvent_t eventType);
 
 	protected:
-		typedef std::map<int32_t, MoveEventList> MoveListMap;
+		using MoveListMap = std::map<int32_t, MoveEventList>;
 		void clearMap(MoveListMap& map);
 
-		typedef std::map<Position, MoveEventList> MovePosListMap;
+		using MovePosListMap = std::map<Position, MoveEventList>;
 		void clear() final;
 		LuaScriptInterface& getScriptInterface() final;
 		std::string getScriptBaseName() const final;
@@ -89,9 +89,9 @@ class MoveEvents final : public BaseEvents
 		LuaScriptInterface scriptInterface;
 };
 
-typedef uint32_t (StepFunction)(Creature* creature, Item* item, const Position& pos);
-typedef uint32_t (MoveFunction)(Item* item, Item* tileItem, const Position& pos);
-typedef uint32_t (EquipFunction)(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool boolean);
+using StepFunction = std::function<uint32_t(Creature* creature, Item* item, const Position& pos)>;
+using MoveFunction = std::function<uint32_t(Item* item, Item* tileItem, const Position& pos)>;
+using EquipFunction = std::function<uint32_t(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool boolean)>;
 
 class MoveEvent final : public Event
 {
@@ -142,18 +142,10 @@ class MoveEvent final : public Event
 	protected:
 		std::string getScriptEventName() const final;
 
-		static StepFunction StepInField;
-		static StepFunction StepOutField;
-
-		static MoveFunction AddItemField;
-		static MoveFunction RemoveItemField;
-		static EquipFunction EquipItem;
-		static EquipFunction DeEquipItem;
-
 		MoveEvent_t eventType = MOVE_EVENT_NONE;
-		StepFunction* stepFunction = nullptr;
-		MoveFunction* moveFunction = nullptr;
-		EquipFunction* equipFunction = nullptr;
+		StepFunction stepFunction;
+		MoveFunction moveFunction;
+		EquipFunction equipFunction;
 		uint32_t slot = SLOTP_WHEREEVER;
 
 		//onEquip information

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -31,7 +31,7 @@ class RSA;
 class NetworkMessage
 {
 	public:
-		typedef uint16_t MsgSize_t;
+		using MsgSize_t = uint16_t;
 		// Headers:
 		// 2 bytes for unencrypted message size
 		// 4 bytes for checksum

--- a/src/outputmessage.cpp
+++ b/src/outputmessage.cpp
@@ -32,9 +32,9 @@ const std::chrono::milliseconds OUTPUTMESSAGE_AUTOSEND_DELAY {10};
 class OutputMessageAllocator
 {
 	public:
-		typedef OutputMessage value_type;
+		using value_type = OutputMessage;
 		template<typename U>
-		struct rebind {typedef LockfreePoolingAllocator<U, OUTPUTMESSAGE_FREE_LIST_CAPACITY> other;};
+		struct rebind {using other = LockfreePoolingAllocator<U, OUTPUTMESSAGE_FREE_LIST_CAPACITY>;};
 };
 
 void OutputMessagePool::scheduleSendAll()

--- a/src/party.h
+++ b/src/party.h
@@ -26,7 +26,7 @@
 class Player;
 class Party;
 
-typedef std::vector<Player*> PlayerVector;
+using PlayerVector = std::vector<Player*>;
 
 class Party
 {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1596,13 +1596,13 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		message.primary.color = TEXTCOLOR_WHITE_EXP;
 		sendTextMessage(message);
 
-		SpectatorVec list;
-		g_game.map.getSpectators(list, position, false, true);
-		list.erase(this);
-		if (!list.empty()) {
+		SpectatorHashSet spectators;
+		g_game.map.getSpectators(spectators, position, false, true);
+		spectators.erase(this);
+		if (!spectators.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
 			message.text = getName() + " gained " + expString;
-			for (Creature* spectator : list) {
+			for (Creature* spectator : spectators) {
 				spectator->getPlayer()->sendTextMessage(message);
 			}
 		}
@@ -1679,13 +1679,13 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		message.primary.color = TEXTCOLOR_RED;
 		sendTextMessage(message);
 
-		SpectatorVec list;
-		g_game.map.getSpectators(list, position, false, true);
-		list.erase(this);
-		if (!list.empty()) {
+		SpectatorHashSet spectators;
+		g_game.map.getSpectators(spectators, position, false, true);
+		spectators.erase(this);
+		if (!spectators.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
 			message.text = getName() + " lost " + expString;
-			for (Creature* spectator : list) {
+			for (Creature* spectator : spectators) {
 				spectator->getPlayer()->sendTextMessage(message);
 			}
 		}
@@ -3718,7 +3718,7 @@ Skulls_t Player::getSkullClient(const Creature* creature) const
 			return SKULL_GREEN;
 		}
 
-		if (!player->getGuildWarList().empty() && guild == player->getGuild()) {
+		if (!player->getGuildWarVector().empty() && guild == player->getGuild()) {
 			return SKULL_GREEN;
 		}
 
@@ -3870,7 +3870,7 @@ bool Player::isInWar(const Player* player) const
 
 bool Player::isInWarList(uint32_t guildId) const
 {
-	return std::find(guildWarList.begin(), guildWarList.end(), guildId) != guildWarList.end();
+	return std::find(guildWarVector.begin(), guildWarVector.end(), guildId) != guildWarVector.end();
 }
 
 bool Player::isPremium() const
@@ -4008,7 +4008,7 @@ GuildEmblems_t Player::getGuildEmblem(const Player* player) const
 		return GUILDEMBLEM_NONE;
 	}
 
-	if (player->getGuildWarList().empty()) {
+	if (player->getGuildWarVector().empty()) {
 		if (guild == playerGuild) {
 			return GUILDEMBLEM_MEMBER;
 		} else {

--- a/src/player.h
+++ b/src/player.h
@@ -251,8 +251,8 @@ class Player final : public Creature, public Cylinder
 
 		uint16_t getClientIcons() const;
 
-		const GuildWarList& getGuildWarList() const {
-			return guildWarList;
+		const GuildWarVector& getGuildWarVector() const {
+			return guildWarVector;
 		}
 
 		Vocation* getVocation() const {
@@ -1182,7 +1182,7 @@ class Player final : public Creature, public Cylinder
 		std::map<uint32_t, int32_t> storageMap;
 
 		std::vector<OutfitEntry> outfits;
-		GuildWarList guildWarList;
+		GuildWarVector guildWarVector;
 
 		std::list<ShopInfo> shopItemList;
 

--- a/src/player.h
+++ b/src/player.h
@@ -103,7 +103,7 @@ struct Skill {
 	uint8_t percent = 0;
 };
 
-typedef std::map<uint32_t, uint32_t> MuteCountMap;
+using MuteCountMap = std::map<uint32_t, uint32_t>;
 
 static constexpr int32_t PLAYER_MAX_SPEED = 1500;
 static constexpr int32_t PLAYER_MIN_SPEED = 10;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -34,7 +34,7 @@ class Tile;
 class Connection;
 class Quest;
 class ProtocolGame;
-typedef std::shared_ptr<ProtocolGame> ProtocolGame_ptr;
+using ProtocolGame_ptr = std::shared_ptr<ProtocolGame>;
 
 extern Game g_game;
 

--- a/src/quests.h
+++ b/src/quests.h
@@ -26,8 +26,8 @@
 class Mission;
 class Quest;
 
-typedef std::list<Mission> MissionsList;
-typedef std::list<Quest> QuestsList;
+using MissionsList = std::list<Mission>;
+using QuestsList = std::list<Quest>;
 
 class Mission
 {

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -180,9 +180,9 @@ Spawn::~Spawn()
 
 bool Spawn::findPlayer(const Position& pos)
 {
-	SpectatorVec list;
-	g_game.map.getSpectators(list, pos, false, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, pos, false, true);
+	for (Creature* spectator : spectators) {
 		if (!spectator->getPlayer()->hasFlag(PlayerFlag_IgnoredByMonsters)) {
 			return true;
 		}

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -61,8 +61,8 @@ class Spawn
 
 	private:
 		//map of the spawned creatures
-		typedef std::multimap<uint32_t, Monster*> SpawnedMap;
-		typedef SpawnedMap::value_type spawned_pair;
+		using SpawnedMap = std::multimap<uint32_t, Monster*>;
+		using spawned_pair = SpawnedMap::value_type;
 		SpawnedMap spawnedMap;
 
 		//map of creatures in the spawn

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -890,6 +890,413 @@ bool InstantSpell::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
+namespace {
+
+House* getHouseFromPos(Creature* creature)
+{
+	if (!creature) {
+		return nullptr;
+	}
+
+	Player* player = creature->getPlayer();
+	if (!player) {
+		return nullptr;
+	}
+
+	HouseTile* houseTile = dynamic_cast<HouseTile*>(player->getTile());
+	if (!houseTile) {
+		return nullptr;
+	}
+
+	House* house = houseTile->getHouse();
+	if (!house) {
+		return nullptr;
+	}
+
+	return house;
+}
+
+bool HouseGuestList(const InstantSpell*, Creature* creature, const std::string&)
+{
+	House* house = getHouseFromPos(creature);
+	if (!house) {
+		return false;
+	}
+
+	Player* player = creature->getPlayer();
+	if (house->canEditAccessList(GUEST_LIST, player)) {
+		player->setEditHouse(house, GUEST_LIST);
+		player->sendHouseWindow(house, GUEST_LIST);
+	} else {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+	}
+	return true;
+}
+
+bool HouseSubOwnerList(const InstantSpell*, Creature* creature, const std::string&)
+{
+	House* house = getHouseFromPos(creature);
+	if (!house) {
+		return false;
+	}
+
+	Player* player = creature->getPlayer();
+	if (house->canEditAccessList(SUBOWNER_LIST, player)) {
+		player->setEditHouse(house, SUBOWNER_LIST);
+		player->sendHouseWindow(house, SUBOWNER_LIST);
+	} else {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+	}
+	return true;
+}
+
+bool HouseDoorList(const InstantSpell*, Creature* creature, const std::string&)
+{
+	House* house = getHouseFromPos(creature);
+	if (!house) {
+		return false;
+	}
+
+	Player* player = creature->getPlayer();
+	Position pos = Spells::getCasterPosition(player, player->getDirection());
+	Door* door = house->getDoorByPosition(pos);
+	if (door && house->canEditAccessList(door->getDoorId(), player)) {
+		player->setEditHouse(house, door->getDoorId());
+		player->sendHouseWindow(house, door->getDoorId());
+	} else {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+	}
+	return true;
+}
+
+bool HouseKick(const InstantSpell*, Creature* creature, const std::string& param)
+{
+	Player* player = creature->getPlayer();
+
+	Player* targetPlayer = g_game.getPlayerByName(param);
+	if (!targetPlayer) {
+		targetPlayer = player;
+	}
+
+	House* house = getHouseFromPos(targetPlayer);
+	if (!house) {
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return false;
+	}
+
+	if (!house->kickPlayer(player, targetPlayer)) {
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return false;
+	}
+	return true;
+}
+
+bool SearchPlayer(const InstantSpell*, Creature* creature, const std::string& param)
+{
+	//a. From 1 to 4 sq's [Person] is standing next to you.
+	//b. From 5 to 100 sq's [Person] is to the south, north, east, west.
+	//c. From 101 to 274 sq's [Person] is far to the south, north, east, west.
+	//d. From 275 to infinite sq's [Person] is very far to the south, north, east, west.
+	//e. South-west, s-e, n-w, n-e (corner coordinates): this phrase appears if the player you're looking for has moved five squares in any direction from the south, north, east or west.
+	//f. Lower level to the (direction): this phrase applies if the person you're looking for is from 1-25 squares up/down the actual floor you're in.
+	//g. Higher level to the (direction): this phrase applies if the person you're looking for is from 1-25 squares up/down the actual floor you're in.
+
+	Player* player = creature->getPlayer();
+	if (!player) {
+		return false;
+	}
+
+	enum distance_t {
+		DISTANCE_BESIDE,
+		DISTANCE_CLOSE,
+		DISTANCE_FAR,
+		DISTANCE_VERYFAR,
+	};
+
+	enum direction_t {
+		DIR_N, DIR_S, DIR_E, DIR_W,
+		DIR_NE, DIR_NW, DIR_SE, DIR_SW,
+	};
+
+	enum level_t {
+		LEVEL_HIGHER,
+		LEVEL_LOWER,
+		LEVEL_SAME,
+	};
+
+	Player* playerExiva = g_game.getPlayerByName(param);
+	if (!playerExiva) {
+		return false;
+	}
+
+	if (playerExiva->isAccessPlayer() && !player->isAccessPlayer()) {
+		player->sendCancelMessage(RETURNVALUE_PLAYERWITHTHISNAMEISNOTONLINE);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		return false;
+	}
+
+	const Position& lookPos = player->getPosition();
+	const Position& searchPos = playerExiva->getPosition();
+
+	int32_t dx = Position::getOffsetX(lookPos, searchPos);
+	int32_t dy = Position::getOffsetY(lookPos, searchPos);
+	int32_t dz = Position::getOffsetZ(lookPos, searchPos);
+
+	distance_t distance;
+
+	direction_t direction;
+
+	level_t level;
+
+	//getting floor
+	if (dz > 0) {
+		level = LEVEL_HIGHER;
+	} else if (dz < 0) {
+		level = LEVEL_LOWER;
+	} else {
+		level = LEVEL_SAME;
+	}
+
+	//getting distance
+	if (std::abs(dx) < 4 && std::abs(dy) < 4) {
+		distance = DISTANCE_BESIDE;
+	} else {
+		int32_t distance2 = dx * dx + dy * dy;
+		if (distance2 < 10000) {
+			distance = DISTANCE_CLOSE;
+		} else if (distance2 < 75076) {
+			distance = DISTANCE_FAR;
+		} else {
+			distance = DISTANCE_VERYFAR;
+		}
+	}
+
+	//getting direction
+	float tan;
+	if (dx != 0) {
+		tan = static_cast<float>(dy) / dx;
+	} else {
+		tan = 10.;
+	}
+
+	if (std::abs(tan) < 0.4142) {
+		if (dx > 0) {
+			direction = DIR_W;
+		} else {
+			direction = DIR_E;
+		}
+	} else if (std::abs(tan) < 2.4142) {
+		if (tan > 0) {
+			if (dy > 0) {
+				direction = DIR_NW;
+			} else {
+				direction = DIR_SE;
+			}
+		} else {
+			if (dx > 0) {
+				direction = DIR_SW;
+			} else {
+				direction = DIR_NE;
+			}
+		}
+	} else {
+		if (dy > 0) {
+			direction = DIR_N;
+		} else {
+			direction = DIR_S;
+		}
+	}
+
+	std::ostringstream ss;
+	ss << playerExiva->getName();
+
+	if (distance == DISTANCE_BESIDE) {
+		if (level == LEVEL_SAME) {
+			ss << " is standing next to you.";
+		} else if (level == LEVEL_HIGHER) {
+			ss << " is above you.";
+		} else if (level == LEVEL_LOWER) {
+			ss << " is below you.";
+		}
+	} else {
+		switch (distance) {
+			case DISTANCE_CLOSE:
+				if (level == LEVEL_SAME) {
+					ss << " is to the ";
+				} else if (level == LEVEL_HIGHER) {
+					ss << " is on a higher level to the ";
+				} else if (level == LEVEL_LOWER) {
+					ss << " is on a lower level to the ";
+				}
+				break;
+			case DISTANCE_FAR:
+				ss << " is far to the ";
+				break;
+			case DISTANCE_VERYFAR:
+				ss << " is very far to the ";
+				break;
+			default:
+				break;
+		}
+
+		switch (direction) {
+			case DIR_N:
+				ss << "north.";
+				break;
+			case DIR_S:
+				ss << "south.";
+				break;
+			case DIR_E:
+				ss << "east.";
+				break;
+			case DIR_W:
+				ss << "west.";
+				break;
+			case DIR_NE:
+				ss << "north-east.";
+				break;
+			case DIR_NW:
+				ss << "north-west.";
+				break;
+			case DIR_SE:
+				ss << "south-east.";
+				break;
+			case DIR_SW:
+				ss << "south-west.";
+				break;
+		}
+	}
+	player->sendTextMessage(MESSAGE_INFO_DESCR, ss.str());
+	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_BLUE);
+	return true;
+}
+
+bool SummonMonster(const InstantSpell* spell, Creature* creature, const std::string& param)
+{
+	Player* player = creature->getPlayer();
+	if (!player) {
+		return false;
+	}
+
+	MonsterType* mType = g_monsters.getMonsterType(param);
+	if (!mType) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		return false;
+	}
+
+	if (!player->hasFlag(PlayerFlag_CanSummonAll)) {
+		if (!mType->info.isSummonable) {
+			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+			return false;
+		}
+
+		if (player->getMana() < mType->info.manaCost) {
+			player->sendCancelMessage(RETURNVALUE_NOTENOUGHMANA);
+			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+			return false;
+		}
+
+		if (player->getSummonCount() >= 2) {
+			player->sendCancelMessage("You cannot summon more creatures.");
+			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+			return false;
+		}
+	}
+
+	Monster* monster = Monster::createMonster(param);
+	if (!monster) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		return false;
+	}
+
+	// Place the monster
+	creature->addSummon(monster);
+
+	if (!g_game.placeCreature(monster, creature->getPosition(), true)) {
+		creature->removeSummon(monster);
+		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		return false;
+	}
+
+	Spell::postCastSpell(player, mType->info.manaCost, spell->getSoulCost());
+	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_BLUE);
+	g_game.addMagicEffect(monster->getPosition(), CONST_ME_TELEPORT);
+	return true;
+}
+
+bool Levitate(const InstantSpell*, Creature* creature, const std::string& param)
+{
+	Player* player = creature->getPlayer();
+	if (!player) {
+		return false;
+	}
+
+	const Position& currentPos = creature->getPosition();
+	const Position& destPos = Spells::getCasterPosition(creature, creature->getDirection());
+
+	ReturnValue ret = RETURNVALUE_NOTPOSSIBLE;
+
+	if (strcasecmp(param.c_str(), "up") == 0) {
+		if (currentPos.z != 8) {
+			Tile* tmpTile = g_game.map.getTile(currentPos.x, currentPos.y, currentPos.getZ() - 1);
+			if (tmpTile == nullptr || (tmpTile->getGround() == nullptr && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID))) {
+				tmpTile = g_game.map.getTile(destPos.x, destPos.y, destPos.getZ() - 1);
+				if (tmpTile && tmpTile->getGround() && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID | TILESTATE_FLOORCHANGE)) {
+					ret = g_game.internalMoveCreature(*player, *tmpTile, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE);
+				}
+			}
+		}
+	} else if (strcasecmp(param.c_str(), "down") == 0) {
+		if (currentPos.z != 7) {
+			Tile* tmpTile = g_game.map.getTile(destPos);
+			if (tmpTile == nullptr || (tmpTile->getGround() == nullptr && !tmpTile->hasFlag(TILESTATE_BLOCKSOLID))) {
+				tmpTile = g_game.map.getTile(destPos.x, destPos.y, destPos.z + 1);
+				if (tmpTile && tmpTile->getGround() && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID | TILESTATE_FLOORCHANGE)) {
+					ret = g_game.internalMoveCreature(*player, *tmpTile, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE);
+				}
+			}
+		}
+	}
+
+	if (ret != RETURNVALUE_NOERROR) {
+		player->sendCancelMessage(ret);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		return false;
+	}
+
+	g_game.addMagicEffect(player->getPosition(), CONST_ME_TELEPORT);
+	return true;
+}
+
+bool Illusion(const InstantSpell*, Creature* creature, const std::string& param)
+{
+	Player* player = creature->getPlayer();
+	if (!player) {
+		return false;
+	}
+
+	ReturnValue ret = Spell::CreateIllusion(creature, param, 180000);
+	if (ret != RETURNVALUE_NOERROR) {
+		player->sendCancelMessage(ret);
+		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		return false;
+	}
+
+	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_RED);
+	return true;
+}
+
+}
+
 bool InstantSpell::loadFunction(const pugi::xml_attribute& attr)
 {
 	const char* functionName = attr.as_string();
@@ -1142,409 +1549,6 @@ bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 	return scriptInterface->callFunction(2);
 }
 
-House* InstantSpell::getHouseFromPos(Creature* creature)
-{
-	if (!creature) {
-		return nullptr;
-	}
-
-	Player* player = creature->getPlayer();
-	if (!player) {
-		return nullptr;
-	}
-
-	HouseTile* houseTile = dynamic_cast<HouseTile*>(player->getTile());
-	if (!houseTile) {
-		return nullptr;
-	}
-
-	House* house = houseTile->getHouse();
-	if (!house) {
-		return nullptr;
-	}
-
-	return house;
-}
-
-bool InstantSpell::HouseGuestList(const InstantSpell*, Creature* creature, const std::string&)
-{
-	House* house = getHouseFromPos(creature);
-	if (!house) {
-		return false;
-	}
-
-	Player* player = creature->getPlayer();
-	if (house->canEditAccessList(GUEST_LIST, player)) {
-		player->setEditHouse(house, GUEST_LIST);
-		player->sendHouseWindow(house, GUEST_LIST);
-	} else {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-	}
-	return true;
-}
-
-bool InstantSpell::HouseSubOwnerList(const InstantSpell*, Creature* creature, const std::string&)
-{
-	House* house = getHouseFromPos(creature);
-	if (!house) {
-		return false;
-	}
-
-	Player* player = creature->getPlayer();
-	if (house->canEditAccessList(SUBOWNER_LIST, player)) {
-		player->setEditHouse(house, SUBOWNER_LIST);
-		player->sendHouseWindow(house, SUBOWNER_LIST);
-	} else {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-	}
-	return true;
-}
-
-bool InstantSpell::HouseDoorList(const InstantSpell*, Creature* creature, const std::string&)
-{
-	House* house = getHouseFromPos(creature);
-	if (!house) {
-		return false;
-	}
-
-	Player* player = creature->getPlayer();
-	Position pos = Spells::getCasterPosition(player, player->getDirection());
-	Door* door = house->getDoorByPosition(pos);
-	if (door && house->canEditAccessList(door->getDoorId(), player)) {
-		player->setEditHouse(house, door->getDoorId());
-		player->sendHouseWindow(house, door->getDoorId());
-	} else {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-	}
-	return true;
-}
-
-bool InstantSpell::HouseKick(const InstantSpell*, Creature* creature, const std::string& param)
-{
-	Player* player = creature->getPlayer();
-
-	Player* targetPlayer = g_game.getPlayerByName(param);
-	if (!targetPlayer) {
-		targetPlayer = player;
-	}
-
-	House* house = getHouseFromPos(targetPlayer);
-	if (!house) {
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return false;
-	}
-
-	if (!house->kickPlayer(player, targetPlayer)) {
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return false;
-	}
-	return true;
-}
-
-bool InstantSpell::SearchPlayer(const InstantSpell*, Creature* creature, const std::string& param)
-{
-	//a. From 1 to 4 sq's [Person] is standing next to you.
-	//b. From 5 to 100 sq's [Person] is to the south, north, east, west.
-	//c. From 101 to 274 sq's [Person] is far to the south, north, east, west.
-	//d. From 275 to infinite sq's [Person] is very far to the south, north, east, west.
-	//e. South-west, s-e, n-w, n-e (corner coordinates): this phrase appears if the player you're looking for has moved five squares in any direction from the south, north, east or west.
-	//f. Lower level to the (direction): this phrase applies if the person you're looking for is from 1-25 squares up/down the actual floor you're in.
-	//g. Higher level to the (direction): this phrase applies if the person you're looking for is from 1-25 squares up/down the actual floor you're in.
-
-	Player* player = creature->getPlayer();
-	if (!player) {
-		return false;
-	}
-
-	enum distance_t {
-		DISTANCE_BESIDE,
-		DISTANCE_CLOSE,
-		DISTANCE_FAR,
-		DISTANCE_VERYFAR,
-	};
-
-	enum direction_t {
-		DIR_N, DIR_S, DIR_E, DIR_W,
-		DIR_NE, DIR_NW, DIR_SE, DIR_SW,
-	};
-
-	enum level_t {
-		LEVEL_HIGHER,
-		LEVEL_LOWER,
-		LEVEL_SAME,
-	};
-
-	Player* playerExiva = g_game.getPlayerByName(param);
-	if (!playerExiva) {
-		return false;
-	}
-
-	if (playerExiva->isAccessPlayer() && !player->isAccessPlayer()) {
-		player->sendCancelMessage(RETURNVALUE_PLAYERWITHTHISNAMEISNOTONLINE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
-	const Position& lookPos = player->getPosition();
-	const Position& searchPos = playerExiva->getPosition();
-
-	int32_t dx = Position::getOffsetX(lookPos, searchPos);
-	int32_t dy = Position::getOffsetY(lookPos, searchPos);
-	int32_t dz = Position::getOffsetZ(lookPos, searchPos);
-
-	distance_t distance;
-
-	direction_t direction;
-
-	level_t level;
-
-	//getting floor
-	if (dz > 0) {
-		level = LEVEL_HIGHER;
-	} else if (dz < 0) {
-		level = LEVEL_LOWER;
-	} else {
-		level = LEVEL_SAME;
-	}
-
-	//getting distance
-	if (std::abs(dx) < 4 && std::abs(dy) < 4) {
-		distance = DISTANCE_BESIDE;
-	} else {
-		int32_t distance2 = dx * dx + dy * dy;
-		if (distance2 < 10000) {
-			distance = DISTANCE_CLOSE;
-		} else if (distance2 < 75076) {
-			distance = DISTANCE_FAR;
-		} else {
-			distance = DISTANCE_VERYFAR;
-		}
-	}
-
-	//getting direction
-	float tan;
-	if (dx != 0) {
-		tan = static_cast<float>(dy) / dx;
-	} else {
-		tan = 10.;
-	}
-
-	if (std::abs(tan) < 0.4142) {
-		if (dx > 0) {
-			direction = DIR_W;
-		} else {
-			direction = DIR_E;
-		}
-	} else if (std::abs(tan) < 2.4142) {
-		if (tan > 0) {
-			if (dy > 0) {
-				direction = DIR_NW;
-			} else {
-				direction = DIR_SE;
-			}
-		} else {
-			if (dx > 0) {
-				direction = DIR_SW;
-			} else {
-				direction = DIR_NE;
-			}
-		}
-	} else {
-		if (dy > 0) {
-			direction = DIR_N;
-		} else {
-			direction = DIR_S;
-		}
-	}
-
-	std::ostringstream ss;
-	ss << playerExiva->getName();
-
-	if (distance == DISTANCE_BESIDE) {
-		if (level == LEVEL_SAME) {
-			ss << " is standing next to you.";
-		} else if (level == LEVEL_HIGHER) {
-			ss << " is above you.";
-		} else if (level == LEVEL_LOWER) {
-			ss << " is below you.";
-		}
-	} else {
-		switch (distance) {
-			case DISTANCE_CLOSE:
-				if (level == LEVEL_SAME) {
-					ss << " is to the ";
-				} else if (level == LEVEL_HIGHER) {
-					ss << " is on a higher level to the ";
-				} else if (level == LEVEL_LOWER) {
-					ss << " is on a lower level to the ";
-				}
-				break;
-			case DISTANCE_FAR:
-				ss << " is far to the ";
-				break;
-			case DISTANCE_VERYFAR:
-				ss << " is very far to the ";
-				break;
-			default:
-				break;
-		}
-
-		switch (direction) {
-			case DIR_N:
-				ss << "north.";
-				break;
-			case DIR_S:
-				ss << "south.";
-				break;
-			case DIR_E:
-				ss << "east.";
-				break;
-			case DIR_W:
-				ss << "west.";
-				break;
-			case DIR_NE:
-				ss << "north-east.";
-				break;
-			case DIR_NW:
-				ss << "north-west.";
-				break;
-			case DIR_SE:
-				ss << "south-east.";
-				break;
-			case DIR_SW:
-				ss << "south-west.";
-				break;
-		}
-	}
-	player->sendTextMessage(MESSAGE_INFO_DESCR, ss.str());
-	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_BLUE);
-	return true;
-}
-
-bool InstantSpell::SummonMonster(const InstantSpell* spell, Creature* creature, const std::string& param)
-{
-	Player* player = creature->getPlayer();
-	if (!player) {
-		return false;
-	}
-
-	MonsterType* mType = g_monsters.getMonsterType(param);
-	if (!mType) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
-	if (!player->hasFlag(PlayerFlag_CanSummonAll)) {
-		if (!mType->info.isSummonable) {
-			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-			return false;
-		}
-
-		if (player->getMana() < mType->info.manaCost) {
-			player->sendCancelMessage(RETURNVALUE_NOTENOUGHMANA);
-			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-			return false;
-		}
-
-		if (player->getSummonCount() >= 2) {
-			player->sendCancelMessage("You cannot summon more creatures.");
-			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-			return false;
-		}
-	}
-
-	Monster* monster = Monster::createMonster(param);
-	if (!monster) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
-	// Place the monster
-	creature->addSummon(monster);
-
-	if (!g_game.placeCreature(monster, creature->getPosition(), true)) {
-		creature->removeSummon(monster);
-		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
-	Spell::postCastSpell(player, mType->info.manaCost, spell->getSoulCost());
-	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_BLUE);
-	g_game.addMagicEffect(monster->getPosition(), CONST_ME_TELEPORT);
-	return true;
-}
-
-bool InstantSpell::Levitate(const InstantSpell*, Creature* creature, const std::string& param)
-{
-	Player* player = creature->getPlayer();
-	if (!player) {
-		return false;
-	}
-
-	const Position& currentPos = creature->getPosition();
-	const Position& destPos = Spells::getCasterPosition(creature, creature->getDirection());
-
-	ReturnValue ret = RETURNVALUE_NOTPOSSIBLE;
-
-	if (strcasecmp(param.c_str(), "up") == 0) {
-		if (currentPos.z != 8) {
-			Tile* tmpTile = g_game.map.getTile(currentPos.x, currentPos.y, currentPos.getZ() - 1);
-			if (tmpTile == nullptr || (tmpTile->getGround() == nullptr && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID))) {
-				tmpTile = g_game.map.getTile(destPos.x, destPos.y, destPos.getZ() - 1);
-				if (tmpTile && tmpTile->getGround() && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID | TILESTATE_FLOORCHANGE)) {
-					ret = g_game.internalMoveCreature(*player, *tmpTile, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE);
-				}
-			}
-		}
-	} else if (strcasecmp(param.c_str(), "down") == 0) {
-		if (currentPos.z != 7) {
-			Tile* tmpTile = g_game.map.getTile(destPos);
-			if (tmpTile == nullptr || (tmpTile->getGround() == nullptr && !tmpTile->hasFlag(TILESTATE_BLOCKSOLID))) {
-				tmpTile = g_game.map.getTile(destPos.x, destPos.y, destPos.z + 1);
-				if (tmpTile && tmpTile->getGround() && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID | TILESTATE_FLOORCHANGE)) {
-					ret = g_game.internalMoveCreature(*player, *tmpTile, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE);
-				}
-			}
-		}
-	}
-
-	if (ret != RETURNVALUE_NOERROR) {
-		player->sendCancelMessage(ret);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
-	g_game.addMagicEffect(player->getPosition(), CONST_ME_TELEPORT);
-	return true;
-}
-
-bool InstantSpell::Illusion(const InstantSpell*, Creature* creature, const std::string& param)
-{
-	Player* player = creature->getPlayer();
-	if (!player) {
-		return false;
-	}
-
-	ReturnValue ret = CreateIllusion(creature, param, 180000);
-	if (ret != RETURNVALUE_NOERROR) {
-		player->sendCancelMessage(ret);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
-	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_RED);
-	return true;
-}
-
 bool InstantSpell::canCast(const Player* player) const
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
@@ -1696,23 +1700,9 @@ bool RuneSpell::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-bool RuneSpell::loadFunction(const pugi::xml_attribute& attr)
-{
-	const char* functionName = attr.as_string();
-	if (strcasecmp(functionName, "chameleon") == 0) {
-		runeFunction = Illusion;
-	} else if (strcasecmp(functionName, "convince") == 0) {
-		runeFunction = Convince;
-	} else {
-		std::cout << "[Warning - RuneSpell::loadFunction] Function \"" << functionName << "\" does not exist." << std::endl;
-		return false;
-	}
+namespace {
 
-	scripted = false;
-	return true;
-}
-
-bool RuneSpell::Illusion(const RuneSpell*, Player* player, const Position& posTo)
+bool RuneIllusion(const RuneSpell*, Player* player, const Position& posTo)
 {
 	Thing* thing = g_game.internalGetThing(player, posTo, 0, 0, STACKPOS_MOVE);
 	if (!thing) {
@@ -1728,7 +1718,7 @@ bool RuneSpell::Illusion(const RuneSpell*, Player* player, const Position& posTo
 		return false;
 	}
 
-	ReturnValue ret = CreateIllusion(player, illusionItem->getID(), 200000);
+	ReturnValue ret = Spell::CreateIllusion(player, illusionItem->getID(), 200000);
 	if (ret != RETURNVALUE_NOERROR) {
 		player->sendCancelMessage(ret);
 		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -1739,7 +1729,7 @@ bool RuneSpell::Illusion(const RuneSpell*, Player* player, const Position& posTo
 	return true;
 }
 
-bool RuneSpell::Convince(const RuneSpell* spell, Player* player, const Position& posTo)
+bool Convince(const RuneSpell* spell, Player* player, const Position& posTo)
 {
 	if (!player->hasFlag(PlayerFlag_CanConvinceAll)) {
 		if (player->getSummonCount() >= 2) {
@@ -1783,6 +1773,24 @@ bool RuneSpell::Convince(const RuneSpell* spell, Player* player, const Position&
 	Spell::postCastSpell(player, manaCost, spell->getSoulCost());
 	g_game.updateCreatureType(convinceCreature);
 	g_game.addMagicEffect(player->getPosition(), CONST_ME_MAGIC_RED);
+	return true;
+}
+
+}
+
+bool RuneSpell::loadFunction(const pugi::xml_attribute& attr)
+{
+	const char* functionName = attr.as_string();
+	if (strcasecmp(functionName, "chameleon") == 0) {
+		runeFunction = RuneIllusion;
+	} else if (strcasecmp(functionName, "convince") == 0) {
+		runeFunction = Convince;
+	} else {
+		std::cout << "[Warning - RuneSpell::loadFunction] Function \"" << functionName << "\" does not exist." << std::endl;
+		return false;
+	}
+
+	scripted = false;
 	return true;
 }
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -31,7 +31,7 @@ class ConjureSpell;
 class RuneSpell;
 class Spell;
 
-typedef std::map<uint16_t, bool> VocSpellMap;
+using VocSpellMap = std::map<uint16_t, bool>;
 
 class Spells final : public BaseEvents
 {
@@ -71,8 +71,8 @@ class Spells final : public BaseEvents
 		LuaScriptInterface scriptInterface { "Spell Interface" };
 };
 
-typedef bool (InstantSpellFunction)(const InstantSpell* spell, Creature* creature, const std::string& param);
-typedef bool (RuneSpellFunction)(const RuneSpell* spell, Player* player, const Position& posTo);
+using InstantSpellFunction = std::function<bool(const InstantSpell* spell, Creature* creature, const std::string& param)>;
+using RuneSpellFunction = std::function<bool(const RuneSpell* spell, Player* player, const Position& posTo)>;
 
 class BaseSpell
 {
@@ -228,20 +228,9 @@ class InstantSpell : public TalkAction, public Spell
 	protected:
 		std::string getScriptEventName() const override;
 
-		static InstantSpellFunction HouseGuestList;
-		static InstantSpellFunction HouseSubOwnerList;
-		static InstantSpellFunction HouseDoorList;
-		static InstantSpellFunction HouseKick;
-		static InstantSpellFunction SearchPlayer;
-		static InstantSpellFunction SummonMonster;
-		static InstantSpellFunction Levitate;
-		static InstantSpellFunction Illusion;
-
-		static House* getHouseFromPos(Creature* creature);
-
 		bool internalCastSpell(Creature* creature, const LuaVariant& var);
 
-		InstantSpellFunction* function = nullptr;
+		InstantSpellFunction function;
 
 		bool needDirection = false;
 		bool hasParam = false;
@@ -311,12 +300,9 @@ class RuneSpell final : public Action, public Spell
 	protected:
 		std::string getScriptEventName() const final;
 
-		static RuneSpellFunction Illusion;
-		static RuneSpellFunction Convince;
-
 		bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
 
-		RuneSpellFunction* runeFunction = nullptr;
+		RuneSpellFunction runeFunction;
 		uint16_t runeId = 0;
 		bool hasCharges = true;
 };

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -384,18 +384,18 @@ void Tile::onAddTileItem(Item* item)
 
 	const Position& cylinderMapPos = getPosition();
 
-	SpectatorVec list;
-	g_game.map.getSpectators(list, cylinderMapPos, true);
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, cylinderMapPos, true);
 
 	//send to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendAddTileItem(this, cylinderMapPos, item);
 		}
 	}
 
 	//event methods
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onAddTileItem(this, cylinderMapPos);
 	}
 }
@@ -422,23 +422,23 @@ void Tile::onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newIte
 
 	const Position& cylinderMapPos = getPosition();
 
-	SpectatorVec list;
-	g_game.map.getSpectators(list, cylinderMapPos, true);
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, cylinderMapPos, true);
 
 	//send to client
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendUpdateTileItem(this, cylinderMapPos, newItem);
 		}
 	}
 
 	//event methods
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onUpdateTileItem(this, cylinderMapPos, oldItem, oldType, newItem, newType);
 	}
 }
 
-void Tile::onRemoveTileItem(const SpectatorVec& list, const std::vector<int32_t>& oldStackPosVector, Item* item)
+void Tile::onRemoveTileItem(const SpectatorHashSet& spectators, const std::vector<int32_t>& oldStackPosVector, Item* item)
 {
 	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
 		auto it = g_game.browseFields.find(this);
@@ -454,24 +454,24 @@ void Tile::onRemoveTileItem(const SpectatorVec& list, const std::vector<int32_t>
 
 	//send to client
 	size_t i = 0;
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendRemoveTileThing(cylinderMapPos, oldStackPosVector[i++]);
 		}
 	}
 
 	//event methods
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->onRemoveTileItem(this, cylinderMapPos, iType, item);
 	}
 }
 
-void Tile::onUpdateTile(const SpectatorVec& list)
+void Tile::onUpdateTile(const SpectatorHashSet& spectators)
 {
 	const Position& cylinderMapPos = getPosition();
 
 	//send to clients
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendUpdateTile(this, cylinderMapPos);
 	}
 }
@@ -1053,9 +1053,9 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 		ground->setParent(nullptr);
 		ground = nullptr;
 
-		SpectatorVec list;
-		g_game.map.getSpectators(list, getPosition(), true);
-		onRemoveTileItem(list, std::vector<int32_t>(list.size(), 0), item);
+		SpectatorHashSet spectators;
+		g_game.map.getSpectators(spectators, getPosition(), true);
+		onRemoveTileItem(spectators, std::vector<int32_t>(spectators.size(), 0), item);
 		return;
 	}
 
@@ -1073,9 +1073,9 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 
 		std::vector<int32_t> oldStackPosVector;
 
-		SpectatorVec list;
-		g_game.map.getSpectators(list, getPosition(), true);
-		for (Creature* spectator : list) {
+		SpectatorHashSet spectators;
+		g_game.map.getSpectators(spectators, getPosition(), true);
+		for (Creature* spectator : spectators) {
 			if (Player* tmpPlayer = spectator->getPlayer()) {
 				oldStackPosVector.push_back(getStackposOfItem(tmpPlayer, item));
 			}
@@ -1083,7 +1083,7 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 
 		item->setParent(nullptr);
 		items->erase(it);
-		onRemoveTileItem(list, oldStackPosVector, item);
+		onRemoveTileItem(spectators, oldStackPosVector, item);
 	} else {
 		auto it = std::find(items->getBeginDownItem(), items->getEndDownItem(), item);
 		if (it == items->getEndDownItem()) {
@@ -1097,9 +1097,9 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 		} else {
 			std::vector<int32_t> oldStackPosVector;
 
-			SpectatorVec list;
-			g_game.map.getSpectators(list, getPosition(), true);
-			for (Creature* spectator : list) {
+			SpectatorHashSet spectators;
+			g_game.map.getSpectators(spectators, getPosition(), true);
+			for (Creature* spectator : spectators) {
 				if (Player* tmpPlayer = spectator->getPlayer()) {
 					oldStackPosVector.push_back(getStackposOfItem(tmpPlayer, item));
 				}
@@ -1108,7 +1108,7 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 			item->setParent(nullptr);
 			items->erase(it);
 			items->addDownItemCount(-1);
-			onRemoveTileItem(list, oldStackPosVector, item);
+			onRemoveTileItem(spectators, oldStackPosVector, item);
 		}
 	}
 }
@@ -1340,9 +1340,9 @@ Thing* Tile::getThing(size_t index) const
 
 void Tile::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
 {
-	SpectatorVec list;
-	g_game.map.getSpectators(list, getPosition(), true, true);
-	for (Creature* spectator : list) {
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, getPosition(), true, true);
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->postAddNotification(thing, oldParent, index, LINK_NEAR);
 	}
 
@@ -1395,14 +1395,14 @@ void Tile::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t 
 
 void Tile::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
 {
-	SpectatorVec list;
-	g_game.map.getSpectators(list, getPosition(), true, true);
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, getPosition(), true, true);
 
 	if (getThingCount() > 8) {
-		onUpdateTile(list);
+		onUpdateTile(spectators);
 	}
 
-	for (Creature* spectator : list) {
+	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->postRemoveNotification(thing, newParent, index, LINK_NEAR);
 	}
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -34,9 +34,9 @@ class MagicField;
 class QTreeLeafNode;
 class BedItem;
 
-typedef std::vector<Creature*> CreatureVector;
-typedef std::vector<Item*> ItemVector;
-typedef std::unordered_set<Creature*> SpectatorVec;
+using CreatureVector = std::vector<Creature*>;
+using ItemVector = std::vector<Item*>;
+using SpectatorVec = std::unordered_set<Creature*>;
 
 enum tileflags_t : uint32_t {
 	TILESTATE_NONE = 0,

--- a/src/tile.h
+++ b/src/tile.h
@@ -36,7 +36,7 @@ class BedItem;
 
 using CreatureVector = std::vector<Creature*>;
 using ItemVector = std::vector<Item*>;
-using SpectatorVec = std::unordered_set<Creature*>;
+using SpectatorHashSet = std::unordered_set<Creature*>;
 
 enum tileflags_t : uint32_t {
 	TILESTATE_NONE = 0,
@@ -285,8 +285,8 @@ class Tile : public Cylinder
 	private:
 		void onAddTileItem(Item* item);
 		void onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newItem, const ItemType& newType);
-		void onRemoveTileItem(const SpectatorVec& list, const std::vector<int32_t>& oldStackPosVector, Item* item);
-		void onUpdateTile(const SpectatorVec& list);
+		void onRemoveTileItem(const SpectatorHashSet& spectators, const std::vector<int32_t>& oldStackPosVector, Item* item);
+		void onUpdateTile(const SpectatorHashSet& spectators);
 
 		void setTileFlags(const Item* item);
 		void resetTileFlags(const Item* item);

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -271,9 +271,9 @@ std::string asUpperCaseString(std::string source)
 	return source;
 }
 
-StringVec explodeString(const std::string& inString, const std::string& separator, int32_t limit/* = -1*/)
+StringVector explodeString(const std::string& inString, const std::string& separator, int32_t limit/* = -1*/)
 {
-	StringVec returnVector;
+	StringVector returnVector;
 	std::string::size_type start = 0, end = 0;
 
 	while (--limit != -1 && (end = inString.find(separator, start)) != std::string::npos) {
@@ -285,9 +285,9 @@ StringVec explodeString(const std::string& inString, const std::string& separato
 	return returnVector;
 }
 
-IntegerVec vectorAtoi(const StringVec& stringVector)
+IntegerVector vectorAtoi(const StringVector& stringVector)
 {
-	IntegerVec returnVector;
+	IntegerVector returnVector;
 	for (const auto& string : stringVector) {
 		returnVector.push_back(std::stoi(string));
 	}

--- a/src/tools.h
+++ b/src/tools.h
@@ -38,11 +38,11 @@ void toLowerCaseString(std::string& source);
 std::string asLowerCaseString(std::string source);
 std::string asUpperCaseString(std::string source);
 
-using StringVec = std::vector<std::string>;
-using IntegerVec = std::vector<int32_t>;
+using StringVector = std::vector<std::string>;
+using IntegerVector = std::vector<int32_t>;
 
-StringVec explodeString(const std::string& inString, const std::string& separator, int32_t limit = -1);
-IntegerVec vectorAtoi(const StringVec& stringVector);
+StringVector explodeString(const std::string& inString, const std::string& separator, int32_t limit = -1);
+IntegerVector vectorAtoi(const StringVector& stringVector);
 inline bool hasBitSet(uint32_t flag, uint32_t flags) {
 	return (flags & flag) != 0;
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -38,8 +38,8 @@ void toLowerCaseString(std::string& source);
 std::string asLowerCaseString(std::string source);
 std::string asUpperCaseString(std::string source);
 
-typedef std::vector<std::string> StringVec;
-typedef std::vector<int32_t> IntegerVec;
+using StringVec = std::vector<std::string>;
+using IntegerVec = std::vector<int32_t>;
 
 StringVec explodeString(const std::string& inString, const std::string& separator, int32_t limit = -1);
 IntegerVec vectorAtoi(const StringVec& stringVector);

--- a/src/town.h
+++ b/src/town.h
@@ -50,7 +50,7 @@ class Town
 		Position templePosition;
 };
 
-typedef std::map<uint32_t, Town*> TownMap;
+using TownMap = std::map<uint32_t, Town*>;
 
 class Towns
 {

--- a/src/waitlist.h
+++ b/src/waitlist.h
@@ -30,8 +30,8 @@ struct Wait {
 	uint32_t playerGUID;
 };
 
-typedef std::list<Wait> WaitList;
-typedef WaitList::iterator WaitListIterator;
+using WaitList = std::list<Wait>;
+using WaitListIterator = WaitList::iterator;
 
 class WaitingList
 {


### PR DESCRIPTION
As an extension of #2036, I applied similar changes throughout the code:

- Moved private static functions to the implementation (cpp) where possible, reducing header sizes.
- Replace `typedef` with `using`, as to have a standard type aliasing method.
- Standardized type aliases and renamed variables where needed (some may went unnoticed, please point)
- Use of `std::function` as function wrapper instead of raw function pointers.

A rune spell function was renamed (`Illusion` to `RuneIllusion`) because of a name clash when converting private static to free function.