### PR TITLE
Remove player from attack list upon death (Fixes a yellow skull issue)

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -624,6 +624,7 @@ void Creature::onDeath()
 
 	Creature* mostDamageCreature = nullptr;
 
+	const Player* targetPlayer = getPlayer();
 	const int64_t timeNow = OTSYS_TIME();
 	const uint32_t inFightTicks = g_config.getNumber(ConfigManager::PZ_LOCKED);
 	int32_t mostDamage = 0;
@@ -638,8 +639,12 @@ void Creature::onDeath()
 
 			if (attacker != this) {
 				uint64_t gainExp = getGainedExperience(attacker);
-				if (Player* player = attacker->getPlayer()) {
-					Party* party = player->getParty();
+				if (Player* attackerPlayer = attacker->getPlayer()) {
+					if (targetPlayer && attackerPlayer->hasAttacked(targetPlayer)) {
+						attackerPlayer->removeAttacked(targetPlayer);
+					}
+
+					Party* party = attackerPlayer->getParty();
 					if (party && party->getLeader() && party->isSharedExperienceActive() && party->isSharedExperienceEnabled()) {
 						attacker = party->getLeader();
 					}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -639,10 +639,7 @@ void Creature::onDeath()
 			if (attacker != this) {
 				uint64_t gainExp = getGainedExperience(attacker);
 				if (Player* attackerPlayer = attacker->getPlayer()) {
-					Player* targetPlayer = getPlayer();
-					if (targetPlayer && attackerPlayer->hasAttacked(targetPlayer)) {
-						attackerPlayer->removeAttacked(targetPlayer);
-					}
+					attackerPlayer->removeAttacked(getPlayer());
 
 					Party* party = attackerPlayer->getParty();
 					if (party && party->getLeader() && party->isSharedExperienceActive() && party->isSharedExperienceEnabled()) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -624,7 +624,6 @@ void Creature::onDeath()
 
 	Creature* mostDamageCreature = nullptr;
 
-	const Player* targetPlayer = getPlayer();
 	const int64_t timeNow = OTSYS_TIME();
 	const uint32_t inFightTicks = g_config.getNumber(ConfigManager::PZ_LOCKED);
 	int32_t mostDamage = 0;
@@ -640,6 +639,7 @@ void Creature::onDeath()
 			if (attacker != this) {
 				uint64_t gainExp = getGainedExperience(attacker);
 				if (Player* attackerPlayer = attacker->getPlayer()) {
+					Player* targetPlayer = getPlayer();
 					if (targetPlayer && attackerPlayer->hasAttacked(targetPlayer)) {
 						attackerPlayer->removeAttacked(targetPlayer);
 					}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3751,6 +3751,20 @@ void Player::addAttacked(const Player* attacked)
 	attackedSet.insert(attacked->guid);
 }
 
+void Player::removeAttacked(const Player* attacked)
+{
+	if (!attacked || attacked == this) {
+		return;
+	}
+
+	auto it = std::find(attackedSet.begin(), attackedSet.end(), attacked->guid);
+	if (it == attackedSet.end()) {
+		return;
+	}
+
+	attackedSet.erase(it);
+}
+
 void Player::clearAttacked()
 {
 	attackedSet.clear();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3757,12 +3757,10 @@ void Player::removeAttacked(const Player* attacked)
 		return;
 	}
 
-	auto it = std::find(attackedSet.begin(), attackedSet.end(), attacked->guid);
-	if (it == attackedSet.end()) {
-		return;
+	auto it = attackedSet.find(attacked->guid);
+	if (it != attackedSet.end()) {
+		attackedSet.erase(it);
 	}
-
-	attackedSet.erase(it);
 }
 
 void Player::clearAttacked()

--- a/src/player.h
+++ b/src/player.h
@@ -664,6 +664,7 @@ class Player final : public Creature, public Cylinder
 
 		bool hasAttacked(const Player* attacked) const;
 		void addAttacked(const Player* attacked);
+		void removeAttacked(const Player* attacked);
 		void clearAttacked();
 		void addUnjustifiedDead(const Player* attacked);
 		void sendCreatureSkull(const Creature* creature) const {


### PR DESCRIPTION
This should eliminate the possibility of receiving a yellow skull after killing another player (if none of them has any skull).

