### PR TITLE
Removed spell Levitate from C++

### DIFF
--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -935,15 +935,8 @@ bool Levitate(const InstantSpell*, Creature* creature, const std::string& param)
 bool InstantSpell::loadFunction(const pugi::xml_attribute& attr)
 {
 	const char* functionName = attr.as_string();
-	if (strcasecmp(functionName, "levitate") == 0) {
-		function = Levitate;
-	} else {
-		std::cout << "[Warning - InstantSpell::loadFunction] Function \"" << functionName << "\" does not exist." << std::endl;
-		return false;
-	}
-
-	scripted = false;
-	return true;
+	std::cout << "[Warning - InstantSpell::loadFunction] Function \"" << functionName << "\" does not exist." << std::endl;
+	return false;
 }
 
 bool InstantSpell::playerCastInstant(Player* player, std::string& param)
@@ -1140,8 +1133,6 @@ bool InstantSpell::internalCastSpell(Creature* creature, const LuaVariant& var)
 {
 	if (scripted) {
 		return executeCastSpell(creature, var);
-	} else if (function) {
-		return function(this, creature, var.text);
 	}
 
 	return false;

--- a/src/spells.h
+++ b/src/spells.h
@@ -75,7 +75,6 @@ class Spells final : public BaseEvents
 		LuaScriptInterface scriptInterface { "Spell Interface" };
 };
 
-using InstantSpellFunction = std::function<bool(const InstantSpell* spell, Creature* creature, const std::string& param)>;
 using RuneSpellFunction = std::function<bool(const RuneSpell* spell, Player* player, const Position& posTo)>;
 
 class BaseSpell
@@ -236,8 +235,6 @@ class InstantSpell : public TalkAction, public Spell
 		std::string getScriptEventName() const override;
 
 		bool internalCastSpell(Creature* creature, const LuaVariant& var);
-
-		InstantSpellFunction function;
 
 		bool needDirection = false;
 		bool hasParam = false;


### PR DESCRIPTION
Made this new PR as requested by @ranisalt in #2081 .

Should the **actual** removing of the spell levitate be here? or just the function loading part (as you indeed told in #2081 ?), I think I have mislead this.