### PR TITLE
Try and use link-time optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 include(FindCXX11)
+include(FindLTO)
 
 # Find packages.
 find_package(GMP REQUIRED)

--- a/cmake/FindLTO.cmake
+++ b/cmake/FindLTO.cmake
@@ -1,0 +1,12 @@
+if(__FIND_LTO_CMAKE__)
+    return()
+endif()
+set(__FIND_LTO_CMAKE__ TRUE)
+
+include(CheckCXXCompilerFlag)
+enable_language(CXX)
+
+check_cxx_compiler_flag("-flto" COMPILER_KNOWS_LTO)
+if(COMPILER_KNOWS_LTO)
+    add_compile_options(-flto)
+endif()


### PR DESCRIPTION
In a similar fashion to how `-std=c++11` is enabled, now try and load `-flto` which does [link-time optimization](https://gcc.gnu.org/onlinedocs/gccint/LTO.html). Should generate smaller and potentially faster code.