### PR TITLE
Fix spellbook not loading

### DIFF
--- a/data/actions/scripts/other/spellbook.lua
+++ b/data/actions/scripts/other/spellbook.lua
@@ -1,9 +1,7 @@
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	local count = getPlayerInstantSpellCount(player)
 	local text = ""
 	local spells = {}
-	for i = 0, count - 1 do
-		local spell = getPlayerInstantSpellInfo(player, i)
+	for _, spell in ipairs(player:getInstantSpells()) do
 		if spell.level ~= 0 then
 			if spell.manapercent > 0 then
 				spell.mana = spell.manapercent .. "%"

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1019,14 +1019,7 @@ function getPlayerInstantSpellInfo(cid, spellId)
 		return false
 	end
 
-	return {
-		["name"] = spell:getName(),
-		["words"] = spell:getWords(),
-		["level"] = spell:getLevel(),
-		["mlevel"] = spell:getMagicLevel(),
-		["mana"] = spell:getManaCost(player),
-		["manapercent"] = spell:getManaPercent()
-	}
+	return spell
 end
 
 function doSetItemOutfit(cid, item, time) local c = Creature(cid) return c ~= nil and c:setItemOutfit(item, time) end

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -46,6 +46,7 @@ class Combat;
 class Condition;
 class Npc;
 class Monster;
+class InstantSpell;
 
 enum {
 	EVENT_ID_LOADING = 1,
@@ -367,6 +368,7 @@ class LuaScriptInterface
 
 		// Push
 		static void pushBoolean(lua_State* L, bool value);
+		static void pushInstantSpell(lua_State* L, const InstantSpell& spell);
 		static void pushPosition(lua_State* L, const Position& position, int32_t stackpos = 0);
 		static void pushOutfit(lua_State* L, const Outfit_t& outfit);
 
@@ -957,7 +959,7 @@ class LuaScriptInterface
 		static int luaPlayerGetContainerById(lua_State* L);
 		static int luaPlayerGetContainerIndex(lua_State* L);
 
-		static int luaPlayerGetInstantSpellCount(lua_State* L);
+		static int luaPlayerGetInstantSpells(lua_State* L);
 		static int luaPlayerCanCast(lua_State* L);
 
 		// Monster
@@ -1247,12 +1249,7 @@ class LuaScriptInterface
 		// Spells
 		static int luaSpellCreate(lua_State* L);
 
-		static int luaSpellGetName(lua_State* L);
-		static int luaSpellGetWords(lua_State* L);
-		static int luaSpellGetLevel(lua_State* L);
-		static int luaSpellGetMagicLevel(lua_State* L);
 		static int luaSpellGetManaCost(lua_State* L);
-		static int luaSpellGetManaPercent(lua_State* L);
 		static int luaSpellGetSoulCost(lua_State* L);
 
 		static int luaSpellIsPremium(lua_State* L);

--- a/src/spells.h
+++ b/src/spells.h
@@ -58,6 +58,10 @@ class Spells final : public BaseEvents
 		static Position getCasterPosition(Creature* creature, Direction dir);
 		std::string getScriptBaseName() const final;
 
+		const std::map<std::string, InstantSpell*>& getInstantSpells() const {
+			return instants;
+		};
+
 	protected:
 		void clear() final;
 		LuaScriptInterface& getScriptInterface() final;
@@ -141,6 +145,9 @@ class Spell : public BaseSpell
 		}
 		uint32_t getMagicLevel() const {
 			return magLevel;
+		}
+		uint32_t getMana() const {
+			return mana;
 		}
 		uint32_t getManaPercent() const {
 			return manaPercent;


### PR DESCRIPTION
Should be more robust than @wibbenz solution #2098 and now a `Spell` object already has attributes and there's no need to call C++ methods. Only `getManaCost` stays in Lua because it can take a player argument to calculate cost and `getSoulCost` because consistency, as it can potentially use a player argument.

Added `player:getInstantSpells()` method filtering which spells a player can cast.