### PR TITLE
Further improved potions script

### DIFF
--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -76,33 +76,29 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	end
 
-	if potion.health or potion.mana or potion.combat then
-		if potion.health then
-			doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2], CONST_ME_MAGIC_BLUE)
-		end
+	if potion.health then
+		doTargetCombatHealth(player:getId(), target, COMBAT_HEALING, potion.health[1], potion.health[2], CONST_ME_MAGIC_BLUE)
+	end
 
-		if potion.mana then
-			doTargetCombatMana(0, target, potion.mana[1], potion.mana[2], CONST_ME_MAGIC_BLUE)
-		end
+	if potion.mana then
+		doTargetCombatMana(player:getId(), target, potion.mana[1], potion.mana[2], CONST_ME_MAGIC_BLUE)
+	end
 
-		if potion.combat then
-			potion.combat:execute(target, Variant(target:getId()))
-		end
-
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		player:addItem(potion.flask, 1)
+	if potion.combat then
+		potion.combat:execute(target, Variant(target:getId()))
 	end
 
 	if potion.condition then
 		player:addCondition(potion.condition)
 		player:say(potion.text, TALKTYPE_MONSTER_SAY)
 		player:getPosition():sendMagicEffect(potion.effect)
-	end
-
-	if potion.transform then
+	elseif potion.transform then
 		item:transform(potion.transform.id[math.random(#potion.transform.id)])
 		item:getPosition():sendMagicEffect(potion.effect)
 		return true
+	else
+		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
+		player:addItem(potion.flask, 1)
 	end
 
 	item:remove(1)

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -98,7 +98,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	else
 		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		player:addItem(potion.flask, 1)
+		player:addItem(potion.flask)
 	end
 
 	item:remove(1)

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -15,13 +15,6 @@ bullseye:setParameter(CONDITION_PARAM_SKILL_DISTANCE, 5)
 bullseye:setParameter(CONDITION_PARAM_SKILL_SHIELD, -10)
 bullseye:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
-local antidote = Combat()
-antidote:setParameter(COMBAT_PARAM_TYPE, COMBAT_HEALING)
-antidote:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
-antidote:setParameter(COMBAT_PARAM_DISPEL, CONDITION_POISON)
-antidote:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
-antidote:setParameter(COMBAT_PARAM_TARGETCASTERORTOPMOST, true)
-
 local potions = {
 	[6558] = {transform = {id = {7588, 7589}}, effect = CONST_ME_DRAWBLOOD},
 	[7439] = {condition = berserk, vocations = {4, 8}, effect = CONST_ME_MAGIC_RED,
@@ -53,7 +46,7 @@ local potions = {
 	[8473] = {health = {650, 850}, vocations = {4, 8}, level = 130, flask = 7635,
 			description = "Only knights of level 130 or above may drink this fluid."},
 
-	[8474] = {combat = antidote, flask = 7636},
+	[8474] = {antidote = true, flask = 7636},
 	[8704] = {health = {60, 90}, flask = 7636},
 	[26029] = {mana = {425, 575}, vocations = {1, 2, 5, 6}, level = 130, flask = 7635,
 			description = "Only druids and sorcerers of level 130 or above may drink this fluid."},
@@ -77,15 +70,15 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	if potion.health then
-		doTargetCombatHealth(player:getId(), target, COMBAT_HEALING, potion.health[1], potion.health[2], CONST_ME_MAGIC_BLUE)
+		doTargetCombatHealth(player:getId(), target, COMBAT_HEALING, potion.health[1], potion.health[2])
 	end
 
 	if potion.mana then
-		doTargetCombatMana(player:getId(), target, potion.mana[1], potion.mana[2], CONST_ME_MAGIC_BLUE)
+		doTargetCombatMana(player:getId(), target, potion.mana[1], potion.mana[2])
 	end
 
-	if potion.combat then
-		potion.combat:execute(target, Variant(target:getId()))
+	if potion.antidote then
+		target:removeCondition(CONDITION_POISON)
 	end
 
 	if potion.condition then
@@ -97,8 +90,9 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		item:getPosition():sendMagicEffect(potion.effect)
 		return true
 	else
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
 		player:addItem(potion.flask)
+		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
+		target:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
 	end
 
 	item:remove(1)

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -97,8 +97,12 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 			parent:addItem(potion.flask)
 		end
 
-		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
-		target:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
+		toPosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)
+
+		local spectators = Game.getSpectators(toPosition, false, true, 1, 1, 1, 1)
+		for _, spectator in ipairs(spectators) do
+			spectator:say("Aaaah...", TALKTYPE_MONSTER_SAY, false, spectator, toPosition)
+		end
 	end
 
 	item:remove(1)

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -70,11 +70,11 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	if potion.health then
-		doTargetCombatHealth(player:getId(), target, COMBAT_HEALING, potion.health[1], potion.health[2])
+		doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2])
 	end
 
 	if potion.mana then
-		doTargetCombatMana(player:getId(), target, potion.mana[1], potion.mana[2])
+		doTargetCombatMana(0, target, potion.mana[1], potion.mana[2])
 	end
 
 	if potion.antidote then

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -69,18 +69,6 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	end
 
-	if potion.health then
-		doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2])
-	end
-
-	if potion.mana then
-		doTargetCombatMana(0, target, potion.mana[1], potion.mana[2])
-	end
-
-	if potion.antidote then
-		target:removeCondition(CONDITION_POISON)
-	end
-
 	if potion.condition then
 		player:addCondition(potion.condition)
 		player:say(potion.text, TALKTYPE_MONSTER_SAY)
@@ -90,6 +78,18 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		item:getPosition():sendMagicEffect(potion.effect)
 		return true
 	else
+		if potion.health then
+			doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2])
+		end
+
+		if potion.mana then
+			doTargetCombatMana(0, target, potion.mana[1], potion.mana[2])
+		end
+
+		if potion.antidote then
+			target:removeCondition(CONDITION_POISON)
+		end
+
 		local parent = item:getParent()
 		if parent:isTile() then
 			Game.createItem(potion.flask, 1, parent:getPosition())

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -90,7 +90,13 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		item:getPosition():sendMagicEffect(potion.effect)
 		return true
 	else
-		player:addItem(potion.flask)
+		local parent = item:getParent()
+		if parent:isTile() then
+			Game.createItem(potion.flask, 1, parent:getPosition())
+		elseif parent:isContainer() then
+			parent:addItem(potion.flask)
+		end
+
 		target:say("Aaaah...", TALKTYPE_MONSTER_SAY)
 		target:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
 	end

--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -16,7 +16,7 @@ bullseye:setParameter(CONDITION_PARAM_SKILL_SHIELD, -10)
 bullseye:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 
 local potions = {
-	[6558] = {transform = {id = {7588, 7589}}, effect = CONST_ME_DRAWBLOOD},
+	[6558] = {transform = {7588, 7589}, effect = CONST_ME_DRAWBLOOD},
 	[7439] = {condition = berserk, vocations = {4, 8}, effect = CONST_ME_MAGIC_RED,
 			description = "Only knights may drink this potion.", text = "You feel stronger."},
 
@@ -74,7 +74,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		player:say(potion.text, TALKTYPE_MONSTER_SAY)
 		player:getPosition():sendMagicEffect(potion.effect)
 	elseif potion.transform then
-		item:transform(potion.transform.id[math.random(#potion.transform.id)])
+		item:transform(potion.transform[math.random(#potion.transform)])
 		item:getPosition():sendMagicEffect(potion.effect)
 		return true
 	else


### PR DESCRIPTION
This PR was initially made to fix combat messages of potions, which I have fixed by replacing the creature id ``0`` in ``doTargetCombatMana`` and ``doTargetCombatHealth`` by ``player:getId()``. But in doing so, such functions would not add mana or health to the target anymore.

If this had not happen I would still need to make a minor modification in ``Game::combatChangeMana`` to send the appropriate text message when ``manaChange > 0``, i.e. **"You gained X mana."**. (this has already been done for mana regeneration in #2137 .)

So now this PR is mainly for further improving potions script.