### PR TITLE
Transform Database class into namespace

### DIFF
--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -60,12 +60,10 @@ bool Ban::acceptConnection(uint32_t clientip)
 
 bool IOBan::isAccountBanned(uint32_t accountId, BanInfo& banInfo)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "SELECT `reason`, `expires_at`, `banned_at`, `banned_by`, (SELECT `name` FROM `players` WHERE `id` = `banned_by`) AS `name` FROM `account_bans` WHERE `account_id` = " << accountId;
 
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -74,7 +72,7 @@ bool IOBan::isAccountBanned(uint32_t accountId, BanInfo& banInfo)
 	if (expiresAt != 0 && time(nullptr) > expiresAt) {
 		// Move the ban to history if it has expired
 		query.str(std::string());
-		query << "INSERT INTO `account_ban_history` (`account_id`, `reason`, `banned_at`, `expired_at`, `banned_by`) VALUES (" << accountId << ',' << db.escapeString(result->getString("reason")) << ',' << result->getNumber<time_t>("banned_at") << ',' << expiresAt << ',' << result->getNumber<uint32_t>("banned_by") << ')';
+		query << "INSERT INTO `account_ban_history` (`account_id`, `reason`, `banned_at`, `expired_at`, `banned_by`) VALUES (" << accountId << ',' << Database::escapeString(result->getString("reason")) << ',' << result->getNumber<time_t>("banned_at") << ',' << expiresAt << ',' << result->getNumber<uint32_t>("banned_by") << ')';
 		g_databaseTasks.addTask(query.str());
 
 		query.str(std::string());
@@ -95,12 +93,10 @@ bool IOBan::isIpBanned(uint32_t clientip, BanInfo& banInfo)
 		return false;
 	}
 
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "SELECT `reason`, `expires_at`, (SELECT `name` FROM `players` WHERE `id` = `banned_by`) AS `name` FROM `ip_bans` WHERE `ip` = " << clientip;
 
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -123,5 +119,5 @@ bool IOBan::isPlayerNamelocked(uint32_t playerId)
 {
 	std::ostringstream query;
 	query << "SELECT 1 FROM `player_namelocks` WHERE `player_id` = " << playerId;
-	return Database::getInstance().storeQuery(query.str()).get() != nullptr;
+	return Database::storeQuery(query.str()).get() != nullptr;
 }

--- a/src/databasemanager.cpp
+++ b/src/databasemanager.cpp
@@ -27,11 +27,10 @@ extern ConfigManager g_config;
 
 bool DatabaseManager::optimizeTables()
 {
-	Database& db = Database::getInstance();
 	std::ostringstream query;
 
-	query << "SELECT `TABLE_NAME` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_config.getString(ConfigManager::MYSQL_DB)) << " AND `DATA_FREE` > 0";
-	DBResult_ptr result = db.storeQuery(query.str());
+	query << "SELECT `TABLE_NAME` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA` = " << Database::escapeString(g_config.getString(ConfigManager::MYSQL_DB)) << " AND `DATA_FREE` > 0";
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -43,7 +42,7 @@ bool DatabaseManager::optimizeTables()
 		query.str(std::string());
 		query << "OPTIMIZE TABLE `" << tableName << '`';
 
-		if (db.executeQuery(query.str())) {
+		if (Database::executeQuery(query.str())) {
 			std::cout << " [success]" << std::endl;
 		} else {
 			std::cout << " [failed]" << std::endl;
@@ -54,27 +53,23 @@ bool DatabaseManager::optimizeTables()
 
 bool DatabaseManager::tableExists(const std::string& tableName)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_config.getString(ConfigManager::MYSQL_DB)) << " AND `TABLE_NAME` = " << db.escapeString(tableName) << " LIMIT 1";
-	return db.storeQuery(query.str()).get() != nullptr;
+	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << Database::escapeString(g_config.getString(ConfigManager::MYSQL_DB)) << " AND `TABLE_NAME` = " << Database::escapeString(tableName) << " LIMIT 1";
+	return Database::storeQuery(query.str()).get() != nullptr;
 }
 
 bool DatabaseManager::isDatabaseSetup()
 {
-	Database& db = Database::getInstance();
 	std::ostringstream query;
-	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_config.getString(ConfigManager::MYSQL_DB));
-	return db.storeQuery(query.str()).get() != nullptr;
+	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << Database::escapeString(g_config.getString(ConfigManager::MYSQL_DB));
+	return Database::storeQuery(query.str()).get() != nullptr;
 }
 
 int32_t DatabaseManager::getDatabaseVersion()
 {
 	if (!tableExists("server_config")) {
-		Database& db = Database::getInstance();
-		db.executeQuery("CREATE TABLE `server_config` (`config` VARCHAR(50) NOT NULL, `value` VARCHAR(256) NOT NULL DEFAULT '', UNIQUE(`config`)) ENGINE = InnoDB");
-		db.executeQuery("INSERT INTO `server_config` VALUES ('db_version', 0)");
+		Database::executeQuery("CREATE TABLE `server_config` (`config` VARCHAR(50) NOT NULL, `value` VARCHAR(256) NOT NULL DEFAULT '', UNIQUE(`config`)) ENGINE = InnoDB");
+		Database::executeQuery("INSERT INTO `server_config` VALUES ('Database::version', 0)");
 		return 0;
 	}
 
@@ -142,11 +137,10 @@ void DatabaseManager::updateDatabase()
 
 bool DatabaseManager::getDatabaseConfig(const std::string& config, int32_t& value)
 {
-	Database& db = Database::getInstance();
 	std::ostringstream query;
-	query << "SELECT `value` FROM `server_config` WHERE `config` = " << db.escapeString(config);
+	query << "SELECT `value` FROM `server_config` WHERE `config` = " << Database::escapeString(config);
 
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -157,16 +151,15 @@ bool DatabaseManager::getDatabaseConfig(const std::string& config, int32_t& valu
 
 void DatabaseManager::registerDatabaseConfig(const std::string& config, int32_t value)
 {
-	Database& db = Database::getInstance();
 	std::ostringstream query;
 
 	int32_t tmp;
 
 	if (!getDatabaseConfig(config, tmp)) {
-		query << "INSERT INTO `server_config` VALUES (" << db.escapeString(config) << ", '" << value << "')";
+		query << "INSERT INTO `server_config` VALUES (" << Database::escapeString(config) << ", '" << value << "')";
 	} else {
-		query << "UPDATE `server_config` SET `value` = '" << value << "' WHERE `config` = " << db.escapeString(config);
+		query << "UPDATE `server_config` SET `value` = '" << value << "' WHERE `config` = " << Database::escapeString(config);
 	}
 
-	db.executeQuery(query.str());
+	Database::executeQuery(query.str());
 }

--- a/src/databasetasks.cpp
+++ b/src/databasetasks.cpp
@@ -27,7 +27,7 @@ extern Dispatcher g_dispatcher;
 
 void DatabaseTasks::start()
 {
-	db.connect();
+	Database::connect();
 	ThreadHolder::start();
 }
 
@@ -71,11 +71,11 @@ void DatabaseTasks::runTask(const DatabaseTask& task)
 	bool success;
 	DBResult_ptr result;
 	if (task.store) {
-		result = db.storeQuery(task.query);
+		result = Database::storeQuery(task.query);
 		success = true;
 	} else {
 		result = nullptr;
-		success = db.executeQuery(task.query);
+		success = Database::executeQuery(task.query);
 	}
 
 	if (task.callback) {

--- a/src/databasetasks.h
+++ b/src/databasetasks.h
@@ -48,7 +48,6 @@ class DatabaseTasks : public ThreadHolder<DatabaseTasks>
 	private:
 		void runTask(const DatabaseTask& task);
 
-		Database db;
 		std::thread thread;
 		std::list<DatabaseTask> tasks;
 		std::mutex taskLock;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4577,37 +4577,33 @@ void Game::updatePremium(Account& account)
 
 void Game::loadMotdNum()
 {
-	Database& db = Database::getInstance();
-
-	DBResult_ptr result = db.storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'motd_num'");
+	DBResult_ptr result = Database::storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'motd_num'");
 	if (result) {
 		motdNum = result->getNumber<uint32_t>("value");
 	} else {
-		db.executeQuery("INSERT INTO `server_config` (`config`, `value`) VALUES ('motd_num', '0')");
+		Database::executeQuery("INSERT INTO `server_config` (`config`, `value`) VALUES ('motd_num', '0')");
 	}
 
-	result = db.storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'motd_hash'");
+	result = Database::storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'motd_hash'");
 	if (result) {
 		motdHash = result->getString("value");
 		if (motdHash != transformToSHA1(g_config.getString(ConfigManager::MOTD))) {
 			++motdNum;
 		}
 	} else {
-		db.executeQuery("INSERT INTO `server_config` (`config`, `value`) VALUES ('motd_hash', '')");
+		Database::executeQuery("INSERT INTO `server_config` (`config`, `value`) VALUES ('motd_hash', '')");
 	}
 }
 
 void Game::saveMotdNum() const
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "UPDATE `server_config` SET `value` = '" << motdNum << "' WHERE `config` = 'motd_num'";
-	db.executeQuery(query.str());
+	Database::executeQuery(query.str());
 
 	query.str(std::string());
 	query << "UPDATE `server_config` SET `value` = '" << transformToSHA1(g_config.getString(ConfigManager::MOTD)) << "' WHERE `config` = 'motd_hash'";
-	db.executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void Game::checkPlayersRecord()
@@ -4626,22 +4622,18 @@ void Game::checkPlayersRecord()
 
 void Game::updatePlayersRecord() const
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "UPDATE `server_config` SET `value` = '" << playersRecord << "' WHERE `config` = 'players_record'";
-	db.executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void Game::loadPlayersRecord()
 {
-	Database& db = Database::getInstance();
-
-	DBResult_ptr result = db.storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'players_record'");
+	DBResult_ptr result = Database::storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'players_record'");
 	if (result) {
 		playersRecord = result->getNumber<uint32_t>("value");
 	} else {
-		db.executeQuery("INSERT INTO `server_config` (`config`, `value`) VALUES ('players_record', '0')");
+		Database::executeQuery("INSERT INTO `server_config` (`config`, `value`) VALUES ('players_record', '0')");
 	}
 }
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -41,11 +41,9 @@ void House::addTile(HouseTile* tile)
 void House::setOwner(uint32_t guid, bool updateDatabase/* = true*/, Player* player/* = nullptr*/)
 {
 	if (updateDatabase && owner != guid) {
-		Database& db = Database::getInstance();
-
 		std::ostringstream query;
 		query << "UPDATE `houses` SET `owner` = " << guid << ", `bid` = 0, `bid_end` = 0, `last_bid` = 0, `highest_bidder` = 0  WHERE `id` = " << id;
-		db.executeQuery(query.str());
+		Database::executeQuery(query.str());
 	}
 
 	if (isLoaded && owner == guid) {

--- a/src/ioguild.cpp
+++ b/src/ioguild.cpp
@@ -24,12 +24,10 @@
 
 uint32_t IOGuild::getGuildIdByName(const std::string& name)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `id` FROM `guilds` WHERE `name` = " << db.escapeString(name);
+	query << "SELECT `id` FROM `guilds` WHERE `name` = " << Database::escapeString(name);
 
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return 0;
 	}
@@ -41,7 +39,7 @@ void IOGuild::getWarList(uint32_t guildId, GuildWarVector& guildWarVector)
 	std::ostringstream query;
 	query << "SELECT `guild1`, `guild2` FROM `guild_wars` WHERE (`guild1` = " << guildId << " OR `guild2` = " << guildId << ") AND `ended` = 0 AND `status` = 1";
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return;
 	}

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -32,7 +32,7 @@ Account IOLoginData::loadAccount(uint32_t accno)
 
 	std::ostringstream query;
 	query << "SELECT `id`, `name`, `password`, `type`, `premdays`, `lastday` FROM `accounts` WHERE `id` = " << accno;
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return account;
 	}
@@ -49,7 +49,7 @@ bool IOLoginData::saveAccount(const Account& acc)
 {
 	std::ostringstream query;
 	query << "UPDATE `accounts` SET `premdays` = " << acc.premiumDays << ", `lastday` = " << acc.lastDay << " WHERE `id` = " << acc.id;
-	return Database::getInstance().executeQuery(query.str());
+	return Database::executeQuery(query.str());
 }
 
 std::string decodeSecret(const std::string& secret)
@@ -83,11 +83,9 @@ std::string decodeSecret(const std::string& secret)
 
 bool IOLoginData::loginserverAuthentication(const std::string& name, const std::string& password, Account& account)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `id`, `name`, `password`, `secret`, `type`, `premdays`, `lastday` FROM `accounts` WHERE `name` = " << db.escapeString(name);
-	DBResult_ptr result = db.storeQuery(query.str());
+	query << "SELECT `id`, `name`, `password`, `secret`, `type`, `premdays`, `lastday` FROM `accounts` WHERE `name` = " << Database::escapeString(name);
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -105,7 +103,7 @@ bool IOLoginData::loginserverAuthentication(const std::string& name, const std::
 
 	query.str(std::string());
 	query << "SELECT `name`, `deletion` FROM `players` WHERE `account_id` = " << account.id;
-	result = db.storeQuery(query.str());
+	result = Database::storeQuery(query.str());
 	if (result) {
 		do {
 			if (result->getNumber<uint64_t>("deletion") == 0) {
@@ -119,11 +117,9 @@ bool IOLoginData::loginserverAuthentication(const std::string& name, const std::
 
 uint32_t IOLoginData::gameworldAuthentication(const std::string& accountName, const std::string& password, std::string& characterName, std::string& token, uint32_t tokenTime)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `id`, `password`, `secret` FROM `accounts` WHERE `name` = " << db.escapeString(accountName);
-	DBResult_ptr result = db.storeQuery(query.str());
+	query << "SELECT `id`, `password`, `secret` FROM `accounts` WHERE `name` = " << Database::escapeString(accountName);
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return 0;
 	}
@@ -147,8 +143,8 @@ uint32_t IOLoginData::gameworldAuthentication(const std::string& accountName, co
 	uint32_t accountId = result->getNumber<uint32_t>("id");
 
 	query.str(std::string());
-	query << "SELECT `account_id`, `name`, `deletion` FROM `players` WHERE `name` = " << db.escapeString(characterName);
-	result = db.storeQuery(query.str());
+	query << "SELECT `account_id`, `name`, `deletion` FROM `players` WHERE `name` = " << Database::escapeString(characterName);
+	result = Database::storeQuery(query.str());
 	if (!result) {
 		return 0;
 	}
@@ -164,7 +160,7 @@ AccountType_t IOLoginData::getAccountType(uint32_t accountId)
 {
 	std::ostringstream query;
 	query << "SELECT `type` FROM `accounts` WHERE `id` = " << accountId;
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return ACCOUNT_TYPE_NORMAL;
 	}
@@ -175,7 +171,7 @@ void IOLoginData::setAccountType(uint32_t accountId, AccountType_t accountType)
 {
 	std::ostringstream query;
 	query << "UPDATE `accounts` SET `type` = " << static_cast<uint16_t>(accountType) << " WHERE `id` = " << accountId;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void IOLoginData::updateOnlineStatus(uint32_t guid, bool login)
@@ -190,20 +186,18 @@ void IOLoginData::updateOnlineStatus(uint32_t guid, bool login)
 	} else {
 		query << "DELETE FROM `players_online` WHERE `player_id` = " << guid;
 	}
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 bool IOLoginData::preloadPlayer(Player* player, const std::string& name)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "SELECT `id`, `account_id`, `group_id`, `deletion`, (SELECT `type` FROM `accounts` WHERE `accounts`.`id` = `account_id`) AS `account_type`";
 	if (!g_config.getBoolean(ConfigManager::FREE_PREMIUM)) {
 		query << ", (SELECT `premdays` FROM `accounts` WHERE `accounts`.`id` = `account_id`) AS `premium_days`";
 	}
-	query << " FROM `players` WHERE `name` = " << db.escapeString(name);
-	DBResult_ptr result = db.storeQuery(query.str());
+	query << " FROM `players` WHERE `name` = " << Database::escapeString(name);
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -231,18 +225,16 @@ bool IOLoginData::preloadPlayer(Player* player, const std::string& name)
 
 bool IOLoginData::loadPlayerById(Player* player, uint32_t id)
 {
-	Database& db = Database::getInstance();
 	std::ostringstream query;
 	query << "SELECT `id`, `name`, `account_id`, `group_id`, `sex`, `vocation`, `experience`, `level`, `maglevel`, `health`, `healthmax`, `blessings`, `mana`, `manamax`, `manaspent`, `soul`, `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `posx`, `posy`, `posz`, `cap`, `lastlogin`, `lastlogout`, `lastip`, `conditions`, `skulltime`, `skull`, `town_id`, `balance`, `offlinetraining_time`, `offlinetraining_skill`, `stamina`, `skill_fist`, `skill_fist_tries`, `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`, `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`, `skill_fishing`, `skill_fishing_tries` FROM `players` WHERE `id` = " << id;
-	return loadPlayer(player, db.storeQuery(query.str()));
+	return loadPlayer(player, Database::storeQuery(query.str()));
 }
 
 bool IOLoginData::loadPlayerByName(Player* player, const std::string& name)
 {
-	Database& db = Database::getInstance();
 	std::ostringstream query;
-	query << "SELECT `id`, `name`, `account_id`, `group_id`, `sex`, `vocation`, `experience`, `level`, `maglevel`, `health`, `healthmax`, `blessings`, `mana`, `manamax`, `manaspent`, `soul`, `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `posx`, `posy`, `posz`, `cap`, `lastlogin`, `lastlogout`, `lastip`, `conditions`, `skulltime`, `skull`, `town_id`, `balance`, `offlinetraining_time`, `offlinetraining_skill`, `stamina`, `skill_fist`, `skill_fist_tries`, `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`, `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`, `skill_fishing`, `skill_fishing_tries` FROM `players` WHERE `name` = " << db.escapeString(name);
-	return loadPlayer(player, db.storeQuery(query.str()));
+	query << "SELECT `id`, `name`, `account_id`, `group_id`, `sex`, `vocation`, `experience`, `level`, `maglevel`, `health`, `healthmax`, `blessings`, `mana`, `manamax`, `manaspent`, `soul`, `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `posx`, `posy`, `posz`, `cap`, `lastlogin`, `lastlogout`, `lastip`, `conditions`, `skulltime`, `skull`, `town_id`, `balance`, `offlinetraining_time`, `offlinetraining_skill`, `stamina`, `skill_fist`, `skill_fist_tries`, `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`, `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`, `skill_fishing`, `skill_fishing_tries` FROM `players` WHERE `name` = " << Database::escapeString(name);
+	return loadPlayer(player, Database::storeQuery(query.str()));
 }
 
 bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
@@ -250,8 +242,6 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	if (!result) {
 		return false;
 	}
-
-	Database& db = Database::getInstance();
 
 	uint32_t accno = result->getNumber<uint32_t>("account_id");
 	Account acc = loadAccount(accno);
@@ -402,7 +392,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	std::ostringstream query;
 	query << "SELECT `guild_id`, `rank_id`, `nick` FROM `guild_membership` WHERE `player_id` = " << player->getGUID();
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		uint32_t guildId = result->getNumber<uint32_t>("guild_id");
 		uint32_t playerRankId = result->getNumber<uint32_t>("rank_id");
 		player->guildNick = result->getString("nick");
@@ -411,14 +401,14 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 		if (!guild) {
 			query.str(std::string());
 			query << "SELECT `name` FROM `guilds` WHERE `id` = " << guildId;
-			if ((result = db.storeQuery(query.str()))) {
+			if ((result = Database::storeQuery(query.str()))) {
 				guild = new Guild(guildId, result->getString("name"));
 				g_game.addGuild(guild);
 
 				query.str(std::string());
 				query << "SELECT `id`, `name`, `level` FROM `guild_ranks` WHERE `guild_id` = " << guildId;
 
-				if ((result = db.storeQuery(query.str()))) {
+				if ((result = Database::storeQuery(query.str()))) {
 					do {
 						guild->addRank(result->getNumber<uint32_t>("id"), result->getString("name"), result->getNumber<uint16_t>("level"));
 					} while (result->next());
@@ -433,7 +423,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 				query.str(std::string());
 				query << "SELECT `id`, `name`, `level` FROM `guild_ranks` WHERE `id` = " << playerRankId;
 
-				if ((result = db.storeQuery(query.str()))) {
+				if ((result = Database::storeQuery(query.str()))) {
 					guild->addRank(result->getNumber<uint32_t>("id"), result->getString("name"), result->getNumber<uint16_t>("level"));
 				}
 
@@ -449,7 +439,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 			query.str(std::string());
 			query << "SELECT COUNT(*) AS `members` FROM `guild_membership` WHERE `guild_id` = " << guildId;
-			if ((result = db.storeQuery(query.str()))) {
+			if ((result = Database::storeQuery(query.str()))) {
 				guild->setMemberCount(result->getNumber<uint32_t>("members"));
 			}
 		}
@@ -457,7 +447,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	query.str(std::string());
 	query << "SELECT `player_id`, `name` FROM `player_spells` WHERE `player_id` = " << player->getGUID();
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		do {
 			player->learnedInstantSpellList.emplace_front(result->getString("name"));
 		} while (result->next());
@@ -468,7 +458,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	query.str(std::string());
 	query << "SELECT `pid`, `sid`, `itemtype`, `count`, `attributes` FROM `player_items` WHERE `player_id` = " << player->getGUID() << " ORDER BY `sid` DESC";
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		loadItems(itemMap, result);
 
 		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
@@ -496,7 +486,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	query.str(std::string());
 	query << "SELECT `pid`, `sid`, `itemtype`, `count`, `attributes` FROM `player_depotitems` WHERE `player_id` = " << player->getGUID() << " ORDER BY `sid` DESC";
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		loadItems(itemMap, result);
 
 		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
@@ -528,7 +518,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	query.str(std::string());
 	query << "SELECT `pid`, `sid`, `itemtype`, `count`, `attributes` FROM `player_inboxitems` WHERE `player_id` = " << player->getGUID() << " ORDER BY `sid` DESC";
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		loadItems(itemMap, result);
 
 		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
@@ -556,7 +546,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	//load storage map
 	query.str(std::string());
 	query << "SELECT `key`, `value` FROM `player_storage` WHERE `player_id` = " << player->getGUID();
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		do {
 			player->addStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int32_t>("value"), true);
 		} while (result->next());
@@ -565,7 +555,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	//load vip
 	query.str(std::string());
 	query << "SELECT `player_id` FROM `account_viplist` WHERE `account_id` = " << player->getAccount();
-	if ((result = db.storeQuery(query.str()))) {
+	if ((result = Database::storeQuery(query.str()))) {
 		do {
 			player->addVIPInternal(result->getNumber<uint32_t>("player_id"));
 		} while (result->next());
@@ -586,7 +576,6 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 
 	int32_t runningId = 100;
 
-	Database& db = Database::getInstance();
 	for (const auto& it : itemList) {
 		int32_t pid = it.first;
 		Item* item = it.second;
@@ -598,7 +587,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 		size_t attributesSize;
 		const char* attributes = propWriteStream.getStream(attributesSize);
 
-		ss << player->getGUID() << ',' << pid << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << db.escapeBlob(attributes, attributesSize);
+		ss << player->getGUID() << ',' << pid << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << Database::escapeBlob(attributes, attributesSize);
 		if (!query_insert.addRow(ss)) {
 			return false;
 		}
@@ -628,7 +617,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 			size_t attributesSize;
 			const char* attributes = propWriteStream.getStream(attributesSize);
 
-			ss << player->getGUID() << ',' << parentId << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << db.escapeBlob(attributes, attributesSize);
+			ss << player->getGUID() << ',' << parentId << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << Database::escapeBlob(attributes, attributesSize);
 			if (!query_insert.addRow(ss)) {
 				return false;
 			}
@@ -643,11 +632,9 @@ bool IOLoginData::savePlayer(Player* player)
 		player->changeHealth(1);
 	}
 
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "SELECT `save` FROM `players` WHERE `id` = " << player->getGUID();
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -655,7 +642,7 @@ bool IOLoginData::savePlayer(Player* player)
 	if (result->getNumber<uint16_t>("save") == 0) {
 		query.str(std::string());
 		query << "UPDATE `players` SET `lastlogin` = " << player->lastLoginSaved << ", `lastip` = " << player->lastIP << " WHERE `id` = " << player->getGUID();
-		return db.executeQuery(query.str());
+		return Database::executeQuery(query.str());
 	}
 
 	//serialize conditions
@@ -708,7 +695,7 @@ bool IOLoginData::savePlayer(Player* player)
 		query << "`lastip` = " << player->lastIP << ',';
 	}
 
-	query << "`conditions` = " << db.escapeBlob(conditions, conditionsSize) << ',';
+	query << "`conditions` = " << Database::escapeBlob(conditions, conditionsSize) << ',';
 
 	if (g_game.getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
 		int32_t skullTime = 0;
@@ -760,14 +747,14 @@ bool IOLoginData::savePlayer(Player* player)
 		return false;
 	}
 
-	if (!db.executeQuery(query.str())) {
+	if (!Database::executeQuery(query.str())) {
 		return false;
 	}
 
 	// learned spells
 	query.str(std::string());
 	query << "DELETE FROM `player_spells` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	if (!Database::executeQuery(query.str())) {
 		return false;
 	}
 
@@ -775,7 +762,7 @@ bool IOLoginData::savePlayer(Player* player)
 
 	DBInsert spellsQuery("INSERT INTO `player_spells` (`player_id`, `name` ) VALUES ");
 	for (const std::string& spellName : player->learnedInstantSpellList) {
-		query << player->getGUID() << ',' << db.escapeString(spellName);
+		query << player->getGUID() << ',' << Database::escapeString(spellName);
 		if (!spellsQuery.addRow(query)) {
 			return false;
 		}
@@ -787,7 +774,7 @@ bool IOLoginData::savePlayer(Player* player)
 
 	//item saving
 	query << "DELETE FROM `player_items` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	if (!Database::executeQuery(query.str())) {
 		return false;
 	}
 
@@ -810,7 +797,7 @@ bool IOLoginData::savePlayer(Player* player)
 		query.str(std::string());
 		query << "DELETE FROM `player_depotitems` WHERE `player_id` = " << player->getGUID();
 
-		if (!db.executeQuery(query.str())) {
+		if (!Database::executeQuery(query.str())) {
 			return false;
 		}
 
@@ -832,7 +819,7 @@ bool IOLoginData::savePlayer(Player* player)
 	//save inbox items
 	query.str(std::string());
 	query << "DELETE FROM `player_inboxitems` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	if (!Database::executeQuery(query.str())) {
 		return false;
 	}
 
@@ -849,7 +836,7 @@ bool IOLoginData::savePlayer(Player* player)
 
 	query.str(std::string());
 	query << "DELETE FROM `player_storage` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	if (!Database::executeQuery(query.str())) {
 		return false;
 	}
 
@@ -877,7 +864,7 @@ std::string IOLoginData::getNameByGuid(uint32_t guid)
 {
 	std::ostringstream query;
 	query << "SELECT `name` FROM `players` WHERE `id` = " << guid;
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return std::string();
 	}
@@ -886,11 +873,9 @@ std::string IOLoginData::getNameByGuid(uint32_t guid)
 
 uint32_t IOLoginData::getGuidByName(const std::string& name)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `id` FROM `players` WHERE `name` = " << db.escapeString(name);
-	DBResult_ptr result = db.storeQuery(query.str());
+	query << "SELECT `id` FROM `players` WHERE `name` = " << Database::escapeString(name);
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return 0;
 	}
@@ -899,11 +884,9 @@ uint32_t IOLoginData::getGuidByName(const std::string& name)
 
 bool IOLoginData::getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `name`, `id`, `group_id`, `account_id` FROM `players` WHERE `name` = " << db.escapeString(name);
-	DBResult_ptr result = db.storeQuery(query.str());
+	query << "SELECT `name`, `id`, `group_id`, `account_id` FROM `players` WHERE `name` = " << Database::escapeString(name);
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -925,12 +908,10 @@ bool IOLoginData::getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string&
 
 bool IOLoginData::formatPlayerName(std::string& name)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "SELECT `name` FROM `players` WHERE `name` = " << db.escapeString(name);
+	query << "SELECT `name` FROM `players` WHERE `name` = " << Database::escapeString(name);
 
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
@@ -969,16 +950,14 @@ void IOLoginData::increaseBankBalance(uint32_t guid, uint64_t bankBalance)
 {
 	std::ostringstream query;
 	query << "UPDATE `players` SET `balance` = `balance` + " << bankBalance << " WHERE `id` = " << guid;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 bool IOLoginData::hasBiddedOnHouse(uint32_t guid)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "SELECT `id` FROM `houses` WHERE `highest_bidder` = " << guid << " LIMIT 1";
-	return db.storeQuery(query.str()).get() != nullptr;
+	return Database::storeQuery(query.str()).get() != nullptr;
 }
 
 std::forward_list<VIPEntry> IOLoginData::getVIPEntries(uint32_t accountId)
@@ -988,7 +967,7 @@ std::forward_list<VIPEntry> IOLoginData::getVIPEntries(uint32_t accountId)
 	std::ostringstream query;
 	query << "SELECT `player_id`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `name`, `description`, `icon`, `notify` FROM `account_viplist` WHERE `account_id` = " << accountId;
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (result) {
 		do {
 			entries.emplace_front(
@@ -1005,39 +984,35 @@ std::forward_list<VIPEntry> IOLoginData::getVIPEntries(uint32_t accountId)
 
 void IOLoginData::addVIPEntry(uint32_t accountId, uint32_t guid, const std::string& description, uint32_t icon, bool notify)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "INSERT INTO `account_viplist` (`account_id`, `player_id`, `description`, `icon`, `notify`) VALUES (" << accountId << ',' << guid << ',' << db.escapeString(description) << ',' << icon << ',' << notify << ')';
-	db.executeQuery(query.str());
+	query << "INSERT INTO `account_viplist` (`account_id`, `player_id`, `description`, `icon`, `notify`) VALUES (" << accountId << ',' << guid << ',' << Database::escapeString(description) << ',' << icon << ',' << notify << ')';
+	Database::executeQuery(query.str());
 }
 
 void IOLoginData::editVIPEntry(uint32_t accountId, uint32_t guid, const std::string& description, uint32_t icon, bool notify)
 {
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
-	query << "UPDATE `account_viplist` SET `description` = " << db.escapeString(description) << ", `icon` = " << icon << ", `notify` = " << notify << " WHERE `account_id` = " << accountId << " AND `player_id` = " << guid;
-	db.executeQuery(query.str());
+	query << "UPDATE `account_viplist` SET `description` = " << Database::escapeString(description) << ", `icon` = " << icon << ", `notify` = " << notify << " WHERE `account_id` = " << accountId << " AND `player_id` = " << guid;
+	Database::executeQuery(query.str());
 }
 
 void IOLoginData::removeVIPEntry(uint32_t accountId, uint32_t guid)
 {
 	std::ostringstream query;
 	query << "DELETE FROM `account_viplist` WHERE `account_id` = " << accountId << " AND `player_id` = " << guid;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void IOLoginData::addPremiumDays(uint32_t accountId, int32_t addDays)
 {
 	std::ostringstream query;
 	query << "UPDATE `accounts` SET `premdays` = `premdays` + " << addDays << " WHERE `id` = " << accountId;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void IOLoginData::removePremiumDays(uint32_t accountId, int32_t removeDays)
 {
 	std::ostringstream query;
 	query << "UPDATE `accounts` SET `premdays` = `premdays` - " << removeDays << " WHERE `id` = " << accountId;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }

--- a/src/iomarket.cpp
+++ b/src/iomarket.cpp
@@ -37,7 +37,7 @@ MarketOfferList IOMarket::getActiveOffers(MarketAction_t action, uint16_t itemId
 	std::ostringstream query;
 	query << "SELECT `id`, `amount`, `price`, `created`, `anonymous`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `player_name` FROM `market_offers` WHERE `sale` = " << action << " AND `itemtype` = " << itemId;
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return offerList;
 	}
@@ -69,7 +69,7 @@ MarketOfferList IOMarket::getOwnOffers(MarketAction_t action, uint32_t playerId)
 	std::ostringstream query;
 	query << "SELECT `id`, `amount`, `price`, `created`, `itemtype` FROM `market_offers` WHERE `player_id` = " << playerId << " AND `sale` = " << action;
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return offerList;
 	}
@@ -93,7 +93,7 @@ HistoryMarketOfferList IOMarket::getOwnHistory(MarketAction_t action, uint32_t p
 	std::ostringstream query;
 	query << "SELECT `itemtype`, `amount`, `price`, `expires_at`, `state` FROM `market_history` WHERE `player_id` = " << playerId << " AND `sale` = " << action;
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return offerList;
 	}
@@ -212,7 +212,7 @@ uint32_t IOMarket::getPlayerOfferCount(uint32_t playerId)
 	std::ostringstream query;
 	query << "SELECT COUNT(*) AS `count` FROM `market_offers` WHERE `player_id` = " << playerId;
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return 0;
 	}
@@ -228,7 +228,7 @@ MarketOfferEx IOMarket::getOfferByCounter(uint32_t timestamp, uint16_t counter)
 	std::ostringstream query;
 	query << "SELECT `id`, `sale`, `itemtype`, `amount`, `created`, `price`, `player_id`, `anonymous`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `player_name` FROM `market_offers` WHERE `created` = " << created << " AND (`id` & 65535) = " << counter << " LIMIT 1";
 
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		offer.id = 0;
 		return offer;
@@ -254,21 +254,21 @@ void IOMarket::createOffer(uint32_t playerId, MarketAction_t action, uint32_t it
 {
 	std::ostringstream query;
 	query << "INSERT INTO `market_offers` (`player_id`, `sale`, `itemtype`, `amount`, `price`, `created`, `anonymous`) VALUES (" << playerId << ',' << action << ',' << itemId << ',' << amount << ',' << price << ',' << time(nullptr) << ',' << anonymous << ')';
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void IOMarket::acceptOffer(uint32_t offerId, uint16_t amount)
 {
 	std::ostringstream query;
 	query << "UPDATE `market_offers` SET `amount` = `amount` - " << amount << " WHERE `id` = " << offerId;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void IOMarket::deleteOffer(uint32_t offerId)
 {
 	std::ostringstream query;
 	query << "DELETE FROM `market_offers` WHERE `id` = " << offerId;
-	Database::getInstance().executeQuery(query.str());
+	Database::executeQuery(query.str());
 }
 
 void IOMarket::appendHistory(uint32_t playerId, MarketAction_t type, uint16_t itemId, uint16_t amount, uint32_t price, time_t timestamp, MarketOfferState_t state)
@@ -284,19 +284,17 @@ bool IOMarket::moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
 {
 	const int32_t marketOfferDuration = g_config.getNumber(ConfigManager::MARKET_OFFER_DURATION);
 
-	Database& db = Database::getInstance();
-
 	std::ostringstream query;
 	query << "SELECT `player_id`, `sale`, `itemtype`, `amount`, `price`, `created` FROM `market_offers` WHERE `id` = " << offerId;
 
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return false;
 	}
 
 	query.str(std::string());
 	query << "DELETE FROM `market_offers` WHERE `id` = " << offerId;
-	if (!db.executeQuery(query.str())) {
+	if (!Database::executeQuery(query.str())) {
 		return false;
 	}
 
@@ -308,7 +306,7 @@ void IOMarket::updateStatistics()
 {
 	std::ostringstream query;
 	query << "SELECT `sale` AS `sale`, `itemtype` AS `itemtype`, COUNT(`price`) AS `num`, MIN(`price`) AS `min`, MAX(`price`) AS `max`, SUM(`price`) AS `sum` FROM `market_history` WHERE `state` = " << OFFERSTATE_ACCEPTED << " GROUP BY `itemtype`, `sale`";
-	DBResult_ptr result = Database::getInstance().storeQuery(query.str());
+	DBResult_ptr result = Database::storeQuery(query.str());
 	if (!result) {
 		return;
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3719,7 +3719,7 @@ const luaL_Reg LuaScriptInterface::luaDatabaseTable[] = {
 
 int LuaScriptInterface::luaDatabaseExecute(lua_State* L)
 {
-	pushBoolean(L, Database::getInstance().executeQuery(getString(L, -1)));
+	pushBoolean(L, Database::executeQuery(getString(L, -1)));
 	return 1;
 }
 
@@ -3755,7 +3755,7 @@ int LuaScriptInterface::luaDatabaseAsyncExecute(lua_State* L)
 
 int LuaScriptInterface::luaDatabaseStoreQuery(lua_State* L)
 {
-	if (DBResult_ptr res = Database::getInstance().storeQuery(getString(L, -1))) {
+	if (DBResult_ptr res = Database::storeQuery(getString(L, -1))) {
 		lua_pushnumber(L, ScriptEnvironment::addResult(res));
 	} else {
 		pushBoolean(L, false);
@@ -3799,20 +3799,20 @@ int LuaScriptInterface::luaDatabaseAsyncStoreQuery(lua_State* L)
 
 int LuaScriptInterface::luaDatabaseEscapeString(lua_State* L)
 {
-	pushString(L, Database::getInstance().escapeString(getString(L, -1)));
+	pushString(L, Database::escapeString(getString(L, -1)));
 	return 1;
 }
 
 int LuaScriptInterface::luaDatabaseEscapeBlob(lua_State* L)
 {
 	uint32_t length = getNumber<uint32_t>(L, 2);
-	pushString(L, Database::getInstance().escapeBlob(getString(L, 1).c_str(), length));
+	pushString(L, Database::escapeBlob(getString(L, 1).c_str(), length));
 	return 1;
 }
 
 int LuaScriptInterface::luaDatabaseLastInsertId(lua_State* L)
 {
-	lua_pushnumber(L, Database::getInstance().getLastInsertId());
+	lua_pushnumber(L, Database::getLastInsertId());
 	return 1;
 }
 

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -146,7 +146,7 @@ void mainLoader(int, char*[], ServiceManager* services)
 
 	std::cout << ">> Establishing database connection..." << std::flush;
 
-	if (!Database::getInstance().connect()) {
+	if (!Database::connect()) {
 		startupErrorMessage("Failed to connect to database.");
 		return;
 	}


### PR DESCRIPTION
Since the Database is a singleton, it can be a namespace instead, for almost the same syntax and no need to control instances through a `getInstance` method. It also moves some private methods to the implementation file rather than header, thus exposing less stuff.

The result is a large cleanup of over 100 hundred lines less :)