### PR TITLE
Added new message types (white messages in channel)

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -133,6 +133,10 @@ bool ChatChannel::removeUser(const Player& player)
 	return true;
 }
 
+bool ChatChannel::hasUser(const Player& player) {
+	return users.find(player.getID()) != users.end();
+}
+
 void ChatChannel::sendToAll(const std::string& message, SpeakClasses type) const
 {
 	for (const auto& it : users) {

--- a/src/chat.h
+++ b/src/chat.h
@@ -41,6 +41,7 @@ class ChatChannel
 
 		bool addUser(Player& player);
 		bool removeUser(const Player& player);
+		bool hasUser(const Player& player);
 
 		bool talk(const Player& fromPlayer, SpeakClasses type, const std::string& text);
 		void sendToAll(const std::string& message, SpeakClasses type) const;

--- a/src/const.h
+++ b/src/const.h
@@ -212,6 +212,9 @@ enum MessageClasses : uint8_t {
 	MESSAGE_EVENT_DEFAULT = 30, /*White message at the bottom of the game window and in the console*/
 	MESSAGE_LOOT = 31,
 
+	MESSAGE_GUILD = 33, /* White message in channel (+ channelId) */
+	MESSAGE_PARTY_MANAGEMENT = 34, /* White message in channel (+ channelId) */
+	MESSAGE_PARTY = 35, /* White message in channel (+ channelId) */
 	MESSAGE_EVENT_ORANGE = 36, /*Orange message in the console*/
 	MESSAGE_STATUS_CONSOLE_ORANGE = 37,  /*Orange message in the console*/
 };

--- a/src/const.h
+++ b/src/const.h
@@ -212,9 +212,9 @@ enum MessageClasses : uint8_t {
 	MESSAGE_EVENT_DEFAULT = 30, /*White message at the bottom of the game window and in the console*/
 	MESSAGE_LOOT = 31,
 
-	MESSAGE_GUILD = 33, /* White message in channel (+ channelId) */
-	MESSAGE_PARTY_MANAGEMENT = 34, /* White message in channel (+ channelId) */
-	MESSAGE_PARTY = 35, /* White message in channel (+ channelId) */
+	MESSAGE_GUILD = 33, /*White message in channel (+ channelId)*/
+	MESSAGE_PARTY_MANAGEMENT = 34, /*White message in channel (+ channelId)*/
+	MESSAGE_PARTY = 35, /*White message in channel (+ channelId)*/
 	MESSAGE_EVENT_ORANGE = 36, /*Orange message in the console*/
 	MESSAGE_STATUS_CONSOLE_ORANGE = 37,  /*Orange message in the console*/
 };

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1367,6 +1367,9 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(MESSAGE_HEALED_OTHERS)
 	registerEnum(MESSAGE_EXPERIENCE_OTHERS)
 	registerEnum(MESSAGE_EVENT_DEFAULT)
+	registerEnum(MESSAGE_GUILD)
+	registerEnum(MESSAGE_PARTY_MANAGEMENT)
+	registerEnum(MESSAGE_PARTY)
 	registerEnum(MESSAGE_EVENT_ORANGE)
 	registerEnum(MESSAGE_STATUS_CONSOLE_ORANGE)
 
@@ -8522,10 +8525,14 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 
 int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 {
-	// player:sendTextMessage(type, text[, position, primaryValue = 0, primaryColor = TEXTCOLOR_NONE[, secondaryValue = 0, secondaryColor = TEXTCOLOR_NONE]])
+	// player:sendTextMessage(type, text, channelId)
 	int parameters = lua_gettop(L);
 
 	TextMessage message(getNumber<MessageClasses>(L, 2), getString(L, 3));
+	if (parameters == 4) {
+		message.channelId = getNumber<uint16_t>(L, 4);
+	}
+	
 	if (parameters >= 6) {
 		message.position = getPosition(L, 4);
 		message.primary.value = getNumber<int32_t>(L, 5);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8546,17 +8546,17 @@ int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 		}
 
 		message.channelId = channelId;
-	}
+	} else {
+		if (parameters >= 6) {
+			message.position = getPosition(L, 4);
+			message.primary.value = getNumber<int32_t>(L, 5);
+			message.primary.color = getNumber<TextColor_t>(L, 6);
+		}
 
-	if (parameters >= 6) {
-		message.position = getPosition(L, 4);
-		message.primary.value = getNumber<int32_t>(L, 5);
-		message.primary.color = getNumber<TextColor_t>(L, 6);
-	}
-
-	if (parameters >= 8) {
-		message.secondary.value = getNumber<int32_t>(L, 7);
-		message.secondary.color = getNumber<TextColor_t>(L, 8);
+		if (parameters >= 8) {
+			message.secondary.value = getNumber<int32_t>(L, 7);
+			message.secondary.color = getNumber<TextColor_t>(L, 8);
+		}
 	}
 
 	player->sendTextMessage(message);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8544,7 +8544,6 @@ int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 			pushBoolean(L, false);
 			return 1;
 		}
-
 		message.channelId = channelId;
 	} else {
 		if (parameters >= 6) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8525,6 +8525,7 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 
 int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 {
+	// player:sendTextMessage(type, text[, position, primaryValue = 0, primaryColor = TEXTCOLOR_NONE[, secondaryValue = 0, secondaryColor = TEXTCOLOR_NONE]])
 	// player:sendTextMessage(type, text, channelId)
 	int parameters = lua_gettop(L);
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1319,6 +1319,11 @@ void ProtocolGame::sendTextMessage(const TextMessage& message)
 			msg.addByte(message.primary.color);
 			break;
 		}
+		case MESSAGE_GUILD:
+		case MESSAGE_PARTY_MANAGEMENT:
+		case MESSAGE_PARTY:
+			msg.add<uint16_t>(message.channelId);
+			break;
 		default: {
 			break;
 		}

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -43,6 +43,7 @@ struct TextMessage
 	MessageClasses type = MESSAGE_STATUS_DEFAULT;
 	std::string text;
 	Position position;
+	uint16_t channelId;
 	struct {
 		int32_t value = 0;
 		TextColor_t color;


### PR DESCRIPTION
This commit will add new message types:
```
MESSAGE_GUILD = 33
MESSAGE_PARTY_MANAGEMENT = 34
MESSAGE_PARTY = 35
```

All of which will send to a channel. Player.sendTextMessage has been modified to support them with the following usage:

`player:sendTextMessage(type, text, channelId)`

Where type must be one of the above (although not enforced, but won't work without them).