### PR TITLE
Non-pushable walking NPC

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -738,7 +738,7 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 			}
 
 			Npc* movingNpc = movingCreature->getNpc();
-            if (movingNpc && (!movingNpc->isPushable() || !Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos))) {
+			if (movingNpc && (!movingNpc->isPushable() || !Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos))) {
 				player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 				return;
 			}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -738,7 +738,7 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 			}
 
 			Npc* movingNpc = movingCreature->getNpc();
-			if (movingNpc && (!movingNpc->isPushable() || !Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos))) {
+			if (movingNpc && !Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos)) {
 				player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 				return;
 			}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -738,7 +738,7 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 			}
 
 			Npc* movingNpc = movingCreature->getNpc();
-			if (movingNpc && !Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos)) {
+            if (movingNpc && (!movingNpc->isPushable() || !Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos))) {
 				player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 				return;
 			}

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -99,7 +99,7 @@ void Npc::reset()
 {
 	loaded = false;
 	walkTicks = 1500;
-    pushable = true;
+	pushable = true;
 	floorChange = false;
 	attackable = false;
 	ignoreHeight = true;
@@ -145,7 +145,7 @@ bool Npc::loadFromXml()
 
 	name = npcNode.attribute("name").as_string();
 	attackable = npcNode.attribute("attackable").as_bool();
-    floorChange = npcNode.attribute("floorchange").as_bool();
+	floorChange = npcNode.attribute("floorchange").as_bool();
 
 	pugi::xml_attribute attr;
 	if ((attr = npcNode.attribute("speed"))) {
@@ -154,11 +154,11 @@ bool Npc::loadFromXml()
 		baseSpeed = 100;
 	}
 
-    if((attr = npcNode.attribute("pushable"))) {
-        pushable = attr.as_bool();
-    } else {
-        pushable = true;
-    }
+        if((attr = npcNode.attribute("pushable"))) {
+            pushable = attr.as_bool();
+        } else {
+            pushable = true;
+        }
 
 	if ((attr = npcNode.attribute("walkinterval"))) {
 		walkTicks = pugi::cast<uint32_t>(attr.value());

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -99,6 +99,7 @@ void Npc::reset()
 {
 	loaded = false;
 	walkTicks = 1500;
+    pushable = true;
 	floorChange = false;
 	attackable = false;
 	ignoreHeight = true;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -145,6 +145,7 @@ bool Npc::loadFromXml()
 	name = npcNode.attribute("name").as_string();
 	attackable = npcNode.attribute("attackable").as_bool();
 	floorChange = npcNode.attribute("floorchange").as_bool();
+    pushable = npcNode.attribute("pushable").as_bool();
 
 	pugi::xml_attribute attr;
 	if ((attr = npcNode.attribute("speed"))) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -144,8 +144,7 @@ bool Npc::loadFromXml()
 
 	name = npcNode.attribute("name").as_string();
 	attackable = npcNode.attribute("attackable").as_bool();
-	floorChange = npcNode.attribute("floorchange").as_bool();
-    pushable = npcNode.attribute("pushable").as_bool();
+    floorChange = npcNode.attribute("floorchange").as_bool();
 
 	pugi::xml_attribute attr;
 	if ((attr = npcNode.attribute("speed"))) {
@@ -153,6 +152,12 @@ bool Npc::loadFromXml()
 	} else {
 		baseSpeed = 100;
 	}
+
+    if((attr = npcNode.attribute("pushable"))) {
+        pushable = attr.as_bool();
+    } else {
+        pushable = true;
+    }
 
 	if ((attr = npcNode.attribute("walkinterval"))) {
 		walkTicks = pugi::cast<uint32_t>(attr.value());

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -154,11 +154,9 @@ bool Npc::loadFromXml()
 		baseSpeed = 100;
 	}
 
-        if((attr = npcNode.attribute("pushable"))) {
-            pushable = attr.as_bool();
-        } else {
-            pushable = true;
-        }
+	if ((attr = npcNode.attribute("pushable"))) {
+		pushable = attr.as_bool();
+	}
 
 	if ((attr = npcNode.attribute("walkinterval"))) {
 		walkTicks = pugi::cast<uint32_t>(attr.value());

--- a/src/npc.h
+++ b/src/npc.h
@@ -118,7 +118,7 @@ class Npc final : public Creature
 		}
 
 		bool isPushable() const final {
-			return walkTicks > 0 && pushable;
+			return pushable && walkTicks != 0;
 		}
 
 		void setID() final {

--- a/src/npc.h
+++ b/src/npc.h
@@ -118,7 +118,7 @@ class Npc final : public Creature
 		}
 
 		bool isPushable() const final {
-			return walkTicks > 0;
+            return walkTicks > 0 && pushable;
 		}
 
 		void setID() final {
@@ -244,6 +244,7 @@ class Npc final : public Creature
 		bool ignoreHeight;
 		bool loaded;
 		bool isIdle;
+        bool pushable;
 
 		static NpcScriptInterface* scriptInterface;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -118,7 +118,7 @@ class Npc final : public Creature
 		}
 
 		bool isPushable() const final {
-            return walkTicks > 0 && pushable;
+			return walkTicks > 0 && pushable;
 		}
 
 		void setID() final {
@@ -244,7 +244,7 @@ class Npc final : public Creature
 		bool ignoreHeight;
 		bool loaded;
 		bool isIdle;
-        bool pushable;
+		bool pushable;
 
 		static NpcScriptInterface* scriptInterface;
 


### PR DESCRIPTION
This will allow marking NPCs as non-pushable even if they can walk on their own. "pushable" XML attribute is optional.