### PR TITLE
Added metatable method Tile.isContainer to core

### DIFF
--- a/data/lib/core/tile.lua
+++ b/data/lib/core/tile.lua
@@ -10,6 +10,10 @@ function Tile.isTile(self)
 	return true
 end
 
+function Tile.isContainer(self)
+	return false
+end
+
 function Tile.relocateTo(self, toPosition)
 	if self:getPosition() == toPosition or not Tile(toPosition) then
 		return false


### PR DESCRIPTION
I felt the need for this in #2341.
```lua
	local parent = item:getParent()
	if parent:isTile() then
		Game.createItem(potion.flask, 1, parent:getPosition())
	end
	if parent:isContainer() then
		-- If parent is a tile then the console will print out an error "attempt to call method 'isContainer' (a nil value)" because there's no isContainer method in Tile metatable.
		parent:addItem(potion.flask)
	end
```

A workaround for that is to use an ``elseif`` structure, so that parent:isTile() is evaluated first.
```lua
	local parent = item:getParent()
	if parent:isTile() then
		Game.createItem(potion.flask, 1, parent:getPosition())
	elseif parent:isContainer() then
		-- parent is stil a tile, but it will not print out an error because "parent:isTile()" is evaluated first.
		parent:addItem(potion.flask)
	end
```