### PR TITLE
new player defense formula based on t-s

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -360,8 +360,7 @@ int32_t Player::getDefense() const
 		}
 	}
 
-	defenseValue = static_cast<int32_t>(((((defenseSkill / 4.) + 2.23) * defenseValue) * 0.15) * getDefenseFactor());
-	return static_cast<int32_t>(static_cast<float>(defenseValue * vocation->defenseMultiplier));
+	return (defenseSkill / 4. + 2.23) * defenseValue * 0.15 * getDefenseFactor() * vocation->defenseMultiplier;
 }
 
 float Player::getAttackFactor() const

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -333,32 +333,38 @@ void Player::getShieldAndWeapon(const Item*& shield, const Item*& weapon) const
 
 int32_t Player::getDefense() const
 {
-	int32_t baseDefense = 5;
-	int32_t defenseValue = 0;
-	int32_t defenseSkill = 0;
-	int32_t extraDefense = 0;
-	float defenseFactor = getDefenseFactor();
+	int32_t defenseSkill = getSkillLevel(SKILL_FIST);
+	int32_t defenseValue = 7;
 	const Item* weapon;
 	const Item* shield;
 	getShieldAndWeapon(shield, weapon);
 
 	if (weapon) {
-		defenseValue = baseDefense + weapon->getDefense();
-		extraDefense = weapon->getExtraDefense();
+		defenseValue = weapon->getDefense() + weapon->getExtraDefense();
 		defenseSkill = getWeaponSkill(weapon);
 	}
 
-	if (shield && shield->getDefense() >= defenseValue) {
-		defenseValue = baseDefense + shield->getDefense() + extraDefense;
+	if (shield) {
+		defenseValue = weapon != nullptr ? shield->getDefense() + weapon->getExtraDefense() : shield->getDefense();
 		defenseSkill = getSkillLevel(SKILL_SHIELD);
 	}
 
 	if (defenseSkill == 0) {
-		return 0;
+		switch (fightMode) {
+			case FIGHTMODE_ATTACK:
+			case FIGHTMODE_BALANCED:
+				return 1;
+
+			case FIGHTMODE_DEFENSE:
+				return 2;
+
+			default:
+				return 0;
+		}
 	}
 
-	defenseValue = static_cast<int32_t>(defenseValue * vocation->defenseMultiplier);
-	return static_cast<int32_t>(std::ceil((static_cast<float>(defenseSkill * (defenseValue * 0.015)) + (defenseValue * 0.1)) * defenseFactor));
+	defenseValue = static_cast<int32_t>(((((defenseSkill / 4.) + 2.23) * defenseValue) * 0.15) * getDefenseFactor());
+	return static_cast<int32_t>(static_cast<float>(defenseValue * vocation->defenseMultiplier));
 }
 
 float Player::getAttackFactor() const
@@ -374,15 +380,9 @@ float Player::getAttackFactor() const
 float Player::getDefenseFactor() const
 {
 	switch (fightMode) {
-		case FIGHTMODE_ATTACK: return 1.0f;
-		case FIGHTMODE_BALANCED: return 1.2f;
-		case FIGHTMODE_DEFENSE: {
-			if ((OTSYS_TIME() - lastAttack) < getAttackSpeed()) {
-				return 1.0f;
-			}
-
-			return 2.0f;
-		}
+		case FIGHTMODE_ATTACK: return (OTSYS_TIME() - lastAttack) < getAttackSpeed() ? 0.5f : 1.0f;
+		case FIGHTMODE_BALANCED: return (OTSYS_TIME() - lastAttack) < getAttackSpeed() ? 0.75f : 1.0f;
+		case FIGHTMODE_DEFENSE: return 1.0f;
 		default: return 1.0f;
 	}
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -357,9 +357,6 @@ int32_t Player::getDefense() const
 
 			case FIGHTMODE_DEFENSE:
 				return 2;
-
-			default:
-				return 0;
 		}
 	}
 


### PR DESCRIPTION
**New Defense Formula based on tibia-stats research**
* Defense formula now uses [Fist Fighting skill](https://github.com/otland/forgottenserver/pull/2080/files#diff-dc52f162280289dd2d4d97d82658362dR336) *if neither weapon nor shield is equipped*.
* No matter if your [weapon's defense](https://github.com/otland/forgottenserver/pull/2080/files#diff-dc52f162280289dd2d4d97d82658362dR343) is higher than your shield's, instead, your [defense from shield](https://github.com/otland/forgottenserver/pull/2080/files#diff-dc52f162280289dd2d4d97d82658362dR348) will be used.
- No matter which **fight mode** you activated **(Balanced or Offensive)**, **both will act as Defensive** ``(defenseFactor == 1.0f)`` unless you are actively attacking ``((OTSYS_TIME() - lastAttack) < getAttackSpeed())`` a creature.

**Comparison**
- Shielding skill = 100
- Shield defense = 37
- Weapon defense = 31 +3 (extra defense)

| **Defense Factor** | **New Formula** | **Current Formula** | **Diff. range** |
| :-: | :-: | :-: | :-: |
| **Defensive** | 163 | 144 | +19 |
| **Balanced** | 122 | 87 | +35 |
| **Offensive** | 81 | 72 | +9 |

This is a remake of #1581 , and a few others haha.