### PR TITLE
Fix monsters walking over fields.

### DIFF
--- a/data/monster/Amazons/amazon.xml
+++ b/data/monster/Amazons/amazon.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Amazons/valkyrie.xml
+++ b/data/monster/Amazons/valkyrie.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Annelids/carrion_worm.xml
+++ b/data/monster/Annelids/carrion_worm.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Annelids/drillworm.xml
+++ b/data/monster/Annelids/drillworm.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" poison="100" />

--- a/data/monster/Annelids/rift_worm.xml
+++ b/data/monster/Annelids/rift_worm.xml
@@ -14,6 +14,9 @@
 		<flag staticattack="50" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-160" />

--- a/data/monster/Annelids/rotworm.xml
+++ b/data/monster/Annelids/rotworm.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Apes/kongra.xml
+++ b/data/monster/Apes/kongra.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Apes/merlkin.xml
+++ b/data/monster/Apes/merlkin.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Apes/sibang.xml
+++ b/data/monster/Apes/sibang.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Arachnids/crystal_spider.xml
+++ b/data/monster/Arachnids/crystal_spider.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" poison="160" />

--- a/data/monster/Arachnids/giant_spider.xml
+++ b/data/monster/Arachnids/giant_spider.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" poison="160" />

--- a/data/monster/Arachnids/giant_spider_wyda.xml
+++ b/data/monster/Arachnids/giant_spider_wyda.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="6" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Arachnids/poison_spider.xml
+++ b/data/monster/Arachnids/poison_spider.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="6" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" poison="30" />

--- a/data/monster/Arachnids/sacred_spider.xml
+++ b/data/monster/Arachnids/sacred_spider.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-160" poison="80" />

--- a/data/monster/Arachnids/sandstone_scorpion.xml
+++ b/data/monster/Arachnids/sandstone_scorpion.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-193" poison="1000" />

--- a/data/monster/Arachnids/scorpion.xml
+++ b/data/monster/Arachnids/scorpion.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="5" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" poison="340" />

--- a/data/monster/Arachnids/spider.xml
+++ b/data/monster/Arachnids/spider.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="6" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />

--- a/data/monster/Arachnids/tarantula.xml
+++ b/data/monster/Arachnids/tarantula.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" poison="40" />

--- a/data/monster/Arachnids/wailing_widow.xml
+++ b/data/monster/Arachnids/wailing_widow.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" poison="160" />

--- a/data/monster/Arena/greenhorn/achad.xml
+++ b/data/monster/Arena/greenhorn/achad.xml
@@ -12,6 +12,9 @@
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
 		<flag runonhealth="55" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Arena/greenhorn/axeitus_headbanger.xml
+++ b/data/monster/Arena/greenhorn/axeitus_headbanger.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Arena/greenhorn/bloodpaw.xml
+++ b/data/monster/Arena/greenhorn/bloodpaw.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Arena/greenhorn/bovinus.xml
+++ b/data/monster/Arena/greenhorn/bovinus.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Arena/greenhorn/colerian_the_barbarian.xml
+++ b/data/monster/Arena/greenhorn/colerian_the_barbarian.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Arena/greenhorn/cursed_gladiator.xml
+++ b/data/monster/Arena/greenhorn/cursed_gladiator.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Arena/greenhorn/frostfur.xml
+++ b/data/monster/Arena/greenhorn/frostfur.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Arena/greenhorn/orcus_the_cruel.xml
+++ b/data/monster/Arena/greenhorn/orcus_the_cruel.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" />

--- a/data/monster/Arena/greenhorn/rocky.xml
+++ b/data/monster/Arena/greenhorn/rocky.xml
@@ -11,6 +11,7 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Arena/greenhorn/the_hairy_one.xml
+++ b/data/monster/Arena/greenhorn/the_hairy_one.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Arena/scrapper/avalanche.xml
+++ b/data/monster/Arena/scrapper/avalanche.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" />

--- a/data/monster/Arena/scrapper/drasilla.xml
+++ b/data/monster/Arena/scrapper/drasilla.xml
@@ -12,6 +12,8 @@
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
 		<flag runonhealth="100" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" />

--- a/data/monster/Arena/scrapper/grimgor_guteater.xml
+++ b/data/monster/Arena/scrapper/grimgor_guteater.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-230" />

--- a/data/monster/Arena/scrapper/kreebosh_the_exile.xml
+++ b/data/monster/Arena/scrapper/kreebosh_the_exile.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Arena/scrapper/slim.xml
+++ b/data/monster/Arena/scrapper/slim.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Arena/scrapper/spirit_of_earth.xml
+++ b/data/monster/Arena/scrapper/spirit_of_earth.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" />

--- a/data/monster/Arena/scrapper/spirit_of_fire.xml
+++ b/data/monster/Arena/scrapper/spirit_of_fire.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" />

--- a/data/monster/Arena/scrapper/spirit_of_water.xml
+++ b/data/monster/Arena/scrapper/spirit_of_water.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Arena/scrapper/the_dark_dancer.xml
+++ b/data/monster/Arena/scrapper/the_dark_dancer.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" poison="220" />

--- a/data/monster/Arena/scrapper/the_hag.xml
+++ b/data/monster/Arena/scrapper/the_hag.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="5" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Arena/warlord/darakan_the_executioner.xml
+++ b/data/monster/Arena/warlord/darakan_the_executioner.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-210" />

--- a/data/monster/Arena/warlord/deathbringer.xml
+++ b/data/monster/Arena/warlord/deathbringer.xml
@@ -11,6 +11,7 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-465" />

--- a/data/monster/Arena/warlord/fallen_mooh'tah_master_ghar.xml
+++ b/data/monster/Arena/warlord/fallen_mooh'tah_master_ghar.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-525" poison="18" />

--- a/data/monster/Arena/warlord/gnorre_chyllson.xml
+++ b/data/monster/Arena/warlord/gnorre_chyllson.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-455" />

--- a/data/monster/Arena/warlord/norgle_glacierbeard.xml
+++ b/data/monster/Arena/warlord/norgle_glacierbeard.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-225" />

--- a/data/monster/Arena/warlord/the_masked_marauder.xml
+++ b/data/monster/Arena/warlord/the_masked_marauder.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-640" />

--- a/data/monster/Arena/warlord/the_obliverator.xml
+++ b/data/monster/Arena/warlord/the_obliverator.xml
@@ -11,6 +11,8 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-700" />

--- a/data/monster/Arena/warlord/the_pit_lord.xml
+++ b/data/monster/Arena/warlord/the_pit_lord.xml
@@ -11,6 +11,9 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-380" />

--- a/data/monster/Arena/warlord/webster.xml
+++ b/data/monster/Arena/warlord/webster.xml
@@ -11,6 +11,7 @@
 		<flag pushable="0" />
 		<flag canpushitems="1" />
 		<flag targetdistance="1" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" />

--- a/data/monster/Barbarians/barbarian_bloodwalker.xml
+++ b/data/monster/Barbarians/barbarian_bloodwalker.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" />

--- a/data/monster/Barbarians/barbarian_brutetamer.xml
+++ b/data/monster/Barbarians/barbarian_brutetamer.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="4" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Barbarians/barbarian_headsplitter.xml
+++ b/data/monster/Barbarians/barbarian_headsplitter.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Barbarians/barbarian_skullhunter.xml
+++ b/data/monster/Barbarians/barbarian_skullhunter.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Bears/bear.xml
+++ b/data/monster/Bears/bear.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />

--- a/data/monster/Bears/panda.xml
+++ b/data/monster/Bears/panda.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Bears/polar_bear.xml
+++ b/data/monster/Bears/polar_bear.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="5" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Bears/undead_cavebear.xml
+++ b/data/monster/Bears/undead_cavebear.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Bio-Elementals/bog_raider.xml
+++ b/data/monster/Bio-Elementals/bog_raider.xml
@@ -14,6 +14,9 @@
 		<flag staticattack="60" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-183" poison="80" />

--- a/data/monster/Bio-Elementals/carniphila.xml
+++ b/data/monster/Bio-Elementals/carniphila.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="100" />

--- a/data/monster/Bio-Elementals/defiler.xml
+++ b/data/monster/Bio-Elementals/defiler.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="85" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" poison="150" />

--- a/data/monster/Bio-Elementals/haunted_treeling.xml
+++ b/data/monster/Bio-Elementals/haunted_treeling.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="85" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Bio-Elementals/leaf_golem.xml
+++ b/data/monster/Bio-Elementals/leaf_golem.xml
@@ -13,6 +13,9 @@
 		<flag canpushitems="1" />
 		<flag canpushcreatures="0" />
 		<flag staticattack="90" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Bio-Elementals/mechanical_fighter.xml
+++ b/data/monster/Bio-Elementals/mechanical_fighter.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />

--- a/data/monster/Bio-Elementals/slime.xml
+++ b/data/monster/Bio-Elementals/slime.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Bio-Elementals/son_of_verminor.xml
+++ b/data/monster/Bio-Elementals/son_of_verminor.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-473" poison="450" />

--- a/data/monster/Bio-Elementals/spit_nettle.xml
+++ b/data/monster/Bio-Elementals/spit_nettle.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="earth" interval="1000" chance="20" range="7" target="1" min="-15" max="-40">

--- a/data/monster/Bio-Elementals/strange_slime.xml
+++ b/data/monster/Bio-Elementals/strange_slime.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="3" defense="10" />
 </monster>

--- a/data/monster/Bio-Elementals/swampling.xml
+++ b/data/monster/Bio-Elementals/swampling.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Bio-Elementals/wilting_leaf_golem.xml
+++ b/data/monster/Bio-Elementals/wilting_leaf_golem.xml
@@ -13,6 +13,9 @@
 		<flag canpushitems="1" />
 		<flag canpushcreatures="0" />
 		<flag staticattack="90" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1500" min="0" max="-120" poison="300" />

--- a/data/monster/Birds/berserker_chicken.xml
+++ b/data/monster/Birds/berserker_chicken.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-200" />

--- a/data/monster/Birds/chicken.xml
+++ b/data/monster/Birds/chicken.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<voices interval="5000" chance="10">

--- a/data/monster/Birds/demon_parrot.xml
+++ b/data/monster/Birds/demon_parrot.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-100" />

--- a/data/monster/Birds/dire_penguin.xml
+++ b/data/monster/Birds/dire_penguin.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Birds/flamingo.xml
+++ b/data/monster/Birds/flamingo.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="0" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<loot>

--- a/data/monster/Birds/marsh_stalker.xml
+++ b/data/monster/Birds/marsh_stalker.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Birds/parrot.xml
+++ b/data/monster/Birds/parrot.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />

--- a/data/monster/Birds/penguin.xml
+++ b/data/monster/Birds/penguin.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="32" />
 		<flag staticattack="90" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-3" />

--- a/data/monster/Birds/pigeon.xml
+++ b/data/monster/Birds/pigeon.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<voices interval="5000" chance="10">

--- a/data/monster/Birds/seagull.xml
+++ b/data/monster/Birds/seagull.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="11" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-3" />

--- a/data/monster/Birds/terror_bird.xml
+++ b/data/monster/Birds/terror_bird.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Blobs/acid_blob.xml
+++ b/data/monster/Blobs/acid_blob.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="85" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Blobs/death_blob.xml
+++ b/data/monster/Blobs/death_blob.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="85" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Blobs/mercury_blob.xml
+++ b/data/monster/Blobs/mercury_blob.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="85" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-75" />

--- a/data/monster/Bonelords/bonelord.xml
+++ b/data/monster/Bonelords/bonelord.xml
@@ -17,8 +17,6 @@
 		<flag runonhealth="0" />
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
-		<flag canwalkonenergy="0" />
-		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />

--- a/data/monster/Bonelords/bonelord.xml
+++ b/data/monster/Bonelords/bonelord.xml
@@ -15,6 +15,10 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />

--- a/data/monster/Bonelords/elder_bonelord.xml
+++ b/data/monster/Bonelords/elder_bonelord.xml
@@ -15,6 +15,10 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-55" />

--- a/data/monster/Bonelords/elder_bonelord.xml
+++ b/data/monster/Bonelords/elder_bonelord.xml
@@ -17,8 +17,6 @@
 		<flag runonhealth="0" />
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
-		<flag canwalkonenergy="0" />
-		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-55" />

--- a/data/monster/Bonelords/eye_of_the_seven.xml
+++ b/data/monster/Bonelords/eye_of_the_seven.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />

--- a/data/monster/Bonelords/gazer.xml
+++ b/data/monster/Bonelords/gazer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Bosses/boogey.xml
+++ b/data/monster/Bosses/boogey.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-120" />

--- a/data/monster/Bosses/chizzoron_the_distorter.xml
+++ b/data/monster/Bosses/chizzoron_the_distorter.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-455" />

--- a/data/monster/Bosses/deadeye_devious.xml
+++ b/data/monster/Bosses/deadeye_devious.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-550" />

--- a/data/monster/Bosses/deathbine.xml
+++ b/data/monster/Bosses/deathbine.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="5" />

--- a/data/monster/Bosses/dirtbeard.xml
+++ b/data/monster/Bosses/dirtbeard.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="50" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-125" />

--- a/data/monster/Bosses/diseased_dan.xml
+++ b/data/monster/Bosses/diseased_dan.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-207" poison="4" />

--- a/data/monster/Bosses/evil_mastermind.xml
+++ b/data/monster/Bosses/evil_mastermind.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="3" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-77" />

--- a/data/monster/Bosses/fleshslicer.xml
+++ b/data/monster/Bosses/fleshslicer.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-99" />

--- a/data/monster/Bosses/heoni.xml
+++ b/data/monster/Bosses/heoni.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" poison="480" />

--- a/data/monster/Bosses/lord_of_the_elements.xml
+++ b/data/monster/Bosses/lord_of_the_elements.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-690" />

--- a/data/monster/Bosses/mad_technomancer.xml
+++ b/data/monster/Bosses/mad_technomancer.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="150" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" />

--- a/data/monster/Bosses/mephiles.xml
+++ b/data/monster/Bosses/mephiles.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="3" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-35" />

--- a/data/monster/Bosses/monstor.xml
+++ b/data/monster/Bosses/monstor.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-167" />

--- a/data/monster/Bosses/pythius_the_rotten.xml
+++ b/data/monster/Bosses/pythius_the_rotten.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1950" min="0" max="-210" />

--- a/data/monster/Bosses/shardhead.xml
+++ b/data/monster/Bosses/shardhead.xml
@@ -16,6 +16,8 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-275" />

--- a/data/monster/Bosses/stonecracker.xml
+++ b/data/monster/Bosses/stonecracker.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />

--- a/data/monster/Bosses/the_blightfather.xml
+++ b/data/monster/Bosses/the_blightfather.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="80" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />

--- a/data/monster/Bosses/the_bloodtusk.xml
+++ b/data/monster/Bosses/the_bloodtusk.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" />

--- a/data/monster/Bosses/the_bloodweb.xml
+++ b/data/monster/Bosses/the_bloodweb.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" poison="8" />

--- a/data/monster/Bosses/the_many.xml
+++ b/data/monster/Bosses/the_many.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-270" />

--- a/data/monster/Bosses/the_noxious_spawn.xml
+++ b/data/monster/Bosses/the_noxious_spawn.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="275" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" />

--- a/data/monster/Bosses/the_old_widow.xml
+++ b/data/monster/Bosses/the_old_widow.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />

--- a/data/monster/Bosses/thul.xml
+++ b/data/monster/Bosses/thul.xml
@@ -15,6 +15,7 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1354" />

--- a/data/monster/Bosses/versperoth.xml
+++ b/data/monster/Bosses/versperoth.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="0" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-650" />

--- a/data/monster/Bosses/zomba.xml
+++ b/data/monster/Bosses/zomba.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Canines/crystal_wolf.xml
+++ b/data/monster/Canines/crystal_wolf.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Canines/dog.xml
+++ b/data/monster/Canines/dog.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="8" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<voices interval="5000" chance="10">

--- a/data/monster/Canines/gnarlhound.xml
+++ b/data/monster/Canines/gnarlhound.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Canines/hot_dog.xml
+++ b/data/monster/Canines/hot_dog.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-55" />

--- a/data/monster/Canines/husky.xml
+++ b/data/monster/Canines/husky.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<voices interval="5000" chance="10">

--- a/data/monster/Canines/war_wolf.xml
+++ b/data/monster/Canines/war_wolf.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Canines/werewolf.xml
+++ b/data/monster/Canines/werewolf.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="300" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-350" />

--- a/data/monster/Canines/winter_wolf.xml
+++ b/data/monster/Canines/winter_wolf.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Canines/wolf.xml
+++ b/data/monster/Canines/wolf.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="8" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Chakoyas/chakoya_toolshaper.xml
+++ b/data/monster/Chakoyas/chakoya_toolshaper.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Chakoyas/chakoya_tribewarden.xml
+++ b/data/monster/Chakoyas/chakoya_tribewarden.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Chakoyas/chakoya_windcaller.xml
+++ b/data/monster/Chakoyas/chakoya_windcaller.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="4" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-22" />

--- a/data/monster/Cnidarians/jellyfish.xml
+++ b/data/monster/Cnidarians/jellyfish.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
 		<flag staticattack="80" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Corym/corym_charlatan.xml
+++ b/data/monster/Corym/corym_charlatan.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-105" />

--- a/data/monster/Corym/corym_skirmisher.xml
+++ b/data/monster/Corym/corym_skirmisher.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Corym/corym_vanguard.xml
+++ b/data/monster/Corym/corym_vanguard.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="50" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />

--- a/data/monster/Crustaceans/blood_crab.xml
+++ b/data/monster/Crustaceans/blood_crab.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-113" />

--- a/data/monster/Crustaceans/blood_crab_underwater.xml
+++ b/data/monster/Crustaceans/blood_crab_underwater.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-113" />

--- a/data/monster/Crustaceans/crab.xml
+++ b/data/monster/Crustaceans/crab.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Cryo-Elementals/ice_golem.xml
+++ b/data/monster/Cryo-Elementals/ice_golem.xml
@@ -16,6 +16,8 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-220" />

--- a/data/monster/Deeplings/deepling_brawler.xml
+++ b/data/monster/Deeplings/deepling_brawler.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Deeplings/deepling_elite.xml
+++ b/data/monster/Deeplings/deepling_elite.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Deeplings/deepling_guard.xml
+++ b/data/monster/Deeplings/deepling_guard.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Deeplings/deepling_master_librarian.xml
+++ b/data/monster/Deeplings/deepling_master_librarian.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="60" />
 		<flag runonhealth="250" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 		</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-210" />

--- a/data/monster/Deeplings/deepling_scout.xml
+++ b/data/monster/Deeplings/deepling_scout.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="0" />
 		<flag runonhealth="50" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Deeplings/deepling_spellsinger.xml
+++ b/data/monster/Deeplings/deepling_spellsinger.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="60" />
 		<flag runonhealth="60" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-152" />

--- a/data/monster/Deeplings/deepling_tyrant.xml
+++ b/data/monster/Deeplings/deepling_tyrant.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-501" />

--- a/data/monster/Deeplings/deepling_warrior.xml
+++ b/data/monster/Deeplings/deepling_warrior.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" />

--- a/data/monster/Deeplings/deepling_worker.xml
+++ b/data/monster/Deeplings/deepling_worker.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Demons/askarak_demon.xml
+++ b/data/monster/Demons/askarak_demon.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-143" />

--- a/data/monster/Demons/dark_torturer.xml
+++ b/data/monster/Demons/dark_torturer.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />

--- a/data/monster/Demons/destroyer.xml
+++ b/data/monster/Demons/destroyer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />

--- a/data/monster/Demons/diabolic_imp.xml
+++ b/data/monster/Demons/diabolic_imp.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="400" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" poison="160" />

--- a/data/monster/Demons/fire_devil.xml
+++ b/data/monster/Demons/fire_devil.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Demons/gozzler.xml
+++ b/data/monster/Demons/gozzler.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Demons/grave_guard.xml
+++ b/data/monster/Demons/grave_guard.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-147" />

--- a/data/monster/Demons/gravedigger.xml
+++ b/data/monster/Demons/gravedigger.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="200" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-320" poison="180" />

--- a/data/monster/Demons/hellspawn.xml
+++ b/data/monster/Demons/hellspawn.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-352" />

--- a/data/monster/Demons/juggernaut.xml
+++ b/data/monster/Demons/juggernaut.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="60" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1470" />

--- a/data/monster/Demons/nightmare.xml
+++ b/data/monster/Demons/nightmare.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Demons/nightmare_scion.xml
+++ b/data/monster/Demons/nightmare_scion.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />

--- a/data/monster/Demons/nightstalker.xml
+++ b/data/monster/Demons/nightstalker.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" poison="80" />

--- a/data/monster/Demons/plaguesmith.xml
+++ b/data/monster/Demons/plaguesmith.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="500" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1500" min="0" max="-539" poison="200" />

--- a/data/monster/Demons/rift_scythe.xml
+++ b/data/monster/Demons/rift_scythe.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="85" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-979" />

--- a/data/monster/Demons/yielothax.xml
+++ b/data/monster/Demons/yielothax.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="75" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1000" min="0" max="-203" />

--- a/data/monster/Djinn/blue_djinn.xml
+++ b/data/monster/Djinn/blue_djinn.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Djinn/efreet.xml
+++ b/data/monster/Djinn/efreet.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Djinn/green_djinn.xml
+++ b/data/monster/Djinn/green_djinn.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Djinn/marid.xml
+++ b/data/monster/Djinn/marid.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Dragons/dragon_hatchling.xml
+++ b/data/monster/Dragons/dragon_hatchling.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="20" />
 		<flag staticattack="90" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-55" />

--- a/data/monster/Dragons/dragon_lord_hatchling.xml
+++ b/data/monster/Dragons/dragon_lord_hatchling.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Dragons/draptor.xml
+++ b/data/monster/Dragons/draptor.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="350" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Dragons/frost_dragon.xml
+++ b/data/monster/Dragons/frost_dragon.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="250" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-225" />

--- a/data/monster/Dragons/frost_dragon_hatchling.xml
+++ b/data/monster/Dragons/frost_dragon_hatchling.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="80" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-160" />

--- a/data/monster/Dragons/ghastly_dragon.xml
+++ b/data/monster/Dragons/ghastly_dragon.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="366" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-603" />

--- a/data/monster/Dragons/undead_dragon.xml
+++ b/data/monster/Dragons/undead_dragon.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-480" />

--- a/data/monster/Dreamhaunters/bad_dream.xml
+++ b/data/monster/Dreamhaunters/bad_dream.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<immunities>
 		<immunity earth="1" />

--- a/data/monster/Dreamhaunters/choking_fear.xml
+++ b/data/monster/Dreamhaunters/choking_fear.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-499" poison="600" />

--- a/data/monster/Dreamhaunters/retching_horror.xml
+++ b/data/monster/Dreamhaunters/retching_horror.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Dreamhaunters/shiversleep.xml
+++ b/data/monster/Dreamhaunters/shiversleep.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />

--- a/data/monster/Dreamhaunters/silencer.xml
+++ b/data/monster/Dreamhaunters/silencer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-315" poison="600" />

--- a/data/monster/Dwarves/dwarf.xml
+++ b/data/monster/Dwarves/dwarf.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Dwarves/dwarf_geomancer.xml
+++ b/data/monster/Dwarves/dwarf_geomancer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="70" />
 		<flag runonhealth="110" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="earth" interval="2000" chance="20" range="7" min="-50" max="-110">

--- a/data/monster/Dwarves/dwarf_guard.xml
+++ b/data/monster/Dwarves/dwarf_guard.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />

--- a/data/monster/Dwarves/dwarf_miner.xml
+++ b/data/monster/Dwarves/dwarf_miner.xml
@@ -14,6 +14,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-26" />

--- a/data/monster/Dwarves/dwarf_soldier.xml
+++ b/data/monster/Dwarves/dwarf_soldier.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Dwarves/enslaved_dwarf.xml
+++ b/data/monster/Dwarves/enslaved_dwarf.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-501" />

--- a/data/monster/Dwarves/lost_basher.xml
+++ b/data/monster/Dwarves/lost_basher.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-351" />

--- a/data/monster/Dwarves/lost_berserker.xml
+++ b/data/monster/Dwarves/lost_berserker.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-501" />

--- a/data/monster/Dwarves/lost_husher.xml
+++ b/data/monster/Dwarves/lost_husher.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="death" interval="2000" chance="10" length="6" spread="0" min="-150" max="-300">

--- a/data/monster/Dwarves/lost_thrower.xml
+++ b/data/monster/Dwarves/lost_thrower.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-301" />

--- a/data/monster/Dworcs/dworc_fleshhunter.xml
+++ b/data/monster/Dworcs/dworc_fleshhunter.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="8" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" poison="20" />

--- a/data/monster/Dworcs/dworc_venomsniper.xml
+++ b/data/monster/Dworcs/dworc_venomsniper.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Dworcs/dworc_voodoomaster.xml
+++ b/data/monster/Dworcs/dworc_voodoomaster.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="80" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Electro-Elementals/energy_elemental.xml
+++ b/data/monster/Electro-Elementals/energy_elemental.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-175" />

--- a/data/monster/Electro-Elementals/massive_energy_elemental.xml
+++ b/data/monster/Electro-Elementals/massive_energy_elemental.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="1" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-175" />

--- a/data/monster/Elemental_Lords/ice_overlord.xml
+++ b/data/monster/Elemental_Lords/ice_overlord.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="1" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Elves/elf.xml
+++ b/data/monster/Elves/elf.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Elves/elf_arcanist.xml
+++ b/data/monster/Elves/elf_arcanist.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Elves/elf_scout.xml
+++ b/data/monster/Elves/elf_scout.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Event_Creatures/herald_of_gloom.xml
+++ b/data/monster/Event_Creatures/herald_of_gloom.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" chance="100" min="0" max="-90" />

--- a/data/monster/Felines/cat.xml
+++ b/data/monster/Felines/cat.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="8" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="0" />

--- a/data/monster/Felines/lion.xml
+++ b/data/monster/Felines/lion.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Felines/tiger.xml
+++ b/data/monster/Felines/tiger.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Fish/fish.xml
+++ b/data/monster/Fish/fish.xml
@@ -14,6 +14,7 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<immunities>

--- a/data/monster/Fish/northern_pike.xml
+++ b/data/monster/Fish/northern_pike.xml
@@ -14,6 +14,7 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="95" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<immunities>

--- a/data/monster/Fish/shark.xml
+++ b/data/monster/Fish/shark.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
 		<flag staticattack="90" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-175" />

--- a/data/monster/Frogs/azure_frog.xml
+++ b/data/monster/Frogs/azure_frog.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />

--- a/data/monster/Frogs/coral_frog.xml
+++ b/data/monster/Frogs/coral_frog.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />

--- a/data/monster/Frogs/crimson_frog.xml
+++ b/data/monster/Frogs/crimson_frog.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />

--- a/data/monster/Frogs/filth_toad.xml
+++ b/data/monster/Frogs/filth_toad.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" poison="20" />

--- a/data/monster/Frogs/green_frog.xml
+++ b/data/monster/Frogs/green_frog.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="6" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />

--- a/data/monster/Frogs/infernal_frog.xml
+++ b/data/monster/Frogs/infernal_frog.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Frogs/orchid_frog.xml
+++ b/data/monster/Frogs/orchid_frog.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />

--- a/data/monster/Frogs/toad.xml
+++ b/data/monster/Frogs/toad.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" poison="20" />

--- a/data/monster/Geo-Elementals/armadile.xml
+++ b/data/monster/Geo-Elementals/armadile.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Geo-Elementals/clay_guardian.xml
+++ b/data/monster/Geo-Elementals/clay_guardian.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="60" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-125" />

--- a/data/monster/Geo-Elementals/cliff_strider.xml
+++ b/data/monster/Geo-Elementals/cliff_strider.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-499" />

--- a/data/monster/Geo-Elementals/crystalcrusher.xml
+++ b/data/monster/Geo-Elementals/crystalcrusher.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-167" />

--- a/data/monster/Geo-Elementals/damaged_worker_golem.xml
+++ b/data/monster/Geo-Elementals/damaged_worker_golem.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Geo-Elementals/diamond_servant.xml
+++ b/data/monster/Geo-Elementals/diamond_servant.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="100" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Geo-Elementals/earth_elemental.xml
+++ b/data/monster/Geo-Elementals/earth_elemental.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="80" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Geo-Elementals/eternal_guardian.xml
+++ b/data/monster/Geo-Elementals/eternal_guardian.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" />

--- a/data/monster/Geo-Elementals/forest_fury.xml
+++ b/data/monster/Geo-Elementals/forest_fury.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-125" />

--- a/data/monster/Geo-Elementals/gargoyle.xml
+++ b/data/monster/Geo-Elementals/gargoyle.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-65" />

--- a/data/monster/Geo-Elementals/golden_servant.xml
+++ b/data/monster/Geo-Elementals/golden_servant.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="50" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Geo-Elementals/iron_servant.xml
+++ b/data/monster/Geo-Elementals/iron_servant.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="50" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Geo-Elementals/ironblight.xml
+++ b/data/monster/Geo-Elementals/ironblight.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="260" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" />

--- a/data/monster/Geo-Elementals/massive_earth_elemental.xml
+++ b/data/monster/Geo-Elementals/massive_earth_elemental.xml
@@ -16,6 +16,8 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Geo-Elementals/medusa.xml
+++ b/data/monster/Geo-Elementals/medusa.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="600" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" poison="840" />

--- a/data/monster/Geo-Elementals/stone_golem.xml
+++ b/data/monster/Geo-Elementals/stone_golem.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Geo-Elementals/vulcongra.xml
+++ b/data/monster/Geo-Elementals/vulcongra.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="220" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-235" />

--- a/data/monster/Geo-Elementals/worker_golem.xml
+++ b/data/monster/Geo-Elementals/worker_golem.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" />

--- a/data/monster/Ghosts/ghost.xml
+++ b/data/monster/Ghosts/ghost.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Ghosts/phantasm.xml
+++ b/data/monster/Ghosts/phantasm.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="350" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-475" />

--- a/data/monster/Ghosts/phantasm_summon.xml
+++ b/data/monster/Ghosts/phantasm_summon.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Ghosts/souleater.xml
+++ b/data/monster/Ghosts/souleater.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-210" />

--- a/data/monster/Ghosts/spectre.xml
+++ b/data/monster/Ghosts/spectre.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-308" poison="300" />

--- a/data/monster/Ghosts/tarnished_spirit.xml
+++ b/data/monster/Ghosts/tarnished_spirit.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Ghosts/wisp.xml
+++ b/data/monster/Ghosts/wisp.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="7" />
 		<flag runonhealth="115" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Giants/behemoth.xml
+++ b/data/monster/Giants/behemoth.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />

--- a/data/monster/Giants/cyclops.xml
+++ b/data/monster/Giants/cyclops.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-105" />

--- a/data/monster/Giants/cyclops_drone.xml
+++ b/data/monster/Giants/cyclops_drone.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-105" />

--- a/data/monster/Giants/cyclops_smith.xml
+++ b/data/monster/Giants/cyclops_smith.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Giants/frost_giant.xml
+++ b/data/monster/Giants/frost_giant.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Giants/frost_giantess.xml
+++ b/data/monster/Giants/frost_giantess.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="4" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Glires/cave_rat.xml
+++ b/data/monster/Glires/cave_rat.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="3" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Glires/killer_rabbit.xml
+++ b/data/monster/Glires/killer_rabbit.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-100" />

--- a/data/monster/Glires/rabbit.xml
+++ b/data/monster/Glires/rabbit.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<loot>

--- a/data/monster/Glires/rat.xml
+++ b/data/monster/Glires/rat.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="5" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Glires/silver_rabbit.xml
+++ b/data/monster/Glires/silver_rabbit.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="0" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<loot>

--- a/data/monster/Glires/squirrel.xml
+++ b/data/monster/Glires/squirrel.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<voices interval="5000" chance="10">

--- a/data/monster/Goblins/goblin.xml
+++ b/data/monster/Goblins/goblin.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Goblins/goblin_assassin.xml
+++ b/data/monster/Goblins/goblin_assassin.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Goblins/goblin_leader.xml
+++ b/data/monster/Goblins/goblin_leader.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Goblins/goblin_scavenger.xml
+++ b/data/monster/Goblins/goblin_scavenger.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Hydro-Elementals/massive_water_elemental.xml
+++ b/data/monster/Hydro-Elementals/massive_water_elemental.xml
@@ -15,6 +15,7 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-220" poison="300" />

--- a/data/monster/Hydro-Elementals/roaring_water_elemental.xml
+++ b/data/monster/Hydro-Elementals/roaring_water_elemental.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="1" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-225" />

--- a/data/monster/Hydro-Elementals/slick_water_elemental.xml
+++ b/data/monster/Hydro-Elementals/slick_water_elemental.xml
@@ -16,6 +16,7 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="1" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-175" />

--- a/data/monster/Hydro-Elementals/water_elemental.xml
+++ b/data/monster/Hydro-Elementals/water_elemental.xml
@@ -15,6 +15,7 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-160" poison="60" />

--- a/data/monster/Insects/ancient_scarab.xml
+++ b/data/monster/Insects/ancient_scarab.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-130" poison="56" />

--- a/data/monster/Insects/blue_butterfly.xml
+++ b/data/monster/Insects/blue_butterfly.xml
@@ -15,5 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="6" />
 		<flag runonhealth="2" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 </monster>

--- a/data/monster/Insects/brimstone_bug.xml
+++ b/data/monster/Insects/brimstone_bug.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-213" poison="400" />

--- a/data/monster/Insects/bug.xml
+++ b/data/monster/Insects/bug.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-23" />

--- a/data/monster/Insects/butterfly.xml
+++ b/data/monster/Insects/butterfly.xml
@@ -15,5 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="8" />
 		<flag runonhealth="2" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 </monster>

--- a/data/monster/Insects/cockroach.xml
+++ b/data/monster/Insects/cockroach.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="5" />
 		<flag runonhealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<loot>
 		<item name="cockroach leg" chance="100000" />

--- a/data/monster/Insects/emerald_damselfly.xml
+++ b/data/monster/Insects/emerald_damselfly.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-4" poison="10" />

--- a/data/monster/Insects/insect_swarm.xml
+++ b/data/monster/Insects/insect_swarm.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" poison="16" />

--- a/data/monster/Insects/insectoid_worker.xml
+++ b/data/monster/Insects/insectoid_worker.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-163" poison="160" />

--- a/data/monster/Insects/kollos.xml
+++ b/data/monster/Insects/kollos.xml
@@ -14,6 +14,7 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-315" />

--- a/data/monster/Insects/lancer_beetle.xml
+++ b/data/monster/Insects/lancer_beetle.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-115" />

--- a/data/monster/Insects/larva.xml
+++ b/data/monster/Insects/larva.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" poison="15" />

--- a/data/monster/Insects/parasite.xml
+++ b/data/monster/Insects/parasite.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="40" />

--- a/data/monster/Insects/pink_butterfly.xml
+++ b/data/monster/Insects/pink_butterfly.xml
@@ -15,5 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="6" />
 		<flag runonhealth="2" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 </monster>

--- a/data/monster/Insects/purple_butterfly.xml
+++ b/data/monster/Insects/purple_butterfly.xml
@@ -15,5 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="6" />
 		<flag runonhealth="2" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 </monster>

--- a/data/monster/Insects/red_butterfly.xml
+++ b/data/monster/Insects/red_butterfly.xml
@@ -15,5 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="6" />
 		<flag runonhealth="2" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 </monster>

--- a/data/monster/Insects/sandcrawler.xml
+++ b/data/monster/Insects/sandcrawler.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-3" />

--- a/data/monster/Insects/scarab.xml
+++ b/data/monster/Insects/scarab.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="80" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-75" />

--- a/data/monster/Insects/spidris.xml
+++ b/data/monster/Insects/spidris.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-298" />

--- a/data/monster/Insects/spitter.xml
+++ b/data/monster/Insects/spitter.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" poison="240" />

--- a/data/monster/Insects/swarmer.xml
+++ b/data/monster/Insects/swarmer.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="0" />
 		<flag runonhealth="50" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-102" poison="80" />

--- a/data/monster/Insects/swarmer_hatchling.xml
+++ b/data/monster/Insects/swarmer_hatchling.xml
@@ -14,6 +14,7 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-99" />

--- a/data/monster/Insects/terramite.xml
+++ b/data/monster/Insects/terramite.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Insects/wasp.xml
+++ b/data/monster/Insects/wasp.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="1500" min="0" max="-20" poison="20" />

--- a/data/monster/Insects/waspoid.xml
+++ b/data/monster/Insects/waspoid.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="0" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-248" poison="400" />

--- a/data/monster/Lizards/draken_abomination.xml
+++ b/data/monster/Lizards/draken_abomination.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-420" />

--- a/data/monster/Lizards/draken_spellweaver.xml
+++ b/data/monster/Lizards/draken_spellweaver.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-252" />

--- a/data/monster/Lizards/lizard_chosen.xml
+++ b/data/monster/Lizards/lizard_chosen.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="50" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-360" />

--- a/data/monster/Lizards/lizard_dragon_priest.xml
+++ b/data/monster/Lizards/lizard_dragon_priest.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="50" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Lizards/lizard_high_guard.xml
+++ b/data/monster/Lizards/lizard_high_guard.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-306" />

--- a/data/monster/Lizards/lizard_legionnaire.xml
+++ b/data/monster/Lizards/lizard_legionnaire.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" />

--- a/data/monster/Lizards/lizard_magistratus.xml
+++ b/data/monster/Lizards/lizard_magistratus.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Lizards/lizard_noble.xml
+++ b/data/monster/Lizards/lizard_noble.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Lizards/lizard_sentinel.xml
+++ b/data/monster/Lizards/lizard_sentinel.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Lizards/lizard_snakecharmer.xml
+++ b/data/monster/Lizards/lizard_snakecharmer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="80" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Lizards/lizard_templar.xml
+++ b/data/monster/Lizards/lizard_templar.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Lizards/wyvern.xml
+++ b/data/monster/Lizards/wyvern.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" poison="480" />

--- a/data/monster/Minotaurs/minotaur.xml
+++ b/data/monster/Minotaurs/minotaur.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Minotaurs/minotaur_archer.xml
+++ b/data/monster/Minotaurs/minotaur_archer.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />

--- a/data/monster/Minotaurs/minotaur_guard.xml
+++ b/data/monster/Minotaurs/minotaur_guard.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Minotaurs/minotaur_mage.xml
+++ b/data/monster/Minotaurs/minotaur_mage.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Misc/Misc Mammals/badger.xml
+++ b/data/monster/Misc/Misc Mammals/badger.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-12" />

--- a/data/monster/Misc/Misc Mammals/bat.xml
+++ b/data/monster/Misc/Misc Mammals/bat.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="3" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-8" />

--- a/data/monster/Misc/Misc Mammals/ghoulish_hyaena.xml
+++ b/data/monster/Misc/Misc Mammals/ghoulish_hyaena.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-112" poison="10" />

--- a/data/monster/Misc/Misc Mammals/hyaena.xml
+++ b/data/monster/Misc/Misc Mammals/hyaena.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Misc/Misc Mammals/skunk.xml
+++ b/data/monster/Misc/Misc Mammals/skunk.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="8" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />

--- a/data/monster/Misc/Misc Mammals/water_buffalo.xml
+++ b/data/monster/Misc/Misc Mammals/water_buffalo.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Misc/Misc Mounts/modified_gnarlhound.xml
+++ b/data/monster/Misc/Misc Mounts/modified_gnarlhound.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<immunities>
 		<immunity energy="1" />

--- a/data/monster/Misc/Misc Reptiles/crocodile.xml
+++ b/data/monster/Misc/Misc Reptiles/crocodile.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Misc/Misc Reptiles/killer_caiman.xml
+++ b/data/monster/Misc/Misc Reptiles/killer_caiman.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" />

--- a/data/monster/Misc/Misc Reptiles/thornback_tortoise.xml
+++ b/data/monster/Misc/Misc Reptiles/thornback_tortoise.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" poison="40" />

--- a/data/monster/Misc/Misc Reptiles/tortoise.xml
+++ b/data/monster/Misc/Misc Reptiles/tortoise.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Mollusks/calamary.xml
+++ b/data/monster/Mollusks/calamary.xml
@@ -14,6 +14,7 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="75" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<elements>
 		<element energyPercent="-5" />

--- a/data/monster/Mollusks/slug.xml
+++ b/data/monster/Mollusks/slug.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-44" />

--- a/data/monster/Monks/dark_monk.xml
+++ b/data/monster/Monks/dark_monk.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Monks/monk.xml
+++ b/data/monster/Monks/monk.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-130" />

--- a/data/monster/Mutated/mutated_bat.xml
+++ b/data/monster/Mutated/mutated_bat.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-168" poison="120" />

--- a/data/monster/Mutated/mutated_human.xml
+++ b/data/monster/Mutated/mutated_human.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" poison="60" />

--- a/data/monster/Mutated/mutated_rat.xml
+++ b/data/monster/Mutated/mutated_rat.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-158" poison="100" />

--- a/data/monster/Myriapods/centipede.xml
+++ b/data/monster/Myriapods/centipede.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" poison="20" />

--- a/data/monster/Myriapods/crawler.xml
+++ b/data/monster/Myriapods/crawler.xml
@@ -14,6 +14,8 @@
 		<flag canpushcreatures="1" />
 		<flag targetdistance="0" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-228" poison="80" />

--- a/data/monster/Myriapods/wiggler.xml
+++ b/data/monster/Myriapods/wiggler.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="359" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="500" />

--- a/data/monster/Necromancers/blood_hand.xml
+++ b/data/monster/Necromancers/blood_hand.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="0" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-158" poison="80" />

--- a/data/monster/Necromancers/blood_priest.xml
+++ b/data/monster/Necromancers/blood_priest.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" poison="100" />

--- a/data/monster/Necromancers/necromancer.xml
+++ b/data/monster/Necromancers/necromancer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" poison="160" />

--- a/data/monster/Necromancers/necromancer_servant.xml
+++ b/data/monster/Necromancers/necromancer_servant.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Necromancers/priestess.xml
+++ b/data/monster/Necromancers/priestess.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-75" />

--- a/data/monster/Necromancers/shadow_pupil.xml
+++ b/data/monster/Necromancers/shadow_pupil.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" poison="90" />

--- a/data/monster/Orcs/orc.xml
+++ b/data/monster/Orcs/orc.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Orcs/orc_berserker.xml
+++ b/data/monster/Orcs/orc_berserker.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />

--- a/data/monster/Orcs/orc_leader.xml
+++ b/data/monster/Orcs/orc_leader.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-185" />

--- a/data/monster/Orcs/orc_marauder.xml
+++ b/data/monster/Orcs/orc_marauder.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Orcs/orc_rider.xml
+++ b/data/monster/Orcs/orc_rider.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-130" />

--- a/data/monster/Orcs/orc_shaman.xml
+++ b/data/monster/Orcs/orc_shaman.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Orcs/orc_spearman.xml
+++ b/data/monster/Orcs/orc_spearman.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />

--- a/data/monster/Orcs/orc_warlord.xml
+++ b/data/monster/Orcs/orc_warlord.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" />

--- a/data/monster/Orcs/orc_warrior.xml
+++ b/data/monster/Orcs/orc_warrior.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="11" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Outlaws/adventurer.xml
+++ b/data/monster/Outlaws/adventurer.xml
@@ -15,5 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="65" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 </monster>

--- a/data/monster/Outlaws/assassin.xml
+++ b/data/monster/Outlaws/assassin.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" />

--- a/data/monster/Outlaws/bandit.xml
+++ b/data/monster/Outlaws/bandit.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Outlaws/crazed_beggar.xml
+++ b/data/monster/Outlaws/crazed_beggar.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="80" />
 		<flag targetdistance="1" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />

--- a/data/monster/Outlaws/crypt_defiler.xml
+++ b/data/monster/Outlaws/crypt_defiler.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Outlaws/feverish_citizen.xml
+++ b/data/monster/Outlaws/feverish_citizen.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-18" />

--- a/data/monster/Outlaws/gang_member.xml
+++ b/data/monster/Outlaws/gang_member.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="35" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Outlaws/gladiator.xml
+++ b/data/monster/Outlaws/gladiator.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Outlaws/grave_robber.xml
+++ b/data/monster/Outlaws/grave_robber.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Outlaws/hero.xml
+++ b/data/monster/Outlaws/hero.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" />

--- a/data/monster/Outlaws/hunter.xml
+++ b/data/monster/Outlaws/hunter.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Outlaws/nomad.xml
+++ b/data/monster/Outlaws/nomad.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Outlaws/poacher.xml
+++ b/data/monster/Outlaws/poacher.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="5" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Outlaws/smuggler.xml
+++ b/data/monster/Outlaws/smuggler.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Outlaws/stalker.xml
+++ b/data/monster/Outlaws/stalker.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Outlaws/wild_warrior.xml
+++ b/data/monster/Outlaws/wild_warrior.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Pharaohs/ashmunrah.xml
+++ b/data/monster/Pharaohs/ashmunrah.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1000" poison="55" />

--- a/data/monster/Pharaohs/dipthrah.xml
+++ b/data/monster/Pharaohs/dipthrah.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="65" />

--- a/data/monster/Pharaohs/mahrdis.xml
+++ b/data/monster/Pharaohs/mahrdis.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" poison="65" />

--- a/data/monster/Pharaohs/morguthis.xml
+++ b/data/monster/Pharaohs/morguthis.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1000" poison="65" />

--- a/data/monster/Pharaohs/omruc.xml
+++ b/data/monster/Pharaohs/omruc.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" poison="65" />

--- a/data/monster/Pharaohs/thalas.xml
+++ b/data/monster/Pharaohs/thalas.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-900" />

--- a/data/monster/Pharaohs/vashresamun.xml
+++ b/data/monster/Pharaohs/vashresamun.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="65" />

--- a/data/monster/Pirates/pirate_buccaneer.xml
+++ b/data/monster/Pirates/pirate_buccaneer.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="50" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-160" />

--- a/data/monster/Pirates/pirate_corsair.xml
+++ b/data/monster/Pirates/pirate_corsair.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-170" />

--- a/data/monster/Pirates/pirate_cutthroat.xml
+++ b/data/monster/Pirates/pirate_cutthroat.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-170" poison="10" />

--- a/data/monster/Pirates/pirate_ghost.xml
+++ b/data/monster/Pirates/pirate_ghost.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="40" />

--- a/data/monster/Pirates/pirate_marauder.xml
+++ b/data/monster/Pirates/pirate_marauder.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />

--- a/data/monster/Pirates/pirate_skeleton.xml
+++ b/data/monster/Pirates/pirate_skeleton.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Pyro-Elementals/blazing_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/blazing_fire_elemental.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Pyro-Elementals/blistering_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/blistering_fire_elemental.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-350" />

--- a/data/monster/Pyro-Elementals/fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/fire_elemental.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Pyro-Elementals/hellfire_fighter.xml
+++ b/data/monster/Pyro-Elementals/hellfire_fighter.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-520" />

--- a/data/monster/Pyro-Elementals/infected_weeper.xml
+++ b/data/monster/Pyro-Elementals/infected_weeper.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-280" />

--- a/data/monster/Pyro-Elementals/lava_golem.xml
+++ b/data/monster/Pyro-Elementals/lava_golem.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />

--- a/data/monster/Pyro-Elementals/magma_crawler.xml
+++ b/data/monster/Pyro-Elementals/magma_crawler.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-203" />

--- a/data/monster/Pyro-Elementals/massive_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/massive_fire_elemental.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" />

--- a/data/monster/Pyro-Elementals/orewalker.xml
+++ b/data/monster/Pyro-Elementals/orewalker.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-300" />

--- a/data/monster/Pyro-Elementals/weeper.xml
+++ b/data/monster/Pyro-Elementals/weeper.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="0" />
 		<flag staticattack="70" />
 		<flag runonhealth="570" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />

--- a/data/monster/Quaras/quara_constrictor.xml
+++ b/data/monster/Quaras/quara_constrictor.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" poison="20" />

--- a/data/monster/Quaras/quara_constrictor_scout.xml
+++ b/data/monster/Quaras/quara_constrictor_scout.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-135" />

--- a/data/monster/Quaras/quara_hydromancer.xml
+++ b/data/monster/Quaras/quara_hydromancer.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" poison="100" />

--- a/data/monster/Quaras/quara_hydromancer_scout.xml
+++ b/data/monster/Quaras/quara_hydromancer_scout.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" poison="100" />

--- a/data/monster/Quaras/quara_mantassin.xml
+++ b/data/monster/Quaras/quara_mantassin.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="80" />
 		<flag targetdistance="1" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-138" />

--- a/data/monster/Quaras/quara_mantassin_scout.xml
+++ b/data/monster/Quaras/quara_mantassin_scout.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Quaras/quara_pincher.xml
+++ b/data/monster/Quaras/quara_pincher.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-342" />

--- a/data/monster/Quaras/quara_pincher_scout.xml
+++ b/data/monster/Quaras/quara_pincher_scout.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" />

--- a/data/monster/Quaras/quara_predator.xml
+++ b/data/monster/Quaras/quara_predator.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-473" />

--- a/data/monster/Quaras/quara_predator_scout.xml
+++ b/data/monster/Quaras/quara_predator_scout.xml
@@ -15,6 +15,8 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-193" />

--- a/data/monster/Salamanders/salamander.xml
+++ b/data/monster/Salamanders/salamander.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" poison="10" />

--- a/data/monster/Serpents/cobra.xml
+++ b/data/monster/Serpents/cobra.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="0" poison="100" />

--- a/data/monster/Serpents/serpent_spawn.xml
+++ b/data/monster/Serpents/serpent_spawn.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="275" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-252" />

--- a/data/monster/Serpents/snake.xml
+++ b/data/monster/Serpents/snake.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-8" poison="15" />

--- a/data/monster/Skeletons/bonebeast.xml
+++ b/data/monster/Skeletons/bonebeast.xml
@@ -17,8 +17,6 @@
 		<flag runonhealth="0" />
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
-		<flag canwalkonenergy="0" />
-		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="100" />

--- a/data/monster/Skeletons/bonebeast.xml
+++ b/data/monster/Skeletons/bonebeast.xml
@@ -15,6 +15,10 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="100" />

--- a/data/monster/Skeletons/demon_skeleton.xml
+++ b/data/monster/Skeletons/demon_skeleton.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-185" />

--- a/data/monster/Skeletons/honour_guard.xml
+++ b/data/monster/Skeletons/honour_guard.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Skeletons/lost_soul.xml
+++ b/data/monster/Skeletons/lost_soul.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="450" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-420" />

--- a/data/monster/Skeletons/skeleton.xml
+++ b/data/monster/Skeletons/skeleton.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Skeletons/skeleton_warrior.xml
+++ b/data/monster/Skeletons/skeleton_warrior.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Skeletons/undead_gladiator.xml
+++ b/data/monster/Skeletons/undead_gladiator.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" />

--- a/data/monster/Skeletons/undead_mine_worker.xml
+++ b/data/monster/Skeletons/undead_mine_worker.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />

--- a/data/monster/Sorcerers/dark_apprentice.xml
+++ b/data/monster/Sorcerers/dark_apprentice.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Sorcerers/dark_magician.xml
+++ b/data/monster/Sorcerers/dark_magician.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />

--- a/data/monster/Sorcerers/fury.xml
+++ b/data/monster/Sorcerers/fury.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-510" />

--- a/data/monster/Sorcerers/ice_witch.xml
+++ b/data/monster/Sorcerers/ice_witch.xml
@@ -16,6 +16,9 @@
 		<flag lightcolor="0" />
 		<flag targetdistance="4" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-60" />

--- a/data/monster/Sorcerers/mad_scientist.xml
+++ b/data/monster/Sorcerers/mad_scientist.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Sorcerers/witch.xml
+++ b/data/monster/Sorcerers/witch.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Traps/flamethrower.xml
+++ b/data/monster/Traps/flamethrower.xml
@@ -16,6 +16,9 @@
 		<flag staticattack="90" />
 		<flag runonhealth="100" />
 		<flag hidehealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="fire" interval="2000" chance="100" range="7" min="0" max="-100">

--- a/data/monster/Traps/hive_pore.xml
+++ b/data/monster/Traps/hive_pore.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses>
 		<defense name="effect" interval="30000" chance="100" target="0" radius="3">

--- a/data/monster/Traps/lavahole.xml
+++ b/data/monster/Traps/lavahole.xml
@@ -16,6 +16,9 @@
 		<flag staticattack="100" />
 		<flag runonhealth="0" />
 		<flag hidehealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="fire" interval="2000" chance="50" range="7" min="0" max="-100">

--- a/data/monster/Traps/magic_pillar.xml
+++ b/data/monster/Traps/magic_pillar.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="100" />
 		<flag hidehealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<summons maxSummons="2">
 		<summon name="Demon" interval="2000" chance="7" max="3" />

--- a/data/monster/Traps/magicthrower.xml
+++ b/data/monster/Traps/magicthrower.xml
@@ -16,6 +16,9 @@
 		<flag staticattack="90" />
 		<flag runonhealth="100" />
 		<flag hidehealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="earth" interval="2000" chance="100" range="7" min="0" max="-100">

--- a/data/monster/Traps/plaguethrower.xml
+++ b/data/monster/Traps/plaguethrower.xml
@@ -16,6 +16,9 @@
 		<flag staticattack="90" />
 		<flag runonhealth="100" />
 		<flag hidehealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="earth" interval="2000" chance="100" range="7" min="0" max="-100">

--- a/data/monster/Traps/shredderthrower.xml
+++ b/data/monster/Traps/shredderthrower.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
 		<flag hidehealth="1" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="physical" interval="2000" chance="100" range="7" min="0" max="-110">

--- a/data/monster/Trolls/frost_troll.xml
+++ b/data/monster/Trolls/frost_troll.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="10" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />

--- a/data/monster/Trolls/island_troll.xml
+++ b/data/monster/Trolls/island_troll.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />

--- a/data/monster/Trolls/swamp_troll.xml
+++ b/data/monster/Trolls/swamp_troll.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-13" poison="1" />

--- a/data/monster/Trolls/troll.xml
+++ b/data/monster/Trolls/troll.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-15" />

--- a/data/monster/Trolls/troll_champion.xml
+++ b/data/monster/Trolls/troll_champion.xml
@@ -14,6 +14,9 @@
 		<flag canpushcreatures="0" />
 		<flag targetdistance="1" />
 		<flag runonhealth="15" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />

--- a/data/monster/Undead_Humanoids/banshee.xml
+++ b/data/monster/Undead_Humanoids/banshee.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="500" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="3" />

--- a/data/monster/Undead_Humanoids/blightwalker.xml
+++ b/data/monster/Undead_Humanoids/blightwalker.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="800" />
+		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-490" />

--- a/data/monster/Undead_Humanoids/crypt_shambler.xml
+++ b/data/monster/Undead_Humanoids/crypt_shambler.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />

--- a/data/monster/Undead_Humanoids/death_priest.xml
+++ b/data/monster/Undead_Humanoids/death_priest.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="70" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />

--- a/data/monster/Undead_Humanoids/elder_mummy.xml
+++ b/data/monster/Undead_Humanoids/elder_mummy.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" poison="3" />

--- a/data/monster/Undead_Humanoids/ghoul.xml
+++ b/data/monster/Undead_Humanoids/ghoul.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />

--- a/data/monster/Undead_Humanoids/grim_reaper.xml
+++ b/data/monster/Undead_Humanoids/grim_reaper.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-320" />

--- a/data/monster/Undead_Humanoids/lich.xml
+++ b/data/monster/Undead_Humanoids/lich.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-75" />

--- a/data/monster/Undead_Humanoids/mummy.xml
+++ b/data/monster/Undead_Humanoids/mummy.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-85" poison="4" />

--- a/data/monster/Undead_Humanoids/tomb_servant.xml
+++ b/data/monster/Undead_Humanoids/tomb_servant.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-130" />

--- a/data/monster/Undead_Humanoids/undead_prospector.xml
+++ b/data/monster/Undead_Humanoids/undead_prospector.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Undead_Humanoids/vampire.xml
+++ b/data/monster/Undead_Humanoids/vampire.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />

--- a/data/monster/Undead_Humanoids/vampire_bride.xml
+++ b/data/monster/Undead_Humanoids/vampire_bride.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-190" />

--- a/data/monster/Undead_Humanoids/zombie.xml
+++ b/data/monster/Undead_Humanoids/zombie.xml
@@ -15,6 +15,7 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-130" />

--- a/data/monster/Ungulates/black_sheep.xml
+++ b/data/monster/Ungulates/black_sheep.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="5" defense="5" />
 	<voices interval="5000" chance="10">

--- a/data/monster/Ungulates/boar.xml
+++ b/data/monster/Ungulates/boar.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />

--- a/data/monster/Ungulates/deer.xml
+++ b/data/monster/Ungulates/deer.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1" />

--- a/data/monster/Ungulates/desperate_white_deer.xml
+++ b/data/monster/Ungulates/desperate_white_deer.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="55" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<defenses armor="15" defense="15">
 		<defense name="speed" interval="2000" chance="15" speedchange="400" duration="4000">

--- a/data/monster/Ungulates/doom_deer.xml
+++ b/data/monster/Ungulates/doom_deer.xml
@@ -15,6 +15,8 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Ungulates/dromedary.xml
+++ b/data/monster/Ungulates/dromedary.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="4" />
 		<flag staticattack="90" />
 		<flag runonhealth="45" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-8" />

--- a/data/monster/Ungulates/elephant.xml
+++ b/data/monster/Ungulates/elephant.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Ungulates/enraged_white_deer.xml
+++ b/data/monster/Ungulates/enraged_white_deer.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />

--- a/data/monster/Ungulates/evil_sheep.xml
+++ b/data/monster/Ungulates/evil_sheep.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />

--- a/data/monster/Ungulates/evil_sheep_lord.xml
+++ b/data/monster/Ungulates/evil_sheep_lord.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-118" />

--- a/data/monster/Ungulates/horse(brown).xml
+++ b/data/monster/Ungulates/horse(brown).xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="75" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<voices interval="5000" chance="10">
 		<voice sentence="Weeeeheeeeeee" />

--- a/data/monster/Ungulates/horse(fire).xml
+++ b/data/monster/Ungulates/horse(fire).xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-2" />

--- a/data/monster/Ungulates/horse(grey).xml
+++ b/data/monster/Ungulates/horse(grey).xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="75" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<voices interval="5000" chance="10">
 		<voice sentence="Weeeeheeeeeee" />

--- a/data/monster/Ungulates/horse.xml
+++ b/data/monster/Ungulates/horse.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="75" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<voices interval="5000" chance="10">
 		<voice sentence="Weeeeheeeeeee" />

--- a/data/monster/Ungulates/mammoth.xml
+++ b/data/monster/Ungulates/mammoth.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />

--- a/data/monster/Ungulates/mushroom_sniffer.xml
+++ b/data/monster/Ungulates/mushroom_sniffer.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<elements>
 		<element earthPercent="90" />

--- a/data/monster/Ungulates/pig.xml
+++ b/data/monster/Ungulates/pig.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="25" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<voices interval="5000" chance="10">
 		<voice sentence="Oink oink" />

--- a/data/monster/Ungulates/sheep.xml
+++ b/data/monster/Ungulates/sheep.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="20" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1" />

--- a/data/monster/Ungulates/stampor.xml
+++ b/data/monster/Ungulates/stampor.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-130" />

--- a/data/monster/Ungulates/terrified_elephant.xml
+++ b/data/monster/Ungulates/terrified_elephant.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Ungulates/vampire_pig.xml
+++ b/data/monster/Ungulates/vampire_pig.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="30" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />

--- a/data/monster/Ungulates/white_deer.xml
+++ b/data/monster/Ungulates/white_deer.xml
@@ -15,6 +15,9 @@
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="195" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<voices interval="5000" chance="10">
 		<voice sentence="*wheeze*" />

--- a/data/monster/Voodoo_Cultists/acolyte_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/acolyte_of_the_cult.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="4" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="2" />

--- a/data/monster/Voodoo_Cultists/adept_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/adept_of_the_cult.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="4" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" poison="2" />

--- a/data/monster/Voodoo_Cultists/enlightened_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/enlightened_of_the_cult.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="50" />
 		<flag targetdistance="4" />
 		<flag runonhealth="0" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="4" />

--- a/data/monster/Voodoo_Cultists/novice_of_the_cult.xml
+++ b/data/monster/Voodoo_Cultists/novice_of_the_cult.xml
@@ -15,6 +15,9 @@
 		<flag staticattack="90" />
 		<flag targetdistance="1" />
 		<flag runonhealth="40" />
+		<flag canwalkonenergy="0" />
+		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-65" poison="1" />

--- a/src/combat.h
+++ b/src/combat.h
@@ -339,6 +339,13 @@ class MagicField final : public Item
 			const ItemType& it = items[getID()];
 			return it.combatType;
 		}
+		int32_t getDamage() const {
+			const ItemType& it = items[getID()];
+			if (it.conditionDamage) {
+				return it.conditionDamage->getTotalDamage();
+			}
+			return 0;
+		}
 		void onStepInField(Creature* creature);
 
 	private:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3999,8 +3999,6 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			return true;
 		}
 
-		target->drainHealth(attacker, realDamage);
-
 		if (spectators.empty()) {
 			map.getSpectators(spectators, targetPos, true, true);
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3999,6 +3999,8 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			return true;
 		}
 
+		target->drainHealth(attacker, realDamage);
+
 		if (spectators.empty()) {
 			map.getSpectators(spectators, targetPos, true, true);
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1106,7 +1106,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 
 	bool result = false;
 	if ((!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
-		if (followCreature || getTimeSinceLastMove() > 1000) {
+		if (getWalkDelay() <= 0) {
 			randomSteping = true;
 			//choose a random direction
 			result = getRandomStep(getPosition(), direction);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1107,12 +1107,12 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 	bool result = false;
 	if ((!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
 		if (getWalkDelay() <= 0) {
-			randomSteping = true;
+			randomStepping = true;
 			//choose a random direction
 			result = getRandomStep(getPosition(), direction);
 		}
 	} else if ((isSummon() && isMasterInRange) || followCreature) {
-		randomSteping = false;
+		randomStepping = false;
 		result = Creature::getNextStep(direction, flags);
 		if (result) {
 			flags |= FLAG_PATHFINDING;
@@ -1907,6 +1907,12 @@ void Monster::setNormalCreatureLight()
 void Monster::drainHealth(Creature* attacker, int32_t damage)
 {
 	Creature::drainHealth(attacker, damage);
+
+	if (damage > 0 && randomStepping) {
+		ignoreFieldDamage = true;
+		updateMapCache();
+	}
+
 	if (isInvisible()) {
 		removeCondition(CONDITION_INVISIBLE);
 	}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -83,6 +83,20 @@ bool Monster::canSee(const Position& pos) const
 	return Creature::canSee(getPosition(), pos, 9, 9);
 }
 
+bool Monster::canWalkOnFieldType(CombatType_t combatType) const
+{
+	switch (combatType) {
+		case COMBAT_ENERGYDAMAGE:
+			return mType->info.canWalkOnEnergy;
+		case COMBAT_FIREDAMAGE:
+			return mType->info.canWalkOnFire;
+		case COMBAT_EARTHDAMAGE:
+			return mType->info.canWalkOnPoison;
+		default:
+			return true;
+	}
+}
+
 void Monster::onAttackedCreatureDisappear(bool)
 {
 	attackTicks = 0;
@@ -667,6 +681,7 @@ void Monster::onAddCondition(ConditionType_t type)
 void Monster::onEndCondition(ConditionType_t type)
 {
 	if (type == CONDITION_FIRE || type == CONDITION_ENERGY || type == CONDITION_POISON) {
+		ignoreFieldDamage = false;
 		updateMapCache();
 	}
 
@@ -1092,14 +1107,20 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 	bool result = false;
 	if ((!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
 		if (followCreature || getTimeSinceLastMove() > 1000) {
+			randomSteping = true;
 			//choose a random direction
 			result = getRandomStep(getPosition(), direction);
 		}
 	} else if ((isSummon() && isMasterInRange) || followCreature) {
+		randomSteping = false;
 		result = Creature::getNextStep(direction, flags);
 		if (result) {
 			flags |= FLAG_PATHFINDING;
 		} else {
+			if (ignoreFieldDamage) {
+				ignoreFieldDamage = false;
+				updateMapCache();
+			}
 			//target dancing
 			if (attackedCreature && attackedCreature == followCreature) {
 				if (isFleeing()) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -123,6 +123,8 @@ class Monster final : public Creature
 		void setSpawn(Spawn* spawn) {
 			this->spawn = spawn;
 		}
+		bool canWalkOnFieldType(CombatType_t combatType) const;
+
 
 		void onAttackedCreatureDisappear(bool isLogout) override;
 
@@ -168,6 +170,15 @@ class Monster final : public Creature
 		bool isTargetNearby() const {
 			return stepDuration >= 1;
 		}
+		bool isRandomSteping() const {
+			return randomSteping;
+		}
+		void setIgnoreFieldDamage(bool ignore) {
+			ignoreFieldDamage = ignore;
+		}
+		bool getIgnoreFieldDamage() const {
+			return ignoreFieldDamage;
+		}
 
 		BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
 		                     bool checkDefense = false, bool checkArmor = false, bool field = false) override;
@@ -200,6 +211,8 @@ class Monster final : public Creature
 		bool isIdle = true;
 		bool extraMeleeAttack = false;
 		bool isMasterInRange = false;
+		bool randomSteping = false;
+		bool ignoreFieldDamage = false;
 
 		void onCreatureEnter(Creature* creature);
 		void onCreatureLeave(Creature* creature);

--- a/src/monster.h
+++ b/src/monster.h
@@ -170,13 +170,7 @@ class Monster final : public Creature
 		bool isTargetNearby() const {
 			return stepDuration >= 1;
 		}
-		bool isRandomSteping() const {
-			return randomSteping;
-		}
-		void setIgnoreFieldDamage(bool ignore) {
-			ignoreFieldDamage = ignore;
-		}
-		bool getIgnoreFieldDamage() const {
+		bool isIgnoringFieldDamage() const {
 			return ignoreFieldDamage;
 		}
 
@@ -211,7 +205,7 @@ class Monster final : public Creature
 		bool isIdle = true;
 		bool extraMeleeAttack = false;
 		bool isMasterInRange = false;
-		bool randomSteping = false;
+		bool randomStepping = false;
 		bool ignoreFieldDamage = false;
 
 		void onCreatureEnter(Creature* creature);
@@ -277,7 +271,7 @@ class Monster final : public Creature
 		}
 		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
 		bool useCacheMap() const override {
-			return !randomSteping;
+			return !randomStepping;
 		}
 
 		friend class LuaScriptInterface;

--- a/src/monster.h
+++ b/src/monster.h
@@ -277,7 +277,7 @@ class Monster final : public Creature
 		}
 		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
 		bool useCacheMap() const override {
-			return true;
+			return !randomSteping;
 		}
 
 		friend class LuaScriptInterface;

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -760,6 +760,12 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 				mType->info.runAwayHealth = pugi::cast<int32_t>(attr.value());
 			} else if (strcasecmp(attrName, "hidehealth") == 0) {
 				mType->info.hiddenHealth = attr.as_bool();
+			} else if (strcasecmp(attrName, "canwalkonenergy") == 0) {
+				mType->info.canWalkOnEnergy = attr.as_bool();
+			} else if (strcasecmp(attrName, "canwalkonfire") == 0) {
+				mType->info.canWalkOnFire = attr.as_bool();
+			} else if (strcasecmp(attrName, "canwalkonpoison") == 0) {
+				mType->info.canWalkOnPoison = attr.as_bool();
 			} else {
 				std::cout << "[Warning - Monsters::loadMonster] Unknown flag attribute: " << attrName << ". " << file << std::endl;
 			}

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -144,6 +144,9 @@ class MonsterType
 		bool isAttackable = true;
 		bool isHostile = true;
 		bool hiddenHealth = false;
+		bool canWalkOnEnergy = true;
+		bool canWalkOnFire = true;
+		bool canWalkOnPoison = true;
 	};
 
 	public:

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -534,20 +534,19 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 			}
 
 			MagicField* field = getFieldItem();
-			if (!field || field->isBlocking()) {
+			if (!field || field->isBlocking() || field->getDamage() == 0) {
 				return RETURNVALUE_NOERROR;
 			}
 
 			CombatType_t combatType = field->getCombatType();
 
 			//There is 3 options for a monster to enter a magic field
-			//1) Monster is able to walk over field type
+			//1) Monster is immune
 			if (!monster->isImmune(combatType)) {
 				//1) Monster is able to walk over field type
-				//2) Monster is already afflicated by this type of condition
-				//3) Being attacked while random stepping will make it ignore field damages
+				//2) Being attacked while random stepping will make it ignore field damages
 				if (hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
-					if (!(monster->canWalkOnFieldType(combatType) || monster->getIgnoreFieldDamage() || monster->hasCondition(Combat::DamageToConditionType(combatType)))) {
+					if (!(monster->canWalkOnFieldType(combatType) || monster->getIgnoreFieldDamage())) {
 						return RETURNVALUE_NOTPOSSIBLE;
 					}
 				} else {

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -541,12 +541,13 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 			CombatType_t combatType = field->getCombatType();
 
 			//There is 3 options for a monster to enter a magic field
-			//1) Monster is immune
+			//1) Monster is able to walk over field type
 			if (!monster->isImmune(combatType)) {
-				//1) Monster is "strong" enough to handle the damage
+				//1) Monster is able to walk over field type
 				//2) Monster is already afflicated by this type of condition
+				//3) Being attacked while random stepping will make it ignore field damages
 				if (hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
-					if (!(monster->canPushItems() || monster->hasCondition(Combat::DamageToConditionType(combatType)))) {
+					if (!(monster->canWalkOnFieldType(combatType) || monster->getIgnoreFieldDamage() || monster->hasCondition(Combat::DamageToConditionType(combatType)))) {
 						return RETURNVALUE_NOTPOSSIBLE;
 					}
 				} else {

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -546,7 +546,7 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 				//1) Monster is able to walk over field type
 				//2) Being attacked while random stepping will make it ignore field damages
 				if (hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
-					if (!(monster->canWalkOnFieldType(combatType) || monster->getIgnoreFieldDamage())) {
+					if (!(monster->canWalkOnFieldType(combatType) || monster->isIgnoringFieldDamage())) {
 						return RETURNVALUE_NOTPOSSIBLE;
 					}
 				} else {


### PR DESCRIPTION
Removed the "strong" condition for going through fields as this is not accurate. Replaced it with flags in monsters:
"canwalkonenergy", "canwalkonfire", "canwalkonpoison".

All monsters have these flags defaulted to 1 unless specified in the XML.

Added a new condition for the monster to go through a field:
Monsters that can't go through a certain field type will ignore it if it has been attacked while he is random stepping (no available reachable target).