### PR TITLE
Remove lastWalkthrough* limiting

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -711,23 +711,7 @@ bool Player::canWalkthrough(const Creature* creature) const
 	}
 
 	const Item* playerTileGround = playerTile->getGround();
-	if (!playerTileGround || !playerTileGround->hasWalkStack()) {
-		return false;
-	}
-
-	Player* thisPlayer = const_cast<Player*>(this);
-	if ((OTSYS_TIME() - lastWalkthroughAttempt) > 2000) {
-		thisPlayer->setLastWalkthroughAttempt(OTSYS_TIME());
-		return false;
-	}
-
-	if (creature->getPosition() != lastWalkthroughPosition) {
-		thisPlayer->setLastWalkthroughPosition(creature->getPosition());
-		return false;
-	}
-
-	thisPlayer->setLastWalkthroughPosition(creature->getPosition());
-	return true;
+	return playerTileGround && playerTileGround->hasWalkStack();
 }
 
 bool Player::canWalkthroughEx(const Creature* creature) const

--- a/src/player.h
+++ b/src/player.h
@@ -238,13 +238,6 @@ class Player final : public Creature, public Cylinder
 		bool isInWar(const Player* player) const;
 		bool isInWarList(uint32_t guild_id) const;
 
-		void setLastWalkthroughAttempt(int64_t walkthroughAttempt) {
-			lastWalkthroughAttempt = walkthroughAttempt;
-		}
-		void setLastWalkthroughPosition(Position walkthroughPosition) {
-			lastWalkthroughPosition = walkthroughPosition;
-		}
-
 		Inbox* getInbox() const {
 			return inbox;
 		}
@@ -1198,7 +1191,6 @@ class Player final : public Creature, public Cylinder
 		Skill skills[SKILL_LAST + 1];
 		LightInfo itemsLight;
 		Position loginPosition;
-		Position lastWalkthroughPosition;
 
 		time_t lastLoginSaved = 0;
 		time_t lastLogout = 0;
@@ -1210,7 +1202,6 @@ class Player final : public Creature, public Cylinder
 		uint64_t lastQuestlogUpdate = 0;
 		int64_t lastFailedFollow = 0;
 		int64_t skullTicks = 0;
-		int64_t lastWalkthroughAttempt = 0;
 		int64_t lastToggleMount = 0;
 		int64_t lastPing;
 		int64_t lastPong;


### PR DESCRIPTION
It does not help limiting walkthrough attempts and, with the current codebase, uses a `const_cast` that invokes undefined behavior. As of #1764, it's better to remove this than try workarounds such as `mutable`.