### PR TITLE
Rename overly abbreviated field names on database

### DIFF
--- a/data/migrations/19.lua
+++ b/data/migrations/19.lua
@@ -1,3 +1,7 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 20 (renaming abbreviated fields)")
+	for _, table in ipairs({"player_depotitems", "player_inboxitems", "player_items"}) do
+		db.query(string.format("ALTER TABLE `%s` CHANGE COLUMN `pid` `parent_id` INT NOT NULL DEFAULT '0', CHANGE COLUMN `sid` `slot_id` INT NOT NULL", table))
+	end
+	return true
 end

--- a/data/migrations/20.lua
+++ b/data/migrations/20.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -271,35 +271,35 @@ CREATE TABLE IF NOT EXISTS `player_deaths` (
 
 CREATE TABLE IF NOT EXISTS `player_depotitems` (
   `player_id` int(11) NOT NULL,
-  `sid` int(11) NOT NULL COMMENT 'any given range eg 0-100 will be reserved for depot lockers and all > 100 will be then normal items inside depots',
-  `pid` int(11) NOT NULL DEFAULT '0',
+  `slot_id` int(11) NOT NULL COMMENT 'any given range eg 0-100 will be reserved for depot lockers and all > 100 will be then normal items inside depots',
+  `parent_id` int(11) NOT NULL DEFAULT '0',
   `itemtype` smallint(6) NOT NULL,
   `count` smallint(5) NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
-  UNIQUE KEY `player_id_2` (`player_id`, `sid`),
+  UNIQUE KEY `player_id_2` (`player_id`, `slot_id`),
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `player_inboxitems` (
   `player_id` int(11) NOT NULL,
-  `sid` int(11) NOT NULL,
-  `pid` int(11) NOT NULL DEFAULT '0',
+  `slot_id` int(11) NOT NULL,
+  `parent_id` int(11) NOT NULL DEFAULT '0',
   `itemtype` smallint(6) NOT NULL,
   `count` smallint(5) NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
-  UNIQUE KEY `player_id_2` (`player_id`, `sid`),
+  UNIQUE KEY `player_id_2` (`player_id`, `slot_id`),
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `player_items` (
   `player_id` int(11) NOT NULL DEFAULT '0',
-  `pid` int(11) NOT NULL DEFAULT '0',
-  `sid` int(11) NOT NULL DEFAULT '0',
+  `parent_id` int(11) NOT NULL DEFAULT '0',
+  `slot_id` int(11) NOT NULL DEFAULT '0',
   `itemtype` smallint(6) NOT NULL DEFAULT '0',
   `count` smallint(5) NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE,
-  KEY `sid` (`sid`)
+  KEY `slot_id` (`slot_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS `player_spells` (


### PR DESCRIPTION
There are some tables which have columns named `pid` and `sid` and that does not describe anything. `pid` generally refers to the process ID and, in this context, can be the player ID too, but in fact means the container parent ID. `sid` is in the best case the sloth from Ice Age and was pretty tricky to understand but I named it `slot_id` instead.

I also renamed some variables using the same names that were close to the queries.