### PR TITLE
Fix getPlayerInstantSpellCount and remove unused function

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1018,7 +1018,7 @@ function Guild.removeMember(self, player)
 	return player:getGuild() == self and player:setGuild(nil)
 end
 
-function getPlayerInstantSpellCount(cid) local p = Player(cid) return p ~= nil and p:getInstantSpellCount() end
+function getPlayerInstantSpellCount(cid) local p = Player(cid) return p ~= nil and #p:getInstantSpells() end
 function getPlayerInstantSpellInfo(cid, spellId)
 	local player = Player(cid)
 	if not player then

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -220,18 +220,6 @@ InstantSpell* Spells::getInstantSpell(const std::string& words)
 	return nullptr;
 }
 
-uint32_t Spells::getInstantSpellCount(const Player* player) const
-{
-	uint32_t count = 0;
-	for (const auto& it : instants) {
-		InstantSpell* instantSpell = it.second;
-		if (instantSpell->canCast(player)) {
-			++count;
-		}
-	}
-	return count;
-}
-
 InstantSpell* Spells::getInstantSpellById(uint32_t spellId)
 {
 	auto it = std::next(instants.begin(), std::min<uint32_t>(spellId, instants.size()));

--- a/src/spells.h
+++ b/src/spells.h
@@ -49,7 +49,6 @@ class Spells final : public BaseEvents
 		InstantSpell* getInstantSpell(const std::string& words);
 		InstantSpell* getInstantSpellByName(const std::string& name);
 
-		uint32_t getInstantSpellCount(const Player* player) const;
 		InstantSpell* getInstantSpellById(uint32_t spellId);
 
 		TalkActionResult_t playerSaySpell(Player* player, std::string& words);


### PR DESCRIPTION
This pull requests fixes the compat Lua function getPlayerInstantSpellCount (there was no Player.getInstantSpellCount registered), and removes Spells:: getInstantSpellCount since it was unused.