### PR TITLE
Fix statements that check if unsigned types are less than zero

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1353,7 +1353,7 @@ int64_t Creature::getStepDuration() const
 	int32_t stepSpeed = getStepSpeed();
 	if (stepSpeed > -Creature::speedB) {
 		calculatedStepSpeed = floor((Creature::speedA * log((stepSpeed / 2) + Creature::speedB) + Creature::speedC) + 0.5);
-		if (calculatedStepSpeed <= 0) {
+		if (calculatedStepSpeed == 0) {
 			calculatedStepSpeed = 1;
 		}
 	} else {

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -85,7 +85,7 @@ bool IOMap::loadMap(Map* map, const std::string& fileName)
 	}
 
 	uint32_t headerVersion = root_header.version;
-	if (headerVersion <= 0) {
+	if (headerVersion == 0) {
 		//In otbm version 1 the count variable after splashes/fluidcontainers and stackables
 		//are saved as attributes instead, this solves alot of problems with items
 		//that is changed (stackable/charges/fluidcontainer/splash) during an update.

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -392,7 +392,7 @@ bool Npc::getNextStep(Direction& dir, uint32_t& flags)
 		return true;
 	}
 
-	if (walkTicks <= 0) {
+	if (walkTicks == 0) {
 		return false;
 	}
 


### PR DESCRIPTION
cppcheck also claims this if anyone wants to have a look at it:
```
[src/fileloader.cpp:117]: (style) Condition '!lastEscaped' is always true
```