### PR TITLE
Fix Exiva spell

### DIFF
--- a/data/spells/scripts/support/find_person.lua
+++ b/data/spells/scripts/support/find_person.lua
@@ -62,13 +62,13 @@ function onCastSpell(creature, variant)
 
 	local direction
 	local distanceOutput = DISTANCE_VERYFAR
-	if math.abs(offset.x) < 4 and math.abs(offset.y) < 4 then
+	local distance = math.max(math.abs(offset.x), math.abs(offset.y))
+	if math.abs(offset.x) <= 4 then
 		distanceOutput = DISTANCE_BESIDE
 	else
-		local distanceFormula = math.pow(offset.x, 2) + math.pow(offset.y, 2)
-		if distanceFormula < 1000 then
+		if distance <= 100 then
 			distanceOutput = DISTANCE_CLOSE
-		elseif distanceFormula < math.pow(274, 2) then
+		elseif distance <= 274 then
 			distanceOutput = DISTANCE_FAR
 		end
 


### PR DESCRIPTION
This should fix #2192. 

It uses chebyshev distance instead of euclidean distance:
![exiva1](https://cloud.githubusercontent.com/assets/7635617/24085423/a95cc8f2-0cda-11e7-9513-60cd1eaee2b8.png)

![exiva2](https://cloud.githubusercontent.com/assets/7635617/24085426/b0c2a8b4-0cda-11e7-83e0-d94b29900144.png)
