### PR TITLE
Lazily load monsters from XML

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -40,10 +40,10 @@ Monster* Monster::createMonster(const std::string& name)
 	return new Monster(mType);
 }
 
-Monster::Monster(MonsterType* mtype) :
+Monster::Monster(MonsterType* mType) :
 	Creature(),
-	strDescription(asLowerCaseString(mtype->nameDescription)),
-	mType(mtype)
+	strDescription(asLowerCaseString(mType->nameDescription)),
+	mType(mType)
 {
 	defaultOutfit = mType->info.outfit;
 	currentOutfit = mType->info.outfit;

--- a/src/monster.h
+++ b/src/monster.h
@@ -44,7 +44,7 @@ class Monster final : public Creature
 		static int32_t despawnRange;
 		static int32_t despawnRadius;
 
-		explicit Monster(MonsterType* mtype);
+		explicit Monster(MonsterType* mType);
 		~Monster();
 
 		// non-copyable

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -166,6 +166,7 @@ bool MonsterType::createLootContainer(Container* parent, const LootBlock& lootbl
 
 bool Monsters::loadFromXml(bool reloading /*= false*/)
 {
+	unloadedMonsters = {};
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file("data/monster/monsters.xml");
 	if (!result) {
@@ -175,30 +176,13 @@ bool Monsters::loadFromXml(bool reloading /*= false*/)
 
 	loaded = true;
 
-	std::list<std::pair<MonsterType*, std::string>> monsterScriptList;
 	for (auto monsterNode : doc.child("monsters").children()) {
-		loadMonster("data/monster/" + std::string(monsterNode.attribute("file").as_string()), monsterNode.attribute("name").as_string(), monsterScriptList, reloading);
-	}
-
-	if (!monsterScriptList.empty()) {
-		if (!scriptInterface) {
-			scriptInterface.reset(new LuaScriptInterface("Monster Interface"));
-			scriptInterface->initState();
-		}
-
-		for (const auto& scriptEntry : monsterScriptList) {
-			MonsterType* mType = scriptEntry.first;
-			if (scriptInterface->loadFile("data/monster/scripts/" + scriptEntry.second) == 0) {
-				mType->info.scriptInterface = scriptInterface.get();
-				mType->info.creatureAppearEvent = scriptInterface->getEvent("onCreatureAppear");
-				mType->info.creatureDisappearEvent = scriptInterface->getEvent("onCreatureDisappear");
-				mType->info.creatureMoveEvent = scriptInterface->getEvent("onCreatureMove");
-				mType->info.creatureSayEvent = scriptInterface->getEvent("onCreatureSay");
-				mType->info.thinkEvent = scriptInterface->getEvent("onThink");
-			} else {
-				std::cout << "[Warning - Monsters::loadMonster] Can not load script: " << scriptEntry.second << std::endl;
-				std::cout << scriptInterface->getLastLuaError() << std::endl;
-			}
+		std::string name = asLowerCaseString(monsterNode.attribute("name").as_string());
+		std::string file = "data/monster/" + std::string(monsterNode.attribute("file").as_string());
+		if (reloading && monsters.find(name) != monsters.end()) {
+			loadMonster(file, name, true);
+		} else {
+			unloadedMonsters.emplace(name, file);
 		}
 	}
 	return true;
@@ -626,39 +610,38 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 	return true;
 }
 
-bool Monsters::loadMonster(const std::string& file, const std::string& monsterName, std::list<std::pair<MonsterType*, std::string>>& monsterScriptList, bool reloading /*= false*/)
+MonsterType* Monsters::loadMonster(const std::string& file, const std::string& monsterName, bool reloading /*= false*/)
 {
 	MonsterType* mType = nullptr;
-	bool new_mType = true;
 
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file(file.c_str());
 	if (!result) {
 		printXMLError("Error - Monsters::loadMonster", file, result);
-		return false;
+		return nullptr;
 	}
 
 	pugi::xml_node monsterNode = doc.child("monster");
 	if (!monsterNode) {
 		std::cout << "[Error - Monsters::loadMonster] Missing monster node in: " << file << std::endl;
-		return false;
+		return nullptr;
 	}
 
 	pugi::xml_attribute attr;
 	if (!(attr = monsterNode.attribute("name"))) {
 		std::cout << "[Error - Monsters::loadMonster] Missing name in: " << file << std::endl;
-		return false;
+		return nullptr;
 	}
 
 	if (reloading) {
-		mType = getMonsterType(monsterName);
-		if (mType != nullptr) {
-			new_mType = false;
+		auto it = monsters.find(asLowerCaseString(monsterName));
+		if (it == monsters.end()) {
+			mType = &it->second;
 			mType->info = {};
 		}
 	}
 
-	if (new_mType) {
+	if (!mType) {
 		mType = &monsters[asLowerCaseString(monsterName)];
 	}
 
@@ -705,7 +688,23 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	}
 
 	if ((attr = monsterNode.attribute("script"))) {
-		monsterScriptList.emplace_back(mType, attr.as_string());
+		if (!scriptInterface) {
+			scriptInterface.reset(new LuaScriptInterface("Monster Interface"));
+			scriptInterface->initState();
+		}
+
+		std::string script = attr.as_string();
+		if (scriptInterface->loadFile("data/monster/scripts/" + script) == 0) {
+			mType->info.scriptInterface = scriptInterface.get();
+			mType->info.creatureAppearEvent = scriptInterface->getEvent("onCreatureAppear");
+			mType->info.creatureDisappearEvent = scriptInterface->getEvent("onCreatureDisappear");
+			mType->info.creatureMoveEvent = scriptInterface->getEvent("onCreatureMove");
+			mType->info.creatureSayEvent = scriptInterface->getEvent("onCreatureSay");
+			mType->info.thinkEvent = scriptInterface->getEvent("onThink");
+		} else {
+			std::cout << "[Warning - Monsters::loadMonster] Can not load script: " << script << std::endl;
+			std::cout << scriptInterface->getLastLuaError() << std::endl;
+		}
 	}
 
 	pugi::xml_node node;
@@ -1103,7 +1102,7 @@ bool Monsters::loadMonster(const std::string& file, const std::string& monsterNa
 	mType->info.defenseSpells.shrink_to_fit();
 	mType->info.voiceVector.shrink_to_fit();
 	mType->info.scripts.shrink_to_fit();
-	return true;
+	return mType;
 }
 
 bool Monsters::loadLootItem(const pugi::xml_node& node, LootBlock& lootBlock)
@@ -1182,10 +1181,16 @@ void Monsters::loadLootContainer(const pugi::xml_node& node, LootBlock& lBlock)
 
 MonsterType* Monsters::getMonsterType(const std::string& name)
 {
-	auto it = monsters.find(asLowerCaseString(name));
+	std::string lowerCaseName = asLowerCaseString(name);
 
+	auto it = monsters.find(lowerCaseName);
 	if (it == monsters.end()) {
-		return nullptr;
+		auto it = unloadedMonsters.find(lowerCaseName);
+		if (it == unloadedMonsters.end()) {
+			return nullptr;
+		}
+
+		return loadMonster(it->second, name);
 	}
 	return &it->second;
 }

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -1185,12 +1185,12 @@ MonsterType* Monsters::getMonsterType(const std::string& name)
 
 	auto it = monsters.find(lowerCaseName);
 	if (it == monsters.end()) {
-		auto it = unloadedMonsters.find(lowerCaseName);
-		if (it == unloadedMonsters.end()) {
+		auto it2 = unloadedMonsters.find(lowerCaseName);
+		if (it2 == unloadedMonsters.end()) {
 			return nullptr;
 		}
 
-		return loadMonster(it->second, name);
+		return loadMonster(it2->second, name);
 	}
 	return &it->second;
 }

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -186,12 +186,13 @@ class Monsters
 		                                    int32_t maxDamage, int32_t minDamage, int32_t startDamage, uint32_t tickInterval);
 		bool deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, const std::string& description = "");
 
-		bool loadMonster(const std::string& file, const std::string& monsterName, std::list<std::pair<MonsterType*, std::string>>& monsterScriptList, bool reloading = false);
+		MonsterType* loadMonster(const std::string& file, const std::string& monsterName, bool reloading = false);
 
 		void loadLootContainer(const pugi::xml_node& node, LootBlock&);
 		bool loadLootItem(const pugi::xml_node& node, LootBlock&);
 
 		std::map<std::string, MonsterType> monsters;
+		std::map<std::string, std::string> unloadedMonsters;
 		std::unique_ptr<LuaScriptInterface> scriptInterface;
 
 		bool loaded = false;


### PR DESCRIPTION
TFS currently has 664 monsters and 7 NPCs but only 59 of them actually spawn on map. Loading all monsters and NPCs is therefore unnecessary, so lazy loading them on demand has benefits to startup time.

On my machine, it brings down the time to load monsters from c. 1.16s to 0.46s with the default map. It should be good for servers with low amount of spawns but high monster count (e.g. lots of event monsters & NPCs) while not a significant difference otherwise.

Motivation: most monsters either have numerous spawns, in which case the penalty of lazy loading is amortized to be constant, or are single, evented spawns, in which case the server benefits from not loading them on startup.