### PR TITLE
Updated Party class to notify the leader if sharing experience is possible

### DIFF
--- a/src/party.cpp
+++ b/src/party.cpp
@@ -446,7 +446,7 @@ SharedExperienceState_t Party::canUseSharedExperience(const Player* player) cons
 		}
 	}
 
-	uint32_t minLevel = static_cast<int32_t>(std::ceil((static_cast<float>(highestLevel) * 2) / 3));
+	uint32_t minLevel = static_cast<uint32_t>(highestLevel * 2 / 3.f);
 	if (player->getLevel() < minLevel) {
 		return SHAREDEXPERIENCE_STATE_ACTIVATED_LEVELSPREADTOOWIDE;
 	}

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -395,15 +395,29 @@ bool Party::setSharedExperience(Player* player, bool sharedExpActive)
 	this->sharedExpActive = sharedExpActive;
 
 	if (sharedExpActive) {
-		this->sharedExpEnabled = canEnableSharedExperience();
+		sharedExpEnabled = canEnableSharedExperience();
+	}
 
-		if (this->sharedExpEnabled) {
+	switch (sharedExpState) {
+		case SHAREDEXPERIENCE_STATE_ACTIVE: {
 			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience is now active.");
-		} else {
-			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience has been activated, but some members of your party are inactive.");
+			break;
 		}
-	} else {
-		leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience has been deactivated.");
+
+		case SHAREDEXPERIENCE_STATE_ACTIVATED_LEVELSPREADTOOWIDE: {
+			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience has been activated, but the level spread of your party is too wide.");
+			break;
+		}
+
+		case SHAREDEXPERIENCE_STATE_ACTIVATED_MEMBERSINACTIVE: {
+			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience has been activated, but some members of your party are inactive.");
+			break;
+		}
+
+		case SHAREDEXPERIENCE_STATE_DEACTIVATED: {
+			leader->sendTextMessage(MESSAGE_INFO_DESCR, "Shared Experience has been deactivated.");
+			break;
+		}
 	}
 
 	updateAllPartyIcons();
@@ -419,10 +433,10 @@ void Party::shareExperience(uint64_t experience, Creature* source/* = nullptr*/)
 	leader->onGainSharedExperience(shareExperience, source);
 }
 
-bool Party::canUseSharedExperience(const Player* player) const
+SharedExperienceState_t Party::canUseSharedExperience(const Player* player) const
 {
 	if (memberList.empty()) {
-		return false;
+		return SHAREDEXPERIENCE_STATE_ACTIVATED_MEMBERSINACTIVE;
 	}
 
 	uint32_t highestLevel = leader->getLevel();
@@ -434,39 +448,45 @@ bool Party::canUseSharedExperience(const Player* player) const
 
 	uint32_t minLevel = static_cast<int32_t>(std::ceil((static_cast<float>(highestLevel) * 2) / 3));
 	if (player->getLevel() < minLevel) {
-		return false;
+		return SHAREDEXPERIENCE_STATE_ACTIVATED_LEVELSPREADTOOWIDE;
 	}
 
 	if (!Position::areInRange<30, 30, 1>(leader->getPosition(), player->getPosition())) {
-		return false;
+		return SHAREDEXPERIENCE_STATE_ACTIVATED_MEMBERSINACTIVE;
 	}
 
 	if (!player->hasFlag(PlayerFlag_NotGainInFight)) {
 		//check if the player has healed/attacked anything recently
 		auto it = ticksMap.find(player->getID());
 		if (it == ticksMap.end()) {
-			return false;
+			return SHAREDEXPERIENCE_STATE_ACTIVATED_MEMBERSINACTIVE;
 		}
 
 		uint64_t timeDiff = OTSYS_TIME() - it->second;
 		if (timeDiff > static_cast<uint64_t>(g_config.getNumber(ConfigManager::PZ_LOCKED))) {
-			return false;
+			return SHAREDEXPERIENCE_STATE_ACTIVATED_MEMBERSINACTIVE;
 		}
 	}
-	return true;
+	return SHAREDEXPERIENCE_STATE_ACTIVE;
 }
 
 bool Party::canEnableSharedExperience()
 {
-	if (!canUseSharedExperience(leader)) {
+	SharedExperienceState_t state = canUseSharedExperience(leader);
+	if (state != SHAREDEXPERIENCE_STATE_ACTIVE) {
+		setSharedExperienceState(state);
 		return false;
 	}
 
 	for (Player* member : memberList) {
-		if (!canUseSharedExperience(member)) {
+		state = canUseSharedExperience(member);
+		if (state != SHAREDEXPERIENCE_STATE_ACTIVE) {
+			setSharedExperienceState(state);
 			return false;
 		}
 	}
+
+	setSharedExperienceState(state);
 	return true;
 }
 

--- a/src/party.h
+++ b/src/party.h
@@ -28,6 +28,13 @@ class Party;
 
 using PlayerVector = std::vector<Player*>;
 
+enum SharedExperienceState_t {
+	SHAREDEXPERIENCE_STATE_DEACTIVATED = 0,
+	SHAREDEXPERIENCE_STATE_ACTIVE = 1,
+	SHAREDEXPERIENCE_STATE_ACTIVATED_LEVELSPREADTOOWIDE = 2,
+	SHAREDEXPERIENCE_STATE_ACTIVATED_MEMBERSINACTIVE = 3,
+};
+
 class Party
 {
 	public:
@@ -75,7 +82,7 @@ class Party
 		bool isSharedExperienceEnabled() const {
 			return sharedExpEnabled;
 		}
-		bool canUseSharedExperience(const Player* player) const;
+		SharedExperienceState_t canUseSharedExperience(const Player* player) const;
 		void updateSharedExperience();
 
 		void updateVocationsList();
@@ -85,6 +92,9 @@ class Party
 
 	protected:
 		bool canEnableSharedExperience();
+		void setSharedExperienceState(const SharedExperienceState_t& state) {
+			sharedExpState = state;
+		}
 
 		std::map<uint32_t, int64_t> ticksMap;
 
@@ -97,6 +107,7 @@ class Party
 
 		bool sharedExpActive = false;
 		bool sharedExpEnabled = false;
+		SharedExperienceState_t sharedExpState = SHAREDEXPERIENCE_STATE_DEACTIVATED;
 };
 
 #endif


### PR DESCRIPTION
All these changes below have been researched on vanilla.

- Fixed the formula of minimum level required to share experience.
- Now the leader will be notified (after enabling shared experience) whenever the level spread of the party is too wide, which improves gaming awareness..