### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,64 @@
+---
+AccessModifierOffset: '-4'
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignOperands: 'true'
+AlignTrailingComments: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: 'true'
+AllowShortLoopsOnASingleLine: 'true'
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'false'
+AlwaysBreakTemplateDeclarations: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: None
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: 'true'
+BreakConstructorInitializersBeforeComma: 'true'
+BreakStringLiterals: 'false'
+ColumnLimit: '120'
+ConstructorInitializerIndentWidth: '4'
+ContinuationIndentWidth: '4'
+Cpp11BracedListStyle: 'false'
+ExperimentalAutoDetectBinPacking: 'false'
+IndentCaseLabels: 'true'
+IndentWidth: '4'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+NamespaceIndentation: Inner
+PenaltyReturnTypeOnItsOwnLine: '100000'
+PointerAlignment: Left
+ReflowComments: 'true'
+SortIncludes: 'true'
+SpaceAfterCStyleCast: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: 'false'
+SpacesBeforeTrailingComments: '1'
+SpacesInAngles: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Always
+
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ addons:
       - libluajit-5.1-dev
       - libmysqlclient-dev
       - libpugixml-dev
+      - clang-format-3.9
 before_script:
   - mkdir build && cd build
   - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_LUAJIT=${LUAJIT} ..
+  - make clangformat && source ../verify-format.sh
 script: make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,4 +50,15 @@ target_link_libraries(tfs ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES} ${Boost_LIBRARIE
 
 set_target_properties(tfs PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "src/otpch.h")
 set_target_properties(tfs PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE)
+
+# clang-format
+find_program(CLANG_FORMAT NAMES clang-format-4.0 clang-format-3.9)
+if(CLANG_FORMAT)
+	file(GLOB_RECURSE tfs_ALL_FILES *.c *.cpp *.h *.hpp *.inl)
+	add_custom_target(
+		clangformat
+		COMMAND ${CLANG_FORMAT} -i -style=file ${tfs_ALL_FILES}
+		)
+endif()
+
 cotire(tfs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)

--- a/verify-format.sh
+++ b/verify-format.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+modified=$(git ls-files --modified ..)
+
+if [[ $modified ]]; then
+	echo "The following files are not following a guideline:"
+	echo $modified
+	exit -1
+else
+	exit 0
+fi


### PR DESCRIPTION
As we were talking in #2307, it would be good idea to use clang-format to format our code. It is somewhat based on my personal preferences so I would like you to suggest modifications if any.  I wanted to make this PR clean so the actual changes are not included in here. 

For know it won't pass the CI so we will have to push changes first. Because of sorting includes it also won't compile but I will make a PR of a fix in a second. If we decide to merge this, it has to go as the last one.