### PR TITLE
Check tile before calling function

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,7 +2,7 @@
  * The Forgotten Server - a free and open-source MMORPG server emulator
  * Copyright (C) 2017 Mark Samman <mark.samman@gmail.com>
  *
- * This program is free tisoftware; you can redistribute it and/or modify
+ * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,7 +2,7 @@
  * The Forgotten Server - a free and open-source MMORPG server emulator
  * Copyright (C) 2017 Mark Samman <mark.samman@gmail.com>
  *
- * This program is free software; you can redistribute it and/or modify
+ * This program is free tisoftware; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
@@ -400,7 +400,7 @@ uint16_t Player::getClientIcons() const
 		icons |= ICON_REDSWORDS;
 	}
 
-	if (tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (tile && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		icons |= ICON_PIGEON;
 
 		// Don't show ICON_SWORDS if player is in protection zone.


### PR DESCRIPTION
This will fix a segmentation fault when a player logs in on top of a onStep event that deals damage.
Now that onStepIn was moved to queryAdd, if a player logs in, he'll receive damage before being placed on the map so tile can be null