### PR TITLE
Fix setMaster() behaviour

### DIFF
--- a/data/actions/scripts/other/music.lua
+++ b/data/actions/scripts/other/music.lua
@@ -47,7 +47,6 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 
 			if monster then
 				player:addSummon(monster)
-				monster:setMaster(player)
 			end
 		end
 

--- a/data/actions/scripts/other/music.lua
+++ b/data/actions/scripts/other/music.lua
@@ -46,6 +46,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 			), false, true)
 
 			if monster then
+				player:addSummon(monster)
 				monster:setMaster(player)
 			end
 		end

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -546,7 +546,7 @@ function doConvinceCreature(cid, target)
 		return false
 	end
 
-	targetCreature:setMaster(creature)
+	creature:addSummon(targetCreature)
 	return true
 end
 

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -91,9 +91,9 @@ function Creature:addSummon(monster)
 		return false
 	end
 
-	summon.setMaster(self)
-	summon.setDropLoot(false)
-	summon.setSkillLoss(false)
+	summon:setMaster(self)
+	summon:setDropLoot(false)
+	summon:setSkillLoss(false)
 
 	return true
 end
@@ -104,9 +104,9 @@ function Creature:removeSummon(monster)
 		return false
 	end
 
-	summon.setMaster(nil)
-	summon.setDropLoot(true)
-	summon.setSkillLoss(true)
+	summon:setMaster(nil)
+	summon:setDropLoot(true)
+	summon:setSkillLoss(true)
 
 	return true
 end

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -91,9 +91,11 @@ function Creature:addSummon(monster)
 		return false
 	end
 
-	summon:setMaster(self)
+	summon:setTarget(nil)
+	summon:setFollowCreature(nil)
 	summon:setDropLoot(false)
 	summon:setSkillLoss(false)
+	summon:setMaster(self)
 
 	return true
 end
@@ -104,9 +106,11 @@ function Creature:removeSummon(monster)
 		return false
 	end
 
-	summon:setMaster(nil)
+	summon:setTarget(nil)
+	summon:setFollowCreature(nil)
 	summon:setDropLoot(true)
 	summon:setSkillLoss(true)
+	summon:setMaster(nil)
 
 	return true
 end

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -84,3 +84,29 @@ function Creature:setItemOutfit(item, time)
 
 	return true
 end
+
+function Creature:addSummon(monster)
+	local summon = Monster(monster)
+	if not summon then
+		return false
+	end
+
+	summon.setMaster(self)
+	summon.setDropLoot(false)
+	summon.setSkillLoss(false)
+
+	return true
+end
+
+function Creature:removeSummon(monster)
+	local summon = Monster(monster)
+	if not summon or summon:getMaster() ~= self then
+		return false
+	end
+
+	summon.setMaster(nil)
+	summon.setDropLoot(true)
+	summon.setSkillLoss(true)
+
+	return true
+end

--- a/data/spells/scripts/support/animate_dead_rune.lua
+++ b/data/spells/scripts/support/animate_dead_rune.lua
@@ -9,7 +9,7 @@ function onCastSpell(creature, variant, isHotkey)
 				local monster = Game.createMonster("Skeleton", position)
 				if monster then
 					corpse:remove()
-					monster:setMaster(creature)
+					creature:addSummon(monster)
 					position:sendMagicEffect(CONST_ME_MAGIC_BLUE)
 					return true
 				end

--- a/data/spells/scripts/support/summon_creature.lua
+++ b/data/spells/scripts/support/summon_creature.lua
@@ -39,8 +39,7 @@ function onCastSpell(creature, variant)
 
 	creature:addMana(-manaCost)
 	creature:addManaSpent(manaCost)
-
-	summon:setMaster(creature)
+	creature:addSummon(summon)
 	position:sendMagicEffect(CONST_ME_MAGIC_BLUE)
 	summon:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 	return true

--- a/data/talkactions/scripts/place_summon.lua
+++ b/data/talkactions/scripts/place_summon.lua
@@ -10,7 +10,7 @@ function onSay(player, words, param)
 	local position = player:getPosition()
 	local monster = Game.createMonster(param, position)
 	if monster ~= nil then
-		monster:setMaster(player)
+		player:addSummon(monster)
 		position:sendMagicEffect(CONST_ME_MAGIC_RED)
 	else
 		player:sendCancelMessage("There is not enough room.")

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -413,7 +413,7 @@ void Creature::onRemoveCreature(Creature* creature, bool)
 	onCreatureDisappear(creature, true);
 	if (creature == this) {
 		if (master && !master->isRemoved()) {
-			master->removeSummon(this);
+			this->setMaster(nullptr);
 		}
 	} else if (isMapLoaded) {
 		if (creature->getPosition().z == getPosition().z) {
@@ -674,7 +674,7 @@ void Creature::onDeath()
 	death(lastHitCreature);
 
 	if (master) {
-		master->removeSummon(this);
+		this->setMaster(nullptr);
 	}
 
 	if (droppedCorpse) {
@@ -1121,24 +1121,17 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 	}
 }
 
-void Creature::addSummon(Creature* creature)
-{
-	creature->setDropLoot(false);
-	creature->setLossSkill(false);
-	creature->setMaster(this);
-	creature->incrementReferenceCounter();
-	summons.push_back(creature);
-}
-
-void Creature::removeSummon(Creature* creature)
-{
-	auto cit = std::find(summons.begin(), summons.end(), creature);
-	if (cit != summons.end()) {
-		creature->setDropLoot(false);
-		creature->setLossSkill(true);
-		creature->setMaster(nullptr);
-		creature->decrementReferenceCounter();
-		summons.erase(cit);
+void Creature::setMaster(Creature* creature) {
+	master = creature;
+	if (creature) {
+		this->incrementReferenceCounter();
+		creature->summons.push_back(this);
+	} else {
+		auto cit = std::find(summons.begin(), summons.end(), this);
+		if (cit != summons.end()) {
+			this->decrementReferenceCounter();
+			summons.erase(cit);
+		}
 	}
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -43,7 +43,6 @@ Creature::~Creature()
 	for (Creature* summon : summons) {
 		summon->setAttackedCreature(nullptr);
 		summon->setMaster(nullptr);
-		summon->decrementReferenceCounter();
 	}
 
 	for (Condition* condition : conditions) {
@@ -1121,16 +1120,16 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 	}
 }
 
-void Creature::setMaster(Creature* creature) {
-	master = creature;
-	if (creature) {
-		this->incrementReferenceCounter();
-		creature->summons.push_back(this);
+void Creature::setMaster(Creature* master) {
+	this->master = master;
+	if (master) {
+		incrementReferenceCounter();
+		master->summons.push_back(this);
 	} else {
-		auto cit = std::find(summons.begin(), summons.end(), this);
-		if (cit != summons.end()) {
-			this->decrementReferenceCounter();
-			summons.erase(cit);
+		auto summon = std::find(master->summons.begin(), master->summons.end(), this);
+		if (summon != master->summons.end()) {
+			decrementReferenceCounter();
+			summons.erase(summon);
 		}
 	}
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1120,18 +1120,26 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 	}
 }
 
-void Creature::setMaster(Creature* master) {
-	this->master = master;
-	if (master) {
+bool Creature::setMaster(Creature* newMaster) {
+	if (!newMaster && !master) {
+		return false;
+	}
+
+	if (newMaster) {
 		incrementReferenceCounter();
-		master->summons.push_back(this);
-	} else {
+		newMaster->summons.push_back(this);
+	}
+
+	if (master) {
 		auto summon = std::find(master->summons.begin(), master->summons.end(), this);
 		if (summon != master->summons.end()) {
 			decrementReferenceCounter();
-			summons.erase(summon);
+			master->summons.erase(summon);
 		}
 	}
+
+	master = newMaster;
+	return true;
 }
 
 bool Creature::addCondition(Condition* condition, bool force/* = false*/)

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -412,7 +412,7 @@ void Creature::onRemoveCreature(Creature* creature, bool)
 	onCreatureDisappear(creature, true);
 	if (creature == this) {
 		if (master && !master->isRemoved()) {
-			this->setMaster(nullptr);
+			setMaster(nullptr);
 		}
 	} else if (isMapLoaded) {
 		if (creature->getPosition().z == getPosition().z) {
@@ -673,7 +673,7 @@ void Creature::onDeath()
 	death(lastHitCreature);
 
 	if (master) {
-		this->setMaster(nullptr);
+		setMaster(nullptr);
 	}
 
 	if (droppedCorpse) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -276,7 +276,7 @@ class Creature : virtual public Thing
 		virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
 		                             bool checkDefense = false, bool checkArmor = false, bool field = false);
 
-		void setMaster(Creature* creature);
+		void setMaster(Creature* master);
 
 		bool isSummon() const {
 			return master != nullptr;

--- a/src/creature.h
+++ b/src/creature.h
@@ -409,7 +409,7 @@ class Creature : virtual public Thing
 		void setDropLoot(bool lootDrop) {
 			this->lootDrop = lootDrop;
 		}
-		void setLossSkill(bool skillLoss) {
+		void setSkillLoss(bool skillLoss) {
 			this->skillLoss = skillLoss;
 		}
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -276,7 +276,7 @@ class Creature : virtual public Thing
 		virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
 		                             bool checkDefense = false, bool checkArmor = false, bool field = false);
 
-		void setMaster(Creature* master);
+		bool setMaster(Creature* master);
 
 		bool isSummon() const {
 			return master != nullptr;

--- a/src/creature.h
+++ b/src/creature.h
@@ -276,7 +276,7 @@ class Creature : virtual public Thing
 		virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
 		                             bool checkDefense = false, bool checkArmor = false, bool field = false);
 
-		bool setMaster(Creature* master);
+		bool setMaster(Creature* newMaster);
 
 		bool isSummon() const {
 			return master != nullptr;

--- a/src/creature.h
+++ b/src/creature.h
@@ -276,9 +276,8 @@ class Creature : virtual public Thing
 		virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
 		                             bool checkDefense = false, bool checkArmor = false, bool field = false);
 
-		void setMaster(Creature* creature) {
-			master = creature;
-		}
+		void setMaster(Creature* creature);
+
 		bool isSummon() const {
 			return master != nullptr;
 		}
@@ -286,8 +285,6 @@ class Creature : virtual public Thing
 			return master;
 		}
 
-		void addSummon(Creature* creature);
-		void removeSummon(Creature* creature);
 		const std::list<Creature*>& getSummons() const {
 			return summons;
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -604,7 +604,7 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 	removeCreatureCheck(creature);
 
 	for (Creature* summon : creature->summons) {
-		summon->setLossSkill(false);
+		summon->setSkillLoss(false);
 		removeCreature(summon);
 	}
 	return true;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -6834,8 +6834,7 @@ int LuaScriptInterface::luaCreatureSetSkillLoss(lua_State* L)
 	if (creature) {
 		creature->setSkillLoss(getBoolean(L, 2));
 		pushBoolean(L, true);
-	}
-	else {
+	} else {
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2081,7 +2081,6 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "setDropLoot", LuaScriptInterface::luaCreatureSetDropLoot);
 	registerMethod("Creature", "setSkillLoss", LuaScriptInterface::luaCreatureSetSkillLoss);
 
-
 	registerMethod("Creature", "getPosition", LuaScriptInterface::luaCreatureGetPosition);
 	registerMethod("Creature", "getTile", LuaScriptInterface::luaCreatureGetTile);
 	registerMethod("Creature", "getDirection", LuaScriptInterface::luaCreatureGetDirection);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -6733,18 +6733,7 @@ int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 		return 1;
 	}
 
-	Creature* master = getCreature(L, 2);
-	if (master) {
-		pushBoolean(L, creature->convinceCreature(master));
-	} else {
-		master = creature->getMaster();
-		if (master) {
-			master->removeSummon(creature);
-			creature->incrementReferenceCounter();
-			creature->setDropLoot(true);
-		}
-		pushBoolean(L, true);
-	}
+	creature->setMaster(getCreature(L, 2));
 	g_game.updateCreatureType(creature);
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -6733,7 +6733,7 @@ int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 		return 1;
 	}
 
-	creature->setMaster(getCreature(L, 2));
+	pushBoolean(L, creature->setMaster(getCreature(L, 2)));
 	g_game.updateCreatureType(creature);
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2079,6 +2079,8 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "changeSpeed", LuaScriptInterface::luaCreatureChangeSpeed);
 
 	registerMethod("Creature", "setDropLoot", LuaScriptInterface::luaCreatureSetDropLoot);
+	registerMethod("Creature", "setSkillLoss", LuaScriptInterface::luaCreatureSetSkillLoss);
+
 
 	registerMethod("Creature", "getPosition", LuaScriptInterface::luaCreatureGetPosition);
 	registerMethod("Creature", "getTile", LuaScriptInterface::luaCreatureGetTile);
@@ -6820,6 +6822,20 @@ int LuaScriptInterface::luaCreatureSetDropLoot(lua_State* L)
 		creature->setDropLoot(getBoolean(L, 2));
 		pushBoolean(L, true);
 	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureSetSkillLoss(lua_State* L)
+{
+	// creature:setSkillLoss(skillLoss)
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (creature) {
+		creature->setSkillLoss(getBoolean(L, 2));
+		pushBoolean(L, true);
+	}
+	else {
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -762,6 +762,7 @@ class LuaScriptInterface
 		static int luaCreatureChangeSpeed(lua_State* L);
 
 		static int luaCreatureSetDropLoot(lua_State* L);
+		static int luaCreatureSetSkillLoss(lua_State* L);
 
 		static int luaCreatureGetPosition(lua_State* L);
 		static int luaCreatureGetTile(lua_State* L);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -934,7 +934,7 @@ void Monster::onThinkDefense(uint32_t interval)
 			if (summon) {
 				if (g_game.placeCreature(summon, getPosition(), false, summonBlock.force)) {
 					summon->setDropLoot(false);
-					summon->setLossSkill(false);
+					summon->setSkillLoss(false);
 					summon->setMaster(this);
 					g_game.addMagicEffect(getPosition(), CONST_ME_MAGIC_BLUE);
 					g_game.addMagicEffect(summon->getPosition(), CONST_ME_TELEPORT);
@@ -1931,7 +1931,7 @@ bool Monster::convinceCreature(Creature* creature)
 	}
 	setMaster(creature);
 	setDropLoot(false);
-	setLossSkill(false);
+	setSkillLoss(false);
 	setFollowCreature(nullptr);
 	setAttackedCreature(nullptr);
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -931,7 +931,7 @@ void Monster::onThinkDefense(uint32_t interval)
 			}
 
 			Monster* summon = Monster::createMonster(summonBlock.name);
-			if (summon){
+			if (summon) {
 				if (g_game.placeCreature(summon, getPosition(), false, summonBlock.force)) {
 					summon->setDropLoot(false);
 					summon->setLossSkill(false);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -931,18 +931,15 @@ void Monster::onThinkDefense(uint32_t interval)
 			}
 
 			Monster* summon = Monster::createMonster(summonBlock.name);
-			if (summon) {
-				const Position& summonPos = getPosition();
-				summon->setDropLoot(false);
-				summon->setLossSkill(false);
-				summon->setMaster(this);
-				if (!g_game.placeCreature(summon, summonPos, false, summonBlock.force)) {
+			if (summon){
+				if (g_game.placeCreature(summon, getPosition(), false, summonBlock.force)) {
 					summon->setDropLoot(false);
-					summon->setLossSkill(true);
-					summon->setMaster(nullptr);
-				} else {
+					summon->setLossSkill(false);
+					summon->setMaster(this);
 					g_game.addMagicEffect(getPosition(), CONST_ME_MAGIC_BLUE);
 					g_game.addMagicEffect(summon->getPosition(), CONST_ME_TELEPORT);
+				} else {
+					delete summon;
 				}
 			}
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1753,7 +1753,6 @@ void Monster::death(Creature*)
 	for (Creature* summon : summons) {
 		summon->changeHealth(-summon->getHealth());
 		summon->setMaster(nullptr);
-		summon->decrementReferenceCounter();
 	}
 	summons.clear();
 
@@ -1943,7 +1942,6 @@ bool Monster::convinceCreature(Creature* creature)
 	for (Creature* summon : summons) {
 		summon->changeHealth(-summon->getHealth());
 		summon->setMaster(nullptr);
-		summon->decrementReferenceCounter();
 	}
 	summons.clear();
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -933,11 +933,13 @@ void Monster::onThinkDefense(uint32_t interval)
 			Monster* summon = Monster::createMonster(summonBlock.name);
 			if (summon) {
 				const Position& summonPos = getPosition();
-
-				addSummon(summon);
-
+				summon->setDropLoot(false);
+				summon->setLossSkill(false);
+				summon->setMaster(this);
 				if (!g_game.placeCreature(summon, summonPos, false, summonBlock.force)) {
-					removeSummon(summon);
+					summon->setDropLoot(false);
+					summon->setLossSkill(true);
+					summon->setMaster(nullptr);
 				} else {
 					g_game.addMagicEffect(getPosition(), CONST_ME_MAGIC_BLUE);
 					g_game.addMagicEffect(summon->getPosition(), CONST_ME_TELEPORT);
@@ -1930,12 +1932,10 @@ bool Monster::convinceCreature(Creature* creature)
 			return false;
 		}
 
-		Creature* oldMaster = getMaster();
-		oldMaster->removeSummon(this);
 	}
-
-	creature->addSummon(this);
-
+	setMaster(creature);
+	setDropLoot(false);
+	setLossSkill(false);
 	setFollowCreature(nullptr);
 	setAttackedCreature(nullptr);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2022,7 +2022,7 @@ void Player::death(Creature* lastHitCreature)
 			}
 		}
 	} else {
-		setLossSkill(true);
+		setSkillLoss(true);
 
 		auto it = conditions.begin(), end = conditions.end();
 		while (it != end) {
@@ -3466,7 +3466,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
 	if (Player* targetPlayer = target->getPlayer()) {
 		if (targetPlayer && targetPlayer->getZone() == ZONE_PVP) {
 			targetPlayer->setDropLoot(false);
-			targetPlayer->setLossSkill(false);
+			targetPlayer->setSkillLoss(false);
 		} else if (!hasFlag(PlayerFlag_NotGainInFight) && !isPartner(targetPlayer)) {
 			if (!Combat::isInPvpZone(this, targetPlayer) && hasAttacked(targetPlayer) && !targetPlayer->hasAttacked(this) && !isGuildMate(targetPlayer) && targetPlayer != this) {
 				if (targetPlayer->getSkull() == SKULL_NONE && !isInWar(targetPlayer)) {


### PR DESCRIPTION
It may break some code.

addSummon and removeSummon were removed because they should only set master not dropLoot and LossSkill, so I made a setMaster that only sets or unsets (add or remove) the monster to the master.

The plan is remove convince creature from the sources to Lua. This is the first step.

Please, test it!