### PR TITLE
make ProtocolGame::login use loadPlayerById instead of loadPlayerByName

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -126,7 +126,7 @@ void ProtocolGame::login(const std::string& name, uint32_t accountId, OperatingS
 			return;
 		}
 
-		if (!IOLoginData::loadPlayerByName(player, name)) {
+		if (!IOLoginData::loadPlayerById(player, player->getGUID())) {
 			disconnectClient("Your character could not be loaded.");
 			return;
 		}


### PR DESCRIPTION
Since the ID was already loaded in preloadPlayer earlier in this function, why not use ID instead of name? Not only it seems more correct to load it using PK - even if `name` column is unique and indexed - but is better for performance.