### PR TITLE
Use base magic level instead of total for condition percent

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -423,7 +423,7 @@ void ConditionAttributes::updatePercentStats(Player* player)
 				break;
 
 			case STAT_MAGICPOINTS:
-				stats[i] = static_cast<int32_t>(player->getMagicLevel() * ((statsPercent[i] - 100) / 100.f));
+				stats[i] = static_cast<int32_t>(player->getBaseMagicLevel() * ((statsPercent[i] - 100) / 100.f));
 				break;
 		}
 	}


### PR DESCRIPTION
this may cause player to earn more magic points than indeed when affected by conditions, like wearing items or casting spells that increase magic points before get affected by a condition