### PR TITLE
Updated Creature.getClosestFreePosition smarter behavior

### DIFF
--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -1,27 +1,22 @@
-function Creature.getClosestFreePosition(self, position, extended)
-	local usePosition = Position(position)
-	local tiles = { Tile(usePosition) }
-	local length = extended and 2 or 1
+function Creature.getClosestFreePosition(self, position, maxRadius)
+	maxRadius = maxRadius or 1
 
-	local tile
-	for y = -length, length do
-		for x = -length, length do
-			if x ~= 0 or y ~= 0 then
-				usePosition.x = position.x + x
-				usePosition.y = position.y + y
-
-				tile = Tile(usePosition)
-				if tile then
-					tiles[#tiles + 1] = tile
-				end
-			end
-		end
+	-- backward compatability (extended)
+	if maxRadius == true then
+		maxRadius = 2
 	end
 
-	for i = 1, #tiles do
-		tile = tiles[i]
-		if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) then
-			return tile:getPosition()
+	for _ = 0, maxRadius do
+		for x = -radius, radius do
+			for y = -radius, radius do
+				if math.abs(x) == radius or math.abs(y) == radius then
+					local checkPosition = Position(position.x + x, position.y + y, position.z)
+					local tile = Tile(checkPosition)
+					if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) then
+						return checkPosition
+					end
+				end
+			end
 		end
 	end
 	return Position()

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -1,4 +1,4 @@
-function Creature.getClosestFreePosition(self, position, maxRadius)
+function Creature.getClosestFreePosition(self, position, maxRadius, mustBeReachable)
 	maxRadius = maxRadius or 1
 
 	-- backward compatability (extended)

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -12,9 +12,9 @@ function Creature.getClosestFreePosition(self, position, maxRadius, mustBeReacha
 		checkPosition.y = checkPosition.y + math.min(1, radius)
 		
 		local total = math.max(1, radius * 8)
-		for y = 1, total do
+		for i = 1, total do
 			if radius > 0 then
-				local direction = math.floor((y - 1) / (radius * 2))
+				local direction = math.floor((i - 1) / (radius * 2))
 				checkPosition:getNextPosition(direction)
 			end
 

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -6,7 +6,7 @@ function Creature.getClosestFreePosition(self, position, maxRadius)
 		maxRadius = 2
 	end
 
-	for _ = 0, maxRadius do
+	for radius = 0, maxRadius do
 		for x = -radius, radius do
 			for y = -radius, radius do
 				if math.abs(x) == radius or math.abs(y) == radius then

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -6,17 +6,22 @@ function Creature.getClosestFreePosition(self, position, maxRadius, mustBeReacha
 		maxRadius = 2
 	end
 
+	local checkPosition = Position(position)
 	for radius = 0, maxRadius do
-		for x = -radius, radius do
-			for y = -radius, radius do
-				if math.abs(x) == radius or math.abs(y) == radius then
-					local checkPosition = Position(position.x + x, position.y + y, position.z)
-					local tile = Tile(checkPosition)
-					if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) and
-						(not mustBeReachable or self:getPathTo(checkPosition)) then
-						return checkPosition
-					end
-				end
+		checkPosition.x = checkPosition.x - math.min(1, radius)
+		checkPosition.y = checkPosition.y + math.min(1, radius)
+		
+		local total = math.max(1, radius * 8)
+		for y = 1, total do
+			if radius > 0 then
+				local direction = math.floor((y - 1) / (radius * 2))
+				checkPosition:getNextPosition(direction)
+			end
+
+			local tile = Tile(checkPosition)
+			if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) and
+				(not mustBeReachable or self:getPathTo(checkPosition)) then
+				return checkPosition
 			end
 		end
 	end

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -12,7 +12,8 @@ function Creature.getClosestFreePosition(self, position, maxRadius)
 				if math.abs(x) == radius or math.abs(y) == radius then
 					local checkPosition = Position(position.x + x, position.y + y, position.z)
 					local tile = Tile(checkPosition)
-					if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) then
+					if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) and
+						(not mustBeReachable or self:getPathTo(checkPosition)) then
 						return checkPosition
 					end
 				end


### PR DESCRIPTION
Creature.getClosestFreePosition should now begin from inside out, meaning if target position is blocked it will pick the closest radius rather than the furthest one (when using extended, as old code would do).

Also with the ability to go further than just radius 2 by setting maxRadius parameter as desired (which is adapted to accept boolean values for backward compatability).


**Edit:**
Also added "mustBeReachable". I was unsure about that one because I feel it might eat too much CPU. Opinions?
(sorry for my noobish methods of updating commit)
