### PR TITLE
Fix party spells

### DIFF
--- a/data/spells/lib/spells.lua
+++ b/data/spells/lib/spells.lua
@@ -301,13 +301,20 @@ function Creature:addDamageCondition(target, conditionType, listType, damage, ti
 	return true
 end
 
-function Player:addPartyCondition(combat, variant, positions, condition, baseMana)
+function Player:addPartyCondition(combat, variant, condition, baseMana)
 	local party = self:getParty()
 	if not party then
 		self:sendCancelMessage(RETURNVALUE_NOPARTYMEMBERSINRANGE)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)
 		return false
 	end
+
+	local positions = {}
+	function onTargetTile(creature, position)
+		positions[#positions + 1] = position
+	end
+
+	combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
 
 	if not combat:execute(self, variant) then
 		return false
@@ -351,3 +358,4 @@ function Player:addPartyCondition(combat, variant, positions, condition, baseMan
 	self:addManaSpent(mana)
 	return true
 end
+

--- a/data/spells/lib/spells.lua
+++ b/data/spells/lib/spells.lua
@@ -302,14 +302,14 @@ function Creature:addDamageCondition(target, conditionType, listType, damage, ti
 end
 
 function Player:addPartyCondition(combat, variant, positions, condition, baseMana)
-	if not combat:execute(self, variant) then
-		return false
-	end
-
 	local party = self:getParty()
 	if not party then
 		self:sendCancelMessage(RETURNVALUE_NOPARTYMEMBERSINRANGE)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
+
+	if not combat:execute(self, variant) then
 		return false
 	end
 

--- a/data/spells/scripts/party/enchant.lua
+++ b/data/spells/scripts/party/enchant.lua
@@ -6,15 +6,6 @@ condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
 condition:setParameter(CONDITION_PARAM_STAT_MAGICPOINTS, 1)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-local positions
-
-function onTargetTile(creature, position)
-	positions[#positions + 1] = position
-end
-
-combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
-
 function onCastSpell(creature, variant)
-	positions = {}
-	return creature:addPartyCondition(combat, variant, positions, condition, 120)
+	return creature:addPartyCondition(combat, variant, condition, 120)
 end

--- a/data/spells/scripts/party/enchant.lua
+++ b/data/spells/scripts/party/enchant.lua
@@ -1,14 +1,20 @@
 local combat = Combat()
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
-combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_ATTRIBUTES)
-condition:setParameter(CONDITION_PARAM_SUBID, 3)
 condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
 condition:setParameter(CONDITION_PARAM_STAT_MAGICPOINTS, 1)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
+local positions
+
+function onTargetTile(creature, position)
+	positions[#positions + 1] = position
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+
 function onCastSpell(creature, variant)
-	return creature:addPartyCondition(combat, variant, condition, 120)
+	positions = {}
+	return creature:addPartyCondition(combat, variant, positions, condition, 120)
 end

--- a/data/spells/scripts/party/heal.lua
+++ b/data/spells/scripts/party/heal.lua
@@ -1,15 +1,22 @@
 local combat = Combat()
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
-combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_REGENERATION)
-condition:setParameter(CONDITION_PARAM_SUBID, 4)
 condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
 condition:setParameter(CONDITION_PARAM_HEALTHGAIN, 20)
-condition:setParameter(CONDITION_PARAM_HEALTHTICKS, 2000)
+condition:setParameter(CONDITION_PARAM_HEALTHTICKS, 2 * 1000)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-function onCastSpell(creature, variant)
-	return creature:addPartyCondition(combat, variant, condition, 120)
+local positions
+
+function onTargetTile(creature, position)
+	positions[#positions + 1] = position
 end
+
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+
+function onCastSpell(creature, variant)
+	positions = {}
+	return creature:addPartyCondition(combat, variant, positions, condition, 120)
+end
+

--- a/data/spells/scripts/party/heal.lua
+++ b/data/spells/scripts/party/heal.lua
@@ -7,16 +7,7 @@ condition:setParameter(CONDITION_PARAM_HEALTHGAIN, 20)
 condition:setParameter(CONDITION_PARAM_HEALTHTICKS, 2 * 1000)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-local positions
-
-function onTargetTile(creature, position)
-	positions[#positions + 1] = position
-end
-
-combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
-
 function onCastSpell(creature, variant)
-	positions = {}
-	return creature:addPartyCondition(combat, variant, positions, condition, 120)
+	return creature:addPartyCondition(combat, variant, condition, 120)
 end
 

--- a/data/spells/scripts/party/protect.lua
+++ b/data/spells/scripts/party/protect.lua
@@ -6,16 +6,7 @@ condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
 condition:setParameter(CONDITION_PARAM_SKILL_SHIELD, 3)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-local positions
-
-function onTargetTile(creature, position)
-	positions[#positions + 1] = position
-end
-
-combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
-
 function onCastSpell(creature, variant)
-	positions = {}
-	return creature:addPartyCondition(combat, variant, positions, condition, 90)
+	return creature:addPartyCondition(combat, variant, condition, 90)
 end
 

--- a/data/spells/scripts/party/protect.lua
+++ b/data/spells/scripts/party/protect.lua
@@ -1,14 +1,21 @@
 local combat = Combat()
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
-combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_ATTRIBUTES)
-condition:setParameter(CONDITION_PARAM_SUBID, 2)
 condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
 condition:setParameter(CONDITION_PARAM_SKILL_SHIELD, 3)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-function onCastSpell(creature, variant)
-	return creature:addPartyCondition(combat, variant, condition, 90)
+local positions
+
+function onTargetTile(creature, position)
+	positions[#positions + 1] = position
 end
+
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+
+function onCastSpell(creature, variant)
+	positions = {}
+	return creature:addPartyCondition(combat, variant, positions, condition, 90)
+end
+

--- a/data/spells/scripts/party/train.lua
+++ b/data/spells/scripts/party/train.lua
@@ -1,16 +1,22 @@
 local combat = Combat()
-combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
-combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 local condition = Condition(CONDITION_ATTRIBUTES)
-condition:setParameter(CONDITION_PARAM_SUBID, 1)
 condition:setParameter(CONDITION_PARAM_TICKS, 2 * 60 * 1000)
 condition:setParameter(CONDITION_PARAM_SKILL_FIST, 3)
 condition:setParameter(CONDITION_PARAM_SKILL_MELEE, 3)
 condition:setParameter(CONDITION_PARAM_SKILL_DISTANCE, 3)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
+local positions
+
+function onTargetTile(creature, position)
+	positions[#positions + 1] = position
+end
+
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
+
 function onCastSpell(creature, variant)
-	return creature:addPartyCondition(combat, variant, condition, 60)
+	positions = {}
+	return creature:addPartyCondition(combat, variant, positions, condition, 60)
 end

--- a/data/spells/scripts/party/train.lua
+++ b/data/spells/scripts/party/train.lua
@@ -8,15 +8,6 @@ condition:setParameter(CONDITION_PARAM_SKILL_MELEE, 3)
 condition:setParameter(CONDITION_PARAM_SKILL_DISTANCE, 3)
 condition:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-local positions
-
-function onTargetTile(creature, position)
-	positions[#positions + 1] = position
-end
-
-combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onTargetTile")
-
 function onCastSpell(creature, variant)
-	positions = {}
-	return creature:addPartyCondition(combat, variant, positions, condition, 60)
+	return creature:addPartyCondition(combat, variant, condition, 60)
 end

--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -103,7 +103,7 @@
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>
-	<instant group="support" spellid="129" name="Enchant Party" words="utori mas sio" lvl="32" mana="120" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/enchant.lua">
+	<instant group="support" spellid="129" name="Enchant Party" words="utori mas sio" lvl="32" mana="0" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/enchant.lua">
 		<vocation name="Sorcerer" />
 		<vocation name="Master Sorcerer" />
 	</instant>
@@ -197,7 +197,7 @@
 		<vocation name="Druid" />
 		<vocation name="Elder Druid" />
 	</instant>
-	<instant group="support" spellid="128" name="Heal Party" words="utura mas sio" lvl="32" mana="120" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/heal.lua">
+	<instant group="support" spellid="128" name="Heal Party" words="utura mas sio" lvl="32" mana="0" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/heal.lua">
 		<vocation name="Druid" />
 		<vocation name="Elder Druid" />
 	</instant>
@@ -325,7 +325,7 @@
 	<instant group="healing" spellid="166" name="Practise Healing" words="exura dis" lvl="1" mana="5" aggressive="0" selftarget="1" cooldown="1000" groupcooldown="1000" needlearn="0" script="healing/practise_healing.lua">
 		<vocation name="None" />
 	</instant>
-	<instant group="support" spellid="127" name="Protect Party" words="utamo mas sio" lvl="32" mana="90" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/protect.lua">
+	<instant group="support" spellid="127" name="Protect Party" words="utamo mas sio" lvl="32" mana="0" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/protect.lua">
 		<vocation name="Paladin" />
 		<vocation name="Royal Paladin" />
 	</instant>
@@ -405,7 +405,7 @@
 		<vocation name="Druid" />
 		<vocation name="Elder Druid" />
 	</instant>
-	<instant group="support" spellid="126" name="Train Party" words="utito mas sio" lvl="32" mana="60" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/train.lua">
+	<instant group="support" spellid="126" name="Train Party" words="utito mas sio" lvl="32" mana="0" prem="1" aggressive="0" selftarget="1" cooldown="2000" groupcooldown="2000" needlearn="0" script="party/train.lua">
 		<vocation name="Knight" />
 		<vocation name="Elite Knight" />
 	</instant>


### PR DESCRIPTION
* Fixed a **bug** where the former code was getting the *affected party members* **by distance from the caster member to other party members**. The affected party members are now gotten **through the positions of the area of effect of these spells**.

In addition of the bug-fix I also took the time to remove subIds of these spells (cause using them makes the spell behavior to differ from that of vanilla) . Removing these subIds keeps the same default behavior before I introduced these changes in #2004.