### PR TITLE
Update monsters in data pack

### DIFF
--- a/data/monster/Annelids/drillworm.xml
+++ b/data/monster/Annelids/drillworm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Drillworm" nameDescription="a drillworm" race="venom" experience="1100" speed="240" manacost="0">
+<monster name="Drillworm" nameDescription="a drillworm" race="venom" experience="1100" speed="240">
 	<health now="1500" max="1500" />
 	<look type="527" corpse="19705" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Annelids/rift_worm.xml
+++ b/data/monster/Annelids/rift_worm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Rift Worm" nameDescription="Rift Worm" race="blood" experience="1195" speed="200" manacost="0">
+<monster name="Rift Worm" nameDescription="Rift Worm" race="blood" experience="1195" speed="200">
 	<health now="2800" max="2800" />
 	<look type="295" corpse="0" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Apes/kongra.xml
+++ b/data/monster/Apes/kongra.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Kongra" nameDescription="a kongra" race="blood" experience="115" speed="210" manacost="0">
+<monster name="Kongra" nameDescription="a kongra" race="blood" experience="115" speed="210">
 	<health now="340" max="340" />
 	<look type="116" corpse="6043" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Apes/merlkin.xml
+++ b/data/monster/Apes/merlkin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Merlkin" nameDescription="a merlkin" race="blood" experience="145" speed="200" manacost="0">
+<monster name="Merlkin" nameDescription="a merlkin" race="blood" experience="145" speed="200">
 	<health now="235" max="235" />
 	<look type="117" corpse="6044" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Apes/sibang.xml
+++ b/data/monster/Apes/sibang.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Sibang" nameDescription="a sibang" race="blood" experience="105" speed="200" manacost="0">
+<monster name="Sibang" nameDescription="a sibang" race="blood" experience="105" speed="200">
 	<health now="225" max="225" />
 	<look type="118" corpse="6045" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Apes/yeti.xml
+++ b/data/monster/Apes/yeti.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Yeti" nameDescription="Yeti" race="blood" experience="460" speed="270" manacost="0">
+<monster name="Yeti" nameDescription="Yeti" race="blood" experience="460" speed="270">
 	<health now="950" max="950" />
 	<look type="110" corpse="6038" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Arachnids/crystal_spider.xml
+++ b/data/monster/Arachnids/crystal_spider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Crystal Spider" nameDescription="a crystal spider" race="undead" experience="900" speed="220" manacost="0">
+<monster name="Crystal Spider" nameDescription="a crystal spider" race="undead" experience="900" speed="220">
 	<health now="1250" max="1250" />
 	<look type="263" corpse="7344" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Arachnids/giant_spider.xml
+++ b/data/monster/Arachnids/giant_spider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Giant Spider" nameDescription="a giant spider" race="venom" experience="900" speed="230" manacost="0">
+<monster name="Giant Spider" nameDescription="a giant spider" race="venom" experience="900" speed="230">
 	<health now="1300" max="1300" />
 	<look type="38" corpse="5977" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Arachnids/poison_spider.xml
+++ b/data/monster/Arachnids/poison_spider.xml
@@ -8,7 +8,7 @@
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="1" />
-		<flag convinceable="1" />
+		<flag convinceable="0" />
 		<flag pushable="1" />
 		<flag canpushitems="0" />
 		<flag canpushcreatures="0" />

--- a/data/monster/Arachnids/sandstone_scorpion.xml
+++ b/data/monster/Arachnids/sandstone_scorpion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Sandstone Scorpion" nameDescription="a sandstone scorpion" race="undead" experience="680" speed="230" manacost="0">
+<monster name="Sandstone Scorpion" nameDescription="a sandstone scorpion" race="undead" experience="680" speed="230">
 	<health now="900" max="900" />
 	<look type="398" corpse="13501" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Arachnids/scorpion.xml
+++ b/data/monster/Arachnids/scorpion.xml
@@ -8,7 +8,7 @@
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="1" />
-		<flag convinceable="1" />
+		<flag convinceable="0" />
 		<flag pushable="1" />
 		<flag canpushitems="0" />
 		<flag canpushcreatures="0" />

--- a/data/monster/Arachnids/wailing_widow.xml
+++ b/data/monster/Arachnids/wailing_widow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wailing Widow" nameDescription="a wailing widow" race="venom" experience="450" speed="220" manacost="0">
+<monster name="Wailing Widow" nameDescription="a wailing widow" race="venom" experience="450" speed="220">
 	<health now="850" max="850" />
 	<look type="347" corpse="11310" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Arena/greenhorn/achad.xml
+++ b/data/monster/Arena/greenhorn/achad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Achad" nameDescription="Achad" race="blood" experience="70" speed="185" manacost="0">
+<monster name="Achad" nameDescription="Achad" race="blood" experience="70" speed="185">
 	<health now="185" max="185" />
 	<look type="146" head="93" body="93" legs="57" feet="97" addons="3" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/axeitus_headbanger.xml
+++ b/data/monster/Arena/greenhorn/axeitus_headbanger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Axeitus Headbanger" nameDescription="Axeitus Headbanger" race="blood" experience="140" speed="170" manacost="0">
+<monster name="Axeitus Headbanger" nameDescription="Axeitus Headbanger" race="blood" experience="140" speed="170">
 	<health now="365" max="365" />
 	<look type="71" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/bloodpaw.xml
+++ b/data/monster/Arena/greenhorn/bloodpaw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bloodpaw" nameDescription="Bloodpaw" race="blood" experience="50" speed="156" manacost="0">
+<monster name="Bloodpaw" nameDescription="Bloodpaw" race="blood" experience="50" speed="156">
 	<health now="100" max="100" />
 	<look type="42" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/bovinus.xml
+++ b/data/monster/Arena/greenhorn/bovinus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bovinus" nameDescription="Bovinus" race="blood" experience="60" speed="170" manacost="0">
+<monster name="Bovinus" nameDescription="Bovinus" race="blood" experience="60" speed="170">
 	<health now="150" max="150" />
 	<look type="25" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/colerian_the_barbarian.xml
+++ b/data/monster/Arena/greenhorn/colerian_the_barbarian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Colerian The Barbarian" nameDescription="Colerian the Barbarian" race="blood" experience="90" speed="190" manacost="0">
+<monster name="Colerian The Barbarian" nameDescription="Colerian the Barbarian" race="blood" experience="90" speed="190">
 	<health now="265" max="265" />
 	<look type="253" head="76" body="115" legs="115" feet="43" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/cursed_gladiator.xml
+++ b/data/monster/Arena/greenhorn/cursed_gladiator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cursed Gladiator" nameDescription="a cursed gladiator" race="undead" experience="215" speed="170" manacost="0">
+<monster name="Cursed Gladiator" nameDescription="a cursed gladiator" race="undead" experience="215" speed="170">
 	<health now="435" max="435" />
 	<look type="100" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/frostfur.xml
+++ b/data/monster/Arena/greenhorn/frostfur.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Frostfur" nameDescription="Frostfur" race="blood" experience="35" speed="170" manacost="0">
+<monster name="Frostfur" nameDescription="Frostfur" race="blood" experience="35" speed="170">
 	<health now="65" max="65" />
 	<look type="52" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/orcus_the_cruel.xml
+++ b/data/monster/Arena/greenhorn/orcus_the_cruel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Orcus the Cruel" nameDescription="Orcus the cruel" race="blood" experience="280" speed="230" manacost="0">
+<monster name="Orcus the Cruel" nameDescription="Orcus the cruel" race="blood" experience="280" speed="230">
 	<health now="480" max="480" />
 	<look type="59" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/rocky.xml
+++ b/data/monster/Arena/greenhorn/rocky.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Rocky" nameDescription="Rocky" race="undead" experience="190" speed="170" manacost="0">
+<monster name="Rocky" nameDescription="Rocky" race="undead" experience="190" speed="170">
 	<health now="390" max="390" />
 	<look type="95" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/greenhorn/the_hairy_one.xml
+++ b/data/monster/Arena/greenhorn/the_hairy_one.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Hairy One" nameDescription="The Hairy One" race="blood" experience="115" speed="240" manacost="0">
+<monster name="The Hairy One" nameDescription="The Hairy One" race="blood" experience="115" speed="240">
 	<health now="325" max="325" />
 	<look type="116" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/avalanche.xml
+++ b/data/monster/Arena/scrapper/avalanche.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Avalanche" nameDescription="Avalanche" race="undead" experience="305" speed="195" manacost="0">
+<monster name="Avalanche" nameDescription="Avalanche" race="undead" experience="305" speed="195">
 	<health now="550" max="550" />
 	<look type="261" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/drasilla.xml
+++ b/data/monster/Arena/scrapper/drasilla.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Drasilla" nameDescription="Drasilla" race="blood" experience="700" speed="170" manacost="0">
+<monster name="Drasilla" nameDescription="Drasilla" race="blood" experience="700" speed="170">
 	<health now="1260" max="1260" />
 	<look type="34" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/grimgor_guteater.xml
+++ b/data/monster/Arena/scrapper/grimgor_guteater.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Grimgor Guteater" nameDescription="Grimgor Guteater" race="blood" experience="670" speed="240" manacost="0">
+<monster name="Grimgor Guteater" nameDescription="Grimgor Guteater" race="blood" experience="670" speed="240">
 	<health now="1115" max="1115" />
 	<look type="2" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/kreebosh_the_exile.xml
+++ b/data/monster/Arena/scrapper/kreebosh_the_exile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Kreebosh the Exile" nameDescription="Kreebosh the Exile" race="blood" experience="350" speed="270" manacost="0">
+<monster name="Kreebosh the Exile" nameDescription="Kreebosh the Exile" race="blood" experience="350" speed="270">
 	<health now="705" max="705" />
 	<look type="103" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/slim.xml
+++ b/data/monster/Arena/scrapper/slim.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Slim" nameDescription="Slim" race="undead" experience="580" speed="200" manacost="0">
+<monster name="Slim" nameDescription="Slim" race="undead" experience="580" speed="200">
 	<health now="1025" max="1025" />
 	<look type="101" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/spirit_of_earth.xml
+++ b/data/monster/Arena/scrapper/spirit_of_earth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Spirit of Earth" nameDescription="a spirit of earth" race="undead" experience="800" speed="180" manacost="0">
+<monster name="Spirit of Earth" nameDescription="a spirit of earth" race="undead" experience="800" speed="180">
 	<health now="1200" max="1200" />
 	<look type="67" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/spirit_of_fire.xml
+++ b/data/monster/Arena/scrapper/spirit_of_fire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Spirit of Fire" nameDescription="a spirit of fire" race="blood" experience="950" speed="220" manacost="0">
+<monster name="Spirit of Fire" nameDescription="a spirit of fire" race="blood" experience="950" speed="220">
 	<health now="2210" max="2210" />
 	<look type="242" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/spirit_of_water.xml
+++ b/data/monster/Arena/scrapper/spirit_of_water.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Spirit of Water" nameDescription="a spirit of water" race="undead" experience="850" speed="200" manacost="0">
+<monster name="Spirit of Water" nameDescription="a spirit of water" race="undead" experience="850" speed="200">
 	<health now="1400" max="1400" />
 	<look type="11" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/the_dark_dancer.xml
+++ b/data/monster/Arena/scrapper/the_dark_dancer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Dark Dancer" nameDescription="The Dark Dancer" race="blood" experience="435" speed="170" manacost="0">
+<monster name="The Dark Dancer" nameDescription="The Dark Dancer" race="blood" experience="435" speed="170">
 	<health now="805" max="805" />
 	<look type="58" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/scrapper/the_hag.xml
+++ b/data/monster/Arena/scrapper/the_hag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Hag" nameDescription="The Hag" race="blood" experience="510" speed="205" manacost="0">
+<monster name="The Hag" nameDescription="The Hag" race="blood" experience="510" speed="205">
 	<health now="935" max="935" />
 	<look type="264" head="78" body="97" legs="95" feet="95" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/darakan_the_executioner.xml
+++ b/data/monster/Arena/warlord/darakan_the_executioner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Darakan the Executioner" nameDescription="Darakan the Executioner" race="blood" experience="1600" speed="205" manacost="0">
+<monster name="Darakan the Executioner" nameDescription="Darakan the Executioner" race="blood" experience="1600" speed="205">
 	<health now="3480" max="3480" />
 	<look type="255" head="78" body="114" legs="114" feet="114" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/deathbringer.xml
+++ b/data/monster/Arena/warlord/deathbringer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Deathbringer" nameDescription="Deathbringer" race="undead" experience="5100" speed="300" manacost="0">
+<monster name="Deathbringer" nameDescription="Deathbringer" race="undead" experience="5100" speed="300">
 	<health now="8440" max="8440" />
 	<look type="231" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/fallen_mooh'tah_master_ghar.xml
+++ b/data/monster/Arena/warlord/fallen_mooh'tah_master_ghar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Fallen Mooh'tah Master Ghar" nameDescription="Fallen Mooh'Tah Master Ghar" race="blood" experience="4400" speed="190" manacost="0">
+<monster name="Fallen Mooh'tah Master Ghar" nameDescription="Fallen Mooh'Tah Master Ghar" race="blood" experience="4400" speed="190">
 	<health now="7990" max="7990" />
 	<look type="29" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/gnorre_chyllson.xml
+++ b/data/monster/Arena/warlord/gnorre_chyllson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Gnorre Chyllson" nameDescription="Gnorre Chyllson" race="blood" experience="4000" speed="370" manacost="0">
+<monster name="Gnorre Chyllson" nameDescription="Gnorre Chyllson" race="blood" experience="4000" speed="370">
 	<health now="7150" max="7150" />
 	<look type="251" head="11" body="9" legs="11" feet="85" addons="1" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/norgle_glacierbeard.xml
+++ b/data/monster/Arena/warlord/norgle_glacierbeard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Norgle Glacierbeard" nameDescription="Norgle Glacierbeard" race="blood" experience="2100" speed="195" manacost="0">
+<monster name="Norgle Glacierbeard" nameDescription="Norgle Glacierbeard" race="blood" experience="2100" speed="195">
 	<health now="4280" max="4280" />
 	<look type="257" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/svoren_the_mad.xml
+++ b/data/monster/Arena/warlord/svoren_the_mad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Svoren the Mad" nameDescription="Svoren the Mad" race="blood" experience="3000" speed="180" manacost="0">
+<monster name="Svoren the Mad" nameDescription="Svoren the Mad" race="blood" experience="3000" speed="180">
 	<health now="6310" max="6310" />
 	<look type="254" head="80" body="99" legs="118" feet="38" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/the_masked_marauder.xml
+++ b/data/monster/Arena/warlord/the_masked_marauder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Masked Marauder" nameDescription="The Masked Marauder" race="blood" experience="3500" speed="250" manacost="0">
+<monster name="The Masked Marauder" nameDescription="The Masked Marauder" race="blood" experience="3500" speed="250">
 	<health now="7320" max="7320" />
 	<look type="234" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/the_obliverator.xml
+++ b/data/monster/Arena/warlord/the_obliverator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Obliverator" nameDescription="The Obliverator" race="fire" experience="6000" speed="280" manacost="0">
+<monster name="The Obliverator" nameDescription="The Obliverator" race="fire" experience="6000" speed="280">
 	<health now="9020" max="9020" />
 	<look type="35" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/the_pit_lord.xml
+++ b/data/monster/Arena/warlord/the_pit_lord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Pit Lord" nameDescription="The Pit Lord" race="blood" experience="2500" speed="270" manacost="0">
+<monster name="The Pit Lord" nameDescription="The Pit Lord" race="blood" experience="2500" speed="270">
 	<health now="5270" max="5270" />
 	<look type="55" corpse="7349" />
 	<flags>

--- a/data/monster/Arena/warlord/webster.xml
+++ b/data/monster/Arena/warlord/webster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Webster" nameDescription="Webster" race="undead" experience="1200" speed="290" manacost="0">
+<monster name="Webster" nameDescription="Webster" race="undead" experience="1200" speed="290">
 	<health now="2950" max="2950" />
 	<look type="263" corpse="7349" />
 	<flags>

--- a/data/monster/Barbarians/barbarian_brutetamer.xml
+++ b/data/monster/Barbarians/barbarian_brutetamer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Barbarian Brutetamer" nameDescription="a barbarian brutetamer" race="blood" experience="90" speed="190" manacost="0">
+<monster name="Barbarian Brutetamer" nameDescription="a barbarian brutetamer" race="blood" experience="90" speed="190">
 	<health now="145" max="145" />
 	<look type="264" head="78" body="116" legs="95" feet="121" corpse="20339" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bears/undead_cavebear.xml
+++ b/data/monster/Bears/undead_cavebear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Undead Cavebear" nameDescription="Undead Cavebear" race="blood" experience="600" speed="250" manacost="0">
+<monster name="Undead Cavebear" nameDescription="Undead Cavebear" race="blood" experience="600" speed="250">
 	<health now="450" max="450" />
 	<look type="384" corpse="13323" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bio-Elementals/bog_raider.xml
+++ b/data/monster/Bio-Elementals/bog_raider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bog Raider" nameDescription="a bog raider" race="venom" experience="800" speed="240" manacost="0">
+<monster name="Bog Raider" nameDescription="a bog raider" race="venom" experience="800" speed="240">
 	<health now="1300" max="1300" />
 	<look type="299" corpse="8951" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/carniphila.xml
+++ b/data/monster/Bio-Elementals/carniphila.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Carniphila" nameDescription="a carniphila" race="venom" experience="150" speed="170" manacost="0">
+<monster name="Carniphila" nameDescription="a carniphila" race="venom" experience="150" speed="170">
 	<health now="255" max="255" />
 	<look type="120" corpse="6047" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/defiler.xml
+++ b/data/monster/Bio-Elementals/defiler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Defiler" nameDescription="a defiler" race="venom" experience="3700" speed="230" manacost="0">
+<monster name="Defiler" nameDescription="a defiler" race="venom" experience="3700" speed="230">
 	<health now="3650" max="3650" />
 	<look type="238" corpse="6532" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/haunted_treeling.xml
+++ b/data/monster/Bio-Elementals/haunted_treeling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Haunted Treeling" nameDescription="a haunted treeling" experience="310" speed="220" race="undead" manacost="0">
+<monster name="Haunted Treeling" nameDescription="a haunted treeling" experience="310" speed="220" race="undead">
 	<health now="450" max="450" />
 	<look type="310" corpse="9867" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/hideous_fungus.xml
+++ b/data/monster/Bio-Elementals/hideous_fungus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hideous Fungus" nameDescription="a hideous fungus" race="venom" experience="2900" speed="260" manacost="0">
+<monster name="Hideous Fungus" nameDescription="a hideous fungus" race="venom" experience="2900" speed="260">
 	<health now="4600" max="4600" />
 	<look type="499" corpse="17428" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/humongous_fungus.xml
+++ b/data/monster/Bio-Elementals/humongous_fungus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Humongous Fungus" nameDescription="a humongous fungus" race="blood" experience="2600" speed="270" manacost="0">
+<monster name="Humongous Fungus" nameDescription="a humongous fungus" race="blood" experience="2600" speed="270">
 	<health now="3400" max="3400" />
 	<look type="488" corpse="18382" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Bio-Elementals/humorless_fungus.xml
+++ b/data/monster/Bio-Elementals/humorless_fungus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Humorless Fungus" nameDescription="a humorless fungus" race="venom" experience="0" speed="230" manacost="0">
+<monster name="Humorless Fungus" nameDescription="a humorless fungus" race="venom" experience="0" speed="230">
 	<health now="2500" max="2500" />
 	<look type="517" corpse="17428" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/mechanical_fighter.xml
+++ b/data/monster/Bio-Elementals/mechanical_fighter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Mechanical Fighter" nameDescription="a mechanical fighter" race="undead" experience="255" speed="200" manacost="0">
+<monster name="Mechanical Fighter" nameDescription="a mechanical fighter" race="undead" experience="255" speed="200">
 	<health now="420" max="420" />
 	<look type="102" corpse="2253" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bio-Elementals/slime.xml
+++ b/data/monster/Bio-Elementals/slime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Slime" nameDescription="a slime" race="venom" experience="160" speed="180" manacost="0">
+<monster name="Slime" nameDescription="a slime" race="venom" experience="160" speed="180">
 	<health now="150" max="150" />
 	<look type="19" corpse="1496" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/son_of_verminor.xml
+++ b/data/monster/Bio-Elementals/son_of_verminor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Son of Verminor" nameDescription="Son of Verminor" race="venom" experience="5900" speed="240" manacost="0">
+<monster name="Son of Verminor" nameDescription="Son of Verminor" race="venom" experience="5900" speed="240">
 	<health now="8500" max="8500" />
 	<look type="19" corpse="1490" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bio-Elementals/spit_nettle.xml
+++ b/data/monster/Bio-Elementals/spit_nettle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Spit Nettle" nameDescription="a spit nettle" race="venom" experience="20" speed="0" manacost="0">
+<monster name="Spit Nettle" nameDescription="a spit nettle" race="venom" experience="20" speed="0">
 	<health now="150" max="150" />
 	<look type="221" corpse="6062" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Bio-Elementals/strange_slime.xml
+++ b/data/monster/Bio-Elementals/strange_slime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Strange Slime" nameDescription="a strange slime" race="venom" experience="0" speed="120" manacost="0">
+<monster name="Strange Slime" nameDescription="a strange slime" race="venom" experience="0" speed="120">
 	<health now="15" max="15" />
 	<look type="19" corpse="1496" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bio-Elementals/swampling.xml
+++ b/data/monster/Bio-Elementals/swampling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Swampling" nameDescription="a swampling" race="venom" experience="45" speed="190" manacost="0">
+<monster name="Swampling" nameDescription="a swampling" race="venom" experience="45" speed="190">
 	<health now="80" max="80" />
 	<look type="535" corpse="19902" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Birds/dire_penguin.xml
+++ b/data/monster/Birds/dire_penguin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dire Penguin" nameDescription="a dire penguin" race="blood" experience="119" speed="200" manacost="0">
+<monster name="Dire Penguin" nameDescription="a dire penguin" race="blood" experience="119" speed="200">
 	<health now="173" max="173" />
 	<look type="250" corpse="7334" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Birds/marsh_stalker.xml
+++ b/data/monster/Birds/marsh_stalker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Marsh Stalker" nameDescription="a marsh stalker" race="blood" experience="50" speed="210" manacost="0">
+<monster name="Marsh Stalker" nameDescription="a marsh stalker" race="blood" experience="50" speed="210">
 	<health now="100" max="100" />
 	<look type="530" corpse="19708" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Birds/pigeon.xml
+++ b/data/monster/Birds/pigeon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Pigeon" nameDescription="a pigeon" race="blood" experience="0" speed="260" manacost="0">
+<monster name="Pigeon" nameDescription="a pigeon" race="blood" experience="0" speed="260">
 	<health now="30" max="30" />
 	<look type="531" corpse="19709" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Blobs/acid_blob.xml
+++ b/data/monster/Blobs/acid_blob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Acid Blob" nameDescription="an acid blob" race="venom" experience="250" speed="180" manacost="0">
+<monster name="Acid Blob" nameDescription="an acid blob" race="venom" experience="250" speed="180">
 	<health now="250" max="250" />
 	<look type="314" corpse="9962" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Blobs/death_blob.xml
+++ b/data/monster/Blobs/death_blob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Death Blob" nameDescription="a death blob" race="undead" experience="300" speed="180" manacost="0">
+<monster name="Death Blob" nameDescription="a death blob" race="undead" experience="300" speed="180">
 	<health now="320" max="320" />
 	<look type="315" corpse="9960" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Blobs/floor_blob.xml
+++ b/data/monster/Blobs/floor_blob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Floor Blob" nameDescription="a floor blob" race="venom" experience="0" speed="0" manacost="0">
+<monster name="Floor Blob" nameDescription="a floor blob" race="venom" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look type="459" corpse="0" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Blobs/mercury_blob.xml
+++ b/data/monster/Blobs/mercury_blob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mercury Blob" nameDescription="a mercury blob" race="undead" experience="180" speed="180" manacost="0">
+<monster name="Mercury Blob" nameDescription="a mercury blob" race="undead" experience="180" speed="180">
 	<health now="150" max="150" />
 	<look type="316" corpse="9961" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Bonelords/bonelord.xml
+++ b/data/monster/Bonelords/bonelord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bonelord" nameDescription="a bonelord" race="venom" experience="170" speed="170" manacost="0">
+<monster name="Bonelord" nameDescription="a bonelord" race="venom" experience="170" speed="170">
 	<health now="260" max="260" />
 	<look type="17" corpse="5992" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bonelords/braindeath.xml
+++ b/data/monster/Bonelords/braindeath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Braindeath" nameDescription="a braindeath" race="undead" experience="985" speed="230" manacost="0">
+<monster name="Braindeath" nameDescription="a braindeath" race="undead" experience="985" speed="230">
 	<health now="1225" max="1225" />
 	<look type="256" corpse="7256" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bonelords/elder_bonelord.xml
+++ b/data/monster/Bonelords/elder_bonelord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Elder Bonelord" nameDescription="an elder bonelord" race="blood" experience="280" speed="180" manacost="0">
+<monster name="Elder Bonelord" nameDescription="an elder bonelord" race="blood" experience="280" speed="180">
 	<health now="500" max="500" />
 	<look type="108" corpse="6037" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bonelords/eye_of_the_seven.xml
+++ b/data/monster/Bonelords/eye_of_the_seven.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Eye of the Seven" nameDescription="an eye of the seven" race="venom" experience="0" speed="0" manacost="0">
+<monster name="Eye of the Seven" nameDescription="an eye of the seven" race="venom" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="1560" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Bonelords/gazer.xml
+++ b/data/monster/Bonelords/gazer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Gazer" nameDescription="a gazer" race="venom" experience="90" speed="180" manacost="0">
+<monster name="Gazer" nameDescription="a gazer" race="venom" experience="90" speed="180">
 	<health now="120" max="120" />
 	<look type="109" corpse="6036" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bosses/abyssador.xml
+++ b/data/monster/Bosses/abyssador.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Abyssador" nameDescription="Abyssador" race="blood" experience="50000" speed="470" manacost="0">
+<monster name="Abyssador" nameDescription="Abyssador" race="blood" experience="50000" speed="470">
 	<health now="300000" max="300000" />
 	<look type="495" corpse="17413" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/annihilon.xml
+++ b/data/monster/Bosses/annihilon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Annihilon" nameDescription="Annihilon" race="fire" experience="15000" speed="380" manacost="0">
+<monster name="Annihilon" nameDescription="Annihilon" race="fire" experience="15000" speed="380">
 	<health now="46500" max="46500" />
 	<look type="12" head="19" body="104" legs="96" feet="96" corpse="6068" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/apocalypse.xml
+++ b/data/monster/Bosses/apocalypse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Apocalypse" nameDescription="Apocalypse" race="fire" experience="35000" speed="380" manacost="0">
+<monster name="Apocalypse" nameDescription="Apocalypse" race="fire" experience="35000" speed="380">
 	<health now="80000" max="80000" />
 	<look type="12" head="38" body="114" legs="0" feet="94" corpse="6068" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Bosses/apprentice_sheng.xml
+++ b/data/monster/Bosses/apprentice_sheng.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Apprentice Sheng" nameDescription="Apprentice Sheng" race="blood" experience="150" speed="170" manacost="0">
+<monster name="Apprentice Sheng" nameDescription="Apprentice Sheng" race="blood" experience="150" speed="170">
 	<health now="95" max="95" />
 	<look type="23" corpse="5981" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/arachir_the_ancient_one.xml
+++ b/data/monster/Bosses/arachir_the_ancient_one.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Arachir The Ancient One" nameDescription="Arachir The Ancient One" race="undead" experience="1800" speed="300" manacost="0">
+<monster name="Arachir The Ancient One" nameDescription="Arachir The Ancient One" race="undead" experience="1800" speed="300">
 	<health now="1600" max="1600" />
 	<look type="287" corpse="8937" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/armenius.xml
+++ b/data/monster/Bosses/armenius.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Armenius" nameDescription="Armenius" race="venom" experience="500" speed="330" manacost="0">
+<monster name="Armenius" nameDescription="Armenius" race="venom" experience="500" speed="330">
 	<health now="550" max="550" />
 	<look type="79" corpse="6021" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/azerus.xml
+++ b/data/monster/Bosses/azerus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Azerus" nameDescription="Azerus" race="blood" experience="6000" speed="320" manacost="0">
+<monster name="Azerus" nameDescription="Azerus" race="blood" experience="6000" speed="320">
 	<health now="26000" max="26000" />
 	<look type="309" head="19" body="96" legs="21" feet="81" corpse="9738" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/barbaria.xml
+++ b/data/monster/Bosses/barbaria.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Barbaria" nameDescription="Barbaria" race="blood" experience="355" speed="280" manacost="0">
+<monster name="Barbaria" nameDescription="Barbaria" race="blood" experience="355" speed="280">
 	<health now="345" max="345" />
 	<look type="264" head="78" body="116" legs="95" feet="121" corpse="20339" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/baron_brute.xml
+++ b/data/monster/Bosses/baron_brute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Baron Brute" nameDescription="Baron Brute" race="blood" experience="3000" speed="290" manacost="0">
+<monster name="Baron Brute" nameDescription="Baron Brute" race="blood" experience="3000" speed="290">
 	<health now="5025" max="5025" />
 	<look type="2" corpse="6008" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/battlemaster_zunzu.xml
+++ b/data/monster/Bosses/battlemaster_zunzu.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Battlemaster Zunzu" nameDescription="Battlemaster Zunzu" race="blood" experience="2500" speed="420" manacost="0">
+<monster name="Battlemaster Zunzu" nameDescription="Battlemaster Zunzu" race="blood" experience="2500" speed="420">
 	<health now="4000" max="4000" />
 	<look type="343" corpse="11281" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/bazir.xml
+++ b/data/monster/Bosses/bazir.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bazir" nameDescription="Bazir" race="fire" experience="30000" speed="530" manacost="0">
+<monster name="Bazir" nameDescription="Bazir" race="fire" experience="30000" speed="530">
 	<health now="110000" max="110000" />
 	<look type="35" head="0" body="0" legs="0" feet="0" corpse="2916" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/bones.xml
+++ b/data/monster/Bosses/bones.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bones" nameDescription="Bones" race="undead" experience="3750" speed="300" manacost="0">
+<monster name="Bones" nameDescription="Bones" race="undead" experience="3750" speed="300">
 	<health now="9500" max="9500" />
 	<look type="231" corpse="6306" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/boogey.xml
+++ b/data/monster/Bosses/boogey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Boogey" nameDescription="Boogey" race="undead" experience="475" speed="400" manacost="0">
+<monster name="Boogey" nameDescription="Boogey" race="undead" experience="475" speed="400">
 	<health now="930" max="930" />
 	<look type="300" corpse="10324" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/brutus_bloodbeard.xml
+++ b/data/monster/Bosses/brutus_bloodbeard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Brutus Bloodbeard" nameDescription="Brutus Bloodbeard" race="blood" experience="795" speed="240" manacost="0">
+<monster name="Brutus Bloodbeard" nameDescription="Brutus Bloodbeard" race="blood" experience="795" speed="240">
 	<health now="1555" max="1555" />
 	<look type="98" corpse="20478" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/chizzoron_the_distorter.xml
+++ b/data/monster/Bosses/chizzoron_the_distorter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Chizzoron The Distorter" nameDescription="Chizzoron the Distorter" race="blood" experience="4000" speed="260" manacost="0">
+<monster name="Chizzoron The Distorter" nameDescription="Chizzoron the Distorter" race="blood" experience="4000" speed="260">
 	<health now="16000" max="16000" />
 	<look type="340" corpse="11316" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/coldheart.xml
+++ b/data/monster/Bosses/coldheart.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Coldheart" nameDescription="Coldheart" race="undead" experience="3500" speed="195" manacost="0">
+<monster name="Coldheart" nameDescription="Coldheart" race="undead" experience="3500" speed="195">
 	<health now="7000" max="7000" />
 	<look type="261" corpse="7282" />
 	<targetchange interval="2000" chance="9" />

--- a/data/monster/Bosses/countess_sorrow.xml
+++ b/data/monster/Bosses/countess_sorrow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Countess Sorrow" nameDescription="Countess Sorrow" race="undead" experience="13000" speed="250" manacost="0">
+<monster name="Countess Sorrow" nameDescription="Countess Sorrow" race="undead" experience="13000" speed="250">
 	<health now="6500" max="6500" />
 	<look type="241" head="20" corpse="6344" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/deadeye_devious.xml
+++ b/data/monster/Bosses/deadeye_devious.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deadeye Devious" nameDescription="Deadeye Devious" race="blood" experience="750" speed="300" manacost="0">
+<monster name="Deadeye Devious" nameDescription="Deadeye Devious" race="blood" experience="750" speed="300">
 	<health now="1450" max="1450" />
 	<look type="151" head="115" body="76" legs="35" feet="117" addons="2" corpse="20378" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/deathbine.xml
+++ b/data/monster/Bosses/deathbine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deathbine" nameDescription="Deathbine" race="venom" experience="340" speed="240" manacost="0">
+<monster name="Deathbine" nameDescription="Deathbine" race="venom" experience="340" speed="240">
 	<health now="525" max="525" />
 	<look type="120" corpse="6047" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/deathstrike.xml
+++ b/data/monster/Bosses/deathstrike.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deathstrike" nameDescription="Deathstrike" race="blood" experience="40000" speed="470" manacost="0">
+<monster name="Deathstrike" nameDescription="Deathstrike" race="blood" experience="40000" speed="470">
 	<health now="200000" max="200000" />
 	<look type="500" corpse="18384" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/demodras.xml
+++ b/data/monster/Bosses/demodras.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Demodras" nameDescription="Demodras" race="blood" experience="6000" speed="230" manacost="0">
+<monster name="Demodras" nameDescription="Demodras" race="blood" experience="6000" speed="230">
 	<health now="4500" max="4500" />
 	<look type="204" corpse="5984" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/dharalion.xml
+++ b/data/monster/Bosses/dharalion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dharalion" nameDescription="Dharalion" race="blood" experience="570" speed="240" manacost="0">
+<monster name="Dharalion" nameDescription="Dharalion" race="blood" experience="570" speed="240">
 	<health now="380" max="380" />
 	<look type="203" corpse="6011" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/diblis_the_fair.xml
+++ b/data/monster/Bosses/diblis_the_fair.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Diblis The Fair" nameDescription="Diblis The Fair" race="undead" experience="1800" speed="280" manacost="0">
+<monster name="Diblis The Fair" nameDescription="Diblis The Fair" race="undead" experience="1800" speed="280">
 	<health now="1500" max="1500" />
 	<look type="287" corpse="8937" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/diseased_bill.xml
+++ b/data/monster/Bosses/diseased_bill.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Diseased Bill" nameDescription="a diseased Bill" race="venom" experience="300" speed="150" manacost="0">
+<monster name="Diseased Bill" nameDescription="a diseased Bill" race="venom" experience="300" speed="150">
 	<health now="1000" max="1000" />
 	<look type="299" corpse="8951" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/diseased_dan.xml
+++ b/data/monster/Bosses/diseased_dan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Diseased Dan" nameDescription="a diseased Dan" race="venom" experience="300" speed="150" manacost="0">
+<monster name="Diseased Dan" nameDescription="a diseased Dan" race="venom" experience="300" speed="150">
 	<health now="800" max="800" />
 	<look type="299" corpse="8951" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/diseased_fred.xml
+++ b/data/monster/Bosses/diseased_fred.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Diseased Fred" nameDescription="a diseased Fred" race="venom" experience="300" speed="150" manacost="0">
+<monster name="Diseased Fred" nameDescription="a diseased Fred" race="venom" experience="300" speed="150">
 	<health now="1100" max="1100" />
 	<look type="299" corpse="8951" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/doomhowl.xml
+++ b/data/monster/Bosses/doomhowl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Doomhowl" nameDescription="Doomhowl" experience="3750" speed="320" race="blood" manacost="0">
+<monster name="Doomhowl" nameDescription="Doomhowl" experience="3750" speed="320" race="blood">
 	<health now="8500" max="8500" />
 	<targetchange speed="0" chance="8" />
 	<look type="308" corpse="6080" />

--- a/data/monster/Bosses/dracola.xml
+++ b/data/monster/Bosses/dracola.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dracola" nameDescription="Dracola" race="undead" experience="11000" speed="410" manacost="0">
+<monster name="Dracola" nameDescription="Dracola" race="undead" experience="11000" speed="410">
 	<health now="16200" max="16200" />
 	<look type="231" corpse="6307" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Bosses/dreadwing.xml
+++ b/data/monster/Bosses/dreadwing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Dreadwing" nameDescription="Dreadwing" race="blood" experience="3750" speed="245" manacost="0">
+<monster name="Dreadwing" nameDescription="Dreadwing" race="blood" experience="3750" speed="245">
 	<health now="8500" max="8500" />
 	<look type="307" corpse="9829" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/energized_raging_mage.xml
+++ b/data/monster/Bosses/energized_raging_mage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="energized raging mage" nameDescription="an energized raging mage" race="blood" experience="0" speed="230" manacost="0">
+<monster name="energized raging mage" nameDescription="an energized raging mage" race="blood" experience="0" speed="230">
 	<health now="3500" max="3500" />
 	<look type="423" corpse="0" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bosses/esmeralda.xml
+++ b/data/monster/Bosses/esmeralda.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Esmeralda" nameDescription="Esmeralda" race="blood" experience="600" speed="245" manacost="0">
+<monster name="Esmeralda" nameDescription="Esmeralda" race="blood" experience="600" speed="245">
 	<health now="800" max="800" />
 	<look type="305" corpse="9871" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/evil_mastermind.xml
+++ b/data/monster/Bosses/evil_mastermind.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Evil Mastermind" nameDescription="Evil Mastermind" race="undead" experience="675" speed="350" manacost="0">
+<monster name="Evil Mastermind" nameDescription="Evil Mastermind" race="undead" experience="675" speed="350">
 	<health now="1295" max="1295" />
 	<look type="256" corpse="10321" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/fatality.xml
+++ b/data/monster/Bosses/fatality.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Fatality" nameDescription="Fatality" race="blood" experience="3250" speed="220" manacost="0">
+<monster name="Fatality" nameDescription="Fatality" race="blood" experience="3250" speed="220">
 	<health now="6000" max="6000" />
 	<look type="113" corpse="4251" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/fernfang.xml
+++ b/data/monster/Bosses/fernfang.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Fernfang" nameDescription="Fernfang" race="blood" experience="600" speed="240" manacost="0">
+<monster name="Fernfang" nameDescription="Fernfang" race="blood" experience="600" speed="240">
 	<health now="400" max="400" />
 	<look type="206" corpse="20566" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/ferumbras.xml
+++ b/data/monster/Bosses/ferumbras.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ferumbras" nameDescription="Ferumbras" race="venom" experience="12000" speed="320" manacost="0">
+<monster name="Ferumbras" nameDescription="Ferumbras" race="venom" experience="12000" speed="320">
 	<health now="50000" max="50000" />
 	<look type="229" corpse="6078" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/fleshslicer.xml
+++ b/data/monster/Bosses/fleshslicer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Fleshslicer" nameDescription="Fleshslicer" race="blood" experience="5500" speed="560" manacost="0">
+<monster name="Fleshslicer" nameDescription="Fleshslicer" race="blood" experience="5500" speed="560">
 	<health now="5700" max="5700" />
 	<look type="457" corpse="15296" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Bosses/fluffy.xml
+++ b/data/monster/Bosses/fluffy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Fluffy" nameDescription="Fluffy" race="blood" experience="3550" speed="310" manacost="0">
+<monster name="Fluffy" nameDescription="Fluffy" race="blood" experience="3550" speed="310">
 	<health now="4500" max="4500" />
 	<look type="240" corpse="6332" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/freegoiz.xml
+++ b/data/monster/Bosses/freegoiz.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Freegoiz" nameDescription="Freegoiz" race="fire" experience="35000" speed="380" manacost="0">
+<monster name="Freegoiz" nameDescription="Freegoiz" race="fire" experience="35000" speed="380">
 	<health now="80000" max="80000" />
 	<look type="12" head="38" body="114" legs="0" feet="94" corpse="6068" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Bosses/fury_of_the_emperor.xml
+++ b/data/monster/Bosses/fury_of_the_emperor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Fury of the Emperor" nameDescription="Fury of the Emperor" race="undead" experience="26600" speed="450" manacost="0">
+<monster name="Fury of the Emperor" nameDescription="Fury of the Emperor" race="undead" experience="26600" speed="450">
 	<health now="28800" max="28800" />
 	<look type="351" corpse="0" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/gaz'haragoth.xml
+++ b/data/monster/Bosses/gaz'haragoth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Gaz'haragoth" nameDescription="Gaz'haragoth" race="undead" experience="1000000" speed="400" manacost="0">
+<monster name="Gaz'haragoth" nameDescription="Gaz'haragoth" race="undead" experience="1000000" speed="400">
 	<health now="350000" max="350000" />
 	<look type="591" head="0" body="94" legs="79" feet="79" corpse="22562" />
 	<targetchange interval="10000" chance="20" />

--- a/data/monster/Bosses/general_murius.xml
+++ b/data/monster/Bosses/general_murius.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="General Murius" nameDescription="General Murius" race="blood" experience="450" speed="240" manacost="0">
+<monster name="General Murius" nameDescription="General Murius" race="blood" experience="450" speed="240">
 	<health now="550" max="550" />
 	<look type="202" corpse="5983" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/ghazbaran.xml
+++ b/data/monster/Bosses/ghazbaran.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ghazbaran" nameDescription="Ghazbaran" race="undead" experience="15000" speed="400" manacost="0">
+<monster name="Ghazbaran" nameDescription="Ghazbaran" race="undead" experience="15000" speed="400">
 	<health now="60000" max="60000" />
 	<look type="12" head="0" body="123" legs="97" feet="94" corpse="6068" />
 	<targetchange interval="10000" chance="20" />

--- a/data/monster/Bosses/glitterscale.xml
+++ b/data/monster/Bosses/glitterscale.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Glitterscale" nameDescription="Glitterscale" race="blood" experience="700" speed="180" manacost="0">
+<monster name="Glitterscale" nameDescription="Glitterscale" race="blood" experience="700" speed="180">
 	<health now="1000" max="1000" />
 	<look type="34" corpse="5973" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/gnomevil.xml
+++ b/data/monster/Bosses/gnomevil.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Gnomevil" nameDescription="Gnomevil" race="blood" experience="45000" speed="470" manacost="0">
+<monster name="Gnomevil" nameDescription="Gnomevil" race="blood" experience="45000" speed="470">
 	<health now="250000" max="250000" />
 	<look type="504" corpse="18443" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/golgordan.xml
+++ b/data/monster/Bosses/golgordan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Golgordan" nameDescription="Golgordan" race="fire" experience="10000" speed="350" manacost="0">
+<monster name="Golgordan" nameDescription="Golgordan" race="fire" experience="10000" speed="350">
 	<health now="40000" max="40000" />
 	<look type="12" head="108" body="100" legs="105" feet="114" corpse="6068" />
 	<targetchange interval="7000" chance="10" />

--- a/data/monster/Bosses/grand_mother_foulscale.xml
+++ b/data/monster/Bosses/grand_mother_foulscale.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Grand Mother Foulscale" nameDescription="Grand Mother Foulscale" race="blood" experience="1400" speed="180" manacost="0">
+<monster name="Grand Mother Foulscale" nameDescription="Grand Mother Foulscale" race="blood" experience="1400" speed="180">
 	<health now="1850" max="1850" />
 	<look type="34" corpse="5973" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/groam.xml
+++ b/data/monster/Bosses/groam.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Groam" nameDescription="Groam" race="blood" experience="180" speed="560" manacost="0">
+<monster name="Groam" nameDescription="Groam" race="blood" experience="180" speed="560">
 	<health now="400" max="400" />
 	<look type="413" corpse="13839" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Bosses/grorlam.xml
+++ b/data/monster/Bosses/grorlam.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Grorlam" nameDescription="Grorlam" race="blood" experience="2400" speed="240" manacost="0">
+<monster name="Grorlam" nameDescription="Grorlam" race="blood" experience="2400" speed="240">
 	<health now="3000" max="3000" />
 	<look type="205" corpse="6005" />
 	<targetchange interval="5000" chance="3" />

--- a/data/monster/Bosses/hairman_the_huge.xml
+++ b/data/monster/Bosses/hairman_the_huge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hairman The Huge" nameDescription="Hairman the Huge" race="blood" experience="335" speed="230" manacost="0">
+<monster name="Hairman The Huge" nameDescription="Hairman the Huge" race="blood" experience="335" speed="230">
 	<health now="600" max="600" />
 	<look type="116" head="20" body="30" legs="40" feet="50" corpse="6043" />
 	<targetchange interval="5000" chance="14" />

--- a/data/monster/Bosses/haunter.xml
+++ b/data/monster/Bosses/haunter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Haunter" nameDescription="Haunter" race="blood" experience="4000" speed="270" manacost="0">
+<monster name="Haunter" nameDescription="Haunter" race="blood" experience="4000" speed="270">
 	<health now="8500" max="8500" />
 	<look type="320" corpse="9915" />
 	<targetchange interval="2000" chance="9" />

--- a/data/monster/Bosses/hellgorak.xml
+++ b/data/monster/Bosses/hellgorak.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hellgorak" nameDescription="Hellgorak" race="blood" experience="10000" speed="360" manacost="0">
+<monster name="Hellgorak" nameDescription="Hellgorak" race="blood" experience="10000" speed="360">
 	<health now="25850" max="25850" />
 	<look type="12" head="19" body="96" legs="21" feet="81" corpse="6068" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/heoni.xml
+++ b/data/monster/Bosses/heoni.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Heoni" nameDescription="Heoni" race="blood" experience="515" speed="300" manacost="0">
+<monster name="Heoni" nameDescription="Heoni" race="blood" experience="515" speed="300">
 	<health now="900" max="900" />
 	<look type="239" corpse="6302" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/horestis.xml
+++ b/data/monster/Bosses/horestis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Horestis" nameDescription="Horestis" race="undead" experience="3500" speed="276" manacost="0">
+<monster name="Horestis" nameDescription="Horestis" race="undead" experience="3500" speed="276">
 	<health now="6000" max="6000" />
 	<look type="88" head="20" body="30" legs="40" feet="50" corpse="6031" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/incineron.xml
+++ b/data/monster/Bosses/incineron.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Incineron" nameDescription="Incineron" race="fire" experience="3500" speed="260" manacost="0">
+<monster name="Incineron" nameDescription="Incineron" race="fire" experience="3500" speed="260">
 	<health now="7000" max="7000" />
 	<look type="243" corpse="6324" />
 	<targetchange interval="2000" chance="9" />

--- a/data/monster/Bosses/infernatil.xml
+++ b/data/monster/Bosses/infernatil.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Infernatil" nameDescription="Infernatil" race="fire" experience="85000" speed="605" manacost="0">
+<monster name="Infernatil" nameDescription="Infernatil" race="fire" experience="85000" speed="605">
 	<health now="270000" max="270000" />
 	<look type="35" head="0" body="0" legs="0" feet="0" corpse="2916" />
 	<targetchange interval="2000" chance="15" />

--- a/data/monster/Bosses/jaul.xml
+++ b/data/monster/Bosses/jaul.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Jaul" nameDescription="Jaul" race="blood" experience="30000" speed="560" manacost="0">
+<monster name="Jaul" nameDescription="Jaul" race="blood" experience="30000" speed="560">
 	<health now="90000" max="90000" />
 	<look type="444" corpse="15220" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Bosses/koshei_the_deathless.xml
+++ b/data/monster/Bosses/koshei_the_deathless.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Koshei The Deathless" nameDescription="Koshei the Deathless" race="undead" experience="0" speed="390" manacost="0">
+<monster name="Koshei The Deathless" nameDescription="Koshei the Deathless" race="undead" experience="0" speed="390">
 	<health now="3000" max="3000" />
 	<look type="99" head="95" body="116" legs="119" feet="115" corpse="6028" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/kraknaknork's_demon.xml
+++ b/data/monster/Bosses/kraknaknork's_demon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Kraknaknork's Demon" nameDescription="Kraknaknork's Demon" race="fire" experience="0" speed="400" manacost="0">
+<monster name="Kraknaknork's Demon" nameDescription="Kraknaknork's Demon" race="fire" experience="0" speed="400">
 	<health now="120" max="120" />
 	<look type="12" head="117" body="58" legs="117" feet="0" corpse="6068" />
 	<targetchange interval="5000" chance="15" />

--- a/data/monster/Bosses/latrivan.xml
+++ b/data/monster/Bosses/latrivan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Latrivan" nameDescription="Latrivan" race="fire" experience="10000" speed="340" manacost="0">
+<monster name="Latrivan" nameDescription="Latrivan" race="fire" experience="10000" speed="340">
 	<health now="25000" max="25000" />
 	<look type="12" head="120" body="128" legs="121" feet="111" corpse="6068" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/lethal_lissy.xml
+++ b/data/monster/Bosses/lethal_lissy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lethal Lissy" nameDescription="Lethal Lissy" race="blood" experience="500" speed="240" manacost="0">
+<monster name="Lethal Lissy" nameDescription="Lethal Lissy" race="blood" experience="500" speed="240">
 	<health now="1450" max="1450" />
 	<look type="155" head="77" body="0" legs="76" feet="132" addons="3" corpse="20438" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/leviathan.xml
+++ b/data/monster/Bosses/leviathan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Leviathan" nameDescription="Leviathan" race="blood" experience="5000" speed="758" manacost="0">
+<monster name="Leviathan" nameDescription="Leviathan" race="blood" experience="5000" speed="758">
 	<health now="6000" max="6000" />
 	<look type="275" corpse="8307" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Bosses/lizard_abomination.xml
+++ b/data/monster/Bosses/lizard_abomination.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Lizard Abomination" nameDescription="a lizard abomination" race="blood" experience="1350" speed="220" manacost="0">
+<monster name="Lizard Abomination" nameDescription="a lizard abomination" race="blood" experience="1350" speed="220">
 	<health now="20000" max="20000" />
 	<look type="364" corpse="12385" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/lord_of_the_elements.xml
+++ b/data/monster/Bosses/lord_of_the_elements.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lord of the Elements" nameDescription="Lord of the Elements" race="undead" experience="8000" speed="370" manacost="0">
+<monster name="Lord of the Elements" nameDescription="Lord of the Elements" race="undead" experience="8000" speed="370">
 	<health now="8000" max="8000" />
 	<look type="290" corpse="9009" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/mad_mage.xml
+++ b/data/monster/Bosses/mad_mage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="mad mage" nameDescription="a mad mage" race="blood" experience="1800" speed="240" manacost="0">
+<monster name="mad mage" nameDescription="a mad mage" race="blood" experience="1800" speed="240">
 	<health now="2500" max="2500" />
 	<look type="394" corpse="13603" />
 	<targetchange interval="5000" chance="30" />

--- a/data/monster/Bosses/mad_technomancer.xml
+++ b/data/monster/Bosses/mad_technomancer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mad Technomancer" nameDescription="a mad technomancer" race="blood" experience="55" speed="200" manacost="0">
+<monster name="Mad Technomancer" nameDescription="a mad technomancer" race="blood" experience="55" speed="200">
 	<health now="1800" max="1800" />
 	<look type="66" corpse="6015" />
 	<targetchange interval="500" chance="25" />

--- a/data/monster/Bosses/madareth.xml
+++ b/data/monster/Bosses/madareth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Madareth" nameDescription="Madareth" race="fire" experience="10000" speed="380" manacost="0">
+<monster name="Madareth" nameDescription="Madareth" race="fire" experience="10000" speed="380">
 	<health now="75000" max="75000" />
 	<look type="12" head="77" body="116" legs="82" feet="79" corpse="6068" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/man_in_the_cave.xml
+++ b/data/monster/Bosses/man_in_the_cave.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Man in the Cave" nameDescription="man in the cave" race="blood" experience="777" speed="210" manacost="0">
+<monster name="Man in the Cave" nameDescription="man in the cave" race="blood" experience="777" speed="210">
 	<health now="485" max="485" />
 	<look type="128" head="95" body="116" legs="95" feet="114" addons="2" corpse="20446" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/massacre.xml
+++ b/data/monster/Bosses/massacre.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Massacre" nameDescription="Massacre" race="blood" experience="20000" speed="390" manacost="0">
+<monster name="Massacre" nameDescription="Massacre" race="blood" experience="20000" speed="390">
 	<health now="32000" max="32000" />
 	<look type="244" corpse="6336" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/mawhawk.xml
+++ b/data/monster/Bosses/mawhawk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mawhawk" nameDescription="Mawhawk" race="blood" experience="14000" speed="270" manacost="0">
+<monster name="Mawhawk" nameDescription="Mawhawk" race="blood" experience="14000" speed="270">
 	<health now="45000" max="45000" />
 	<look type="595" corpse="22629" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/menace.xml
+++ b/data/monster/Bosses/menace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Menace" nameDescription="Menace" race="blood" experience="3250" speed="220" manacost="0">
+<monster name="Menace" nameDescription="Menace" race="blood" experience="3250" speed="220">
 	<health now="6000" max="6000" />
 	<look type="113" corpse="4251" />
 	<targetchange interval="2000" chance="9" />

--- a/data/monster/Bosses/mephiles.xml
+++ b/data/monster/Bosses/mephiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Mephiles" nameDescription="Mephiles" race="blood" experience="415" speed="300" manacost="0">
+<monster name="Mephiles" nameDescription="Mephiles" race="blood" experience="415" speed="300">
 	<health now="415" max="415" />
 	<look type="237" corpse="10323" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/minishabaal.xml
+++ b/data/monster/Bosses/minishabaal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Minishabaal" nameDescription="Minishabaal" race="blood" experience="4000" speed="700" manacost="0">
+<monster name="Minishabaal" nameDescription="Minishabaal" race="blood" experience="4000" speed="700">
 	<health now="3500" max="3500" />
 	<look type="237" corpse="6364" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/monstor.xml
+++ b/data/monster/Bosses/monstor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Monstor" nameDescription="Monstor" race="blood" experience="575" speed="350" manacost="0">
+<monster name="Monstor" nameDescription="Monstor" race="blood" experience="575" speed="350">
 	<health now="960" max="960" />
 	<look type="244" corpse="10322" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/morgaroth.xml
+++ b/data/monster/Bosses/morgaroth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Morgaroth" nameDescription="Morgaroth" race="undead" experience="15000" speed="400" manacost="0">
+<monster name="Morgaroth" nameDescription="Morgaroth" race="undead" experience="15000" speed="400">
 	<health now="55000" max="55000" />
 	<look type="12" head="0" body="94" legs="79" feet="79" corpse="6068" />
 	<targetchange interval="10000" chance="20" />

--- a/data/monster/Bosses/mr._punish.xml
+++ b/data/monster/Bosses/mr._punish.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mr. Punish" nameDescription="Mr. Punish" race="undead" experience="9000" speed="470" manacost="0">
+<monster name="Mr. Punish" nameDescription="Mr. Punish" race="undead" experience="9000" speed="470">
 	<health now="22000" max="22000" />
 	<look type="234" corpse="6331" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Bosses/necropharus.xml
+++ b/data/monster/Bosses/necropharus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Necropharus" nameDescription="Necropharus" race="blood" experience="1050" speed="240" manacost="0">
+<monster name="Necropharus" nameDescription="Necropharus" race="blood" experience="1050" speed="240">
 	<health now="750" max="750" />
 	<look type="209" corpse="20574" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/obujos.xml
+++ b/data/monster/Bosses/obujos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Obujos" nameDescription="Obujos" race="blood" experience="20000" speed="560" manacost="0">
+<monster name="Obujos" nameDescription="Obujos" race="blood" experience="20000" speed="560">
 	<health now="35000" max="35000" />
 	<look type="445" corpse="15224" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Bosses/orshabaal.xml
+++ b/data/monster/Bosses/orshabaal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Orshabaal" nameDescription="Orshabaal" race="fire" experience="10000" speed="380" manacost="0">
+<monster name="Orshabaal" nameDescription="Orshabaal" race="fire" experience="10000" speed="380">
 	<health now="20500" max="20500" />
 	<look type="201" corpse="2916" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/pythius_the_rotten.xml
+++ b/data/monster/Bosses/pythius_the_rotten.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Pythius The Rotten" nameDescription="Pythius the rotten" race="undead" experience="7000" speed="350" manacost="0">
+<monster name="Pythius The Rotten" nameDescription="Pythius the rotten" race="undead" experience="7000" speed="350">
 	<health now="9500" max="9500" />
 	<look type="231" corpse="7349" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/raging_mage.xml
+++ b/data/monster/Bosses/raging_mage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="raging mage" nameDescription="a raging mage" race="blood" experience="3250" speed="200" manacost="0">
+<monster name="raging mage" nameDescription="a raging mage" race="blood" experience="3250" speed="200">
 	<health now="3500" max="3500" />
 	<look type="416" corpse="13834" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Bosses/ron_the_ripper.xml
+++ b/data/monster/Bosses/ron_the_ripper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ron the Ripper" nameDescription="Ron the Ripper" race="blood" experience="500" speed="240" manacost="0">
+<monster name="Ron the Ripper" nameDescription="Ron the Ripper" race="blood" experience="500" speed="240">
 	<health now="1500" max="1500" />
 	<look type="151" head="95" body="94" legs="117" feet="97" addons="1" corpse="20502" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/rottie_the_rotworm.xml
+++ b/data/monster/Bosses/rottie_the_rotworm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Rottie the Rotworm" nameDescription="Rottie the Rotworm" race="blood" experience="40" speed="180" manacost="0">
+<monster name="Rottie the Rotworm" nameDescription="Rottie the Rotworm" race="blood" experience="40" speed="180">
 	<health now="65" max="65" />
 	<look type="26" head="20" body="30" legs="40" feet="50" corpse="5967" />
 	<targetchange interval="2000" chance="0" />

--- a/data/monster/Bosses/rotworm_queen.xml
+++ b/data/monster/Bosses/rotworm_queen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Rotworm Queen" nameDescription="a rotworm queen" race="blood" experience="75" speed="126" manacost="0">
+<monster name="Rotworm Queen" nameDescription="a rotworm queen" race="blood" experience="75" speed="126">
 	<health now="105" max="105" />
 	<look type="295" corpse="8947" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Bosses/scorn_of_the_emperor.xml
+++ b/data/monster/Bosses/scorn_of_the_emperor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Scorn of the Emperor" nameDescription="Scorn of the Emperor" race="undead" experience="4600" speed="410" manacost="0">
+<monster name="Scorn of the Emperor" nameDescription="Scorn of the Emperor" race="undead" experience="4600" speed="410">
 	<health now="7800" max="7800" />
 	<look type="351" corpse="0" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/shardhead.xml
+++ b/data/monster/Bosses/shardhead.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shardhead" nameDescription="Shardhead" race="undead" experience="650" speed="195" manacost="0">
+<monster name="Shardhead" nameDescription="Shardhead" race="undead" experience="650" speed="195">
 	<health now="800" max="800" />
 	<look type="261" corpse="7282" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Bosses/sharptooth.xml
+++ b/data/monster/Bosses/sharptooth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Sharptooth" nameDescription="Sharptooth" race="blood" experience="1600" speed="290" manacost="0">
+<monster name="Sharptooth" nameDescription="Sharptooth" race="blood" experience="1600" speed="290">
 	<health now="2500" max="2500" />
 	<look type="20" corpse="6067" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/sir_valorcrest.xml
+++ b/data/monster/Bosses/sir_valorcrest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Sir Valorcrest" nameDescription="Sir Valorcrest" race="undead" experience="1800" speed="270" manacost="0">
+<monster name="Sir Valorcrest" nameDescription="Sir Valorcrest" race="undead" experience="1800" speed="270">
 	<health now="1600" max="1600" />
 	<look type="287" corpse="8937" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/snake_god_essence.xml
+++ b/data/monster/Bosses/snake_god_essence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Snake God Essence" nameDescription="Snake God Essence" race="blood" experience="1350" speed="300" manacost="0">
+<monster name="Snake God Essence" nameDescription="Snake God Essence" race="blood" experience="1350" speed="300">
 	<health now="20000" max="20000" />
 	<look type="356" corpse="12385" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/snake_thing.xml
+++ b/data/monster/Bosses/snake_thing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Snake Thing" nameDescription="Snake Thing" race="venom" experience="4600" speed="240" manacost="0">
+<monster name="Snake Thing" nameDescription="Snake Thing" race="venom" experience="4600" speed="240">
 	<health now="20000" max="20000" />
 	<look type="220" corpse="12385" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/spite_of_the_emperor.xml
+++ b/data/monster/Bosses/spite_of_the_emperor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Spite of the Emperor" nameDescription="Spite of the Emperor" race="undead" experience="5600" speed="410" manacost="0">
+<monster name="Spite of the Emperor" nameDescription="Spite of the Emperor" race="undead" experience="5600" speed="410">
 	<health now="8000" max="8000" />
 	<look type="351" corpse="0" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/stonecracker.xml
+++ b/data/monster/Bosses/stonecracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Stonecracker" nameDescription="Stonecracker" race="blood" experience="3500" speed="280" manacost="0">
+<monster name="Stonecracker" nameDescription="Stonecracker" race="blood" experience="3500" speed="280">
 	<health now="6500" max="6500" />
 	<look type="55" corpse="5999" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/tanjis.xml
+++ b/data/monster/Bosses/tanjis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Tanjis" nameDescription="Tanjis" race="blood" experience="15000" speed="560" manacost="0">
+<monster name="Tanjis" nameDescription="Tanjis" race="blood" experience="15000" speed="560">
 	<health now="30000" max="30000" />
 	<look type="446" corpse="15228" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Bosses/the_abomination.xml
+++ b/data/monster/Bosses/the_abomination.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Abomination" nameDescription="The Abomination" race="venom" experience="25000" speed="340" manacost="0">
+<monster name="The Abomination" nameDescription="The Abomination" race="venom" experience="25000" speed="340">
 	<health now="38050" max="38050" />
 	<look type="238" corpse="6532" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_blightfather.xml
+++ b/data/monster/Bosses/the_blightfather.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Blightfather" nameDescription="The Blightfather" race="venom" experience="600" speed="290" manacost="0">
+<monster name="The Blightfather" nameDescription="The Blightfather" race="venom" experience="600" speed="290">
 	<health now="400" max="400" />
 	<look type="348" corpse="11375" />
 	<targetchange interval="5000" chance="12" />

--- a/data/monster/Bosses/the_bloodtusk.xml
+++ b/data/monster/Bosses/the_bloodtusk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Bloodtusk" nameDescription="The Bloodtusk" race="blood" experience="300" speed="190" manacost="0">
+<monster name="The Bloodtusk" nameDescription="The Bloodtusk" race="blood" experience="300" speed="190">
 	<health now="600" max="600" />
 	<look type="199" corpse="6074" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_bloodweb.xml
+++ b/data/monster/Bosses/the_bloodweb.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Bloodweb" nameDescription="The Bloodweb" race="undead" experience="1450" speed="340" manacost="0">
+<monster name="The Bloodweb" nameDescription="The Bloodweb" race="undead" experience="1450" speed="340">
 	<health now="1750" max="1750" />
 	<look type="263" corpse="7344" />
 	<targetchange speed="20000" chance="8" />

--- a/data/monster/Bosses/the_collector.xml
+++ b/data/monster/Bosses/the_collector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Collector" nameDescription="The Collector" race="undead" experience="100" speed="195" manacost="0">
+<monster name="The Collector" nameDescription="The Collector" race="undead" experience="100" speed="195">
 	<health now="340" max="340" />
 	<look type="261" corpse="7282" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Bosses/the_count.xml
+++ b/data/monster/Bosses/the_count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Count" nameDescription="The Count" race="undead" experience="450" speed="370" manacost="0">
+<monster name="The Count" nameDescription="The Count" race="undead" experience="450" speed="370">
 	<health now="1250" max="1250" />
 	<look type="287" corpse="8937" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/the_dreadorian.xml
+++ b/data/monster/Bosses/the_dreadorian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Dreadorian" nameDescription="The Dreadorian" race="blood" experience="4000" speed="250" manacost="0">
+<monster name="The Dreadorian" nameDescription="The Dreadorian" race="blood" experience="4000" speed="250">
 	<health now="9000" max="9000" />
 	<look type="234" corpse="6328" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_evil_eye.xml
+++ b/data/monster/Bosses/the_evil_eye.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Evil Eye" nameDescription="The Evil Eye" race="blood" experience="750" speed="240" manacost="0">
+<monster name="The Evil Eye" nameDescription="The Evil Eye" race="blood" experience="750" speed="240">
 	<health now="1200" max="1200" />
 	<look type="210" corpse="6037" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_handmaiden.xml
+++ b/data/monster/Bosses/the_handmaiden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Handmaiden" nameDescription="The Handmaiden" race="blood" experience="7500" speed="450" manacost="0">
+<monster name="The Handmaiden" nameDescription="The Handmaiden" race="blood" experience="7500" speed="450">
 	<health now="19500" max="19500" />
 	<look type="230" corpse="6312" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_horned_fox.xml
+++ b/data/monster/Bosses/the_horned_fox.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Horned Fox" nameDescription="The Horned Fox" race="blood" experience="300" speed="210" manacost="0">
+<monster name="The Horned Fox" nameDescription="The Horned Fox" race="blood" experience="300" speed="210">
 	<health now="265" max="265" />
 	<look type="202" corpse="5983" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_imperor.xml
+++ b/data/monster/Bosses/the_imperor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Imperor" nameDescription="The Imperor" race="fire" experience="8000" speed="330" manacost="0">
+<monster name="The Imperor" nameDescription="The Imperor" race="fire" experience="8000" speed="330">
 	<health now="15000" max="15000" />
 	<look type="237" corpse="8635" />
 	<targetchange interval="5000" chance="5" />

--- a/data/monster/Bosses/the_many.xml
+++ b/data/monster/Bosses/the_many.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Many" nameDescription="The Many" race="blood" experience="4000" speed="260" manacost="0">
+<monster name="The Many" nameDescription="The Many" race="blood" experience="4000" speed="260">
 	<health now="5000" max="5000" />
 	<look type="121" corpse="6048" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_noxious_spawn.xml
+++ b/data/monster/Bosses/the_noxious_spawn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Noxious Spawn" nameDescription="The Noxious Spawn" race="venom" experience="6000" speed="360" manacost="0">
+<monster name="The Noxious Spawn" nameDescription="The Noxious Spawn" race="venom" experience="6000" speed="360">
 	<health now="9500" max="9500" />
 	<look type="220" corpse="4323" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_old_widow.xml
+++ b/data/monster/Bosses/the_old_widow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Old Widow" nameDescription="The Old Widow" race="blood" experience="4200" speed="240" manacost="0">
+<monster name="The Old Widow" nameDescription="The Old Widow" race="blood" experience="4200" speed="240">
 	<health now="3200" max="3200" />
 	<look type="208" corpse="5977" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_pale_count.xml
+++ b/data/monster/Bosses/the_pale_count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Pale Count" nameDescription="The Pale Count" race="blood" experience="28000" speed="300" manacost="0">
+<monster name="The Pale Count" nameDescription="The Pale Count" race="blood" experience="28000" speed="300">
 	<health now="50000" max="50000" />
 	<look type="558" corpse="21279" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/the_plasmother.xml
+++ b/data/monster/Bosses/the_plasmother.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="The Plasmother" nameDescription="The Plasmother" race="venom" experience="12000" speed="310" manacost="0">
+<monster name="The Plasmother" nameDescription="The Plasmother" race="venom" experience="12000" speed="310">
 	<health now="7500" max="7500" />
 	<look type="238" corpse="6532" />
 	<targetchange interval="5500" chance="10" />

--- a/data/monster/Bosses/tiquandas_revenge.xml
+++ b/data/monster/Bosses/tiquandas_revenge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Tiquandas Revenge" nameDescription="Tiquandas Revenge" race="venom" experience="2635" speed="440" manacost="0">
+<monster name="Tiquandas Revenge" nameDescription="Tiquandas Revenge" race="venom" experience="2635" speed="440">
 	<health now="1800" max="1800" />
 	<look type="120" corpse="6047" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/tirecz.xml
+++ b/data/monster/Bosses/tirecz.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Tirecz" nameDescription="Tirecz" race="blood" experience="6000" speed="220" manacost="0">
+<monster name="Tirecz" nameDescription="Tirecz" race="blood" experience="6000" speed="220">
 	<health now="25000" max="25000" />
 	<look type="334" corpse="11103" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/tremorak.xml
+++ b/data/monster/Bosses/tremorak.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Tremorak" nameDescription="Tremorak" race="undead" experience="1300" speed="290" manacost="0">
+<monster name="Tremorak" nameDescription="Tremorak" race="undead" experience="1300" speed="290">
 	<health now="10000" max="10000" />
 	<look type="285" corpse="8933" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Bosses/ushuriel.xml
+++ b/data/monster/Bosses/ushuriel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ushuriel" nameDescription="Ushuriel" race="fire" experience="10500" speed="350" manacost="0">
+<monster name="Ushuriel" nameDescription="Ushuriel" race="fire" experience="10500" speed="350">
 	<health now="31500" max="31500" />
 	<look type="12" head="0" body="95" legs="19" feet="112" corpse="6068" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/verminor.xml
+++ b/data/monster/Bosses/verminor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Verminor" nameDescription="Verminor" race="fire" experience="35000" speed="380" manacost="0">
+<monster name="Verminor" nameDescription="Verminor" race="fire" experience="35000" speed="380">
 	<health now="80000" max="80000" />
 	<look type="12" head="38" body="114" legs="0" feet="94" corpse="6068" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Bosses/versperoth.xml
+++ b/data/monster/Bosses/versperoth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Versperoth" nameDescription="Versperoth" race="blood" experience="20000" speed="0" manacost="0">
+<monster name="Versperoth" nameDescription="Versperoth" race="blood" experience="20000" speed="0">
 	<health now="100000" max="100000" />
 	<look type="295" corpse="0" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/warlord_ruzad.xml
+++ b/data/monster/Bosses/warlord_ruzad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Warlord Ruzad" nameDescription="Warlord Ruzad" race="blood" experience="1700" speed="270" manacost="0">
+<monster name="Warlord Ruzad" nameDescription="Warlord Ruzad" race="blood" experience="1700" speed="270">
 	<health now="2500" max="2500" />
 	<look type="2" head="20" body="30" legs="40" feet="50" corpse="6008" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Bosses/wrath_of_the_emperor.xml
+++ b/data/monster/Bosses/wrath_of_the_emperor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Wrath of the Emperor" nameDescription="Wrath of the Emperor" race="undead" experience="600" speed="410" manacost="0">
+<monster name="Wrath of the Emperor" nameDescription="Wrath of the Emperor" race="undead" experience="600" speed="410">
 	<health now="55000" max="55000" />
 	<look type="351" corpse="0" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/yaga_the_crone.xml
+++ b/data/monster/Bosses/yaga_the_crone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Yaga The Crone" nameDescription="Yaga the Crone" race="blood" experience="375" speed="240" manacost="0">
+<monster name="Yaga The Crone" nameDescription="Yaga the Crone" race="blood" experience="375" speed="240">
 	<health now="620" max="620" />
 	<look type="54" corpse="6081" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Bosses/yakchal.xml
+++ b/data/monster/Bosses/yakchal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Yakchal" nameDescription="Yakchal" race="blood" experience="4400" speed="200" manacost="0">
+<monster name="Yakchal" nameDescription="Yakchal" race="blood" experience="4400" speed="200">
 	<health now="5750" max="5750" />
 	<look type="149" head="0" body="47" legs="105" feet="105" addons="0" corpse="20546" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Bosses/zevelon_duskbringer.xml
+++ b/data/monster/Bosses/zevelon_duskbringer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Zevelon Duskbringer" nameDescription="Zevelon Duskbringer" race="undead" experience="1800" speed="310" manacost="0">
+<monster name="Zevelon Duskbringer" nameDescription="Zevelon Duskbringer" race="undead" experience="1800" speed="310">
 	<health now="1400" max="1400" />
 	<look type="287" corpse="8937" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Bosses/zoralurk.xml
+++ b/data/monster/Bosses/zoralurk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Zoralurk" nameDescription="Zoralurk" race="undead" experience="30000" speed="400" manacost="0">
+<monster name="Zoralurk" nameDescription="Zoralurk" race="undead" experience="30000" speed="400">
 	<health now="55000" max="55000" />
 	<look type="12" head="0" body="98" legs="86" feet="94" corpse="6068" />
 	<targetchange interval="10000" chance="20" />

--- a/data/monster/Bosses/zugurosh.xml
+++ b/data/monster/Bosses/zugurosh.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Zugurosh" nameDescription="Zugurosh" race="fire" experience="10000" speed="340" manacost="0">
+<monster name="Zugurosh" nameDescription="Zugurosh" race="fire" experience="10000" speed="340">
 	<health now="90500" max="90500" />
 	<look type="12" head="2" body="35" legs="57" feet="91" corpse="6068" />
 	<targetchange interval="5000" chance="15" />

--- a/data/monster/Bosses/zulazza_the_corruptor.xml
+++ b/data/monster/Bosses/zulazza_the_corruptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Zulazza the Corruptor" nameDescription="Zulazza The Corruptor" race="blood" experience="9800" speed="290" manacost="0">
+<monster name="Zulazza the Corruptor" nameDescription="Zulazza The Corruptor" race="blood" experience="9800" speed="290">
 	<health now="28000" max="28000" />
 	<look type="334" corpse="11107" />
 	<targetchange interval="2000" chance="10" />

--- a/data/monster/Canines/crystal_wolf.xml
+++ b/data/monster/Canines/crystal_wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Crystal Wolf" nameDescription="a crystal wolf" race="undead" experience="275" speed="200" manacost="0">
+<monster name="Crystal Wolf" nameDescription="a crystal wolf" race="undead" experience="275" speed="200">
 	<health now="750" max="750" />
 	<look type="391" corpse="13584" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Canines/starving_wolf.xml
+++ b/data/monster/Canines/starving_wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="starving wolf" nameDescription="a starving wolf" race="blood" experience="65" speed="170" manacost="0">
+<monster name="starving wolf" nameDescription="a starving wolf" race="blood" experience="65" speed="170">
 	<health now="85" max="85" />
 	<look type="27" head="20" body="30" legs="40" feet="50" corpse="5968" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Canines/thornfire_wolf.xml
+++ b/data/monster/Canines/thornfire_wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Thornfire Wolf" nameDescription="a thornfire wolf" race="energy" experience="200" speed="250" manacost="0">
+<monster name="Thornfire Wolf" nameDescription="a thornfire wolf" race="energy" experience="200" speed="250">
 	<health now="600" max="600" />
 	<look type="414" corpse="13859" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Canines/war_wolf.xml
+++ b/data/monster/Canines/war_wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="War Wolf" nameDescription="a war wolf" race="blood" experience="55" speed="200">
+<monster name="War Wolf" nameDescription="a war wolf" race="blood" experience="55" speed="200" manacost="420">
 	<health now="140" max="140" />
 	<look type="3" corpse="6009" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Canines/war_wolf.xml
+++ b/data/monster/Canines/war_wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="War Wolf" nameDescription="a war wolf" race="blood" experience="55" speed="200" manacost="0">
+<monster name="War Wolf" nameDescription="a war wolf" race="blood" experience="55" speed="200">
 	<health now="140" max="140" />
 	<look type="3" corpse="6009" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Canines/werewolf.xml
+++ b/data/monster/Canines/werewolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Werewolf" nameDescription="a werewolf" experience="1900" speed="200" race="blood" manacost="0">
+<monster name="Werewolf" nameDescription="a werewolf" experience="1900" speed="200" race="blood">
 	<health now="1955" max="1955" />
 	<targetchange interval="4000" chance="10" />
 	<look type="308" corpse="20380" />

--- a/data/monster/Chakoyas/chakoya_toolshaper.xml
+++ b/data/monster/Chakoyas/chakoya_toolshaper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Chakoya Toolshaper" nameDescription="a chakoya toolshaper" race="blood" experience="40" speed="200" manacost="0">
+<monster name="Chakoya Toolshaper" nameDescription="a chakoya toolshaper" race="blood" experience="40" speed="200">
 	<health now="80" max="80" />
 	<look type="259" corpse="7320" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Cnidarians/jellyfish.xml
+++ b/data/monster/Cnidarians/jellyfish.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Jellyfish" nameDescription="a jellyfish" race="undead" experience="0" speed="170" manacost="0">
+<monster name="Jellyfish" nameDescription="a jellyfish" race="undead" experience="0" speed="170">
 	<health now="55" max="55" />
 	<look type="452" corpse="15284" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Corym/corym_charlatan.xml
+++ b/data/monster/Corym/corym_charlatan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Corym Charlatan" nameDescription="a corym charlatan" race="blood" experience="150" speed="180" manacost="0">
+<monster name="Corym Charlatan" nameDescription="a corym charlatan" race="blood" experience="150" speed="180">
 	<health now="250" max="250" />
 	<look type="532" body="97" legs="116" corpse="19725" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Corym/corym_skirmisher.xml
+++ b/data/monster/Corym/corym_skirmisher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Corym Skirmisher" nameDescription="a corym skirmisher" race="blood" experience="260" speed="200" manacost="0">
+<monster name="Corym Skirmisher" nameDescription="a corym skirmisher" race="blood" experience="260" speed="200">
 	<health now="450" max="450" />
 	<look type="533" legs="101" corpse="19726" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Corym/corym_vanguard.xml
+++ b/data/monster/Corym/corym_vanguard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Corym Vanguard" nameDescription="a corym vanguard" race="blood" experience="490" speed="210" manacost="0">
+<monster name="Corym Vanguard" nameDescription="a corym vanguard" race="blood" experience="490" speed="210">
 	<health now="700" max="700" />
 	<look type="534" head="101" legs="101" corpse="19734" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Corym/little_corym_charlatan.xml
+++ b/data/monster/Corym/little_corym_charlatan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Little Corym Charlatan" nameDescription="a little corym charlatan" race="blood" experience="40" speed="170" manacost="0">
+<monster name="Little Corym Charlatan" nameDescription="a little corym charlatan" race="blood" experience="40" speed="170">
 	<health now="90" max="90" />
 	<look type="532" body="97" legs="116" corpse="19729" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Crustaceans/crustacea_gigantica.xml
+++ b/data/monster/Crustaceans/crustacea_gigantica.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Crustacea Gigantica" nameDescription="a crustacea gigantica" race="blood" experience="1800" speed="290" manacost="0">
+<monster name="Crustacea Gigantica" nameDescription="a crustacea gigantica" race="blood" experience="1800" speed="290">
 	<health now="1600" max="1600" />
 	<look type="383" corpse="13331" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Cryo-Elementals/ice_golem.xml
+++ b/data/monster/Cryo-Elementals/ice_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ice Golem" nameDescription="an ice golem" race="undead" experience="295" speed="195" manacost="0">
+<monster name="Ice Golem" nameDescription="an ice golem" race="undead" experience="295" speed="195">
 	<health now="385" max="385" />
 	<look type="261" corpse="7282" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Deeplings/deepling_brawler.xml
+++ b/data/monster/Deeplings/deepling_brawler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Brawler" nameDescription="a deepling brawler" race="blood" experience="260" speed="190" manacost="0">
+<monster name="Deepling Brawler" nameDescription="a deepling brawler" race="blood" experience="260" speed="190">
 	<health now="380" max="380" />
 	<look type="470" corpse="13840" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_elite.xml
+++ b/data/monster/Deeplings/deepling_elite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Elite" nameDescription="a deepling elite" race="blood" experience="3000" speed="210" manacost="0">
+<monster name="Deepling Elite" nameDescription="a deepling elite" race="blood" experience="3000" speed="210">
 	<health now="3200" max="3200" />
 	<look type="441" corpse="15176" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_master_librarian.xml
+++ b/data/monster/Deeplings/deepling_master_librarian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Master Librarian" nameDescription="a deepling master librarian" race="blood" experience="1900" speed="190" manacost="0">
+<monster name="Deepling Master Librarian" nameDescription="a deepling master librarian" race="blood" experience="1900" speed="190">
 	<health now="1700" max="1700" />
 	<look type="443" corpse="15211" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_scout.xml
+++ b/data/monster/Deeplings/deepling_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Scout" nameDescription="a deepling scout" race="blood" experience="160" speed="200" manacost="0">
+<monster name="Deepling Scout" nameDescription="a deepling scout" race="blood" experience="160" speed="200">
 	<health now="240" max="240" />
 	<look type="413" corpse="13839" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_spellsinger.xml
+++ b/data/monster/Deeplings/deepling_spellsinger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Spellsinger" nameDescription="a deepling spellsinger" race="blood" experience="1000" speed="190" manacost="0">
+<monster name="Deepling Spellsinger" nameDescription="a deepling spellsinger" race="blood" experience="1000" speed="190">
 	<health now="850" max="850" />
 	<look type="443" corpse="15208" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_tyrant.xml
+++ b/data/monster/Deeplings/deepling_tyrant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Tyrant" nameDescription="a deepling tyrant" race="blood" experience="4200" speed="260" manacost="0">
+<monster name="Deepling Tyrant" nameDescription="a deepling tyrant" race="blood" experience="4200" speed="260">
 	<health now="4900" max="4900" />
 	<look type="442" corpse="15188" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_warrior.xml
+++ b/data/monster/Deeplings/deepling_warrior.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Warrior" nameDescription="a deepling warrior" race="blood" experience="1500" speed="210" manacost="0">
+<monster name="Deepling Warrior" nameDescription="a deepling warrior" race="blood" experience="1500" speed="210">
 	<health now="1600" max="1600" />
 	<look type="441" corpse="15175" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Deeplings/deepling_worker.xml
+++ b/data/monster/Deeplings/deepling_worker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deepling Worker" nameDescription="a deepling worker" race="blood" experience="130" speed="210" manacost="0">
+<monster name="Deepling Worker" nameDescription="a deepling worker" race="blood" experience="130" speed="210">
 	<health now="190" max="190" />
 	<look type="470" corpse="15497" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/askarak_demon.xml
+++ b/data/monster/Demons/askarak_demon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Askarak Demon" nameDescription="an askarak demon" race="venom" experience="900" speed="220" manacost="0">
+<monster name="Askarak Demon" nameDescription="an askarak demon" race="venom" experience="900" speed="220">
 	<health now="1500" max="1500" />
 	<look type="420" corpse="13815" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/askarak_lord.xml
+++ b/data/monster/Demons/askarak_lord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Askarak Lord" nameDescription="an askarak lord" race="venom" experience="1200" speed="230" manacost="0">
+<monster name="Askarak Lord" nameDescription="an askarak lord" race="venom" experience="1200" speed="230">
 	<health now="2100" max="2100" />
 	<look type="410" corpse="13956" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/askarak_prince.xml
+++ b/data/monster/Demons/askarak_prince.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Askarak Prince" nameDescription="an askarak prince" race="venom" experience="1700" speed="240" manacost="0">
+<monster name="Askarak Prince" nameDescription="an askarak prince" race="venom" experience="1700" speed="240">
 	<health now="2600" max="2600" />
 	<look type="419" corpse="13957" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/dark_torturer.xml
+++ b/data/monster/Demons/dark_torturer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dark Torturer" nameDescription="a dark torturer" race="undead" experience="4650" speed="240" manacost="0">
+<monster name="Dark Torturer" nameDescription="a dark torturer" race="undead" experience="4650" speed="240">
 	<health now="7350" max="7350" />
 	<look type="234" corpse="6328" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/demon.xml
+++ b/data/monster/Demons/demon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Demon" nameDescription="a demon" race="fire" experience="6000" speed="280" manacost="0">
+<monster name="Demon" nameDescription="a demon" race="fire" experience="6000" speed="280">
 	<health now="8200" max="8200" />
 	<look type="35" corpse="5995" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Demons/destroyer.xml
+++ b/data/monster/Demons/destroyer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Destroyer" nameDescription="a destroyer" race="undead" experience="2500" speed="270" manacost="0">
+<monster name="Destroyer" nameDescription="a destroyer" race="undead" experience="2500" speed="270">
 	<health now="3700" max="3700" />
 	<look type="236" corpse="6320" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/diabolic_imp.xml
+++ b/data/monster/Demons/diabolic_imp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Diabolic Imp" nameDescription="a diabolic imp" race="fire" experience="2900" speed="220" manacost="0">
+<monster name="Diabolic Imp" nameDescription="a diabolic imp" race="fire" experience="2900" speed="220">
 	<health now="1950" max="1950" />
 	<look type="237" corpse="6364" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/grave_guard.xml
+++ b/data/monster/Demons/grave_guard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Grave Guard" nameDescription="a grave guard" race="undead" experience="485" speed="200" manacost="0">
+<monster name="Grave Guard" nameDescription="a grave guard" race="undead" experience="485" speed="200">
 	<health now="720" max="720" />
 	<look type="234" corpse="13975" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/gravedigger.xml
+++ b/data/monster/Demons/gravedigger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Gravedigger" nameDescription="a gravedigger" race="blood" experience="950" speed="230" manacost="0">
+<monster name="Gravedigger" nameDescription="a gravedigger" race="blood" experience="950" speed="230">
 	<health now="1500" max="1500" />
 	<look type="558" corpse="21279" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/hand_of_cursed_fate.xml
+++ b/data/monster/Demons/hand_of_cursed_fate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hand of Cursed Fate" nameDescription="a hand of cursed fate" race="blood" experience="5000" speed="260" manacost="0">
+<monster name="Hand of Cursed Fate" nameDescription="a hand of cursed fate" race="blood" experience="5000" speed="260">
 	<health now="7500" max="7500" />
 	<look type="230" corpse="6312" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/hellhound.xml
+++ b/data/monster/Demons/hellhound.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hellhound" nameDescription="a hellhound" race="blood" experience="6800" speed="280" manacost="0">
+<monster name="Hellhound" nameDescription="a hellhound" race="blood" experience="6800" speed="280">
 	<health now="7500" max="7500" />
 	<look type="240" corpse="6332" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/hellspawn.xml
+++ b/data/monster/Demons/hellspawn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hellspawn" nameDescription="a hellspawn" experience="2550" speed="260" race="fire" manacost="0">
+<monster name="Hellspawn" nameDescription="a hellspawn" experience="2550" speed="260" race="fire">
 	<health now="3500" max="3500" />
 	<targetchange interval="4000" chance="15" />
 	<look type="322" corpse="9923" />

--- a/data/monster/Demons/juggernaut.xml
+++ b/data/monster/Demons/juggernaut.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Juggernaut" nameDescription="a juggernaut" race="blood" experience="14000" speed="290" manacost="0">
+<monster name="Juggernaut" nameDescription="a juggernaut" race="blood" experience="14000" speed="290">
 	<health now="20000" max="20000" />
 	<look type="244" corpse="6336" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/nightmare.xml
+++ b/data/monster/Demons/nightmare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Nightmare" nameDescription="a nightmare" race="blood" experience="2150" speed="240" manacost="0">
+<monster name="Nightmare" nameDescription="a nightmare" race="blood" experience="2150" speed="240">
 	<health now="2700" max="2700" />
 	<look type="245" corpse="6340" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/nightmare_scion.xml
+++ b/data/monster/Demons/nightmare_scion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Nightmare Scion" nameDescription="a nightmare scion" race="blood" experience="1350" speed="230" manacost="0">
+<monster name="Nightmare Scion" nameDescription="a nightmare scion" race="blood" experience="1350" speed="230">
 	<health now="1400" max="1400" />
 	<look type="321" corpse="9919" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/plaguesmith.xml
+++ b/data/monster/Demons/plaguesmith.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Plaguesmith" nameDescription="a plaguesmith" race="venom" experience="4500" speed="240" manacost="0">
+<monster name="Plaguesmith" nameDescription="a plaguesmith" race="venom" experience="4500" speed="240">
 	<health now="8250" max="8250" />
 	<look type="247" corpse="6516" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/rift_brood.xml
+++ b/data/monster/Demons/rift_brood.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Rift Brood" nameDescription="Rift Brood" race="energy" experience="1600" speed="300" manacost="0">
+<monster name="Rift Brood" nameDescription="Rift Brood" race="energy" experience="1600" speed="300">
 	<health now="3000" max="3000" />
 	<look type="290" corpse="1495" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Demons/rift_scythe.xml
+++ b/data/monster/Demons/rift_scythe.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Rift Scythe" nameDescription="Rift Scythe" race="undead" experience="2000" speed="370" manacost="0">
+<monster name="Rift Scythe" nameDescription="Rift Scythe" race="undead" experience="2000" speed="370">
 	<health now="3600" max="3600" />
 	<look type="300" corpse="0" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Demons/shaburak_demon.xml
+++ b/data/monster/Demons/shaburak_demon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shaburak Demon" nameDescription="a shaburak demon" race="fire" experience="900" speed="220" manacost="0">
+<monster name="Shaburak Demon" nameDescription="a shaburak demon" race="fire" experience="900" speed="220">
 	<health now="1500" max="1500" />
 	<look type="417" corpse="13814" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/shaburak_lord.xml
+++ b/data/monster/Demons/shaburak_lord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shaburak Lord" nameDescription="a shaburak lord" race="fire" experience="1200" speed="230" manacost="0">
+<monster name="Shaburak Lord" nameDescription="a shaburak lord" race="fire" experience="1200" speed="230">
 	<health now="2100" max="2100" />
 	<look type="409" corpse="13958" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/shaburak_prince.xml
+++ b/data/monster/Demons/shaburak_prince.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shaburak Prince" nameDescription="a shaburak Prince" race="fire" experience="1700" speed="240" manacost="0">
+<monster name="Shaburak Prince" nameDescription="a shaburak Prince" race="fire" experience="1700" speed="240">
 	<health now="2600" max="2600" />
 	<look type="418" corpse="13969" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Demons/yielothax.xml
+++ b/data/monster/Demons/yielothax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Yielothax" nameDescription="Yielothax" race="venom" experience="1250" speed="240" manacost="0">
+<monster name="Yielothax" nameDescription="Yielothax" race="venom" experience="1250" speed="240">
 	<health now="1500" max="1500" />
 	<look type="408" corpse="13752" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Djinn/blue_djinn.xml
+++ b/data/monster/Djinn/blue_djinn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Blue Djinn" nameDescription="a blue djinn" race="blood" experience="215" speed="180" manacost="0">
+<monster name="Blue Djinn" nameDescription="a blue djinn" race="blood" experience="215" speed="180">
 	<health now="330" max="330" />
 	<look type="80" corpse="6020" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Djinn/efreet.xml
+++ b/data/monster/Djinn/efreet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Efreet" nameDescription="an efreet" race="blood" experience="410" speed="180" manacost="0">
+<monster name="Efreet" nameDescription="an efreet" race="blood" experience="410" speed="180">
 	<health now="550" max="550" />
 	<look type="103" corpse="6032" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Djinn/green_djinn.xml
+++ b/data/monster/Djinn/green_djinn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Green Djinn" nameDescription="a green djinn" race="blood" experience="215" speed="180" manacost="0">
+<monster name="Green Djinn" nameDescription="a green djinn" race="blood" experience="215" speed="180">
 	<health now="330" max="330" />
 	<look type="51" corpse="6016" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Djinn/marid.xml
+++ b/data/monster/Djinn/marid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Marid" nameDescription="a marid" race="blood" experience="410" speed="180" manacost="0">
+<monster name="Marid" nameDescription="a marid" race="blood" experience="410" speed="180">
 	<health now="550" max="550" />
 	<look type="104" corpse="6033" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/dragon.xml
+++ b/data/monster/Dragons/dragon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dragon" nameDescription="a dragon" race="blood" experience="700" speed="185" manacost="0">
+<monster name="Dragon" nameDescription="a dragon" race="blood" experience="700" speed="185">
 	<health now="1000" max="1000" />
 	<look type="34" corpse="5973" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/dragon_hatchling.xml
+++ b/data/monster/Dragons/dragon_hatchling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dragon Hatchling" nameDescription="a dragon hatchling" race="blood" experience="185" speed="170" manacost="0">
+<monster name="Dragon Hatchling" nameDescription="a dragon hatchling" race="blood" experience="185" speed="170">
 	<health now="380" max="380" />
 	<look type="271" corpse="7621" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/dragon_lord.xml
+++ b/data/monster/Dragons/dragon_lord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dragon Lord" nameDescription="a dragon lord" race="blood" experience="2100" speed="200" manacost="0">
+<monster name="Dragon Lord" nameDescription="a dragon lord" race="blood" experience="2100" speed="200">
 	<health now="1900" max="1900" />
 	<look type="39" corpse="5984" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/dragon_lord_hatchling.xml
+++ b/data/monster/Dragons/dragon_lord_hatchling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dragon Lord Hatchling" nameDescription="a dragon lord hatchling" race="blood" experience="645" speed="190" manacost="0">
+<monster name="Dragon Lord Hatchling" nameDescription="a dragon lord hatchling" race="blood" experience="645" speed="190">
 	<health now="750" max="750" />
 	<look type="272" corpse="7622" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/dragonling.xml
+++ b/data/monster/Dragons/dragonling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dragonling" nameDescription="a dragonling" race="blood" experience="2200" speed="330" manacost="0">
+<monster name="Dragonling" nameDescription="a dragonling" race="blood" experience="2200" speed="330">
 	<health now="2600" max="2600" />
 	<look type="505" corpse="18438" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/draptor.xml
+++ b/data/monster/Dragons/draptor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Draptor" nameDescription="a draptor" race="blood" experience="2400" speed="282" manacost="0">
+<monster name="Draptor" nameDescription="a draptor" race="blood" experience="2400" speed="282">
 	<health now="3000" max="3000" />
 	<look type="382" corpse="13316" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Dragons/elder_wyrm.xml
+++ b/data/monster/Dragons/elder_wyrm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Elder Wyrm" nameDescription="an elder wyrm" race="blood" experience="2500" speed="260" manacost="0">
+<monster name="Elder Wyrm" nameDescription="an elder wyrm" race="blood" experience="2500" speed="260">
 	<health now="2700" max="2700" />
 	<look type="561" corpse="21283" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Dragons/frost_dragon.xml
+++ b/data/monster/Dragons/frost_dragon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Frost Dragon" nameDescription="a frost dragon" race="undead" experience="2100" speed="240" manacost="0">
+<monster name="Frost Dragon" nameDescription="a frost dragon" race="undead" experience="2100" speed="240">
 	<health now="1800" max="1800" />
 	<look type="248" corpse="7091" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/frost_dragon_hatchling.xml
+++ b/data/monster/Dragons/frost_dragon_hatchling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Frost Dragon Hatchling" nameDescription="a frost dragon hatchling" race="undead" experience="745" speed="200" manacost="0">
+<monster name="Frost Dragon Hatchling" nameDescription="a frost dragon hatchling" race="undead" experience="745" speed="200">
 	<health now="800" max="800" />
 	<look type="283" corpse="7969" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/ghastly_dragon.xml
+++ b/data/monster/Dragons/ghastly_dragon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ghastly Dragon" nameDescription="a ghastly dragon" race="undead" experience="4600" speed="320" manacost="0">
+<monster name="Ghastly Dragon" nameDescription="a ghastly dragon" race="undead" experience="4600" speed="320">
 	<health now="7800" max="7800" />
 	<look type="351" corpse="11362" />
 	<targetchange interval="4000" chance="5" />

--- a/data/monster/Dragons/undead_dragon.xml
+++ b/data/monster/Dragons/undead_dragon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Undead Dragon" nameDescription="an undead dragon" race="undead" experience="7200" speed="250" manacost="0">
+<monster name="Undead Dragon" nameDescription="an undead dragon" race="undead" experience="7200" speed="250">
 	<health now="8350" max="8350" />
 	<look type="231" corpse="6306" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dragons/wyrm.xml
+++ b/data/monster/Dragons/wyrm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wyrm" nameDescription="a wyrm" race="blood" experience="1550" speed="230" manacost="0">
+<monster name="Wyrm" nameDescription="a wyrm" race="blood" experience="1550" speed="230">
 	<health now="1825" max="1825" />
 	<look type="291" corpse="8941" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/bad_dream.xml
+++ b/data/monster/Dreamhaunters/bad_dream.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bad Dream" nameDescription="a bad dream" race="blood" experience="0" speed="0" manacost="0">
+<monster name="Bad Dream" nameDescription="a bad dream" race="blood" experience="0" speed="0">
 	<health now="7200" max="7200" />
 	<look typeex="22444" corpse="22497" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/choking_fear.xml
+++ b/data/monster/Dreamhaunters/choking_fear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Choking Fear" nameDescription="a choking fear" race="undead" experience="4700" speed="260" manacost="0">
+<monster name="Choking Fear" nameDescription="a choking fear" race="undead" experience="4700" speed="260">
 	<health now="5800" max="5800" />
 	<look type="586" corpse="22493" />
 	<targetchange interval="4000" chance="5" />

--- a/data/monster/Dreamhaunters/demon_outcast.xml
+++ b/data/monster/Dreamhaunters/demon_outcast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Demon Outcast" nameDescription="a demon outcast" race="blood" experience="6200" speed="280" manacost="0">
+<monster name="Demon Outcast" nameDescription="a demon outcast" race="blood" experience="6200" speed="280">
 	<health now="6900" max="6900" />
 	<look type="590" corpse="22549" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/feversleep.xml
+++ b/data/monster/Dreamhaunters/feversleep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Feversleep" nameDescription="a feversleep" race="blood" experience="4400" speed="270" manacost="0">
+<monster name="Feversleep" nameDescription="a feversleep" race="blood" experience="4400" speed="270">
 	<health now="5900" max="5900" />
 	<look type="593" corpse="22497" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/frazzlemaw.xml
+++ b/data/monster/Dreamhaunters/frazzlemaw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Frazzlemaw" nameDescription="a frazzlemaw" race="blood" experience="3400" speed="250" manacost="0">
+<monster name="Frazzlemaw" nameDescription="a frazzlemaw" race="blood" experience="3400" speed="250">
 	<health now="4100" max="4100" />
 	<look type="594" corpse="22567" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/guzzlemaw.xml
+++ b/data/monster/Dreamhaunters/guzzlemaw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Guzzlemaw" nameDescription="a guzzlemaw" race="blood" experience="5500" speed="270" manacost="0">
+<monster name="Guzzlemaw" nameDescription="a guzzlemaw" race="blood" experience="5500" speed="270">
 	<health now="6400" max="6400" />
 	<look type="584" corpse="22485" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/minion_of_gaz'haragoth.xml
+++ b/data/monster/Dreamhaunters/minion_of_gaz'haragoth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Minion of Gaz'haragoth" nameDescription="a minion of Gaz'haragoth" race="blood" experience="0" speed="270" manacost="0">
+<monster name="Minion of Gaz'haragoth" nameDescription="a minion of Gaz'haragoth" race="blood" experience="0" speed="270">
 	<health now="5500" max="5500" />
 	<look type="590" corpse="22549" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Dreamhaunters/nightmare_of_gaz'haragoth.xml
+++ b/data/monster/Dreamhaunters/nightmare_of_gaz'haragoth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Nightmare of Gaz'haragoth" nameDescription="a nightmare of Gaz'haragoth" race="blood" experience="0" speed="270" manacost="0">
+<monster name="Nightmare of Gaz'haragoth" nameDescription="a nightmare of Gaz'haragoth" race="blood" experience="0" speed="270">
 	<health now="5500" max="5500" />
 	<look type="587" corpse="22497" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Dreamhaunters/retching_horror.xml
+++ b/data/monster/Dreamhaunters/retching_horror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Retching Horror" nameDescription="a retching horror" race="fire" experience="3900" speed="250" manacost="0">
+<monster name="Retching Horror" nameDescription="a retching horror" race="fire" experience="3900" speed="250">
 	<health now="5300" max="5300" />
 	<look type="588" corpse="22508" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/shiversleep.xml
+++ b/data/monster/Dreamhaunters/shiversleep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shiversleep" nameDescription="Shiversleep" race="blood" experience="1900" speed="270" manacost="0">
+<monster name="Shiversleep" nameDescription="Shiversleep" race="blood" experience="1900" speed="270">
 	<health now="4600" max="4600" />
 	<look type="592" corpse="22497" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Dreamhaunters/shock_head.xml
+++ b/data/monster/Dreamhaunters/shock_head.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shock Head" nameDescription="a shock head" race="blood" experience="2300" speed="250" manacost="0">
+<monster name="Shock Head" nameDescription="a shock head" race="blood" experience="2300" speed="250">
 	<health now="4200" max="4200" />
 	<look type="579" corpse="22392" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dreamhaunters/sight_of_surrender.xml
+++ b/data/monster/Dreamhaunters/sight_of_surrender.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Sight of Surrender" nameDescription="a sight of surrender" race="undead" experience="17000" speed="300" manacost="0">
+<monster name="Sight of Surrender" nameDescription="a sight of surrender" race="undead" experience="17000" speed="300">
 	<health now="28000" max="28000" />
 	<look type="583" corpse="22478" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Dreamhaunters/silencer.xml
+++ b/data/monster/Dreamhaunters/silencer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Silencer" nameDescription="a silencer" race="blood" experience="5100" speed="230" manacost="0">
+<monster name="Silencer" nameDescription="a silencer" race="blood" experience="5100" speed="230">
 	<health now="5400" max="5400" />
 	<look type="585" corpse="22489" />
 	<targetchange interval="4000" chance="5" />

--- a/data/monster/Dreamhaunters/terrorsleep.xml
+++ b/data/monster/Dreamhaunters/terrorsleep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Terrorsleep" nameDescription="a terrorsleep" race="blood" experience="5900" speed="270" manacost="0">
+<monster name="Terrorsleep" nameDescription="a terrorsleep" race="blood" experience="5900" speed="270">
 	<health now="7200" max="7200" />
 	<look type="593" corpse="22497" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dwarves/dwarf_geomancer.xml
+++ b/data/monster/Dwarves/dwarf_geomancer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dwarf Geomancer" nameDescription="a dwarf geomancer" race="blood" experience="265" speed="190" manacost="0">
+<monster name="Dwarf Geomancer" nameDescription="a dwarf geomancer" race="blood" experience="265" speed="190">
 	<health now="380" max="380" />
 	<look type="66" corpse="6015" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dwarves/enslaved_dwarf.xml
+++ b/data/monster/Dwarves/enslaved_dwarf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Enslaved Dwarf" nameDescription="an enslaved dwarf" race="blood" experience="2700" speed="280" manacost="0">
+<monster name="Enslaved Dwarf" nameDescription="an enslaved dwarf" race="blood" experience="2700" speed="280">
 	<health now="3800" max="3800" />
 	<look type="494" corpse="17408" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dwarves/lost_basher.xml
+++ b/data/monster/Dwarves/lost_basher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lost Basher" nameDescription="a lost basher" race="blood" experience="1800" speed="250" manacost="0">
+<monster name="Lost Basher" nameDescription="a lost basher" race="blood" experience="1800" speed="250">
 	<health now="2600" max="2600" />
 	<look type="538" corpse="19963" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dwarves/lost_berserker.xml
+++ b/data/monster/Dwarves/lost_berserker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lost Berserker" nameDescription="a lost berserker" race="blood" experience="4400" speed="250" manacost="0">
+<monster name="Lost Berserker" nameDescription="a lost berserker" race="blood" experience="4400" speed="250">
 	<health now="5900" max="5900" />
 	<look type="496" corpse="17416" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Dwarves/lost_husher.xml
+++ b/data/monster/Dwarves/lost_husher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lost Husher" nameDescription="a lost husher" race="blood" experience="1800" speed="220" manacost="0">
+<monster name="Lost Husher" nameDescription="a lost husher" race="blood" experience="1800" speed="220">
 	<health now="1600" max="1600" />
 	<look type="537" corpse="19964" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dwarves/lost_thrower.xml
+++ b/data/monster/Dwarves/lost_thrower.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lost Thrower" nameDescription="a lost thrower" race="blood" experience="1200" speed="220" manacost="0">
+<monster name="Lost Thrower" nameDescription="a lost thrower" race="blood" experience="1200" speed="220">
 	<health now="1700" max="1700" />
 	<look type="539" corpse="19998" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Dworcs/dworc_fleshhunter.xml
+++ b/data/monster/Dworcs/dworc_fleshhunter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dworc Fleshhunter" nameDescription="a dworc fleshhunter" race="blood" experience="40" speed="180" manacost="0">
+<monster name="Dworc Fleshhunter" nameDescription="a dworc fleshhunter" race="blood" experience="40" speed="180">
 	<health now="85" max="85" />
 	<look type="215" corpse="6058" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Dworcs/dworc_venomsniper.xml
+++ b/data/monster/Dworcs/dworc_venomsniper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dworc Venomsniper" namedescription="a dworc venomsniper" race="blood" experience="35" speed="180" manacost="0">
+<monster name="Dworc Venomsniper" namedescription="a dworc venomsniper" race="blood" experience="35" speed="180">
 	<health now="80" max="80" />
 	<look type="216" corpse="6059" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Dworcs/dworc_voodoomaster.xml
+++ b/data/monster/Dworcs/dworc_voodoomaster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dworc Voodoomaster" namedescription="a dworc voodoomaster" race="blood" experience="55" speed="190" manacost="0">
+<monster name="Dworc Voodoomaster" namedescription="a dworc voodoomaster" race="blood" experience="55" speed="190">
 	<health now="80" max="80" />
 	<look type="214" corpse="6055" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Electro-Elementals/charged_energy_elemental.xml
+++ b/data/monster/Electro-Elementals/charged_energy_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Charged Energy Elemental" nameDescription="a charged energy elemental" race="undead" experience="450" speed="270" manacost="0">
+<monster name="Charged Energy Elemental" nameDescription="a charged energy elemental" race="undead" experience="450" speed="270">
 	<health now="500" max="500" />
 	<look type="293" corpse="8966" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Electro-Elementals/energy_elemental.xml
+++ b/data/monster/Electro-Elementals/energy_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Energy Elemental" nameDescription="an energy elemental" race="energy" experience="550" speed="200" manacost="0">
+<monster name="Energy Elemental" nameDescription="an energy elemental" race="energy" experience="550" speed="200">
 	<health now="500" max="500" />
 	<look type="293" corpse="8966" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Electro-Elementals/massive_energy_elemental.xml
+++ b/data/monster/Electro-Elementals/massive_energy_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Massive Energy Elemental" nameDescription="a massive energy elemental" race="energy" experience="950" speed="210" manacost="0">
+<monster name="Massive Energy Elemental" nameDescription="a massive energy elemental" race="energy" experience="950" speed="210">
 	<health now="1100" max="1100" />
 	<look type="290" corpse="8966" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Electro-Elementals/overcharged_energy_element.xml
+++ b/data/monster/Electro-Elementals/overcharged_energy_element.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Overcharged Energy Element" nameDescription="an orvercharged energy element" race="undead" experience="1300" speed="300" manacost="0">
+<monster name="Overcharged Energy Element" nameDescription="an orvercharged energy element" race="undead" experience="1300" speed="300">
 	<health now="1700" max="1700" />
 	<look type="290" corpse="8966" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Elemental_Lords/earth_overlord.xml
+++ b/data/monster/Elemental_Lords/earth_overlord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Earth Overlord" nameDescription="an Earth Overlord" race="undead" experience="2800" speed="330" manacost="0">
+<monster name="Earth Overlord" nameDescription="an Earth Overlord" race="undead" experience="2800" speed="330">
 	<health now="4000" max="4000" />
 	<look type="285" corpse="8933" />
 	<targetchange interval="20000" chance="30" />

--- a/data/monster/Elemental_Lords/energy_overlord.xml
+++ b/data/monster/Elemental_Lords/energy_overlord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Energy Overlord" nameDescription="an Energy Overlord" race="undead" experience="2800" speed="290" manacost="0">
+<monster name="Energy Overlord" nameDescription="an Energy Overlord" race="undead" experience="2800" speed="290">
 	<health now="4000" max="4000" />
 	<look type="290" corpse="8966" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Elemental_Lords/fire_overlord.xml
+++ b/data/monster/Elemental_Lords/fire_overlord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Fire Overlord" nameDescription="a Fire Overlord" race="fire" experience="2800" speed="300" manacost="0">
+<monster name="Fire Overlord" nameDescription="a Fire Overlord" race="fire" experience="2800" speed="300">
 	<health now="4000" max="4000" />
 	<look type="243" corpse="8964" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Elemental_Lords/ice_overlord.xml
+++ b/data/monster/Elemental_Lords/ice_overlord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ice Overlord" nameDescription="an Ice Overlord" race="undead" experience="2800" speed="390" manacost="0">
+<monster name="Ice Overlord" nameDescription="an Ice Overlord" race="undead" experience="2800" speed="390">
 	<health now="4000" max="4000" />
 	<look type="11" corpse="8965" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Elves/elf_arcanist.xml
+++ b/data/monster/Elves/elf_arcanist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Elf Arcanist" nameDescription="an elf arcanist" race="blood" experience="175" speed="170" manacost="0">
+<monster name="Elf Arcanist" nameDescription="an elf arcanist" race="blood" experience="175" speed="170">
 	<health now="220" max="220" />
 	<look type="63" corpse="6011" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Elves/firestarter.xml
+++ b/data/monster/Elves/firestarter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Firestarter" nameDescription="a firestarter" race="blood" experience="80" speed="180" manacost="0">
+<monster name="Firestarter" nameDescription="a firestarter" race="blood" experience="80" speed="180">
 	<health now="180" max="180" />
 	<look type="159" head="94" body="77" legs="78" feet="79" corpse="20599" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Event_Creatures/bane_bringer.xml
+++ b/data/monster/Event_Creatures/bane_bringer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bane Bringer" nameDescription="a bane bringer" experience="400" speed="260" race="undead" manacost="0">
+<monster name="Bane Bringer" nameDescription="a bane bringer" experience="400" speed="260" race="undead">
 	<health now="2500" max="2500" />
 	<look type="310" corpse="9867" />
 	<targetchange speed="0" chance="8" />

--- a/data/monster/Event_Creatures/essence_of_darkness.xml
+++ b/data/monster/Event_Creatures/essence_of_darkness.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Essence of Darkness" nameDescription="an essence of darkness" race="undead" experience="30" speed="230" manacost="0">
+<monster name="Essence of Darkness" nameDescription="an essence of darkness" race="undead" experience="30" speed="230">
 	<health now="1000" max="1000" />
 	<look type="315" corpse="9960" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Event_Creatures/grynch_clan_goblin.xml
+++ b/data/monster/Event_Creatures/grynch_clan_goblin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Grynch Clan Goblin" nameDescription="Grynch Clan Goblin" race="blood" experience="4" speed="870" manacost="0">
+<monster name="Grynch Clan Goblin" nameDescription="Grynch Clan Goblin" race="blood" experience="4" speed="870">
 	<health now="80" max="80" />
 	<look type="61" corpse="6002" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Event_Creatures/hacker.xml
+++ b/data/monster/Event_Creatures/hacker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hacker" nameDescription="a hacker" race="blood" experience="45" speed="250" manacost="0">
+<monster name="Hacker" nameDescription="a hacker" race="blood" experience="45" speed="250">
 	<health now="430" max="430" />
 	<look type="8" corpse="5980" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Event_Creatures/midnight_spawn.xml
+++ b/data/monster/Event_Creatures/midnight_spawn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Midnight Spawn" nameDescription="a midnight spawn" race="undead" experience="900" speed="230" manacost="0">
+<monster name="Midnight Spawn" nameDescription="a midnight spawn" race="undead" experience="900" speed="230">
 	<health now="1000" max="1000" />
 	<look type="315" corpse="9960" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Event_Creatures/primitive.xml
+++ b/data/monster/Event_Creatures/primitive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Primitive" nameDescription="Primitive" race="blood" experience="45" speed="300" manacost="0">
+<monster name="Primitive" nameDescription="Primitive" race="blood" experience="45" speed="300">
 	<health now="200" max="200" />
 	<look type="143" head="1" body="1" legs="1" feet="1" corpse="6080" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Event_Creatures/shadow_hound.xml
+++ b/data/monster/Event_Creatures/shadow_hound.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shadow Hound" nameDescription="a shadow hound" experience="600" speed="360" race="blood" manacost="0">
+<monster name="Shadow Hound" nameDescription="a shadow hound" experience="600" speed="360" race="blood">
 	<health now="555" max="555" />
 	<targetchange speed="0" chance="8" />
 	<look type="322" corpse="9923" />

--- a/data/monster/Event_Creatures/spectral_scum.xml
+++ b/data/monster/Event_Creatures/spectral_scum.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<monster name="Spectral Scum" nameDescription="Spectral Scum" race="undead" experience="0" speed="230" manacost="0">
+<monster name="Spectral Scum" nameDescription="Spectral Scum" race="undead" experience="0" speed="230">
 	<health now="1" max="1" />
 	<look type="195" head="0" body="0" legs="0" feet="0" corpse="6070" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Event_Creatures/the_halloween_hare.xml
+++ b/data/monster/Event_Creatures/the_halloween_hare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="The Halloween Hare" nameDescription="The Halloween Hare" race="blood" experience="0" speed="150" manacost="0">
+<monster name="The Halloween Hare" nameDescription="The Halloween Hare" race="blood" experience="0" speed="150">
 	<health now="1" max="1" />
 	<look type="74" />
 	<targetchange interval="2000" chance="95" />

--- a/data/monster/Felines/midnight_panther.xml
+++ b/data/monster/Felines/midnight_panther.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Midnight Panther" nameDescription="a midnight panther" race="blood" experience="900" speed="250" manacost="0">
+<monster name="Midnight Panther" nameDescription="a midnight panther" race="blood" experience="900" speed="250">
 	<health now="1200" max="1200" />
 	<look type="385" corpse="13327" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Fish/fish.xml
+++ b/data/monster/Fish/fish.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Fish" nameDescription="a fish" race="undead" experience="0" speed="180" manacost="0">
+<monster name="Fish" nameDescription="a fish" race="undead" experience="0" speed="180">
 	<health now="25" max="25" />
 	<look type="455" corpse="2667" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Fish/manta_ray.xml
+++ b/data/monster/Fish/manta_ray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Manta Ray" nameDescription="a manta ray" race="blood" experience="125" speed="200" manacost="0">
+<monster name="Manta Ray" nameDescription="a manta ray" race="blood" experience="125" speed="200">
 	<health now="680" max="680" />
 	<look type="449" corpse="15276" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Fish/northern_pike.xml
+++ b/data/monster/Fish/northern_pike.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Northern Pike" nameDescription="a northern pike" race="undead" experience="0" speed="180" manacost="0">
+<monster name="Northern Pike" nameDescription="a northern pike" race="undead" experience="0" speed="180">
 	<health now="95" max="95" />
 	<look type="454" corpse="2669" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Fish/shark.xml
+++ b/data/monster/Fish/shark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shark" nameDescription="a shark" race="blood" experience="700" speed="230" manacost="0">
+<monster name="Shark" nameDescription="a shark" race="blood" experience="700" speed="230">
 	<health now="1200" max="1200" />
 	<look type="453" corpse="15287" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Frogs/azure_frog.xml
+++ b/data/monster/Frogs/azure_frog.xml
@@ -4,11 +4,11 @@
 	<look type="226" head="69" body="66" legs="69" feet="66" corpse="6079" />
 	<targetchange interval="4000" chance="0" />
 	<flags>
-		<flag summonable="1" />
+		<flag summonable="0" />
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="0" />
-		<flag convinceable="0" />
+		<flag convinceable="1" />
 		<flag pushable="0" />
 		<flag canpushitems="0" />
 		<flag canpushcreatures="0" />

--- a/data/monster/Frogs/filth_toad.xml
+++ b/data/monster/Frogs/filth_toad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Filth Toad" nameDescription="a filth toad" race="blood" experience="90" speed="210" manacost="0">
+<monster name="Filth Toad" nameDescription="a filth toad" race="blood" experience="90" speed="210">
 	<health now="185" max="185" />
 	<look type="222" corpse="6077" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Frogs/infernal_frog.xml
+++ b/data/monster/Frogs/infernal_frog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Infernal Frog" nameDescription="an infernal frog" race="blood" experience="190" speed="220" manacost="0">
+<monster name="Infernal Frog" nameDescription="an infernal frog" race="blood" experience="190" speed="220">
 	<health now="655" max="655" />
 	<look type="224" head="69" body="66" legs="69" feet="66" corpse="6079" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/armadile.xml
+++ b/data/monster/Geo-Elementals/armadile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Armadile" nameDescription="an armadile" race="undead" experience="2900" speed="210" manacost="0">
+<monster name="Armadile" nameDescription="an armadile" race="undead" experience="2900" speed="210">
 	<health now="3800" max="3800" />
 	<look type="487" corpse="18378" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/clay_guardian.xml
+++ b/data/monster/Geo-Elementals/clay_guardian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Clay Guardian" nameDescription="a clay guardian" race="undead" experience="400" speed="210" manacost="0">
+<monster name="Clay Guardian" nameDescription="a clay guardian" race="undead" experience="400" speed="210">
 	<health now="625" max="625" />
 	<look type="333" corpse="13972" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/cliff_strider.xml
+++ b/data/monster/Geo-Elementals/cliff_strider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Cliff Strider" nameDescription="a cliff strider" race="undead" experience="5700" speed="260" manacost="0">
+<monster name="Cliff Strider" nameDescription="a cliff strider" race="undead" experience="5700" speed="260">
 	<health now="9400" max="9400" />
 	<look type="497" corpse="17420" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/crystalcrusher.xml
+++ b/data/monster/Geo-Elementals/crystalcrusher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Crystalcrusher" nameDescription="a crystalcrusher" race="undead" experience="500" speed="230" manacost="0">
+<monster name="Crystalcrusher" nameDescription="a crystalcrusher" race="undead" experience="500" speed="230">
 	<health now="570" max="570" />
 	<look type="511" corpse="18487" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/damaged_crystal_golem.xml
+++ b/data/monster/Geo-Elementals/damaged_crystal_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Damaged Crystal Golem" nameDescription="a damaged crystal golem" race="energy" experience="0" speed="180" manacost="0">
+<monster name="Damaged Crystal Golem" nameDescription="a damaged crystal golem" race="energy" experience="0" speed="180">
 	<health now="500" max="500" />
 	<look type="508" corpse="18466" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/damaged_worker_golem.xml
+++ b/data/monster/Geo-Elementals/damaged_worker_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Damaged Worker Golem" nameDescription="a damaged worker golem" race="energy" experience="95" speed="200" manacost="0">
+<monster name="Damaged Worker Golem" nameDescription="a damaged worker golem" race="energy" experience="95" speed="200">
 	<health now="260" max="260" />
 	<look type="304" corpse="9801" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/diamond_servant.xml
+++ b/data/monster/Geo-Elementals/diamond_servant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Diamond Servant" nameDescription="a diamond servant" race="energy" experience="700" speed="210" manacost="0">
+<monster name="Diamond Servant" nameDescription="a diamond servant" race="energy" experience="700" speed="210">
 	<health now="1000" max="1000" />
 	<look type="397" corpse="13485" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/earth_elemental.xml
+++ b/data/monster/Geo-Elementals/earth_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Earth Elemental" nameDescription="an earth elemental" race="undead" experience="450" speed="220" manacost="0">
+<monster name="Earth Elemental" nameDescription="an earth elemental" race="undead" experience="450" speed="220">
 	<health now="650" max="650" />
 	<look type="301" corpse="8933" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/enraged_crystal_golem.xml
+++ b/data/monster/Geo-Elementals/enraged_crystal_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Enraged Crystal Golem" nameDescription="enraged crystal golem" race="energy" experience="550" speed="200" manacost="0">
+<monster name="Enraged Crystal Golem" nameDescription="enraged crystal golem" race="energy" experience="550" speed="200">
 	<health now="700" max="700" />
 	<look type="508" corpse="18466" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/eternal_guardian.xml
+++ b/data/monster/Geo-Elementals/eternal_guardian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Eternal Guardian" nameDescription="an eternal guardian" race="undead" experience="1800" speed="180" manacost="0">
+<monster name="Eternal Guardian" nameDescription="an eternal guardian" race="undead" experience="1800" speed="180">
 	<health now="2500" max="2500" />
 	<look type="345" corpse="11300" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/forest_fury.xml
+++ b/data/monster/Geo-Elementals/forest_fury.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Forest Fury" nameDescription="a forest fury" race="blood" experience="235" speed="210" manacost="0">
+<monster name="Forest Fury" nameDescription="a forest fury" race="blood" experience="235" speed="210">
 	<health now="480" max="480" />
 	<look type="569" corpse="21359" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/gargoyle.xml
+++ b/data/monster/Geo-Elementals/gargoyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Gargoyle" nameDescription="a gargoyle" race="undead" experience="150" speed="200" manacost="0">
+<monster name="Gargoyle" nameDescription="a gargoyle" race="undead" experience="150" speed="200">
 	<health now="250" max="250" />
 	<look type="95" corpse="6027" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/golden_servant.xml
+++ b/data/monster/Geo-Elementals/golden_servant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Golden Servant" nameDescription="a golden servant" race="energy" experience="450" speed="205" manacost="0">
+<monster name="Golden Servant" nameDescription="a golden servant" race="energy" experience="450" speed="205">
 	<health now="550" max="550" />
 	<look type="396" corpse="13489" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/iron_servant.xml
+++ b/data/monster/Geo-Elementals/iron_servant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Iron Servant" nameDescription="an iron servant" race="energy" experience="210" speed="190" manacost="0">
+<monster name="Iron Servant" nameDescription="an iron servant" race="energy" experience="210" speed="190">
 	<health now="350" max="350" />
 	<look type="395" corpse="13486" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/ironblight.xml
+++ b/data/monster/Geo-Elementals/ironblight.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ironblight" nameDescription="Ironblight" race="undead" experience="4400" speed="220" manacost="0">
+<monster name="Ironblight" nameDescription="Ironblight" race="undead" experience="4400" speed="220">
 	<health now="6600" max="6600" />
 	<look type="498" corpse="17424" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/jagged_earth_elemental.xml
+++ b/data/monster/Geo-Elementals/jagged_earth_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Jagged Earth Elemental" nameDescription="a jagged earth elemental" race="undead" experience="1300" speed="280" manacost="0">
+<monster name="Jagged Earth Elemental" nameDescription="a jagged earth elemental" race="undead" experience="1300" speed="280">
 	<health now="1500" max="1500" />
 	<look type="285" corpse="8933" />
 	<targetchange interval="20000" chance="50" />

--- a/data/monster/Geo-Elementals/massive_earth_elemental.xml
+++ b/data/monster/Geo-Elementals/massive_earth_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Massive Earth Elemental" nameDescription="a massive earth elemental" race="undead" experience="950" speed="240" manacost="0">
+<monster name="Massive Earth Elemental" nameDescription="a massive earth elemental" race="undead" experience="950" speed="240">
 	<health now="1330" max="1330" />
 	<look type="285" corpse="8933" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/medusa.xml
+++ b/data/monster/Geo-Elementals/medusa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Medusa" nameDescription="a medusa" race="blood" experience="4050" speed="280" manacost="0">
+<monster name="Medusa" nameDescription="a medusa" race="blood" experience="4050" speed="280">
 	<health now="4500" max="4500" />
 	<look type="330" corpse="10524" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Geo-Elementals/muddy_earth_elemental.xml
+++ b/data/monster/Geo-Elementals/muddy_earth_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Muddy Earth Elemental" nameDescription="a muddy earth elemental" race="undead" experience="450" speed="260" manacost="0">
+<monster name="Muddy Earth Elemental" nameDescription="a muddy earth elemental" race="undead" experience="450" speed="260">
 	<health now="650" max="650" />
 	<look type="301" corpse="8933" />
 	<targetchange interval="20000" chance="50" />

--- a/data/monster/Geo-Elementals/stone_devourer.xml
+++ b/data/monster/Geo-Elementals/stone_devourer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Stone Devourer" nameDescription="a stone devourer" race="undead" experience="2900" speed="250" manacost="0">
+<monster name="Stone Devourer" nameDescription="a stone devourer" race="undead" experience="2900" speed="250">
 	<health now="4200" max="4200" />
 	<look type="486" corpse="18375" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/vulcongra.xml
+++ b/data/monster/Geo-Elementals/vulcongra.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vulcongra" nameDescription="Vulcongra" race="fire" experience="1100" speed="230" manacost="0">
+<monster name="Vulcongra" nameDescription="Vulcongra" race="fire" experience="1100" speed="230">
 	<health now="1600" max="1600" />
 	<look type="509" corpse="18476" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/war_golem.xml
+++ b/data/monster/Geo-Elementals/war_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="War Golem" nameDescription="a war golem" race="energy" experience="2750" speed="240" manacost="0">
+<monster name="War Golem" nameDescription="a war golem" race="energy" experience="2750" speed="240">
 	<health now="4300" max="4300" />
 	<look type="326" corpse="10005" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Geo-Elementals/worker_golem.xml
+++ b/data/monster/Geo-Elementals/worker_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Worker Golem" nameDescription="a worker golem" race="energy" experience="1250" speed="230" manacost="0">
+<monster name="Worker Golem" nameDescription="a worker golem" race="energy" experience="1250" speed="230">
 	<health now="1470" max="1470" />
 	<look type="304" corpse="9801" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/phantasm.xml
+++ b/data/monster/Ghosts/phantasm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Phantasm" nameDescription="a phantasm" race="undead" experience="4400" speed="240" manacost="0">
+<monster name="Phantasm" nameDescription="a phantasm" race="undead" experience="4400" speed="240">
 	<health now="3950" max="3950" />
 	<look type="241" head="20" corpse="6344" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/phantasm_summon.xml
+++ b/data/monster/Ghosts/phantasm_summon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Phantasm" nameDescription="a phantasm" race="undead" experience="0" speed="240" manacost="0">
+<monster name="Phantasm" nameDescription="a phantasm" race="undead" experience="0" speed="240">
 	<health now="65" max="65" />
 	<look type="241" head="20" corpse="6344" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/souleater.xml
+++ b/data/monster/Ghosts/souleater.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Souleater" nameDescription="a souleater" race="undead" experience="1300" speed="200" manacost="0">
+<monster name="Souleater" nameDescription="a souleater" race="undead" experience="1300" speed="200">
 	<health now="1100" max="1100" />
 	<look type="355" corpse="12631" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/spectre.xml
+++ b/data/monster/Ghosts/spectre.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Spectre" nameDescription="a spectre" race="undead" experience="2100" speed="230" manacost="0">
+<monster name="Spectre" nameDescription="a spectre" race="undead" experience="2100" speed="230">
 	<health now="1350" max="1350" />
 	<look type="235" head="20" corpse="6348" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/tarnished_spirit.xml
+++ b/data/monster/Ghosts/tarnished_spirit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Tarnished Spirit" nameDescription="a tarnished spirit" race="undead" experience="120" speed="180" manacost="0">
+<monster name="Tarnished Spirit" nameDescription="a tarnished spirit" race="undead" experience="120" speed="180">
 	<health now="150" max="150" />
 	<look type="566" corpse="21366" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/white_shade.xml
+++ b/data/monster/Ghosts/white_shade.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="White Shade" nameDescription="a white shade" race="undead" experience="120" speed="190" manacost="0">
+<monster name="White Shade" nameDescription="a white shade" race="undead" experience="120" speed="190">
 	<health now="260" max="260" />
 	<look type="560" corpse="21376" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ghosts/wisp.xml
+++ b/data/monster/Ghosts/wisp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wisp" nameDescription="a wisp" race="undead" experience="0" speed="180" manacost="0">
+<monster name="Wisp" nameDescription="a wisp" race="undead" experience="0" speed="180">
 	<health now="115" max="115" />
 	<look type="294" corpse="6324" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Giants/behemoth.xml
+++ b/data/monster/Giants/behemoth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Behemoth" nameDescription="a behemoth" race="blood" experience="2500" speed="260" manacost="0">
+<monster name="Behemoth" nameDescription="a behemoth" race="blood" experience="2500" speed="260">
 	<health now="4000" max="4000" />
 	<look type="55" corpse="5999" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Goblins/demon_(goblin).xml
+++ b/data/monster/Goblins/demon_(goblin).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Demon" nameDescription="a demon" race="blood" experience="25" speed="150" manacost="0">
+<monster name="Demon" nameDescription="a demon" race="blood" experience="25" speed="150">
 	<health now="50" max="50" />
 	<look type="35" corpse="5995" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Hydro-Elementals/massive_water_elemental.xml
+++ b/data/monster/Hydro-Elementals/massive_water_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Massive Water Elemental" nameDescription="a massive water elemental" race="undead" experience="1100" speed="280" manacost="0">
+<monster name="Massive Water Elemental" nameDescription="a massive water elemental" race="undead" experience="1100" speed="280">
 	<health now="1250" max="1250" />
 	<look type="11" corpse="10499" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Hydro-Elementals/roaring_water_elemental.xml
+++ b/data/monster/Hydro-Elementals/roaring_water_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Roaring Water Elemental" nameDescription="a roaring water elemental" race="undead" experience="1300" speed="390" manacost="0">
+<monster name="Roaring Water Elemental" nameDescription="a roaring water elemental" race="undead" experience="1300" speed="390">
 	<health now="1750" max="1750" />
 	<look type="11" corpse="8965" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Hydro-Elementals/slick_water_elemental.xml
+++ b/data/monster/Hydro-Elementals/slick_water_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Slick Water Elemental" nameDescription="a slick water elemental" race="undead" experience="450" speed="280" manacost="0">
+<monster name="Slick Water Elemental" nameDescription="a slick water elemental" race="undead" experience="450" speed="280">
 	<health now="550" max="550" />
 	<look type="286" corpse="8965" />
 	<targetchange interval="20000" chance="15" />

--- a/data/monster/Hydro-Elementals/water_elemental.xml
+++ b/data/monster/Hydro-Elementals/water_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Water Elemental" nameDescription="a water elemental" race="undead" experience="650" speed="220" manacost="0">
+<monster name="Water Elemental" nameDescription="a water elemental" race="undead" experience="650" speed="220">
 	<health now="550" max="550" />
 	<look type="286" corpse="10499" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/ancient_scarab.xml
+++ b/data/monster/Insects/ancient_scarab.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ancient Scarab" nameDescription="an ancient scarab" race="venom" experience="720" speed="230" manacost="0">
+<monster name="Ancient Scarab" nameDescription="an ancient scarab" race="venom" experience="720" speed="230">
 	<health now="1000" max="1000" />
 	<look type="79" corpse="6021" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/blue_butterfly.xml
+++ b/data/monster/Insects/blue_butterfly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<monster name="Butterfly" namedescription="a butterfly" race="venom" experience="0" speed="230" manacost="0">
+<monster name="Butterfly" namedescription="a butterfly" race="venom" experience="0" speed="230">
 	<health now="2" max="2" />
 	<look type="227" corpse="4994" />
 	<targetchange interval="4000" chance="8" />

--- a/data/monster/Insects/brimstone_bug.xml
+++ b/data/monster/Insects/brimstone_bug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Brimstone Bug" namedescription="a brimstone bug" race="venom" experience="900" speed="200" manacost="0">
+<monster name="Brimstone Bug" namedescription="a brimstone bug" race="venom" experience="900" speed="200">
 	<health now="1300" max="1300" />
 	<look type="352" corpse="12527" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/butterfly.xml
+++ b/data/monster/Insects/butterfly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<monster name="butterfly" namedescription="a butterfly" race="venom" experience="0" speed="230" manacost="0">
+<monster name="butterfly" namedescription="a butterfly" race="venom" experience="0" speed="230">
 	<health now="2" max="2" />
 	<look type="227" head="20" body="30" legs="40" feet="50" corpse="4313" />
 	<targetchange interval="4000" chance="8" />

--- a/data/monster/Insects/cockroach.xml
+++ b/data/monster/Insects/cockroach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Cockroach" nameDescription="a cockroach" race="venom" experience="0" speed="180" manacost="0">
+<monster name="Cockroach" nameDescription="a cockroach" race="venom" experience="0" speed="180">
 	<health now="1" max="1" />
 	<look type="284" corpse="8593" />
 	<targetchange interval="60000" chance="0" />

--- a/data/monster/Insects/emerald_damselfly.xml
+++ b/data/monster/Insects/emerald_damselfly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Emerald Damselfly" nameDescription="an emerald damselfly" race="venom" experience="35" speed="220" manacost="0">
+<monster name="Emerald Damselfly" nameDescription="an emerald damselfly" race="venom" experience="35" speed="220">
 	<health now="90" max="90" />
 	<look type="528" corpse="19706" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Insects/hive_overseer.xml
+++ b/data/monster/Insects/hive_overseer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hive Overseer" nameDescription="a hive overseer" race="venom" experience="5500" speed="200" manacost="0">
+<monster name="Hive Overseer" nameDescription="a hive overseer" race="venom" experience="5500" speed="200">
 	<health now="7500" max="7500" />
 	<look type="458" corpse="15354" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/insect_swarm.xml
+++ b/data/monster/Insects/insect_swarm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Insect Swarm" nameDescription="an insect swarm" race="undead" experience="40" speed="150" manacost="0">
+<monster name="Insect Swarm" nameDescription="an insect swarm" race="undead" experience="40" speed="150">
 	<health now="50" max="50" />
 	<look type="349" corpse="0" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Insects/insectoid_scout.xml
+++ b/data/monster/Insects/insectoid_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Insectoid Scout" nameDescription="an insectoid scout" race="venom" experience="150" speed="190" manacost="0">
+<monster name="Insectoid Scout" nameDescription="an insectoid scout" race="venom" experience="150" speed="190">
 	<health now="230" max="230" />
 	<look type="403" corpse="13514" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Insects/insectoid_worker.xml
+++ b/data/monster/Insects/insectoid_worker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Insectoid Worker" nameDescription="an insectoid worker" race="venom" experience="650" speed="200" manacost="0">
+<monster name="Insectoid Worker" nameDescription="an insectoid worker" race="venom" experience="650" speed="200">
 	<health now="950" max="950" />
 	<look type="403" corpse="13514" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/kollos.xml
+++ b/data/monster/Insects/kollos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Kollos" nameDescription="Kollos" race="venom" experience="2400" speed="200" manacost="0">
+<monster name="Kollos" nameDescription="Kollos" race="venom" experience="2400" speed="200">
 	<health now="3800" max="3800" />
 	<look type="458" corpse="15354" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/ladybug.xml
+++ b/data/monster/Insects/ladybug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ladybug" nameDescription="Ladybug" race="venom" experience="70" speed="200" manacost="0">
+<monster name="Ladybug" nameDescription="Ladybug" race="venom" experience="70" speed="200">
 	<health now="255" max="255" />
 	<look type="448" corpse="15272" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Insects/lancer_beetle.xml
+++ b/data/monster/Insects/lancer_beetle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lancer Beetle" nameDescription="a lancer beetle" race="venom" experience="275" speed="200" manacost="0">
+<monster name="Lancer Beetle" nameDescription="a lancer beetle" race="venom" experience="275" speed="200">
 	<health now="400" max="400" />
 	<look type="348" corpse="11375" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/lesser_swarmer.xml
+++ b/data/monster/Insects/lesser_swarmer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Lesser Swarmer" nameDescription="a lesser swarmer" race="venom" experience="0" speed="180" manacost="0">
+<monster name="Lesser Swarmer" nameDescription="a lesser swarmer" race="venom" experience="0" speed="180">
 	<health now="230" max="230" />
 	<look type="460" corpse="15388" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Insects/pink_butterfly.xml
+++ b/data/monster/Insects/pink_butterfly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230" manacost="0">
+<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230">
 	<health now="2" max="2" />
 	<look type="213" corpse="4313" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Insects/purple_butterfly.xml
+++ b/data/monster/Insects/purple_butterfly.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230" manacost="0">
+<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230">
 	<health now="2" max="2" />
 	<look type="213" corpse="4993" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Insects/red_butterfly.xml
+++ b/data/monster/Insects/red_butterfly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230" manacost="0">
+<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230">
 	<health now="2" max="2" />
 	<look type="228" corpse="4992" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Insects/spidris.xml
+++ b/data/monster/Insects/spidris.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Spidris" nameDescription="Spidris" race="venom" experience="2600" speed="260" manacost="0">
+<monster name="Spidris" nameDescription="Spidris" race="venom" experience="2600" speed="260">
 	<health now="3700" max="3700" />
 	<look type="457" corpse="15296" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/spidris_elite.xml
+++ b/data/monster/Insects/spidris_elite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Spidris Elite" nameDescription="Spidris Elite" race="venom" experience="4000" speed="260" manacost="0">
+<monster name="Spidris Elite" nameDescription="Spidris Elite" race="venom" experience="4000" speed="260">
 	<health now="5000" max="5000" />
 	<look type="457" corpse="15296" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Insects/spitter.xml
+++ b/data/monster/Insects/spitter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Spitter" nameDescription="a spitter" race="venom" experience="1100" speed="190" manacost="0">
+<monster name="Spitter" nameDescription="a spitter" race="venom" experience="1100" speed="190">
 	<health now="1500" max="1500" />
 	<look type="461" corpse="15392" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/swarmer.xml
+++ b/data/monster/Insects/swarmer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Swarmer" nameDescription="a swarmer" race="venom" experience="350" speed="190" manacost="0">
+<monster name="Swarmer" nameDescription="a swarmer" race="venom" experience="350" speed="190">
 	<health now="460" max="460" />
 	<look type="460" corpse="15388" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Insects/swarmer_hatchling.xml
+++ b/data/monster/Insects/swarmer_hatchling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Swarmer Hatchling" nameDescription="a swarmer hatchling" race="blood" experience="0" speed="560" manacost="0">
+<monster name="Swarmer Hatchling" nameDescription="a swarmer hatchling" race="blood" experience="0" speed="560">
 	<health now="5" max="5" />
 	<look type="460" corpse="15388" />
 	<targetchange interval="2000" chance="50" />

--- a/data/monster/Insects/waspoid.xml
+++ b/data/monster/Insects/waspoid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Waspoid" nameDescription="Waspoid" race="venom" experience="830" speed="210" manacost="0">
+<monster name="Waspoid" nameDescription="Waspoid" race="venom" experience="830" speed="210">
 	<health now="1100" max="1100" />
 	<look type="462" corpse="15396" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Insects/yellow_butterfly.xml
+++ b/data/monster/Insects/yellow_butterfly.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230" manacost="0">
+<monster name="Butterfly" nameDescription="a butterfly" race="venom" experience="0" speed="230">
 	<health now="2" max="2" />
 	<look type="10" corpse="4313" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Lizards/draken_abomination.xml
+++ b/data/monster/Lizards/draken_abomination.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Draken Abomination" nameDescription="a draken abomination" race="venom" experience="3800" speed="230" manacost="0">
+<monster name="Draken Abomination" nameDescription="a draken abomination" race="venom" experience="3800" speed="230">
 	<health now="6250" max="6250" />
 	<look type="357" corpse="12623" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/draken_elite.xml
+++ b/data/monster/Lizards/draken_elite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Draken Elite" nameDescription="a draken elite" race="blood" experience="4200" speed="250" manacost="0">
+<monster name="Draken Elite" nameDescription="a draken elite" race="blood" experience="4200" speed="250">
 	<health now="5550" max="5550" />
 	<look type="362" corpse="12609" />
 	<targetchange interval="5000" chance="10" />

--- a/data/monster/Lizards/draken_spellweaver.xml
+++ b/data/monster/Lizards/draken_spellweaver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Draken Spellweaver" nameDescription="a draken spellweaver" race="blood" experience="3100" speed="210" manacost="0">
+<monster name="Draken Spellweaver" nameDescription="a draken spellweaver" race="blood" experience="3100" speed="210">
 	<health now="5000" max="5000" />
 	<look type="340" corpse="11316" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/draken_warmaster.xml
+++ b/data/monster/Lizards/draken_warmaster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Draken Warmaster" nameDescription="a draken warmaster" race="blood" experience="2400" speed="220" manacost="0">
+<monster name="Draken Warmaster" nameDescription="a draken warmaster" race="blood" experience="2400" speed="220">
 	<health now="4150" max="4150" />
 	<look type="334" corpse="11107" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_chosen.xml
+++ b/data/monster/Lizards/lizard_chosen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Chosen" nameDescription="a lizard chosen" race="blood" experience="2200" speed="260" manacost="0">
+<monster name="Lizard Chosen" nameDescription="a lizard chosen" race="blood" experience="2200" speed="260">
 	<health now="3050" max="3050" />
 	<look type="344" corpse="11288" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_dragon_priest.xml
+++ b/data/monster/Lizards/lizard_dragon_priest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Dragon Priest" nameDescription="a lizard dragon priest" race="blood" experience="1320" speed="220" manacost="0">
+<monster name="Lizard Dragon Priest" nameDescription="a lizard dragon priest" race="blood" experience="1320" speed="220">
 	<health now="1450" max="1450" />
 	<look type="339" corpse="11280" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_high_guard.xml
+++ b/data/monster/Lizards/lizard_high_guard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard High Guard" nameDescription="a lizard high guard" race="blood" experience="1450" speed="240" manacost="0">
+<monster name="Lizard High Guard" nameDescription="a lizard high guard" race="blood" experience="1450" speed="240">
 	<health now="1800" max="1800" />
 	<look type="337" corpse="11272" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_legionnaire.xml
+++ b/data/monster/Lizards/lizard_legionnaire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Legionnaire" nameDescription="a lizard legionnaire" race="blood" experience="1100" speed="230" manacost="0">
+<monster name="Lizard Legionnaire" nameDescription="a lizard legionnaire" race="blood" experience="1100" speed="230">
 	<health now="1400" max="1400" />
 	<look type="338" corpse="11276" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_magistratus.xml
+++ b/data/monster/Lizards/lizard_magistratus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Magistratus" nameDescription="a lizard magistratus" race="blood" experience="2000" speed="200" manacost="0">
+<monster name="Lizard Magistratus" nameDescription="a lizard magistratus" race="blood" experience="2000" speed="200">
 	<health now="8000" max="8000" />
 	<look type="115" corpse="6041" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_noble.xml
+++ b/data/monster/Lizards/lizard_noble.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Noble" nameDescription="a lizard noble" race="blood" experience="2000" speed="200" manacost="0">
+<monster name="Lizard Noble" nameDescription="a lizard noble" race="blood" experience="2000" speed="200">
 	<health now="7000" max="7000" />
 	<look type="115" corpse="6041" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_sentinel.xml
+++ b/data/monster/Lizards/lizard_sentinel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Sentinel" nameDescription="a lizard sentinel" race="blood" experience="110" speed="180" manacost="0">
+<monster name="Lizard Sentinel" nameDescription="a lizard sentinel" race="blood" experience="110" speed="180" manacost="560">
 	<health now="265" max="265" />
 	<look type="114" corpse="6040" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_snakecharmer.xml
+++ b/data/monster/Lizards/lizard_snakecharmer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Snakecharmer" nameDescription="a lizard snakecharmer" race="blood" experience="210" speed="190" manacost="0">
+<monster name="Lizard Snakecharmer" nameDescription="a lizard snakecharmer" race="blood" experience="210" speed="190">
 	<health now="325" max="325" />
 	<look type="115" corpse="6041" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/lizard_templar.xml
+++ b/data/monster/Lizards/lizard_templar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Templar" nameDescription="a lizard templar" race="blood" experience="155" speed="200" manacost="0">
+<monster name="Lizard Templar" nameDescription="a lizard templar" race="blood" experience="155" speed="200">
 	<health now="410" max="410" />
 	<look type="113" corpse="4251" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Lizards/lizard_zaogun.xml
+++ b/data/monster/Lizards/lizard_zaogun.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lizard Zaogun" nameDescription="a lizard zaogun" race="blood" experience="1700" speed="250" manacost="0">
+<monster name="Lizard Zaogun" nameDescription="a lizard zaogun" race="blood" experience="1700" speed="250">
 	<health now="2955" max="2955" />
 	<look type="343" corpse="11284" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Lizards/wyvern.xml
+++ b/data/monster/Lizards/wyvern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wyvern" nameDescription="a wyvern" race="blood" experience="515" speed="200" manacost="0">
+<monster name="Wyvern" nameDescription="a wyvern" race="blood" experience="515" speed="200">
 	<health now="795" max="795" />
 	<look type="239" corpse="6302" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Minotaurs/minotaur_mage.xml
+++ b/data/monster/Minotaurs/minotaur_mage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Minotaur Mage" nameDescription="a minotaur mage" race="blood" experience="150" speed="170" manacost="0">
+<monster name="Minotaur Mage" nameDescription="a minotaur mage" race="blood" experience="150" speed="170">
 	<health now="155" max="155" />
 	<look type="23" corpse="5981" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Misc/Misc Mammals/water_buffalo.xml
+++ b/data/monster/Misc/Misc Mammals/water_buffalo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Water Buffalo" nameDescription="a water buffalo" race="blood" experience="20" speed="210" manacost="0">
+<monster name="Water Buffalo" nameDescription="a water buffalo" race="blood" experience="20" speed="210">
 	<health now="390" max="390" />
 	<look type="523" corpse="19701" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Misc/Misc Reptiles/hydra.xml
+++ b/data/monster/Misc/Misc Reptiles/hydra.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hydra" nameDescription="a hydra" race="blood" experience="2100" speed="250" manacost="0">
+<monster name="Hydra" nameDescription="a hydra" race="blood" experience="2100" speed="250">
 	<health now="2350" max="2350" />
 	<look type="121" corpse="6048" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Misc/Misc Reptiles/killer_caiman.xml
+++ b/data/monster/Misc/Misc Reptiles/killer_caiman.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Killer Caiman" nameDescription="a killer caiman" race="blood" experience="900" speed="230" manacost="0">
+<monster name="Killer Caiman" nameDescription="a killer caiman" race="blood" experience="900" speed="230">
 	<health now="1500" max="1500" />
 	<look type="358" corpse="11430" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Mollusks/calamary.xml
+++ b/data/monster/Mollusks/calamary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Calamary" nameDescription="a calamary" race="undead" experience="0" speed="160" manacost="0">
+<monster name="Calamary" nameDescription="a calamary" race="undead" experience="0" speed="160">
 	<health now="75" max="75" />
 	<look type="451" corpse="15280" />
 	<targetchange interval="4000" chance="8" />

--- a/data/monster/Mollusks/slug.xml
+++ b/data/monster/Mollusks/slug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Slug" nameDescription="a slug" race="venom" experience="70" speed="150" manacost="0">
+<monster name="Slug" nameDescription="a slug" race="venom" experience="70" speed="150">
 	<health now="255" max="255" />
 	<look type="407" corpse="13515" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Monks/dark_monk.xml
+++ b/data/monster/Monks/dark_monk.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dark Monk" nameDescription="a dark monk" race="blood" experience="145" speed="210" manacost="0">
+<monster name="Dark Monk" nameDescription="a dark monk" race="blood" experience="145" speed="210" manacost="480">
 	<health now="190" max="190" />
 	<look type="225" corpse="20371" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Mutated/mutated_bat.xml
+++ b/data/monster/Mutated/mutated_bat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mutated Bat" nameDescription="a mutated bat" race="blood" experience="615" speed="210" manacost="0">
+<monster name="Mutated Bat" nameDescription="a mutated bat" race="blood" experience="615" speed="210">
 	<health now="900" max="900" />
 	<look type="307" corpse="9829" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Mutated/mutated_human.xml
+++ b/data/monster/Mutated/mutated_human.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mutated Human" nameDescription="a mutated human" race="blood" experience="150" speed="200" manacost="0">
+<monster name="Mutated Human" nameDescription="a mutated human" race="blood" experience="150" speed="200">
 	<health now="240" max="240" />
 	<look type="323" corpse="9107" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Mutated/mutated_rat.xml
+++ b/data/monster/Mutated/mutated_rat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mutated Rat" nameDescription="a mutated rat" race="blood" experience="450" speed="220" manacost="0">
+<monster name="Mutated Rat" nameDescription="a mutated rat" race="blood" experience="450" speed="220">
 	<health now="550" max="550" />
 	<look type="305" corpse="9871" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Mutated/mutated_tiger.xml
+++ b/data/monster/Mutated/mutated_tiger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mutated Tiger" nameDescription="a mutated tiger" race="blood" experience="750" speed="240" manacost="0">
+<monster name="Mutated Tiger" nameDescription="a mutated tiger" race="blood" experience="750" speed="240">
 	<health now="1100" max="1100" />
 	<look type="318" corpse="9913" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Myriapods/crawler.xml
+++ b/data/monster/Myriapods/crawler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Crawler" nameDescription="a crawler" race="venom" experience="1000" speed="200" manacost="0">
+<monster name="Crawler" nameDescription="a crawler" race="venom" experience="1000" speed="200">
 	<health now="1450" max="1450" />
 	<look type="456" corpse="15292" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Myriapods/wiggler.xml
+++ b/data/monster/Myriapods/wiggler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wiggler" namedescription="a wiggler" race="venom" experience="900" speed="220" manacost="0">
+<monster name="Wiggler" namedescription="a wiggler" race="venom" experience="900" speed="220">
 	<health now="1200" max="1200" />
 	<look type="510" corpse="18483" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Necromancers/blood_hand.xml
+++ b/data/monster/Necromancers/blood_hand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Blood Hand" nameDescription="a blood hand" race="blood" experience="750" speed="220" manacost="0">
+<monster name="Blood Hand" nameDescription="a blood hand" race="blood" experience="750" speed="220">
 	<health now="700" max="700" />
 	<look type="552" corpse="21257" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Necromancers/blood_priest.xml
+++ b/data/monster/Necromancers/blood_priest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Blood Priest" nameDescription="a blood priest" race="blood" experience="900" speed="210" manacost="0">
+<monster name="Blood Priest" nameDescription="a blood priest" race="blood" experience="900" speed="210">
 	<health now="820" max="820" />
 	<look type="553" corpse="21262" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Necromancers/necromancer.xml
+++ b/data/monster/Necromancers/necromancer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Necromancer" nameDescription="a necromancer" race="blood" experience="580" speed="200" manacost="0">
+<monster name="Necromancer" nameDescription="a necromancer" race="blood" experience="580" speed="200">
 	<health now="580" max="580" />
 	<look type="9" corpse="20455" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Necromancers/priestess.xml
+++ b/data/monster/Necromancers/priestess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Priestess" nameDescription="a priestess" race="blood" experience="420" speed="200" manacost="0">
+<monster name="Priestess" nameDescription="a priestess" race="blood" experience="420" speed="200">
 	<health now="390" max="390" />
 	<look type="58" corpse="20491" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Necromancers/shadow_pupil.xml
+++ b/data/monster/Necromancers/shadow_pupil.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Shadow Pupil" nameDescription="a shadow pupil" race="blood" experience="410" speed="210" manacost="0">
+<monster name="Shadow Pupil" nameDescription="a shadow pupil" race="blood" experience="410" speed="210">
 	<health now="450" max="450" />
 	<look type="551" corpse="21254" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Orcs/orc_marauder.xml
+++ b/data/monster/Orcs/orc_marauder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Orc Marauder" nameDescription="an orc marauder" race="blood" experience="205" speed="210" manacost="0">
+<monster name="Orc Marauder" nameDescription="an orc marauder" race="blood" experience="205" speed="210">
 	<health now="235" max="235" />
 	<look type="342" corpse="11251" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Orcs/orc_rider.xml
+++ b/data/monster/Orcs/orc_rider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Orc Rider" nameDescription="an orc rider" race="blood" experience="110" speed="210" manacost="0">
+<monster name="Orc Rider" nameDescription="an orc rider" race="blood" experience="110" speed="210" manacost="490">
 	<health now="180" max="180" />
 	<look type="4" corpse="6010" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Orcs/orc_shaman.xml
+++ b/data/monster/Orcs/orc_shaman.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Orc Shaman" nameDescription="an orc shaman" race="blood" experience="110" speed="180" manacost="0">
+<monster name="Orc Shaman" nameDescription="an orc shaman" race="blood" experience="110" speed="180">
 	<health now="115" max="115" />
 	<look type="6" corpse="5978" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Orcs/orc_warlord.xml
+++ b/data/monster/Orcs/orc_warlord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Orc Warlord" nameDescription="an orc warlord" race="blood" experience="670" speed="240" manacost="0">
+<monster name="Orc Warlord" nameDescription="an orc warlord" race="blood" experience="670" speed="240">
 	<health now="950" max="950" />
 	<look type="2" corpse="6008" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Orcs/rorc.xml
+++ b/data/monster/Orcs/rorc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Rorc" nameDescription="a rorc" race="blood" experience="105" speed="200" manacost="0">
+<monster name="Rorc" nameDescription="a rorc" race="blood" experience="105" speed="200">
 	<health now="260" max="260" />
 	<look type="550" corpse="21223" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Outlaws/adventurer.xml
+++ b/data/monster/Outlaws/adventurer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Adventurer" nameDescription="an adventurer" race="blood" experience="0" speed="170" manacost="0">
+<monster name="Adventurer" nameDescription="an adventurer" race="blood" experience="0" speed="170">
 	<health now="65" max="65" />
 	<look type="129" head="92" body="15" legs="92" feet="82" corpse="20315" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Outlaws/angry_adventurer.xml
+++ b/data/monster/Outlaws/angry_adventurer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Angry Adventurer" nameDescription="an angry adventurer" race="blood" experience="50" speed="195" manacost="0">
+<monster name="Angry Adventurer" nameDescription="an angry adventurer" race="blood" experience="50" speed="195">
 	<health now="65" max="65" />
 	<look type="129" head="92" body="15" legs="92" feet="82" corpse="20315" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Outlaws/black_knight.xml
+++ b/data/monster/Outlaws/black_knight.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Black Knight" nameDescription="a black knight" race="blood" experience="1600" speed="250" manacost="0">
+<monster name="Black Knight" nameDescription="a black knight" race="blood" experience="1600" speed="250">
 	<health now="1800" max="1800" />
 	<look type="131" head="95" body="95" legs="95" feet="95" addons="3" corpse="20355" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Outlaws/crypt_defiler.xml
+++ b/data/monster/Outlaws/crypt_defiler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Crypt Defiler" nameDescription="a crypt defiler" race="blood" experience="70" speed="205" manacost="0">
+<monster name="Crypt Defiler" nameDescription="a crypt defiler" race="blood" experience="70" speed="205">
 	<health now="180" max="180" />
 	<look type="146" head="115" body="115" legs="61" feet="96" addons="3" corpse="20359" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Outlaws/feverish_citizen.xml
+++ b/data/monster/Outlaws/feverish_citizen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Feverish Citizen" nameDescription="a feverish citizen" race="blood" experience="30" speed="185" manacost="0">
+<monster name="Feverish Citizen" nameDescription="a feverish citizen" race="blood" experience="30" speed="185">
 	<health now="125" max="125" />
 	<look type="425" corpse="20395" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Outlaws/hero.xml
+++ b/data/monster/Outlaws/hero.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hero" nameDescription="a hero" race="blood" experience="1200" speed="240" manacost="0">
+<monster name="Hero" nameDescription="a hero" race="blood" experience="1200" speed="240">
 	<health now="1400" max="1400" />
 	<look type="73" corpse="20415" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Outlaws/stalker.xml
+++ b/data/monster/Outlaws/stalker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Stalker" nameDescription="a stalker" race="blood" experience="90" speed="200" manacost="0">
+<monster name="Stalker" nameDescription="a stalker" race="blood" experience="90" speed="200">
 	<health now="120" max="120" />
 	<look type="128" head="78" body="116" legs="95" feet="114" corpse="20511" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pharaohs/ashmunrah.xml
+++ b/data/monster/Pharaohs/ashmunrah.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ashmunrah" nameDescription="Ashmunrah" race="undead" experience="3100" speed="320" manacost="0">
+<monster name="Ashmunrah" nameDescription="Ashmunrah" race="undead" experience="3100" speed="320">
 	<health now="5000" max="5000" />
 	<look type="87" corpse="6031" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/dipthrah.xml
+++ b/data/monster/Pharaohs/dipthrah.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dipthrah" nameDescription="Dipthrah" race="undead" experience="2900" speed="320" manacost="0">
+<monster name="Dipthrah" nameDescription="Dipthrah" race="undead" experience="2900" speed="320">
 	<health now="4200" max="4200" />
 	<look type="87" corpse="6031" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/mahrdis.xml
+++ b/data/monster/Pharaohs/mahrdis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mahrdis" nameDescription="Mahrdis" race="undead" experience="3050" speed="340" manacost="0">
+<monster name="Mahrdis" nameDescription="Mahrdis" race="undead" experience="3050" speed="340">
 	<health now="3900" max="3900" />
 	<look type="90" corpse="6025" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/morguthis.xml
+++ b/data/monster/Pharaohs/morguthis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Morguthis" nameDescription="Morguthis" race="undead" experience="3000" speed="320" manacost="0">
+<monster name="Morguthis" nameDescription="Morguthis" race="undead" experience="3000" speed="320">
 	<health now="4800" max="4800" />
 	<look type="90" corpse="6025" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/omruc.xml
+++ b/data/monster/Pharaohs/omruc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Omruc" nameDescription="Omruc" race="undead" experience="2950" speed="370" manacost="0">
+<monster name="Omruc" nameDescription="Omruc" race="undead" experience="2950" speed="370">
 	<health now="4300" max="4300" />
 	<look type="90" corpse="6025" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/rahemos.xml
+++ b/data/monster/Pharaohs/rahemos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Rahemos" nameDescription="Rahemos" race="undead" experience="3100" speed="320" manacost="0">
+<monster name="Rahemos" nameDescription="Rahemos" race="undead" experience="3100" speed="320">
 	<health now="3700" max="3700" />
 	<look type="87" corpse="6031" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/thalas.xml
+++ b/data/monster/Pharaohs/thalas.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Thalas" nameDescription="Thalas" race="undead" experience="2950" speed="320" manacost="0">
+<monster name="Thalas" nameDescription="Thalas" race="undead" experience="2950" speed="320">
 	<health now="4100" max="4100" />
 	<look type="90" corpse="6025" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pharaohs/vashresamun.xml
+++ b/data/monster/Pharaohs/vashresamun.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vashresamun" nameDescription="Vashresamun" race="undead" experience="2950" speed="340" manacost="0">
+<monster name="Vashresamun" nameDescription="Vashresamun" race="undead" experience="2950" speed="340">
 	<health now="4000" max="4000" />
 	<look type="90" corpse="6025" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pirates/pirate_buccaneer.xml
+++ b/data/monster/Pirates/pirate_buccaneer.xml
@@ -4,11 +4,11 @@
 	<look type="97" corpse="20471" />
 	<targetchange interval="4000" chance="15" />
 	<flags>
-		<flag summonable="1" />
+		<flag summonable="0" />
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="0" />
-		<flag convinceable="0" />
+		<flag convinceable="1" />
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag canpushcreatures="1" />

--- a/data/monster/Pirates/pirate_ghost.xml
+++ b/data/monster/Pirates/pirate_ghost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Pirate Ghost" nameDescription="a pirate ghost" race="undead" experience="250" speed="170" manacost="0">
+<monster name="Pirate Ghost" nameDescription="a pirate ghost" race="undead" experience="250" speed="170">
 	<health now="275" max="275" />
 	<look type="196" corpse="5566" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pirates/pirate_skeleton.xml
+++ b/data/monster/Pirates/pirate_skeleton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Pirate Skeleton" nameDescription="a pirate skeleton" race="undead" experience="85" speed="180" manacost="0">
+<monster name="Pirate Skeleton" nameDescription="a pirate skeleton" race="undead" experience="85" speed="180">
 	<health now="190" max="190" />
 	<look type="195" corpse="6070" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Pyro-Elementals/blazing_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/blazing_fire_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Blazing Fire Elemental" nameDescription="a blazing fire elemental" race="fire" experience="450" speed="220" manacost="0">
+<monster name="Blazing Fire Elemental" nameDescription="a blazing fire elemental" race="fire" experience="450" speed="220">
 	<health now="650" max="650" />
 	<look type="49" corpse="8964" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pyro-Elementals/blistering_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/blistering_fire_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Blistering Fire Elemental" nameDescription="a blistering fire elemental" race="fire" experience="1300" speed="230" manacost="0">
+<monster name="Blistering Fire Elemental" nameDescription="a blistering fire elemental" race="fire" experience="1300" speed="230">
 	<health now="1500" max="1500" />
 	<look type="242" corpse="8964" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Pyro-Elementals/fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/fire_elemental.xml
@@ -8,7 +8,7 @@
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="1" />
-		<flag convinceable="1" />
+		<flag convinceable="0" />
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag canpushcreatures="0" />

--- a/data/monster/Pyro-Elementals/hellfire_fighter.xml
+++ b/data/monster/Pyro-Elementals/hellfire_fighter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hellfire Fighter" nameDescription="a hellfire fighter" race="fire" experience="3900" speed="220" manacost="0">
+<monster name="Hellfire Fighter" nameDescription="a hellfire fighter" race="fire" experience="3900" speed="220">
 	<health now="3800" max="3800" />
 	<look type="243" corpse="6324" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pyro-Elementals/infected_weeper.xml
+++ b/data/monster/Pyro-Elementals/infected_weeper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Infected Weeper" nameDescription="an infected weeper" race="fire" experience="4800" speed="250" manacost="0">
+<monster name="Infected Weeper" nameDescription="an infected weeper" race="fire" experience="4800" speed="250">
 	<health now="6800" max="6800" />
 	<look type="489" corpse="17251" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pyro-Elementals/lava_golem.xml
+++ b/data/monster/Pyro-Elementals/lava_golem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lava Golem" nameDescription="a lava golem" race="fire" experience="6200" speed="290" manacost="0">
+<monster name="Lava Golem" nameDescription="a lava golem" race="fire" experience="6200" speed="290">
 	<health now="9000" max="9000" />
 	<look type="491" corpse="17333" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Pyro-Elementals/magma_crawler.xml
+++ b/data/monster/Pyro-Elementals/magma_crawler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Magma Crawler" nameDescription="a magma crawler" race="fire" experience="2700" speed="220" manacost="0">
+<monster name="Magma Crawler" nameDescription="a magma crawler" race="fire" experience="2700" speed="220">
 	<health now="4800" max="4800" />
 	<look type="492" corpse="17336" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pyro-Elementals/massive_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/massive_fire_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Massive Fire Elemental" nameDescription="a massive fire elemental" race="fire" experience="1400" speed="210" manacost="0">
+<monster name="Massive Fire Elemental" nameDescription="a massive fire elemental" race="fire" experience="1400" speed="210">
 	<health now="1200" max="1200" />
 	<look type="242" corpse="6324" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pyro-Elementals/orewalker.xml
+++ b/data/monster/Pyro-Elementals/orewalker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Orewalker" nameDescription="an orewalker" race="undead" experience="4800" speed="250" manacost="0">
+<monster name="Orewalker" nameDescription="an orewalker" race="undead" experience="4800" speed="250">
 	<health now="7200" max="7200" />
 	<look type="490" corpse="17256" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Pyro-Elementals/weeper.xml
+++ b/data/monster/Pyro-Elementals/weeper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Weeper" nameDescription="a weeper" race="fire" experience="4800" speed="260" manacost="0">
+<monster name="Weeper" nameDescription="a weeper" race="fire" experience="4800" speed="260">
 	<health now="6800" max="6800" />
 	<look type="489" corpse="17252" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Quaras/quara_hydromancer.xml
+++ b/data/monster/Quaras/quara_hydromancer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Quara Hydromancer" nameDescription="a quara hydromancer" race="blood" experience="800" speed="250" manacost="0">
+<monster name="Quara Hydromancer" nameDescription="a quara hydromancer" race="blood" experience="800" speed="250">
 	<health now="1100" max="1100" />
 	<look type="47" corpse="6066" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Quaras/quara_hydromancer_scout.xml
+++ b/data/monster/Quaras/quara_hydromancer_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Quara Hydromancer Scout" nameDescription="a quara hydromancer scout" race="undead" experience="800" speed="240" manacost="0">
+<monster name="Quara Hydromancer Scout" nameDescription="a quara hydromancer scout" race="undead" experience="800" speed="240">
 	<health now="1100" max="1100" />
 	<look type="47" corpse="6066" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Quaras/quara_pincher.xml
+++ b/data/monster/Quaras/quara_pincher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Quara Pincher" nameDescription="a quara pincher" race="blood" experience="1200" speed="210" manacost="0">
+<monster name="Quara Pincher" nameDescription="a quara pincher" race="blood" experience="1200" speed="210">
 	<health now="1800" max="1800" />
 	<look type="77" corpse="6063" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Quaras/quara_pincher_scout.xml
+++ b/data/monster/Quaras/quara_pincher_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Quara Pincher Scout" nameDescription="a quara pincher scout" race="blood" experience="600" speed="200" manacost="0">
+<monster name="Quara Pincher Scout" nameDescription="a quara pincher scout" race="blood" experience="600" speed="200">
 	<health now="775" max="775" />
 	<look type="77" corpse="6063" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Quaras/quara_predator.xml
+++ b/data/monster/Quaras/quara_predator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Quara Predator" nameDescription="a quara predator" race="blood" experience="1600" speed="280" manacost="0">
+<monster name="Quara Predator" nameDescription="a quara predator" race="blood" experience="1600" speed="280">
 	<health now="2200" max="2200" />
 	<look type="20" corpse="6067" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Quaras/quara_predator_scout.xml
+++ b/data/monster/Quaras/quara_predator_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Quara Predator Scout" nameDescription="a quara predator scout" race="blood" experience="400" speed="250" manacost="0">
+<monster name="Quara Predator Scout" nameDescription="a quara predator scout" race="blood" experience="400" speed="250">
 	<health now="890" max="890" />
 	<look type="20" corpse="6067" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Salamanders/salamander.xml
+++ b/data/monster/Salamanders/salamander.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Salamander" nameDescription="a salamander" race="blood" experience="25" speed="220" manacost="0">
+<monster name="Salamander" nameDescription="a salamander" race="blood" experience="25" speed="220">
 	<health now="70" max="70" />
 	<look type="529" corpse="19707" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Serpents/cobra.xml
+++ b/data/monster/Serpents/cobra.xml
@@ -8,7 +8,7 @@
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="1" />
-		<flag convinceable="1" />
+		<flag convinceable="0" />
 		<flag pushable="1" />
 		<flag canpushitems="0" />
 		<flag canpushcreatures="0" />

--- a/data/monster/Serpents/serpent_spawn.xml
+++ b/data/monster/Serpents/serpent_spawn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Serpent Spawn" nameDescription="a serpent spawn" race="venom" experience="3050" speed="250" manacost="0">
+<monster name="Serpent Spawn" nameDescription="a serpent spawn" race="venom" experience="3050" speed="250">
 	<health now="3000" max="3000" />
 	<look type="220" corpse="6061" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Serpents/snake.xml
+++ b/data/monster/Serpents/snake.xml
@@ -8,7 +8,7 @@
 		<flag attackable="1" />
 		<flag hostile="1" />
 		<flag illusionable="1" />
-		<flag convinceable="1" />
+		<flag convinceable="0" />
 		<flag pushable="1" />
 		<flag canpushitems="0" />
 		<flag canpushcreatures="0" />

--- a/data/monster/Shapeshifters/mimic.xml
+++ b/data/monster/Shapeshifters/mimic.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<monster name="Mimic" nameDescription="a mimic" race="blood" experience="0" speed="170" manacost="0">
+<monster name="Mimic" nameDescription="a mimic" race="blood" experience="0" speed="170">
 	<health now="30" max="30" />
 	<look type="92" corpse="1740" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Skeletons/betrayed_wraith.xml
+++ b/data/monster/Skeletons/betrayed_wraith.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Betrayed Wraith" nameDescription="a betrayed wraith" race="undead" experience="3500" speed="230" manacost="0">
+<monster name="Betrayed Wraith" nameDescription="a betrayed wraith" race="undead" experience="3500" speed="230">
 	<health now="4200" max="4200" />
 	<look type="233" corpse="6316" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Skeletons/bonebeast.xml
+++ b/data/monster/Skeletons/bonebeast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bonebeast" nameDescription="a bonebeast" race="undead" experience="580" speed="210" manacost="0">
+<monster name="Bonebeast" nameDescription="a bonebeast" race="undead" experience="580" speed="210">
 	<health now="515" max="515" />
 	<look type="101" corpse="6030" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Skeletons/honour_guard.xml
+++ b/data/monster/Skeletons/honour_guard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Honour Guard" nameDescription="an honour guard" race="undead" experience="55" speed="180" manacost="0">
+<monster name="Honour Guard" nameDescription="an honour guard" race="undead" experience="55" speed="180">
 	<health now="85" max="85" />
 	<look type="298" corpse="2843" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Skeletons/lost_soul.xml
+++ b/data/monster/Skeletons/lost_soul.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lost Soul" nameDescription="a lost soul" race="undead" experience="4000" speed="220" manacost="0">
+<monster name="Lost Soul" nameDescription="a lost soul" race="undead" experience="4000" speed="220">
 	<health now="5800" max="5800" />
 	<look type="232" corpse="6310" />
 	<targetchange interval="4000" chance="15" />

--- a/data/monster/Skeletons/undead_gladiator.xml
+++ b/data/monster/Skeletons/undead_gladiator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Undead Gladiator" nameDescription="an undead gladiator" race="undead" experience="800" speed="180" manacost="0">
+<monster name="Undead Gladiator" nameDescription="an undead gladiator" race="undead" experience="800" speed="180">
 	<health now="1000" max="1000" />
 	<look type="306" corpse="9823" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Skeletons/undead_mine_worker.xml
+++ b/data/monster/Skeletons/undead_mine_worker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Undead Mine Worker" nameDescription="an undead mine worker" race="undead" experience="45" speed="150" manacost="0">
+<monster name="Undead Mine Worker" nameDescription="an undead mine worker" race="undead" experience="45" speed="150">
 	<health now="65" max="65" />
 	<look type="33" corpse="5972" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Sorcerers/dark_apprentice.xml
+++ b/data/monster/Sorcerers/dark_apprentice.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dark Apprentice" nameDescription="a dark apprentice" race="blood" experience="100" speed="190" manacost="0">
+<monster name="Dark Apprentice" nameDescription="a dark apprentice" race="blood" experience="100" speed="190">
 	<health now="225" max="225" />
 	<look type="133" head="78" body="57" legs="95" feet="115" addons="1" corpse="20363" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/dark_magician.xml
+++ b/data/monster/Sorcerers/dark_magician.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dark Magician" nameDescription="a dark magician" race="blood" experience="185" speed="210" manacost="0">
+<monster name="Dark Magician" nameDescription="a dark magician" race="blood" experience="185" speed="210">
 	<health now="325" max="325" />
 	<look type="133" head="116" body="95" legs="50" feet="132" addons="2" corpse="20367" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/fury.xml
+++ b/data/monster/Sorcerers/fury.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Fury" nameDescription="a fury" race="blood" experience="4500" speed="250" manacost="0">
+<monster name="Fury" nameDescription="a fury" race="blood" experience="4500" speed="250">
 	<health now="4100" max="4100" />
 	<look type="149" head="94" body="77" legs="96" feet="0" addons="3" corpse="20399" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/ice_witch.xml
+++ b/data/monster/Sorcerers/ice_witch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ice Witch" nameDescription="an ice witch" race="blood" experience="580" speed="200" manacost="0">
+<monster name="Ice Witch" nameDescription="an ice witch" race="blood" experience="580" speed="200">
 	<health now="650" max="650" />
 	<look type="149" head="0" body="47" legs="105" feet="105" addons="0" corpse="20423" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/incredibly_old_witch.xml
+++ b/data/monster/Sorcerers/incredibly_old_witch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Incredibly Old Witch" nameDescription="an incredibly old witch" race="blood" experience="0" speed="180" manacost="0">
+<monster name="Incredibly Old Witch" nameDescription="an incredibly old witch" race="blood" experience="0" speed="180">
 	<health now="1" max="1" />
 	<look type="54" head="20" body="30" legs="40" feet="50" corpse="6081" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Sorcerers/infernalist.xml
+++ b/data/monster/Sorcerers/infernalist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Infernalist" nameDescription="an infernalist" race="blood" experience="4000" speed="220" manacost="0">
+<monster name="Infernalist" nameDescription="an infernalist" race="blood" experience="4000" speed="220">
 	<health now="3650" max="3650" />
 	<look type="130" head="78" body="76" legs="94" feet="115" addons="2" corpse="20427" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/mad_scientist.xml
+++ b/data/monster/Sorcerers/mad_scientist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mad Scientist" nameDescription="a mad scientist" race="blood" experience="205" speed="190" manacost="0">
+<monster name="Mad Scientist" nameDescription="a mad scientist" race="blood" experience="205" speed="190">
 	<health now="325" max="325" />
 	<look type="133" head="97" body="0" legs="38" feet="97" addons="1" corpse="20439" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/warlock.xml
+++ b/data/monster/Sorcerers/warlock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Warlock" nameDescription="a warlock" race="blood" experience="4000" speed="220" manacost="0">
+<monster name="Warlock" nameDescription="a warlock" race="blood" experience="4000" speed="220">
 	<health now="3500" max="3500" />
 	<look type="130" head="19" body="71" legs="128" feet="128" addons="1" corpse="20527" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/witch.xml
+++ b/data/monster/Sorcerers/witch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Witch" nameDescription="a witch" race="blood" experience="120" speed="195" manacost="0">
+<monster name="Witch" nameDescription="a witch" race="blood" experience="120" speed="195">
 	<health now="300" max="300" />
 	<look type="54" corpse="20535" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Sorcerers/yalahari.xml
+++ b/data/monster/Sorcerers/yalahari.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Yalahari" nameDescription="a Yalahari" race="blood" experience="5" speed="200" manacost="0">
+<monster name="Yalahari" nameDescription="a Yalahari" race="blood" experience="5" speed="200">
 	<health now="150" max="150" />
 	<look type="309" corpse="20550" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Traps/deathslicer.xml
+++ b/data/monster/Traps/deathslicer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Deathslicer" nameDescription="a deathslicer" race="undead" experience="0" speed="200" manacost="0">
+<monster name="Deathslicer" nameDescription="a deathslicer" race="undead" experience="0" speed="200">
 	<health now="1" max="1" />
 	<look type="102" corpse="2253" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Traps/flamethrower.xml
+++ b/data/monster/Traps/flamethrower.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Flamethrower" nameDescription="a flamethrower" race="undead" experience="0" speed="0" manacost="0">
+<monster name="Flamethrower" nameDescription="a flamethrower" race="undead" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="1551" />
 	<targetchange interval="5000" chance="5" />

--- a/data/monster/Traps/lavahole.xml
+++ b/data/monster/Traps/lavahole.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<monster name="Lavahole" nameDescription="a lavahole" race="undead" experience="0" speed="0" manacost="0">
+<monster name="Lavahole" nameDescription="a lavahole" race="undead" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="389" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Traps/magic_pillar.xml
+++ b/data/monster/Traps/magic_pillar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Magic Pillar" nameDescription="a magic pillar" race="undead" experience="0" speed="0" manacost="0">
+<monster name="Magic Pillar" nameDescription="a magic pillar" race="undead" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="1551" corpse="0" />
 	<targetchange interval="2000" chance="0" />

--- a/data/monster/Traps/magicthrower.xml
+++ b/data/monster/Traps/magicthrower.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Magicthrower" nameDescription="a magicthrower" race="undead" experience="0" speed="0" manacost="0">
+<monster name="Magicthrower" nameDescription="a magicthrower" race="undead" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="1551" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Traps/plaguethrower.xml
+++ b/data/monster/Traps/plaguethrower.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Plaguethrower" nameDescription="a plaguethrower" race="undead" experience="0" speed="0" manacost="0">
+<monster name="Plaguethrower" nameDescription="a plaguethrower" race="undead" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="1551" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Traps/shredderthrower.xml
+++ b/data/monster/Traps/shredderthrower.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Shredderthrower" nameDescription="a shredderthrower" race="undead" experience="0" speed="0" manacost="0">
+<monster name="Shredderthrower" nameDescription="a shredderthrower" race="undead" experience="0" speed="0">
 	<health now="1" max="1" />
 	<look typeex="1551" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Trolls/furious_troll.xml
+++ b/data/monster/Trolls/furious_troll.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Furious Troll" nameDescription="a furious troll" race="blood" experience="185" speed="190" manacost="0">
+<monster name="Furious Troll" nameDescription="a furious troll" race="blood" experience="185" speed="190">
 	<health now="245" max="245" />
 	<look type="15" corpse="5960" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Trolls/troll_guard.xml
+++ b/data/monster/Trolls/troll_guard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Troll Guard" nameDescription="a troll guard" race="blood" experience="25" speed="180" manacost="0">
+<monster name="Troll Guard" nameDescription="a troll guard" race="blood" experience="25" speed="180">
 	<health now="60" max="60" />
 	<look type="281" corpse="7926" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Trolls/troll_legionnaire.xml
+++ b/data/monster/Trolls/troll_legionnaire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Troll Legionnaire" nameDescription="a troll legionnaire" race="blood" experience="140" speed="190" manacost="0">
+<monster name="Troll Legionnaire" nameDescription="a troll legionnaire" race="blood" experience="140" speed="190">
 	<health now="210" max="210" />
 	<look type="53" corpse="5998" />
 	<targetchange interval="2000" chance="5" />

--- a/data/monster/Trolls/young_troll.xml
+++ b/data/monster/Trolls/young_troll.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Young Troll" nameDescription="a young troll" race="blood" experience="12" speed="380" manacost="0">
+<monster name="Young Troll" nameDescription="a young troll" race="blood" experience="12" speed="380">
 	<health now="30" max="30" />
 	<look type="15" corpse="5960" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Undead_Humanoids/banshee.xml
+++ b/data/monster/Undead_Humanoids/banshee.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Banshee" nameDescription="a banshee" race="undead" experience="900" speed="200" manacost="0">
+<monster name="Banshee" nameDescription="a banshee" race="undead" experience="900" speed="200">
 	<health now="1000" max="1000" />
 	<look type="78" corpse="6019" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/blightwalker.xml
+++ b/data/monster/Undead_Humanoids/blightwalker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Blightwalker" nameDescription="a blightwalker" race="undead" experience="5850" speed="250" manacost="0">
+<monster name="Blightwalker" nameDescription="a blightwalker" race="undead" experience="5850" speed="250">
 	<health now="8900" max="8900" />
 	<look type="246" corpse="6354" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/death_priest.xml
+++ b/data/monster/Undead_Humanoids/death_priest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Death Priest" nameDescription="a death priest" race="undead" experience="750" speed="220" manacost="0">
+<monster name="Death Priest" nameDescription="a death priest" race="undead" experience="750" speed="220">
 	<health now="800" max="800" />
 	<look type="99" head="95" body="116" legs="119" feet="115" corpse="13975" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/elder_mummy.xml
+++ b/data/monster/Undead_Humanoids/elder_mummy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Elder Mummy" nameDescription="an elder mummy" race="undead" experience="560" speed="180" manacost="0">
+<monster name="Elder Mummy" nameDescription="an elder mummy" race="undead" experience="560" speed="180">
 	<health now="850" max="850" />
 	<look type="65" head="20" body="30" legs="40" feet="50" corpse="6004" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/grim_reaper.xml
+++ b/data/monster/Undead_Humanoids/grim_reaper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Grim Reaper" nameDescription="a grim reaper" race="undead" experience="5500" speed="260" manacost="0">
+<monster name="Grim Reaper" nameDescription="a grim reaper" race="undead" experience="5500" speed="260">
 	<health now="3900" max="3900" />
 	<look type="300" corpse="8955" />
 	<targetchange interval="5000" chance="20" />

--- a/data/monster/Undead_Humanoids/lich.xml
+++ b/data/monster/Undead_Humanoids/lich.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Lich" nameDescription="a lich" race="undead" experience="900" speed="220" manacost="0">
+<monster name="Lich" nameDescription="a lich" race="undead" experience="900" speed="220">
 	<health now="880" max="880" />
 	<look type="99" head="95" body="116" legs="119" feet="115" corpse="6028" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/mummy.xml
+++ b/data/monster/Undead_Humanoids/mummy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Mummy" nameDescription="a mummy" race="undead" experience="150" speed="150" manacost="0">
+<monster name="Mummy" nameDescription="a mummy" race="undead" experience="150" speed="150">
 	<health now="240" max="240" />
 	<look type="65" corpse="6004" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/nightfiend.xml
+++ b/data/monster/Undead_Humanoids/nightfiend.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Nightfiend" nameDescription="a nightfiend" race="blood" experience="2100" speed="210" manacost="0">
+<monster name="Nightfiend" nameDescription="a nightfiend" race="blood" experience="2100" speed="210">
 	<health now="2700" max="2700" />
 	<look type="568" corpse="2669" />
 	<targetchange interval="5000" chance="8" />

--- a/data/monster/Undead_Humanoids/tomb_servant.xml
+++ b/data/monster/Undead_Humanoids/tomb_servant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Tomb Servant" nameDescription="a tomb servant" race="undead" experience="215" speed="190" manacost="0">
+<monster name="Tomb Servant" nameDescription="a tomb servant" race="undead" experience="215" speed="190">
 	<health now="475" max="475" />
 	<look type="100" corpse="6029" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/vampire.xml
+++ b/data/monster/Undead_Humanoids/vampire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vampire" nameDescription="a vampire" race="blood" experience="305" speed="220" manacost="0">
+<monster name="Vampire" nameDescription="a vampire" race="blood" experience="305" speed="220">
 	<health now="475" max="475" />
 	<look type="68" corpse="6006" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/vampire_bride.xml
+++ b/data/monster/Undead_Humanoids/vampire_bride.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vampire Bride" nameDescription="a vampire bride" race="blood" experience="1050" speed="230" manacost="0">
+<monster name="Vampire Bride" nameDescription="a vampire bride" race="blood" experience="1050" speed="230">
 	<health now="1200" max="1200" />
 	<look type="312" corpse="9658" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/vampire_viscount.xml
+++ b/data/monster/Undead_Humanoids/vampire_viscount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vampire Viscount" nameDescription="a vampire viscount" race="blood" experience="800" speed="250" manacost="0">
+<monster name="Vampire Viscount" nameDescription="a vampire viscount" race="blood" experience="800" speed="250">
 	<health now="1200" max="1200" />
 	<look type="555" corpse="21275" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/vicious_manbat.xml
+++ b/data/monster/Undead_Humanoids/vicious_manbat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vicious Manbat" nameDescription="a vicious manbat" race="blood" experience="1200" speed="220" manacost="0">
+<monster name="Vicious Manbat" nameDescription="a vicious manbat" race="blood" experience="1200" speed="220">
 	<health now="1700" max="1700" />
 	<look type="554" corpse="21266" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Undead_Humanoids/zombie.xml
+++ b/data/monster/Undead_Humanoids/zombie.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Zombie" nameDescription="a zombie" race="undead" experience="280" speed="180" manacost="0">
+<monster name="Zombie" nameDescription="a zombie" race="undead" experience="280" speed="180">
 	<health now="500" max="500" />
 	<look type="311" corpse="9875" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ungulates/desperate_white_deer.xml
+++ b/data/monster/Ungulates/desperate_white_deer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Desperate White Deer" nameDescription="a desperate white deer" race="blood" experience="35" speed="225" manacost="0">
+<monster name="Desperate White Deer" nameDescription="a desperate white deer" race="blood" experience="35" speed="225">
 	<health now="55" max="255" />
 	<look type="400" corpse="13513" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Ungulates/doom_deer.xml
+++ b/data/monster/Ungulates/doom_deer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Doom Deer" nameDescription="a doom deer" race="blood" experience="200" speed="300" manacost="0">
+<monster name="Doom Deer" nameDescription="a doom deer" race="blood" experience="200" speed="300">
 	<health now="405" max="405" />
 	<look type="31" corpse="5970" />
 	<targetchange interval="2000" chance="20" />

--- a/data/monster/Ungulates/enraged_white_deer.xml
+++ b/data/monster/Ungulates/enraged_white_deer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Enraged White Deer" nameDescription="an enraged white deer" race="blood" experience="165" speed="210" manacost="0">
+<monster name="Enraged White Deer" nameDescription="an enraged white deer" race="blood" experience="165" speed="210">
 	<health now="255" max="255" />
 	<look type="400" corpse="13513" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Ungulates/evil_sheep.xml
+++ b/data/monster/Ungulates/evil_sheep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Evil Sheep" nameDescription="an evil sheep" race="blood" experience="240" speed="250" manacost="0">
+<monster name="Evil Sheep" nameDescription="an evil sheep" race="blood" experience="240" speed="250">
 	<health now="350" max="350" />
 	<look type="14" corpse="5991" />
 	<targetchange interval="2000" chance="20" />

--- a/data/monster/Ungulates/evil_sheep_lord.xml
+++ b/data/monster/Ungulates/evil_sheep_lord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Evil Sheep Lord" nameDescription="an evil sheep lord" race="blood" experience="340" speed="300" manacost="0">
+<monster name="Evil Sheep Lord" nameDescription="an evil sheep lord" race="blood" experience="340" speed="300">
 	<health now="400" max="400" />
 	<look type="13" corpse="5994" />
 	<targetchange interval="2000" chance="20" />

--- a/data/monster/Ungulates/horse(brown).xml
+++ b/data/monster/Ungulates/horse(brown).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190" manacost="0">
+<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190">
 	<health now="75" max="75" />
 	<look type="436" corpse="0" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Ungulates/horse(grey).xml
+++ b/data/monster/Ungulates/horse(grey).xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190" manacost="0">
+<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190">
 	<health now="75" max="75" />
 	<look type="434" corpse="0" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Ungulates/horse.xml
+++ b/data/monster/Ungulates/horse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190" manacost="0">
+<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190">
 	<health now="75" max="75" />
 	<look type="435" corpse="0" />
 	<targetchange interval="4000" chance="20" />

--- a/data/monster/Ungulates/mushroom_sniffer.xml
+++ b/data/monster/Ungulates/mushroom_sniffer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Mushroom Sniffer" nameDescription="a mushroom sniffer" race="blood" experience="0" speed="120" manacost="0">
+<monster name="Mushroom Sniffer" nameDescription="a mushroom sniffer" race="blood" experience="0" speed="120">
 	<health now="250" max="250" />
 	<look type="60" corpse="2935" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Ungulates/vampire_pig.xml
+++ b/data/monster/Ungulates/vampire_pig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Vampire Pig" nameDescription="a vampire pig" race="blood" experience="165" speed="300" manacost="0">
+<monster name="Vampire Pig" nameDescription="a vampire pig" race="blood" experience="165" speed="300">
 	<health now="305" max="305" />
 	<look type="60" corpse="6000" />
 	<targetchange interval="2000" chance="0" />

--- a/data/monster/Ungulates/white_deer.xml
+++ b/data/monster/Ungulates/white_deer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="White Deer" nameDescription="a white deer" race="blood" experience="0" speed="190" manacost="0">
+<monster name="White Deer" nameDescription="a white deer" race="blood" experience="0" speed="190">
 	<health now="195" max="195" />
 	<look type="400" corpse="13513" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Voodoo_Cultists/acolyte_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/acolyte_of_the_cult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Acolyte of the Cult" nameDescription="an acolyte of the cult" race="blood" experience="300" speed="200" manacost="0">
+<monster name="Acolyte of the Cult" nameDescription="an acolyte of the cult" race="blood" experience="300" speed="200">
 	<health now="390" max="390" />
 	<look type="194" head="114" body="121" legs="121" feet="57" corpse="20319" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Voodoo_Cultists/adept_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/adept_of_the_cult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Adept of the Cult" nameDescription="an adept of the cult" race="blood" experience="400" speed="215" manacost="0">
+<monster name="Adept of the Cult" nameDescription="an adept of the cult" race="blood" experience="400" speed="215">
 	<health now="430" max="430" />
 	<look type="194" head="114" body="94" legs="94" feet="57" corpse="20311" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Voodoo_Cultists/enlightened_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/enlightened_of_the_cult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Enlightened of the Cult" nameDescription="an enlightened of the cult" race="blood" experience="500" speed="210" manacost="0">
+<monster name="Enlightened of the Cult" nameDescription="an enlightened of the cult" race="blood" experience="500" speed="210">
 	<health now="700" max="700" />
 	<look type="193" corpse="20391" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Voodoo_Cultists/novice_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/novice_of_the_cult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Novice of the Cult" nameDescription="a novice of the cult" race="blood" experience="100" speed="200" manacost="0">
+<monster name="Novice of the Cult" nameDescription="a novice of the cult" race="blood" experience="100" speed="200">
 	<health now="285" max="285" />
 	<look type="133" head="114" body="95" legs="114" feet="114" corpse="20467" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/Wild_Magics/wild_fire_magic.xml
+++ b/data/monster/Wild_Magics/wild_fire_magic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Wild Fire Magic" nameDescription="a wild fire magic" race="undead" experience="0" speed="210" manacost="0">
+<monster name="Wild Fire Magic" nameDescription="a wild fire magic" race="undead" experience="0" speed="210">
 	<health now="1" max="1" />
 	<targetchange interval="4000" chance="10" />
 	<flags>

--- a/data/monster/Wild_Magics/wild_fury_magic.xml
+++ b/data/monster/Wild_Magics/wild_fury_magic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Wild Fury Magic" nameDescription="a wild fury magic" race="undead" experience="0" speed="210" manacost="0">
+<monster name="Wild Fury Magic" nameDescription="a wild fury magic" race="undead" experience="0" speed="210">
 	<health now="1" max="1" />
 	<targetchange interval="4000" chance="10" />
 	<flags>

--- a/data/monster/Wild_Magics/wild_nature_magic.xml
+++ b/data/monster/Wild_Magics/wild_nature_magic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Wild Nature Magic" nameDescription="a wild nature magic" race="undead" experience="0" speed="210" manacost="0">
+<monster name="Wild Nature Magic" nameDescription="a wild nature magic" race="undead" experience="0" speed="210">
 	<health now="1" max="1" />
 	<targetchange interval="4000" chance="10" />
 	<flags>

--- a/data/monster/Wild_Magics/wild_water_magic.xml
+++ b/data/monster/Wild_Magics/wild_water_magic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Wild Water Magic" nameDescription="a wild water magic" race="undead" experience="0" speed="210" manacost="0">
+<monster name="Wild Water Magic" nameDescription="a wild water magic" race="undead" experience="0" speed="210">
 	<health now="1" max="1" />
 	<targetchange interval="4000" chance="10" />
 	<flags>


### PR DESCRIPTION
Update monsters in data pack

Removed all manacost="0" from XML as it is already the default.
Fixed only convinceable monsters and only summonable monsters.
Fixed issue with some convinceable monsters spending 0 mana to convince.

Detailed Information about changes: (summonable/convinceable)
```cpp
Name          Previous - Changed

Azure Frog         1/0 - 0/1
Poison Spider      1/1 - 1/0
Scorpion           1/1 - 1/0
Snake              1/1 - 1/0
Pirate Buccaneer   1/0 - 0/1
Fire Elemental     1/1 - 1/0
Cobra              1/1 - 1/0
```

Fixed manacost="0" to some convinceable creatures:
War Wolf, Lizard Sentinel, Dark Monk, Orc Rider