### PR TITLE
Move WaitingList attributes to private implementation

### DIFF
--- a/src/waitlist.cpp
+++ b/src/waitlist.cpp
@@ -29,7 +29,8 @@ extern Game g_game;
 
 namespace {
 
-struct Wait {
+struct Wait
+{
 	constexpr Wait(std::size_t timeout, uint32_t playerGUID) :
 			timeout(timeout), playerGUID(playerGUID) {}
 
@@ -59,9 +60,10 @@ std::size_t getTimeout(std::size_t slot)
 	return WaitingList::getTime(slot) + 15;
 }
 
-}
+} // namespace
 
-struct WaitListInfo {
+struct WaitListInfo
+{
 	WaitList priorityWaitList;
 	WaitList waitList;
 
@@ -82,8 +84,8 @@ struct WaitListInfo {
 	}
 };
 
-
-WaitingList& WaitingList::getInstance() {
+WaitingList& WaitingList::getInstance()
+{
 	static WaitingList waitingList;
 	return waitingList;
 }

--- a/src/waitlist.h
+++ b/src/waitlist.h
@@ -22,36 +22,21 @@
 
 #include "player.h"
 
-struct Wait {
-	constexpr Wait(int64_t timeout, uint32_t playerGUID) :
-		timeout(timeout), playerGUID(playerGUID) {}
-
-	int64_t timeout;
-	uint32_t playerGUID;
-};
-
-using WaitList = std::list<Wait>;
-using WaitListIterator = WaitList::iterator;
+class WaitListInfo;
 
 class WaitingList
 {
 	public:
-		static WaitingList& getInstance() {
-			static WaitingList waitingList;
-			return waitingList;
-		}
+		static WaitingList& getInstance();
 
 		bool clientLogin(const Player* player);
-		uint32_t getClientSlot(const Player* player);
-		static uint32_t getTime(uint32_t slot);
+		std::size_t getClientSlot(const Player* player);
+		static std::size_t getTime(std::size_t slot);
 
-	protected:
-		WaitList priorityWaitList;
-		WaitList waitList;
+	private:
+		WaitingList();
 
-		static uint32_t getTimeout(uint32_t slot);
-		WaitListIterator findClient(const Player* player, uint32_t& slot);
-		static void cleanupList(WaitList& list);
+		std::unique_ptr<WaitListInfo> info;
 };
 
 #endif


### PR DESCRIPTION
This is a different idiom I intend to apply on classes with huge loads of attributes (e.g. `Player` and `Monster`). It already is applied somewhat in `NetworkMessage` too.

Moving attributes to a implementation pointer has the effect of reducing pollution of global namespace at the cost of one more indirection in memory access.

There are also small fixes on attribute and return types.