### PR TITLE
changed warlock shootEfect from "burstarrow" to "fire" as said at #2277

### DIFF
--- a/data/monster/Sorcerers/warlock.xml
+++ b/data/monster/Sorcerers/warlock.xml
@@ -24,7 +24,7 @@
 		<attack name="warlock skill reducer" range="5" interval="2000" chance="5" />
 		<attack name="manadrain" interval="2000" chance="10" range="7" min="0" max="-120" />
 		<attack name="fire" interval="2000" chance="20" range="7" radius="3" target="1" min="-50" max="-180">
-			<attribute key="shootEffect" value="burstarrow" />
+			<attribute key="shootEffect" value="fire" />
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
 		<attack name="firefield" interval="2000" chance="10" range="7" radius="2" target="1">


### PR DESCRIPTION
As @murilow1 said at #2277, the current warlock shoot effect its wrong, the right one is fire.