### PR TITLE
Small adjustment to combatChangeMana and combatChangeHealth

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3765,6 +3765,10 @@ void Game::combatGetTypeInfo(CombatType_t combatType, Creature* target, TextColo
 
 bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage& damage)
 {
+	if (damage.primary.value == 0) {
+		return false;
+	}
+	
 	const Position& targetPos = target->getPosition();
 	if (damage.primary.value > 0) {
 		if (target->getHealth() <= 0) {
@@ -4094,6 +4098,10 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 bool Game::combatChangeMana(Creature* attacker, Creature* target, int32_t manaChange, CombatOrigin origin)
 {
+	if (manaChange == 0) {
+		return false;
+	}
+	
 	if (manaChange > 0) {
 		if (attacker) {
 			const Player* attackerPlayer = attacker->getPlayer();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3768,7 +3768,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 	if (damage.primary.value == 0) {
 		return false;
 	}
-	
+
 	const Position& targetPos = target->getPosition();
 	if (damage.primary.value > 0) {
 		if (target->getHealth() <= 0) {
@@ -4101,7 +4101,7 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, int32_t manaCh
 	if (manaChange == 0) {
 		return false;
 	}
-	
+
 	if (manaChange > 0) {
 		if (attacker) {
 			const Player* attackerPlayer = attacker->getPlayer();


### PR DESCRIPTION
IMO combatChangeMana and combatChangeHealth shouldn't be executed when the damage or manachange is 0. There is no reason to execute it. Correct me if I'm wrong.
