### PR TITLE
Fix monster reload

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -635,7 +635,7 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 
 	if (reloading) {
 		auto it = monsters.find(asLowerCaseString(monsterName));
-		if (it == monsters.end()) {
+		if (it != monsters.end()) {
 			mType = &it->second;
 			mType->info = {};
 		}


### PR DESCRIPTION
Forgot to make a pull request. It fixes the issue #2255 of doubling monster's attacks and loot during reload.