### PR TITLE
Move house management function to Lua scripts

### DIFF
--- a/data/spells/scripts/house/edit_door_list.lua
+++ b/data/spells/scripts/house/edit_door_list.lua
@@ -1,27 +1,11 @@
-local function getNextPosition(player)
-	local position = player:getPosition()
-	local direction = player:getDirection()
-
-	-- a player can only be facing cardinal directions
-	if direction == DIRECTION_NORTH then
-		position.y = position.y - 1
-	elseif direction == DIRECTION_SOUTH then
-		position.y = position.y + 1
-	elseif direction == DIRECTION_WEST then
-		position.x = position.x - 1
-	else
-		position.x = position.x + 1
-	end
-	return position
-end
-
 function onCastSpell(player, variant)
 	local house = player:getTile():getHouse()
 	if not house then
 		return false
 	end
 
-	local doorId = house:getDoorIdByPosition(getNextPosition(player))
+	local doorPos = player:getPosition():getNextPosition(player:getDirection())
+	local doorId = house:getDoorIdByPosition(doorPos)
 	if doorId ~= nil and house:canEditAccessList(doorId, player) then
 		player:setEditHouse(house, doorId)
 		player:sendHouseWindow(house, doorId)

--- a/data/spells/scripts/house/edit_door_list.lua
+++ b/data/spells/scripts/house/edit_door_list.lua
@@ -1,0 +1,33 @@
+local function getNextPosition(player)
+	local position = player:getPosition()
+	local direction = player:getDirection()
+
+	-- a player can only be facing cardinal directions
+	if direction == DIRECTION_NORTH then
+		position.y = position.y - 1
+	elseif direction == DIRECTION_SOUTH then
+		position.y = position.y + 1
+	elseif direction == DIRECTION_WEST then
+		position.x = position.x - 1
+	else
+		position.x = position.x + 1
+	end
+	return position
+end
+
+function onCastSpell(player, variant)
+	local house = player:getTile():getHouse()
+	if not house then
+		return false
+	end
+
+	local doorId = house:getDoorIdByPosition(getNextPosition(player))
+	if doorId ~= nil and house:canEditAccessList(doorId, player) then
+		player:setEditHouse(house, doorId)
+		player:sendHouseWindow(house, doorId)
+	else
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+	end
+	return true
+end

--- a/data/spells/scripts/house/edit_door_list.lua
+++ b/data/spells/scripts/house/edit_door_list.lua
@@ -10,7 +10,7 @@ function onCastSpell(player, variant)
 		player:setEditHouse(house, doorId)
 		player:sendHouseWindow(house, doorId)
 	else
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 	end
 	return true

--- a/data/spells/scripts/house/edit_guest_list.lua
+++ b/data/spells/scripts/house/edit_guest_list.lua
@@ -8,7 +8,7 @@ function onCastSpell(player, variant)
 		player:setEditHouse(house, GUEST_LIST)
 		player:sendHouseWindow(house, GUEST_LIST)
 	else
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 	end
 	return true

--- a/data/spells/scripts/house/edit_guest_list.lua
+++ b/data/spells/scripts/house/edit_guest_list.lua
@@ -1,0 +1,15 @@
+function onCastSpell(player, variant)
+	local house = player:getTile():getHouse()
+	if not house then
+		return false
+	end
+
+	if house:canEditAccessList(GUEST_LIST, player) then
+		player:setEditHouse(house, GUEST_LIST)
+		player:sendHouseWindow(house, GUEST_LIST)
+	else
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+	end
+	return true
+end

--- a/data/spells/scripts/house/edit_subowner_list.lua
+++ b/data/spells/scripts/house/edit_subowner_list.lua
@@ -8,7 +8,7 @@ function onCastSpell(player, variant)
 		player:setEditHouse(house, SUBOWNER_LIST)
 		player:sendHouseWindow(house, SUBOWNER_LIST)
 	else
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 	end
 	return true

--- a/data/spells/scripts/house/edit_subowner_list.lua
+++ b/data/spells/scripts/house/edit_subowner_list.lua
@@ -1,0 +1,15 @@
+function onCastSpell(player, variant)
+	local house = player:getTile():getHouse()
+	if not house then
+		return false
+	end
+
+	if house:canEditAccessList(SUBOWNER_LIST, player) then
+		player:setEditHouse(house, SUBOWNER_LIST)
+		player:sendHouseWindow(house, SUBOWNER_LIST)
+	else
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+	end
+	return true
+end

--- a/data/spells/scripts/house/kick.lua
+++ b/data/spells/scripts/house/kick.lua
@@ -6,7 +6,7 @@ function onCastSpell(player, variant)
 
 	local house = targetPlayer:getTile():getHouse()
 	if not house or not house:kickPlayer(player, targetPlayer) then
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 		return false
 	end

--- a/data/spells/scripts/house/kick.lua
+++ b/data/spells/scripts/house/kick.lua
@@ -1,9 +1,5 @@
 function onCastSpell(player, variant)
-	local targetPlayer = Player(variant:getString())
-	if not targetPlayer then
-		targetPlayer = player
-	end
-
+	local targetPlayer = Player(variant:getString()) or player
 	local house = targetPlayer:getTile():getHouse()
 	if not house or not house:kickPlayer(player, targetPlayer) then
 		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)

--- a/data/spells/scripts/house/kick.lua
+++ b/data/spells/scripts/house/kick.lua
@@ -1,0 +1,14 @@
+function onCastSpell(player, variant)
+	local targetPlayer = Player(variant:getString())
+	if not targetPlayer then
+		targetPlayer = player
+	end
+
+	local house = targetPlayer:getTile():getHouse()
+	if not house or not house:kickPlayer(player, targetPlayer) then
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Sorry, not possible.")
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
+	return true
+end

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -737,10 +737,10 @@
 	</conjure>
 
 	<!-- House Spells -->
-	<instant spellid="71" name="House Guest List" words="aleta sio" selftarget="1" aggressive="0" function="editHouseGuest" />
-	<instant spellid="72" name="House Subowner List" words="aleta som" selftarget="1" aggressive="0" function="editHouseSubOwner" />
-	<instant spellid="73" name="House Door List" words="aleta grav" selftarget="1" aggressive="0" function="editHouseDoor" />
-	<instant spellid="74" name="House Kick" words="alana sio" params="1" aggressive="0" function="houseKick" />
+	<instant name="House Guest List" words="aleta sio" aggressive="0" script="house/edit_guest_list.lua" />
+	<instant name="House Subowner List" words="aleta som" aggressive="0" script="house/edit_subowner_list.lua" />
+	<instant name="House Door List" words="aleta grav" aggressive="0" script="house/edit_door_list.lua" />
+	<instant name="House Kick" words="alana sio" params="1" aggressive="0" script="house/kick.lua" />
 
 	<!-- Monster Spells -->
 	<instant name="ghastly dragon curse" words="###1" aggressive="1" blockwalls="1" needtarget="1" needlearn="1" script="monster/ghastly_dragon_curse.lua" />

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2240,7 +2240,10 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Player", "isPzLocked", LuaScriptInterface::luaPlayerIsPzLocked);
 
 	registerMethod("Player", "getClient", LuaScriptInterface::luaPlayerGetClient);
+
 	registerMethod("Player", "getHouse", LuaScriptInterface::luaPlayerGetHouse);
+	registerMethod("Player", "sendHouseWindow", LuaScriptInterface::luaPlayerSendHouseWindow);
+	registerMethod("Player", "setEditHouse", LuaScriptInterface::luaPlayerSetEditHouse);
 
 	registerMethod("Player", "setGhostMode", LuaScriptInterface::luaPlayerSetGhostMode);
 
@@ -2373,12 +2376,16 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("House", "getDoors", LuaScriptInterface::luaHouseGetDoors);
 	registerMethod("House", "getDoorCount", LuaScriptInterface::luaHouseGetDoorCount);
+	registerMethod("House", "getDoorIdByPosition", LuaScriptInterface::luaHouseGetDoorIdByPosition);
 
 	registerMethod("House", "getTiles", LuaScriptInterface::luaHouseGetTiles);
 	registerMethod("House", "getTileCount", LuaScriptInterface::luaHouseGetTileCount);
 
+	registerMethod("House", "canEditAccessList", LuaScriptInterface::luaHouseCanEditAccessList);
 	registerMethod("House", "getAccessList", LuaScriptInterface::luaHouseGetAccessList);
 	registerMethod("House", "setAccessList", LuaScriptInterface::luaHouseSetAccessList);
+
+	registerMethod("House", "kickPlayer", LuaScriptInterface::luaHouseKickPlayer);
 
 	// ItemType
 	registerClass("ItemType", "", LuaScriptInterface::luaItemTypeCreate);
@@ -9185,6 +9192,48 @@ int LuaScriptInterface::luaPlayerGetHouse(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaPlayerSendHouseWindow(lua_State* L)
+{
+	// player:sendHouseWindow(house, listId)
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	House* house = getUserdata<House>(L, 2);
+	if (!house) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	uint32_t listId = getNumber<uint32_t>(L, 3);
+	player->sendHouseWindow(house, listId);
+	pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerSetEditHouse(lua_State* L)
+{
+	// player:setEditHouse(house, listId)
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	House* house = getUserdata<House>(L, 2);
+	if (!house) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	uint32_t listId = getNumber<uint32_t>(L, 3);
+	player->setEditHouse(house, listId);
+	pushBoolean(L, true);
+	return 1;
+}
+
 int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 {
 	// player:setGhostMode(enabled)
@@ -10395,6 +10444,24 @@ int LuaScriptInterface::luaHouseGetDoorCount(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaHouseGetDoorIdByPosition(lua_State* L)
+{
+	// house:getDoorIdByPosition(position)
+	House* house = getUserdata<House>(L, 1);
+	if (!house) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	Door* door = house->getDoorByPosition(getPosition(L, 2));
+	if (door) {
+		lua_pushnumber(L, door->getDoorId());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int LuaScriptInterface::luaHouseGetTiles(lua_State* L)
 {
 	// house:getTiles()
@@ -10425,6 +10492,22 @@ int LuaScriptInterface::luaHouseGetTileCount(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+int LuaScriptInterface::luaHouseCanEditAccessList(lua_State* L)
+{
+	// house:canEditAccessList(listId, player)
+	House* house = getUserdata<House>(L, 1);
+	if (!house) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	uint32_t listId = getNumber<uint32_t>(L, 2);
+	Player* player = getPlayer(L, 3);
+
+	pushBoolean(L, house->canEditAccessList(listId, player));
 	return 1;
 }
 
@@ -10460,6 +10543,19 @@ int LuaScriptInterface::luaHouseSetAccessList(lua_State* L)
 	const std::string& list = getString(L, 3);
 	house->setAccessList(listId, list);
 	pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaHouseKickPlayer(lua_State* L)
+{
+	// house:kickPlayer(player, targetPlayer)
+	House* house = getUserdata<House>(L, 1);
+	if (!house) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	pushBoolean(L, house->kickPlayer(getPlayer(L, 2), getPlayer(L, 3)));
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -950,7 +950,10 @@ class LuaScriptInterface
 		static int luaPlayerIsPzLocked(lua_State* L);
 
 		static int luaPlayerGetClient(lua_State* L);
+
 		static int luaPlayerGetHouse(lua_State* L);
+		static int luaPlayerSendHouseWindow(lua_State* L);
+		static int luaPlayerSetEditHouse(lua_State* L);
 
 		static int luaPlayerSetGhostMode(lua_State* L);
 
@@ -1076,12 +1079,16 @@ class LuaScriptInterface
 
 		static int luaHouseGetDoors(lua_State* L);
 		static int luaHouseGetDoorCount(lua_State* L);
+		static int luaHouseGetDoorIdByPosition(lua_State* L);
 
 		static int luaHouseGetTiles(lua_State* L);
 		static int luaHouseGetTileCount(lua_State* L);
 
+		static int luaHouseCanEditAccessList(lua_State* L);
 		static int luaHouseGetAccessList(lua_State* L);
 		static int luaHouseSetAccessList(lua_State* L);
+
+		static int luaHouseKickPlayer(lua_State* L);
 
 		// ItemType
 		static int luaItemTypeCreate(lua_State* L);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -892,110 +892,6 @@ bool InstantSpell::configureEvent(const pugi::xml_node& node)
 
 namespace {
 
-House* getHouseFromPos(Creature* creature)
-{
-	if (!creature) {
-		return nullptr;
-	}
-
-	Player* player = creature->getPlayer();
-	if (!player) {
-		return nullptr;
-	}
-
-	HouseTile* houseTile = dynamic_cast<HouseTile*>(player->getTile());
-	if (!houseTile) {
-		return nullptr;
-	}
-
-	House* house = houseTile->getHouse();
-	if (!house) {
-		return nullptr;
-	}
-
-	return house;
-}
-
-bool HouseGuestList(const InstantSpell*, Creature* creature, const std::string&)
-{
-	House* house = getHouseFromPos(creature);
-	if (!house) {
-		return false;
-	}
-
-	Player* player = creature->getPlayer();
-	if (house->canEditAccessList(GUEST_LIST, player)) {
-		player->setEditHouse(house, GUEST_LIST);
-		player->sendHouseWindow(house, GUEST_LIST);
-	} else {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-	}
-	return true;
-}
-
-bool HouseSubOwnerList(const InstantSpell*, Creature* creature, const std::string&)
-{
-	House* house = getHouseFromPos(creature);
-	if (!house) {
-		return false;
-	}
-
-	Player* player = creature->getPlayer();
-	if (house->canEditAccessList(SUBOWNER_LIST, player)) {
-		player->setEditHouse(house, SUBOWNER_LIST);
-		player->sendHouseWindow(house, SUBOWNER_LIST);
-	} else {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-	}
-	return true;
-}
-
-bool HouseDoorList(const InstantSpell*, Creature* creature, const std::string&)
-{
-	House* house = getHouseFromPos(creature);
-	if (!house) {
-		return false;
-	}
-
-	Player* player = creature->getPlayer();
-	Position pos = Spells::getCasterPosition(player, player->getDirection());
-	Door* door = house->getDoorByPosition(pos);
-	if (door && house->canEditAccessList(door->getDoorId(), player)) {
-		player->setEditHouse(house, door->getDoorId());
-		player->sendHouseWindow(house, door->getDoorId());
-	} else {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-	}
-	return true;
-}
-
-bool HouseKick(const InstantSpell*, Creature* creature, const std::string& param)
-{
-	Player* player = creature->getPlayer();
-
-	Player* targetPlayer = g_game.getPlayerByName(param);
-	if (!targetPlayer) {
-		targetPlayer = player;
-	}
-
-	House* house = getHouseFromPos(targetPlayer);
-	if (!house) {
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return false;
-	}
-
-	if (!house->kickPlayer(player, targetPlayer)) {
-		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return false;
-	}
-	return true;
-}
-
 bool SummonMonster(const InstantSpell* spell, Creature* creature, const std::string& param)
 {
 	Player* player = creature->getPlayer();
@@ -1120,15 +1016,7 @@ bool Illusion(const InstantSpell*, Creature* creature, const std::string& param)
 bool InstantSpell::loadFunction(const pugi::xml_attribute& attr)
 {
 	const char* functionName = attr.as_string();
-	if (strcasecmp(functionName, "edithouseguest") == 0) {
-		function = HouseGuestList;
-	} else if (strcasecmp(functionName, "edithousesubowner") == 0) {
-		function = HouseSubOwnerList;
-	} else if (strcasecmp(functionName, "edithousedoor") == 0) {
-		function = HouseDoorList;
-	} else if (strcasecmp(functionName, "housekick") == 0) {
-		function = HouseKick;
-	} else if (strcasecmp(functionName, "levitate") == 0) {
+	if (strcasecmp(functionName, "levitate") == 0) {
 		function = Levitate;
 	} else if (strcasecmp(functionName, "illusion") == 0) {
 		function = Illusion;


### PR DESCRIPTION
This moves house management spells (aleta sio, aleta som, aleta grav and alana sio) to Lua scripts.

aleta sio and aleta som are working great, but I'm not sure about aleta grav. It inserts (and deletes, when erased) multiple rows at `house_lists` table, but ingame it works properly and it should not be related to these changes.

alana sio also works great but GM players can't kick themselves as they have the `CanEditHouses` flag set and [House::kickPlayer](https://github.com/otland/forgottenserver/blob/master/src/house.cpp#L160) disallows. I could fix while I'm at it.