### PR TITLE
More updates on Party spells

### DIFF
--- a/data/spells/lib/spells.lua
+++ b/data/spells/lib/spells.lua
@@ -301,10 +301,10 @@ function Creature:addDamageCondition(target, conditionType, listType, damage, ti
 	return true
 end
 
-function Creature:addPartyCondition(combat, variant, condition, baseMana)
+function Player:addPartyCondition(combat, variant, condition, baseMana)
 	local party = self:getParty()
 	if not party then
-		self:sendCancelMessage("No party members in range.")
+		self:sendCancelMessage(RETURNVALUE_NOPARTYMEMBERSINRANGE)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)
 		return false
 	end
@@ -321,7 +321,7 @@ function Creature:addPartyCondition(combat, variant, condition, baseMana)
 	end
 
 	if #affectedMembers <= 1 then
-		self:sendCancelMessage("No party members in range.")
+		self:sendCancelMessage(RETURNVALUE_NOPARTYMEMBERSINRANGE)
 		position:sendMagicEffect(CONST_ME_POFF)
 		return false
 	end
@@ -347,4 +347,3 @@ function Creature:addPartyCondition(combat, variant, condition, baseMana)
 	end
 	return true
 end
-

--- a/data/spells/scripts/party/enchant.lua
+++ b/data/spells/scripts/party/enchant.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
-combat:setArea(createCombatArea(AREA_CIRCLE5X5))
+combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_SUBID, 3)

--- a/data/spells/scripts/party/heal.lua
+++ b/data/spells/scripts/party/heal.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
-combat:setArea(createCombatArea(AREA_CIRCLE5X5))
+combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_REGENERATION)
 condition:setParameter(CONDITION_PARAM_SUBID, 4)

--- a/data/spells/scripts/party/protect.lua
+++ b/data/spells/scripts/party/protect.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
-combat:setArea(createCombatArea(AREA_CIRCLE5X5))
+combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_SUBID, 2)

--- a/data/spells/scripts/party/train.lua
+++ b/data/spells/scripts/party/train.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
-combat:setArea(createCombatArea(AREA_CIRCLE5X5))
+combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_SUBID, 1)


### PR DESCRIPTION
* Updated spells lib function to use the ``RETURNVALUE`` equivalent of ``"No party members in
range"`` in ``sendCancelMessage``.
* Switched function metatable from Creature to Player.
* Updated spell to use correct area (AREA_CIRCLE3X3).