### PR TITLE
Reload talkaction shouldn't be displayed in chat

### DIFF
--- a/data/talkactions/scripts/reload.lua
+++ b/data/talkactions/scripts/reload.lua
@@ -75,5 +75,5 @@ function onSay(player, words, param)
 
 	Game.reload(reloadType.targetType)
 	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, string.format("Reloaded %s.", reloadType.name))
-	return true
+	return false
 end


### PR DESCRIPTION
This keeps old behaviour of not showing words, params in game chat.