### PR TITLE
Fix function attributes and visibility issues

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -75,11 +75,11 @@ class Actions final : public BaseEvents
 		ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
 		static void showUseHotkeyMessage(Player* player, const Item* item, uint32_t count);
 
-		void clear() final;
-		LuaScriptInterface& getScriptInterface() final;
-		std::string getScriptBaseName() const final;
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
+		void clear() override;
+		LuaScriptInterface& getScriptInterface() override;
+		std::string getScriptBaseName() const override;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
 
 		using ActionUseMap = std::map<uint16_t, Action*>;
 		ActionUseMap useItemMap;

--- a/src/actions.h
+++ b/src/actions.h
@@ -46,7 +46,7 @@ class Action : public Event
 
 		ActionFunction function;
 
-	protected:
+	private:
 		std::string getScriptEventName() const override;
 
 		bool allowFarUse;
@@ -71,7 +71,7 @@ class Actions final : public BaseEvents
 		ReturnValue canUse(const Player* player, const Position& pos, const Item* item);
 		ReturnValue canUseFar(const Creature* creature, const Position& toPos, bool checkLineOfSight, bool checkFloor);
 
-	protected:
+	private:
 		ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
 		static void showUseHotkeyMessage(Player* player, const Item* item, uint32_t count);
 

--- a/src/ban.h
+++ b/src/ban.h
@@ -42,7 +42,7 @@ class Ban
 	public:
 		bool acceptConnection(uint32_t clientip);
 
-	protected:
+	private:
 		IpConnectMap ipConnectMap;
 		std::recursive_mutex lock;
 };

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -60,7 +60,7 @@ class BaseEvents
 			return loaded;
 		}
 
-	protected:
+	private:
 		virtual LuaScriptInterface& getScriptInterface() = 0;
 		virtual std::string getScriptBaseName() const = 0;
 		virtual Event* getEvent(const std::string& nodeName) = 0;
@@ -81,6 +81,7 @@ class CallBack
 		int32_t scriptId = 0;
 		LuaScriptInterface* scriptInterface = nullptr;
 
+	private:
 		bool loaded = false;
 };
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -30,17 +30,17 @@ class BedItem final : public Item
 	public:
 		explicit BedItem(uint16_t id);
 
-		BedItem* getBed() final {
+		BedItem* getBed() override {
 			return this;
 		}
-		const BedItem* getBed() const final {
+		const BedItem* getBed() const override {
 			return this;
 		}
 
-		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) final;
-		void serializeAttr(PropWriteStream& propWriteStream) const final;
+		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
+		void serializeAttr(PropWriteStream& propWriteStream) const override;
 
-		bool canRemove() const final {
+		bool canRemove() const override {
 			return house == nullptr;
 		}
 
@@ -60,7 +60,7 @@ class BedItem final : public Item
 
 		BedItem* getNextBedItem() const;
 
-	protected:
+	private:
 		void updateAppearance(const Player* player);
 		void regeneratePlayer(Player* player) const;
 		void internalSetSleeper(const Player* player);

--- a/src/chat.h
+++ b/src/chat.h
@@ -91,7 +91,7 @@ class PrivateChatChannel final : public ChatChannel
 	public:
 		PrivateChatChannel(uint16_t channelId, std::string channelName) : ChatChannel(channelId, channelName) {}
 
-		uint32_t getOwner() const final {
+		uint32_t getOwner() const override {
 			return owner;
 		}
 		void setOwner(uint32_t owner) {
@@ -107,11 +107,11 @@ class PrivateChatChannel final : public ChatChannel
 
 		void closeChannel() const;
 
-		const InvitedMap* getInvitedUsers() const final {
+		const InvitedMap* getInvitedUsers() const override {
 			return &invites;
 		}
 
-	protected:
+	private:
 		InvitedMap invites;
 		uint32_t owner = 0;
 };

--- a/src/chat.h
+++ b/src/chat.h
@@ -34,8 +34,7 @@ class ChatChannel
 	public:
 		ChatChannel() = default;
 		ChatChannel(uint16_t channelId, std::string channelName):
-			name(std::move(channelName)),
-			id(channelId) {}
+			id{channelId}, name{std::move(channelName)} {}
 
 		virtual ~ChatChannel() = default;
 
@@ -73,6 +72,9 @@ class ChatChannel
 	protected:
 		UsersMap users;
 
+		uint16_t id;
+
+	private:
 		std::string name;
 
 		int32_t canJoinEvent = -1;
@@ -80,7 +82,6 @@ class ChatChannel
 		int32_t onLeaveEvent = -1;
 		int32_t onSpeakEvent = -1;
 
-		uint16_t id;
 		bool publicChannel = false;
 
 	friend class Chat;

--- a/src/combat.h
+++ b/src/combat.h
@@ -46,18 +46,12 @@ class TileCallback final : public CallBack
 {
 	public:
 		void onTileCombat(Creature* creature, Tile* tile) const;
-
-	private:
-		formulaType_t type;
 };
 
 class TargetCallback final : public CallBack
 {
 	public:
 		void onTargetCombat(Creature* creature, Creature* target) const;
-
-	private:
-		formulaType_t type;
 };
 
 struct CombatParams {

--- a/src/combat.h
+++ b/src/combat.h
@@ -38,7 +38,7 @@ class ValueCallback final : public CallBack
 		explicit ValueCallback(formulaType_t type): type(type) {}
 		void getMinMaxValues(Player* player, CombatDamage& damage, bool useCharges) const;
 
-	protected:
+	private:
 		formulaType_t type;
 };
 
@@ -47,7 +47,7 @@ class TileCallback final : public CallBack
 	public:
 		void onTileCombat(Creature* creature, Tile* tile) const;
 
-	protected:
+	private:
 		formulaType_t type;
 };
 
@@ -56,7 +56,7 @@ class TargetCallback final : public CallBack
 	public:
 		void onTargetCombat(Creature* creature, Creature* target) const;
 
-	protected:
+	private:
 		formulaType_t type;
 };
 
@@ -158,7 +158,7 @@ class MatrixArea
 			return data_[i];
 		}
 
-	protected:
+	private:
 		uint32_t centerX;
 		uint32_t centerY;
 
@@ -188,7 +188,7 @@ class AreaCombat
 		void setupExtArea(const std::list<uint32_t>& list, uint32_t rows);
 		void clear();
 
-	protected:
+	private:
 		enum MatrixOperation_t {
 			MATRIXOPERATION_COPY,
 			MATRIXOPERATION_MIRROR,
@@ -299,7 +299,7 @@ class Combat
 			params.origin = origin;
 		}
 
-	protected:
+	private:
 		static void doCombatDefault(Creature* caster, Creature* target, const CombatParams& params);
 
 		static void CombatFunc(Creature* caster, const Position& pos, const AreaCombat* area, const CombatParams& params, CombatFunction func, CombatDamage* data);
@@ -331,10 +331,10 @@ class MagicField final : public Item
 	public:
 		explicit MagicField(uint16_t type) : Item(type), createTime(OTSYS_TIME()) {}
 
-		MagicField* getMagicField() final {
+		MagicField* getMagicField() override {
 			return this;
 		}
-		const MagicField* getMagicField() const final {
+		const MagicField* getMagicField() const override {
 			return this;
 		}
 

--- a/src/condition.h
+++ b/src/condition.h
@@ -72,7 +72,7 @@ class Condition
 		Condition() = default;
 		Condition(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			endTime(ticks == -1 ? std::numeric_limits<int64_t>::max() : 0),
-			subId(subId), ticks(ticks),	conditionType(type), id(id), isBuff(buff) {}
+			subId(subId), ticks(ticks), conditionType(type), isBuff(buff), id(id) {}
 		virtual ~Condition() = default;
 
 		virtual bool startCondition(Creature* creature);
@@ -113,14 +113,16 @@ class Condition
 		bool isPersistent() const;
 
 	protected:
+		virtual bool updateCondition(const Condition* addCondition);
+
 		int64_t endTime;
 		uint32_t subId;
 		int32_t ticks;
 		ConditionType_t conditionType;
-		ConditionId_t id;
 		bool isBuff;
 
-		virtual bool updateCondition(const Condition* addCondition);
+	private:
+		ConditionId_t id;
 };
 
 class ConditionGeneric : public Condition

--- a/src/condition.h
+++ b/src/condition.h
@@ -146,22 +146,22 @@ class ConditionAttributes final : public ConditionGeneric
 		ConditionAttributes(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			ConditionGeneric(id, type, ticks, buff, subId) {}
 
-		bool startCondition(Creature* creature) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
-		void endCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* condition) final;
+		bool startCondition(Creature* creature) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
+		void endCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* condition) override;
 
-		bool setParam(ConditionParam_t param, int32_t value) final;
+		bool setParam(ConditionParam_t param, int32_t value) override;
 
-		ConditionAttributes* clone() const final {
+		ConditionAttributes* clone() const override {
 			return new ConditionAttributes(*this);
 		}
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
-		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		int32_t skills[SKILL_LAST + 1] = {};
 		int32_t skillsPercent[SKILL_LAST + 1] = {};
 		int32_t stats[STAT_LAST + 1] = {};
@@ -181,20 +181,20 @@ class ConditionRegeneration final : public ConditionGeneric
 		ConditionRegeneration(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0):
 			ConditionGeneric(id, type, ticks, buff, subId) {}
 
-		void addCondition(Creature* creature, const Condition* addCondition) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
+		void addCondition(Creature* creature, const Condition* addCondition) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
 
-		bool setParam(ConditionParam_t param, int32_t value) final;
+		bool setParam(ConditionParam_t param, int32_t value) override;
 
-		ConditionRegeneration* clone() const final {
+		ConditionRegeneration* clone() const override {
 			return new ConditionRegeneration(*this);
 		}
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
- 		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+ 		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		uint32_t internalHealthTicks = 0;
 		uint32_t internalManaTicks = 0;
 
@@ -210,20 +210,20 @@ class ConditionSoul final : public ConditionGeneric
 		ConditionSoul(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			ConditionGeneric(id, type, ticks, buff, subId) {}
 
-		void addCondition(Creature* creature, const Condition* addCondition) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
+		void addCondition(Creature* creature, const Condition* addCondition) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
 
-		bool setParam(ConditionParam_t param, int32_t value) final;
+		bool setParam(ConditionParam_t param, int32_t value) override;
 
-		ConditionSoul* clone() const final {
+		ConditionSoul* clone() const override {
 			return new ConditionSoul(*this);
 		}
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
-		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		uint32_t internalSoulTicks = 0;
 		uint32_t soulTicks = 0;
 		uint32_t soulGain = 0;
@@ -235,10 +235,10 @@ class ConditionInvisible final : public ConditionGeneric
 		ConditionInvisible(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			ConditionGeneric(id, type, ticks, buff, subId) {}
 
-		bool startCondition(Creature* creature) final;
-		void endCondition(Creature* creature) final;
+		bool startCondition(Creature* creature) override;
+		void endCondition(Creature* creature) override;
 
-		ConditionInvisible* clone() const final {
+		ConditionInvisible* clone() const override {
 			return new ConditionInvisible(*this);
 		}
 };
@@ -252,17 +252,17 @@ class ConditionDamage final : public Condition
 
 		static void generateDamageList(int32_t amount, int32_t start, std::list<int32_t>& list);
 
-		bool startCondition(Creature* creature) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
-		void endCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* condition) final;
-		uint32_t getIcons() const final;
+		bool startCondition(Creature* creature) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
+		void endCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* condition) override;
+		uint32_t getIcons() const override;
 
-		ConditionDamage* clone() const final {
+		ConditionDamage* clone() const override {
 			return new ConditionDamage(*this);
 		}
 
-		bool setParam(ConditionParam_t param, int32_t value) final;
+		bool setParam(ConditionParam_t param, int32_t value) override;
 
 		bool addDamage(int32_t rounds, int32_t time, int32_t value);
 		bool doForceUpdate() const {
@@ -271,10 +271,10 @@ class ConditionDamage final : public Condition
 		int32_t getTotalDamage() const;
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
-		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		int32_t maxDamage = 0;
 		int32_t minDamage = 0;
 		int32_t startDamage = 0;
@@ -294,7 +294,7 @@ class ConditionDamage final : public Condition
 		bool getNextDamage(int32_t& damage);
 		bool doDamage(Creature* creature, int32_t healthChange);
 
-		bool updateCondition(const Condition* addCondition) final;
+		bool updateCondition(const Condition* addCondition) override;
 };
 
 class ConditionSpeed final : public Condition
@@ -303,25 +303,25 @@ class ConditionSpeed final : public Condition
 		ConditionSpeed(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, int32_t changeSpeed) :
 			Condition(id, type, ticks, buff, subId), speedDelta(changeSpeed) {}
 
-		bool startCondition(Creature* creature) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
-		void endCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* condition) final;
-		uint32_t getIcons() const final;
+		bool startCondition(Creature* creature) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
+		void endCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* condition) override;
+		uint32_t getIcons() const override;
 
-		ConditionSpeed* clone() const final {
+		ConditionSpeed* clone() const override {
 			return new ConditionSpeed(*this);
 		}
 
-		bool setParam(ConditionParam_t param, int32_t value) final;
+		bool setParam(ConditionParam_t param, int32_t value) override;
 
 		void setFormulaVars(float mina, float minb, float maxa, float maxb);
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
-		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		void getFormulaValues(int32_t var, int32_t& min, int32_t& max) const;
 
 		int32_t speedDelta;
@@ -339,22 +339,22 @@ class ConditionOutfit final : public Condition
 		ConditionOutfit(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			Condition(id, type, ticks, buff, subId) {}
 
-		bool startCondition(Creature* creature) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
-		void endCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* condition) final;
+		bool startCondition(Creature* creature) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
+		void endCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* condition) override;
 
-		ConditionOutfit* clone() const final {
+		ConditionOutfit* clone() const override {
 			return new ConditionOutfit(*this);
 		}
 
 		void setOutfit(const Outfit_t& outfit);
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
-		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		Outfit_t outfit;
 };
 
@@ -364,22 +364,22 @@ class ConditionLight final : public Condition
 		ConditionLight(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff, uint32_t subId, uint8_t lightlevel, uint8_t lightcolor) :
 			Condition(id, type, ticks, buff, subId), lightInfo(lightlevel, lightcolor) {}
 
-		bool startCondition(Creature* creature) final;
-		bool executeCondition(Creature* creature, int32_t interval) final;
-		void endCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* addCondition) final;
+		bool startCondition(Creature* creature) override;
+		bool executeCondition(Creature* creature, int32_t interval) override;
+		void endCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* addCondition) override;
 
-		ConditionLight* clone() const final {
+		ConditionLight* clone() const override {
 			return new ConditionLight(*this);
 		}
 
-		bool setParam(ConditionParam_t param, int32_t value) final;
+		bool setParam(ConditionParam_t param, int32_t value) override;
 
 		//serialization
-		void serialize(PropWriteStream& propWriteStream) final;
-		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) final;
+		void serialize(PropWriteStream& propWriteStream) override;
+		bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
 
-	protected:
+	private:
 		LightInfo lightInfo;
 		uint32_t internalLightTicks = 0;
 		uint32_t lightChangeInterval = 0;
@@ -391,10 +391,10 @@ class ConditionSpellCooldown final : public ConditionGeneric
 		ConditionSpellCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			ConditionGeneric(id, type, ticks, buff, subId) {}
 
-		bool startCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* condition) final;
+		bool startCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* condition) override;
 
-		ConditionSpellCooldown* clone() const final {
+		ConditionSpellCooldown* clone() const override {
 			return new ConditionSpellCooldown(*this);
 		}
 };
@@ -405,10 +405,10 @@ class ConditionSpellGroupCooldown final : public ConditionGeneric
 		ConditionSpellGroupCooldown(ConditionId_t id, ConditionType_t type, int32_t ticks, bool buff = false, uint32_t subId = 0) :
 			ConditionGeneric(id, type, ticks, buff, subId) {}
 
-		bool startCondition(Creature* creature) final;
-		void addCondition(Creature* creature, const Condition* condition) final;
+		bool startCondition(Creature* creature) override;
+		void addCondition(Creature* creature, const Condition* condition) override;
 
-		ConditionSpellGroupCooldown* clone() const final {
+		ConditionSpellGroupCooldown* clone() const override {
 			return new ConditionSpellGroupCooldown(*this);
 		}
 };

--- a/src/connection.h
+++ b/src/connection.h
@@ -49,7 +49,7 @@ class ConnectionManager
 		void releaseConnection(const Connection_ptr& connection);
 		void closeAll();
 
-	protected:
+	private:
 		ConnectionManager() = default;
 
 		std::unordered_set<Connection_ptr> connections;

--- a/src/container.h
+++ b/src/container.h
@@ -149,17 +149,18 @@ class Container : public Item, public Cylinder
 		void startDecaying() override final;
 
 	protected:
+		ItemDeque itemlist;
+
+	private:
 		std::ostringstream& getContentDescription(std::ostringstream& os) const;
 
 		uint32_t maxSize;
 		uint32_t totalWeight = 0;
-		ItemDeque itemlist;
 		uint32_t serializationCount = 0;
 
 		bool unlocked;
 		bool pagination;
 
-	private:
 		void onAddContainerItem(Item* item);
 		void onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem);
 		void onRemoveContainerItem(uint32_t index, Item* item);

--- a/src/container.h
+++ b/src/container.h
@@ -39,7 +39,7 @@ class ContainerIterator
 		void advance();
 		Item* operator*();
 
-	protected:
+	private:
 		std::list<const Container*> over;
 		ItemDeque::const_iterator cur;
 
@@ -58,12 +58,12 @@ class Container : public Item, public Cylinder
 		Container(const Container&) = delete;
 		Container& operator=(const Container&) = delete;
 
-		Item* clone() const final;
+		Item* clone() const override final;
 
-		Container* getContainer() final {
+		Container* getContainer() override final {
 			return this;
 		}
-		const Container* getContainer() const final {
+		const Container* getContainer() const override final {
 			return this;
 		}
 
@@ -107,7 +107,7 @@ class Container : public Item, public Cylinder
 		bool isHoldingItem(const Item* item) const;
 
 		uint32_t getItemHoldingCount() const;
-		uint32_t getWeight() const final;
+		uint32_t getWeight() const override final;
 
 		bool isUnlocked() const {
 			return unlocked;
@@ -120,41 +120,33 @@ class Container : public Item, public Cylinder
 		virtual ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-				uint32_t flags) const final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const final;
+				uint32_t flags) const override final;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const override final;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) final;
+				uint32_t& flags) override final;
 
-		void addThing(Thing* thing) final;
-		void addThing(int32_t index, Thing* thing) final;
+		void addThing(Thing* thing) override final;
+		void addThing(int32_t index, Thing* thing) override final;
 		void addItemBack(Item* item);
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) final;
-		void replaceThing(uint32_t index, Thing* thing) final;
+		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override final;
+		void replaceThing(uint32_t index, Thing* thing) override final;
 
-		void removeThing(Thing* thing, uint32_t count) final;
+		void removeThing(Thing* thing, uint32_t count) override final;
 
-		int32_t getThingIndex(const Thing* thing) const final;
-		size_t getFirstIndex() const final;
-		size_t getLastIndex() const final;
-		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const final;
-		std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const final;
-		Thing* getThing(size_t index) const final;
+		int32_t getThingIndex(const Thing* thing) const override final;
+		size_t getFirstIndex() const override final;
+		size_t getLastIndex() const override final;
+		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override final;
+		std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const override final;
+		Thing* getThing(size_t index) const override final;
 
 		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
-		void internalAddThing(Thing* thing) final;
-		void internalAddThing(uint32_t index, Thing* thing) final;
-		void startDecaying() final;
-
-	private:
-		void onAddContainerItem(Item* item);
-		void onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem);
-		void onRemoveContainerItem(uint32_t index, Item* item);
-
-		Container* getParentContainer();
-		void updateItemWeight(int32_t diff);
+		void internalAddThing(Thing* thing) override final;
+		void internalAddThing(uint32_t index, Thing* thing) override final;
+		void startDecaying() override final;
 
 	protected:
 		std::ostringstream& getContentDescription(std::ostringstream& os) const;
@@ -166,6 +158,14 @@ class Container : public Item, public Cylinder
 
 		bool unlocked;
 		bool pagination;
+
+	private:
+		void onAddContainerItem(Item* item);
+		void onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem);
+		void onRemoveContainerItem(uint32_t index, Item* item);
+
+		Container* getParentContainer();
+		void updateItemWeight(int32_t diff);
 
 		friend class ContainerIterator;
 		friend class IOMapSerialize;

--- a/src/creature.h
+++ b/src/creature.h
@@ -82,7 +82,7 @@ class FrozenPathingConditionCall
 		bool isInRange(const Position& startPos, const Position& testPos,
 		               const FindPathParams& fpp) const;
 
-	protected:
+	private:
 		Position targetPos;
 };
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -104,10 +104,10 @@ class Creature : virtual public Thing
 		Creature(const Creature&) = delete;
 		Creature& operator=(const Creature&) = delete;
 
-		Creature* getCreature() final {
+		Creature* getCreature() override final {
 			return this;
 		}
-		const Creature* getCreature() const final {
+		const Creature* getCreature() const override final {
 			return this;
 		}
 		virtual Player* getPlayer() {
@@ -172,13 +172,13 @@ class Creature : virtual public Thing
 			hiddenHealth = b;
 		}
 
-		int32_t getThrowRange() const final {
+		int32_t getThrowRange() const override final {
 			return 1;
 		}
 		bool isPushable() const override {
 			return getWalkDelay() <= 0;
 		}
-		bool isRemoved() const final {
+		bool isRemoved() const override final {
 			return isInternalRemoved;
 		}
 		virtual bool canSeeInvisibility() const {
@@ -414,22 +414,22 @@ class Creature : virtual public Thing
 		bool registerCreatureEvent(const std::string& name);
 		bool unregisterCreatureEvent(const std::string& name);
 
-		Cylinder* getParent() const final {
+		Cylinder* getParent() const override final {
 			return tile;
 		}
-		void setParent(Cylinder* cylinder) final {
+		void setParent(Cylinder* cylinder) override final {
 			tile = static_cast<Tile*>(cylinder);
 			position = tile->getPosition();
 		}
 
-		const Position& getPosition() const final {
+		const Position& getPosition() const override final {
 			return position;
 		}
 
-		Tile* getTile() final {
+		Tile* getTile() override final {
 			return tile;
 		}
-		const Tile* getTile() const final {
+		const Tile* getTile() const override final {
 			return tile;
 		}
 

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -59,12 +59,12 @@ class CreatureEvents final : public BaseEvents
 
 		CreatureEvent* getEventByName(const std::string& name, bool forceLoaded = true);
 
-	protected:
-		LuaScriptInterface& getScriptInterface() final;
-		std::string getScriptBaseName() const final;
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
-		void clear() final;
+	private:
+		LuaScriptInterface& getScriptInterface() override;
+		std::string getScriptBaseName() const override;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
+		void clear() override;
 
 		//creature events
 		using CreatureEventMap = std::map<std::string, CreatureEvent*>;
@@ -78,7 +78,7 @@ class CreatureEvent final : public Event
 	public:
 		explicit CreatureEvent(LuaScriptInterface* interface);
 
-		bool configureEvent(const pugi::xml_node& node) final;
+		bool configureEvent(const pugi::xml_node& node) override;
 
 		CreatureEventType_t getEventType() const {
 			return type;
@@ -108,8 +108,8 @@ class CreatureEvent final : public Event
 		void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);
 		//
 
-	protected:
-		std::string getScriptEventName() const final;
+	private:
+		std::string getScriptEventName() const override;
 
 		std::string eventName;
 		CreatureEventType_t type;

--- a/src/database.h
+++ b/src/database.h
@@ -117,7 +117,7 @@ class Database
 			return maxPacketSize;
 		}
 
-	protected:
+	private:
 		/**
 		 * Transaction related methods.
 		 *
@@ -129,7 +129,6 @@ class Database
 		bool rollback();
 		bool commit();
 
-	private:
 		MYSQL* handle = nullptr;
 		std::recursive_mutex databaseLock;
 		uint64_t maxPacketSize = 1048576;
@@ -195,7 +194,7 @@ class DBInsert
 		bool addRow(std::ostringstream& row);
 		bool execute();
 
-	protected:
+	private:
 		std::string query;
 		std::string values;
 		size_t length;

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -34,18 +34,18 @@ class DepotChest final : public Container
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const;
+				uint32_t flags, Creature* actor = nullptr) const override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER);
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER);
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		//overrides
-		bool canRemove() const {
+		bool canRemove() const override {
 			return false;
 		}
 
-		Cylinder* getParent() const;
-		Cylinder* getRealParent() const {
+		Cylinder* getParent() const override;
+		Cylinder* getRealParent() const override {
 			return parent;
 		}
 

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -28,17 +28,17 @@ class DepotLocker final : public Container
 	public:
 		explicit DepotLocker(uint16_t type);
 
-		DepotLocker* getDepotLocker() final {
+		DepotLocker* getDepotLocker() override {
 			return this;
 		}
-		const DepotLocker* getDepotLocker() const final {
+		const DepotLocker* getDepotLocker() const override {
 			return this;
 		}
 
 		void removeInbox(Inbox* inbox);
 
 		//serialization
-		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) final;
+		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 
 		uint16_t getDepotId() const {
 			return depotId;
@@ -49,12 +49,12 @@ class DepotLocker final : public Container
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const final;
+				uint32_t flags, Creature* actor = nullptr) const override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
-		bool canRemove() const final {
+		bool canRemove() const override {
 			return false;
 		}
 

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -138,7 +138,7 @@ class PropStream
 			return true;
 		}
 
-	protected:
+	private:
 		const char* p = nullptr;
 		const char* end = nullptr;
 };
@@ -178,7 +178,7 @@ class PropWriteStream
 			std::copy(str.begin(), str.end(), std::back_inserter(buffer));
 		}
 
-	protected:
+	private:
 		std::vector<char> buffer;
 };
 

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -54,11 +54,11 @@ struct Node
 };
 
 struct LoadError : std::exception {
-	const char* what() const noexcept = 0;
+	const char* what() const noexcept override = 0;
 };
 
-struct InvalidOTBFormat : LoadError {
-	const char* what() const noexcept final {
+struct InvalidOTBFormat final : LoadError {
+	const char* what() const noexcept override {
 		return "Invalid OTBM file format";
 	}
 };

--- a/src/game.h
+++ b/src/game.h
@@ -503,7 +503,7 @@ class Game
 		Raids raids;
 		Quests quests;
 
-	protected:
+	private:
 		bool playerSaySpell(Player* player, SpeakClasses type, const std::string& text);
 		void playerWhisper(Player* player, const std::string& text);
 		bool playerYell(Player* player, const std::string& text);

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -54,16 +54,16 @@ class GlobalEvents final : public BaseEvents
 		GlobalEventMap getEventMap(GlobalEvent_t type);
 		static void clearMap(GlobalEventMap& map);
 
-	protected:
-		std::string getScriptBaseName() const final {
+	private:
+		std::string getScriptBaseName() const override {
 			return "globalevents";
 		}
-		void clear() final;
+		void clear() override;
 
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
 
-		LuaScriptInterface& getScriptInterface() final {
+		LuaScriptInterface& getScriptInterface() override {
 			return scriptInterface;
 		}
 		LuaScriptInterface scriptInterface;
@@ -77,7 +77,7 @@ class GlobalEvent final : public Event
 	public:
 		explicit GlobalEvent(LuaScriptInterface* interface);
 
-		bool configureEvent(const pugi::xml_node& node) final;
+		bool configureEvent(const pugi::xml_node& node) override;
 
 		bool executeRecord(uint32_t current, uint32_t old);
 		bool executeEvent();
@@ -101,10 +101,10 @@ class GlobalEvent final : public Event
 			nextExecution = time;
 		}
 
-	protected:
+	private:
 		GlobalEvent_t eventType = GLOBALEVENT_NONE;
 
-		std::string getScriptEventName() const final;
+		std::string getScriptEventName() const override;
 
 		std::string name;
 		int64_t nextExecution = 0;

--- a/src/house.h
+++ b/src/house.h
@@ -60,10 +60,10 @@ class Door final : public Item
 		Door(const Door&) = delete;
 		Door& operator=(const Door&) = delete;
 
-		Door* getDoor() final {
+		Door* getDoor() override {
 			return this;
 		}
-		const Door* getDoor() const final {
+		const Door* getDoor() const override {
 			return this;
 		}
 
@@ -72,8 +72,8 @@ class Door final : public Item
 		}
 
 		//serialization
-		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) final;
-		void serializeAttr(PropWriteStream&) const final {}
+		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
+		void serializeAttr(PropWriteStream&) const override {}
 
 		void setDoorId(uint32_t doorId) {
 			setIntAttr(ITEM_ATTRIBUTE_DOORID, doorId);
@@ -87,12 +87,11 @@ class Door final : public Item
 		void setAccessList(const std::string& textlist);
 		bool getAccessList(std::string& list) const;
 
-		void onRemoved() final;
-
-	protected:
-		void setHouse(House* house);
+		void onRemoved() override;
 
 	private:
+		void setHouse(House* house);
+
 		House* house = nullptr;
 		std::unique_ptr<AccessList> accessList;
 		friend class House;
@@ -120,12 +119,12 @@ class HouseTransferItem final : public Item
 
 		explicit HouseTransferItem(House* house) : Item(0), house(house) {}
 
-		void onTradeEvent(TradeEvents_t event, Player* owner) final;
-		bool canTransform() const final {
+		void onTradeEvent(TradeEvents_t event, Player* owner) override;
+		bool canTransform() const override {
 			return false;
 		}
 
-	protected:
+	private:
 		House* house;
 };
 

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -31,13 +31,13 @@ class HouseTile final : public DynamicTile
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const final;
+				uint32_t flags, Creature* actor = nullptr) const override;
 
 		Tile* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) final;
+				uint32_t& flags) override;
 
-		void addThing(int32_t index, Thing* thing) final;
-		void internalAddThing(uint32_t index, Thing* thing) final;
+		void addThing(int32_t index, Thing* thing) override;
+		void internalAddThing(uint32_t index, Thing* thing) override;
 
 		House* getHouse() {
 			return house;

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -29,18 +29,18 @@ class Inbox final : public Container
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const final;
+				uint32_t flags, Creature* actor = nullptr) const override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		//overrides
-		bool canRemove() const final {
+		bool canRemove() const override {
 			return false;
 		}
 
-		Cylinder* getParent() const final;
-		Cylinder* getRealParent() const final {
+		Cylinder* getParent() const override;
+		Cylinder* getRealParent() const override {
 			return parent;
 		}
 };

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -59,7 +59,7 @@ class IOLoginData
 		static void addPremiumDays(uint32_t accountId, int32_t addDays);
 		static void removePremiumDays(uint32_t accountId, int32_t removeDays);
 
-	protected:
+	private:
 		using ItemMap = std::map<uint32_t, std::pair<Item*, uint32_t>>;
 
 		static void loadItems(ItemMap& itemMap, DBResult_ptr result);

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -147,7 +147,7 @@ class IOMap
 			errorString = error;
 		}
 
-	protected:
+	private:
 		bool parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map, const std::string& fileName);
 		bool parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map);
 		bool parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map);

--- a/src/iomapserialize.h
+++ b/src/iomapserialize.h
@@ -31,7 +31,7 @@ class IOMapSerialize
 		static bool loadHouseInfo();
 		static bool saveHouseInfo();
 
-	protected:
+	private:
 		static void saveItem(PropWriteStream& stream, const Item* item);
 		static void saveTile(PropWriteStream& stream, const Tile* tile);
 

--- a/src/item.h
+++ b/src/item.h
@@ -318,10 +318,10 @@ class Item : virtual public Thing
 
 		bool equals(const Item* otherItem) const;
 
-		Item* getItem() final {
+		Item* getItem() override final {
 			return this;
 		}
-		const Item* getItem() const final {
+		const Item* getItem() const override final {
 			return this;
 		}
 		virtual Teleport* getTeleport() {
@@ -521,7 +521,7 @@ class Item : virtual public Thing
 		static std::string getNameDescription(const ItemType& it, const Item* item = nullptr, int32_t subType = -1, bool addArticle = true);
 		static std::string getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count = 1);
 
-		std::string getDescription(int32_t lookDistance) const final;
+		std::string getDescription(int32_t lookDistance) const override final;
 		std::string getNameDescription() const;
 		std::string getWeightDescription() const;
 
@@ -532,10 +532,10 @@ class Item : virtual public Thing
 
 		virtual void serializeAttr(PropWriteStream& propWriteStream) const;
 
-		bool isPushable() const final {
+		bool isPushable() const override final {
 			return isMoveable();
 		}
-		int32_t getThrowRange() const final {
+		int32_t getThrowRange() const override final {
 			return (isPickupable() ? 15 : 2);
 		}
 
@@ -731,17 +731,17 @@ class Item : virtual public Thing
 			}
 		}
 
-		Cylinder* getParent() const {
+		Cylinder* getParent() const override {
 			return parent;
 		}
-		void setParent(Cylinder* cylinder) {
+		void setParent(Cylinder* cylinder) override {
 			parent = cylinder;
 		}
 		Cylinder* getTopParent();
 		const Cylinder* getTopParent() const;
-		Tile* getTile();
-		const Tile* getTile() const;
-		bool isRemoved() const {
+		Tile* getTile() override;
+		const Tile* getTile() const override;
+		bool isRemoved() const override {
 			return !parent || parent->isRemoved();
 		}
 

--- a/src/item.h
+++ b/src/item.h
@@ -206,7 +206,7 @@ class ItemAttributes
 			return static_cast<ItemDecayState_t>(getIntAttr(ITEM_ATTRIBUTE_DECAYSTATE));
 		}
 
-	protected:
+	private:
 		bool hasAttribute(itemAttrTypes type) const {
 			return (type & attributeBits) != 0;
 		}
@@ -746,14 +746,17 @@ class Item : virtual public Thing
 		}
 
 	protected:
+		Cylinder* parent = nullptr;
+
+		uint16_t id;  // the same id as in ItemType
+
+	private:
 		std::string getWeightDescription(uint32_t weight) const;
 
-		Cylinder* parent = nullptr;
 		std::unique_ptr<ItemAttributes> attributes;
 
 		uint32_t referenceCounter = 0;
 
-		uint16_t id;  // the same id as in ItemType
 		uint8_t count = 1; // number of stacked items
 
 		bool loadedFromMap = false;

--- a/src/items.h
+++ b/src/items.h
@@ -306,7 +306,7 @@ class Items
 
 		NameMap nameToItems;
 
-	protected:
+	private:
 		std::map<uint16_t, uint16_t> reverseItemMap;
 		std::vector<ItemType> items;
 };

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -401,9 +401,21 @@ class LuaScriptInterface
 
 		void registerFunctions();
 
+		void registerMethod(const std::string& className, const std::string& methodName, lua_CFunction func);
+
+		static std::string getErrorDesc(ErrorCode_t code);
+
+		lua_State* luaState = nullptr;
+
+		int32_t eventTableRef = -1;
+		int32_t runningEventId = EVENT_ID_USER;
+
+		//script file cache
+		std::map<int32_t, std::string> cacheFiles;
+
+	private:
 		void registerClass(const std::string& className, const std::string& baseClass, lua_CFunction newFunction = nullptr);
 		void registerTable(const std::string& tableName);
-		void registerMethod(const std::string& className, const std::string& methodName, lua_CFunction func);
 		void registerMetaMethod(const std::string& className, const std::string& methodName, lua_CFunction func);
 		void registerGlobalMethod(const std::string& functionName, lua_CFunction func);
 		void registerVariable(const std::string& tableName, const std::string& name, lua_Number value);
@@ -412,7 +424,6 @@ class LuaScriptInterface
 
 		std::string getStackTrace(const std::string& error_desc);
 
-		static std::string getErrorDesc(ErrorCode_t code);
 		static bool getArea(lua_State* L, std::list<uint32_t>& list, uint32_t& rows);
 
 		//lua functions
@@ -1266,20 +1277,14 @@ class LuaScriptInterface
 		static int luaSpellIsLearnable(lua_State* L);
 
 		//
-		lua_State* luaState = nullptr;
 		std::string lastLuaError;
 
 		std::string interfaceName;
-		int32_t eventTableRef = -1;
 
 		static ScriptEnvironment scriptEnv[16];
 		static int32_t scriptEnvIndex;
 
-		int32_t runningEventId = EVENT_ID_USER;
 		std::string loadingFile;
-
-		//script file cache
-		std::map<int32_t, std::string> cacheFiles;
 };
 
 class LuaEnvironment : public LuaScriptInterface

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1292,9 +1292,9 @@ class LuaEnvironment : public LuaScriptInterface
 		LuaEnvironment(const LuaEnvironment&) = delete;
 		LuaEnvironment& operator=(const LuaEnvironment&) = delete;
 
-		bool initState();
+		bool initState() override;
 		bool reInitState();
-		bool closeState();
+		bool closeState() override;
 
 		LuaScriptInterface* getTestInterface();
 

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -29,32 +29,32 @@ class Mailbox final : public Item, public Cylinder
 	public:
 		explicit Mailbox(uint16_t itemId) : Item(itemId) {}
 
-		Mailbox* getMailbox() final {
+		Mailbox* getMailbox() override {
 			return this;
 		}
-		const Mailbox* getMailbox() const final {
+		const Mailbox* getMailbox() const override {
 			return this;
 		}
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const final;
+				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t& maxQueryCount, uint32_t flags) const final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const final;
+				uint32_t& maxQueryCount, uint32_t flags) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const override;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) final;
+				uint32_t& flags) override;
 
-		void addThing(Thing* thing) final;
-		void addThing(int32_t index, Thing* thing) final;
+		void addThing(Thing* thing) override;
+		void addThing(int32_t index, Thing* thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) final;
-		void replaceThing(uint32_t index, Thing* thing) final;
+		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, Thing* thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) final;
+		void removeThing(Thing* thing, uint32_t count) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 	private:
 		bool getReceiver(Item* item, std::string& name) const;

--- a/src/map.h
+++ b/src/map.h
@@ -127,9 +127,10 @@ class QTreeNode
 		QTreeLeafNode* createLeaf(uint32_t x, uint32_t y, uint32_t level);
 
 	protected:
-		QTreeNode* child[4] = {};
-
 		bool leaf = false;
+
+	private:
+		QTreeNode* child[4] = {};
 
 		friend class Map;
 };
@@ -152,7 +153,7 @@ class QTreeLeafNode final : public QTreeNode
 		void addCreature(Creature* c);
 		void removeCreature(Creature* c);
 
-	protected:
+	private:
 		static bool newLeaf;
 		QTreeLeafNode* leafS = nullptr;
 		QTreeLeafNode* leafE = nullptr;
@@ -262,7 +263,8 @@ class Map
 		Spawns spawns;
 		Towns towns;
 		Houses houses;
-	protected:
+
+	private:
 		SpectatorCache spectatorCache;
 		SpectatorCache playersSpectatorCache;
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -51,33 +51,33 @@ class Monster final : public Creature
 		Monster(const Monster&) = delete;
 		Monster& operator=(const Monster&) = delete;
 
-		Monster* getMonster() final {
+		Monster* getMonster() override {
 			return this;
 		}
-		const Monster* getMonster() const final {
+		const Monster* getMonster() const override {
 			return this;
 		}
 
-		void setID() final {
+		void setID() override {
 			if (id == 0) {
 				id = monsterAutoID++;
 			}
 		}
 
-		void removeList() final;
-		void addList() final;
+		void removeList() override;
+		void addList() override;
 
-		const std::string& getName() const final {
+		const std::string& getName() const override {
 			return mType->name;
 		}
-		const std::string& getNameDescription() const final {
+		const std::string& getNameDescription() const override {
 			return mType->nameDescription;
 		}
-		std::string getDescription(int32_t) const final {
+		std::string getDescription(int32_t) const override {
 			return strDescription + '.';
 		}
 
-		CreatureType_t getType() const final {
+		CreatureType_t getType() const override {
 			return CREATURETYPE_MONSTER;
 		}
 
@@ -88,19 +88,19 @@ class Monster final : public Creature
 			masterPos = pos;
 		}
 
-		RaceType_t getRace() const final {
+		RaceType_t getRace() const override {
 			return mType->info.race;
 		}
-		int32_t getArmor() const final {
+		int32_t getArmor() const override {
 			return mType->info.armor;
 		}
-		int32_t getDefense() const final {
+		int32_t getDefense() const override {
 			return mType->info.defense;
 		}
-		bool isPushable() const final {
+		bool isPushable() const override {
 			return mType->info.pushable && baseSpeed != 0;
 		}
-		bool isAttackable() const final {
+		bool isAttackable() const override {
 			return mType->info.isAttackable;
 		}
 
@@ -113,8 +113,8 @@ class Monster final : public Creature
 		bool isHostile() const {
 			return mType->info.isHostile;
 		}
-		bool canSee(const Position& pos) const final;
-		bool canSeeInvisibility() const final {
+		bool canSee(const Position& pos) const override;
+		bool canSeeInvisibility() const override {
 			return isImmune(CONDITION_INVISIBLE);
 		}
 		uint32_t getManaCost() const {
@@ -124,29 +124,29 @@ class Monster final : public Creature
 			this->spawn = spawn;
 		}
 
-		void onAttackedCreatureDisappear(bool isLogout) final;
+		void onAttackedCreatureDisappear(bool isLogout) override;
 
-		void onCreatureAppear(Creature* creature, bool isLogin) final;
-		void onRemoveCreature(Creature* creature, bool isLogout) final;
-		void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile, const Position& oldPos, bool teleport) final;
-		void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) final;
+		void onCreatureAppear(Creature* creature, bool isLogin) override;
+		void onRemoveCreature(Creature* creature, bool isLogout) override;
+		void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile, const Position& oldPos, bool teleport) override;
+		void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) override;
 
-		void drainHealth(Creature* attacker, int32_t damage) final;
-		void changeHealth(int32_t healthChange, bool sendHealthChange = true) final;
-		void onWalk() final;
-		bool getNextStep(Direction& direction, uint32_t& flags) final;
-		void onFollowCreatureComplete(const Creature* creature) final;
+		void drainHealth(Creature* attacker, int32_t damage) override;
+		void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
+		void onWalk() override;
+		bool getNextStep(Direction& direction, uint32_t& flags) override;
+		void onFollowCreatureComplete(const Creature* creature) override;
 
-		void onThink(uint32_t interval) final;
+		void onThink(uint32_t interval) override;
 
-		bool challengeCreature(Creature* creature) final;
-		bool convinceCreature(Creature* creature) final;
+		bool challengeCreature(Creature* creature) override;
+		bool convinceCreature(Creature* creature) override;
 
-		void setNormalCreatureLight() final;
-		bool getCombatValues(int32_t& min, int32_t& max) final;
+		void setNormalCreatureLight() override;
+		bool getCombatValues(int32_t& min, int32_t& max) override;
 
-		void doAttacking(uint32_t interval) final;
-		bool hasExtraSwing() final {
+		void doAttacking(uint32_t interval) override;
+		bool hasExtraSwing() override {
 			return extraMeleeAttack;
 		}
 
@@ -171,7 +171,7 @@ class Monster final : public Creature
 		}
 
 		BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
-		                     bool checkDefense = false, bool checkArmor = false, bool field = false);
+		                     bool checkDefense = false, bool checkArmor = false, bool field = false) override;
 
 		static uint32_t monsterAutoID;
 
@@ -217,8 +217,8 @@ class Monster final : public Creature
 		void clearTargetList();
 		void clearFriendList();
 
-		void death(Creature* lastHitCreature) final;
-		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) final;
+		void death(Creature* lastHitCreature) override;
+		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) override;
 
 		void setIdle(bool idle);
 		void updateIdleStatus();
@@ -226,9 +226,9 @@ class Monster final : public Creature
 			return isIdle;
 		}
 
-		void onAddCondition(ConditionType_t type) final;
-		void onEndCondition(ConditionType_t type) final;
-		void onCreatureConvinced(const Creature* convincer, const Creature* creature) final;
+		void onAddCondition(ConditionType_t type) override;
+		void onEndCondition(ConditionType_t type) override;
+		void onCreatureConvinced(const Creature* convincer, const Creature* creature) override;
 
 		bool canUseAttack(const Position& pos, const Creature* target) const;
 		bool canUseSpell(const Position& pos, const Position& targetPos,
@@ -251,21 +251,21 @@ class Monster final : public Creature
 		bool isFriend(const Creature* creature) const;
 		bool isOpponent(const Creature* creature) const;
 
-		uint64_t getLostExperience() const final {
+		uint64_t getLostExperience() const override {
 			return skillLoss ? mType->info.experience : 0;
 		}
-		uint16_t getLookCorpse() const final {
+		uint16_t getLookCorpse() const override {
 			return mType->info.lookcorpse;
 		}
-		void dropLoot(Container* corpse, Creature* lastHitCreature) final;
-		uint32_t getDamageImmunities() const final {
+		void dropLoot(Container* corpse, Creature* lastHitCreature) override;
+		uint32_t getDamageImmunities() const override {
 			return mType->info.damageImmunities;
 		}
-		uint32_t getConditionImmunities() const final {
+		uint32_t getConditionImmunities() const override {
 			return mType->info.conditionImmunities;
 		}
-		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const final;
-		bool useCacheMap() const final {
+		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
+		bool useCacheMap() const override {
 			return true;
 		}
 

--- a/src/movement.h
+++ b/src/movement.h
@@ -63,16 +63,16 @@ class MoveEvents final : public BaseEvents
 
 		MoveEvent* getEvent(Item* item, MoveEvent_t eventType);
 
-	protected:
+	private:
 		using MoveListMap = std::map<int32_t, MoveEventList>;
 		void clearMap(MoveListMap& map);
 
 		using MovePosListMap = std::map<Position, MoveEventList>;
-		void clear() final;
-		LuaScriptInterface& getScriptInterface() final;
-		std::string getScriptBaseName() const final;
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
+		void clear() override;
+		LuaScriptInterface& getScriptInterface() override;
+		std::string getScriptBaseName() const override;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
 
 		void addEvent(MoveEvent* moveEvent, int32_t id, MoveListMap& map);
 
@@ -101,8 +101,8 @@ class MoveEvent final : public Event
 		MoveEvent_t getEventType() const;
 		void setEventType(MoveEvent_t type);
 
-		bool configureEvent(const pugi::xml_node& node) final;
-		bool loadFunction(const pugi::xml_attribute& attr) final;
+		bool configureEvent(const pugi::xml_node& node) override;
+		bool loadFunction(const pugi::xml_attribute& attr) override;
 
 		uint32_t fireStepEvent(Creature* creature, Item* item, const Position& pos);
 		uint32_t fireAddRemItem(Item* item, Item* tileItem, const Position& pos);
@@ -138,8 +138,8 @@ class MoveEvent final : public Event
 			return vocEquipMap;
 		}
 
-	protected:
-		std::string getScriptEventName() const final;
+	private:
+		std::string getScriptEventName() const override;
 
 		MoveEvent_t eventType = MOVE_EVENT_NONE;
 		StepFunction stepFunction;

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -150,6 +150,16 @@ class NetworkMessage
 		}
 
 	protected:
+		struct NetworkMessageInfo {
+			MsgSize_t length = 0;
+			MsgSize_t position = INITIAL_BUFFER_POSITION;
+			bool overrun = false;
+		};
+
+		NetworkMessageInfo info;
+		uint8_t buffer[NETWORKMESSAGE_MAXSIZE];
+
+	private:
 		bool canAdd(size_t size) const {
 			return (size + info.position) < MAX_BODY_LENGTH;
 		}
@@ -161,15 +171,6 @@ class NetworkMessage
 			}
 			return true;
 		}
-
-		struct NetworkMessageInfo {
-			MsgSize_t length = 0;
-			MsgSize_t position = INITIAL_BUFFER_POSITION;
-			bool overrun = false;
-		};
-
-		NetworkMessageInfo info;
-		uint8_t buffer[NETWORKMESSAGE_MAXSIZE];
 };
 
 #endif // #ifndef __NETWORK_MESSAGE_H__

--- a/src/npc.h
+++ b/src/npc.h
@@ -41,7 +41,7 @@ class NpcScriptInterface final : public LuaScriptInterface
 
 		bool loadNpcLib(const std::string& file);
 
-	protected:
+	private:
 		void registerFunctions();
 
 		static int luaActionSay(lua_State* L);
@@ -65,8 +65,8 @@ class NpcScriptInterface final : public LuaScriptInterface
 		static int luaNpcCloseShopWindow(lua_State* L);
 
 	private:
-		bool initState() final;
-		bool closeState() final;
+		bool initState() override;
+		bool closeState() override;
 
 		bool libLoaded;
 };
@@ -87,7 +87,7 @@ class NpcEventsHandler
 
 		bool isLoaded() const;
 
-	protected:
+	private:
 		Npc* npc;
 		NpcScriptInterface* scriptInterface;
 
@@ -110,45 +110,45 @@ class Npc final : public Creature
 		Npc(const Npc&) = delete;
 		Npc& operator=(const Npc&) = delete;
 
-		Npc* getNpc() final {
+		Npc* getNpc() override {
 			return this;
 		}
-		const Npc* getNpc() const final {
+		const Npc* getNpc() const override {
 			return this;
 		}
 
-		bool isPushable() const final {
+		bool isPushable() const override {
 			return pushable && walkTicks != 0;
 		}
 
-		void setID() final {
+		void setID() override {
 			if (id == 0) {
 				id = npcAutoID++;
 			}
 		}
 
-		void removeList() final;
-		void addList() final;
+		void removeList() override;
+		void addList() override;
 
 		static Npc* createNpc(const std::string& name);
 
-		bool canSee(const Position& pos) const final;
+		bool canSee(const Position& pos) const override;
 
 		bool load();
 		void reload();
 
-		const std::string& getName() const final {
+		const std::string& getName() const override {
 			return name;
 		}
-		const std::string& getNameDescription() const final {
+		const std::string& getNameDescription() const override {
 			return name;
 		}
 
-		CreatureType_t getType() const final {
+		CreatureType_t getType() const override {
 			return CREATURETYPE_NPC;
 		}
 
-		uint8_t getSpeechBubble() const final {
+		uint8_t getSpeechBubble() const override {
 			return speechBubble;
 		}
 		void setSpeechBubble(const uint8_t bubble) {
@@ -185,28 +185,28 @@ class Npc final : public Creature
 
 		static uint32_t npcAutoID;
 
-	protected:
+	private:
 		explicit Npc(const std::string& name);
 
-		void onCreatureAppear(Creature* creature, bool isLogin) final;
-		void onRemoveCreature(Creature* creature, bool isLogout) final;
+		void onCreatureAppear(Creature* creature, bool isLogin) override;
+		void onRemoveCreature(Creature* creature, bool isLogout) override;
 		void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos,
-		                            const Tile* oldTile, const Position& oldPos, bool teleport) final;
+		                            const Tile* oldTile, const Position& oldPos, bool teleport) override;
 
-		void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) final;
-		void onThink(uint32_t interval) final;
-		std::string getDescription(int32_t lookDistance) const final;
+		void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) override;
+		void onThink(uint32_t interval) override;
+		std::string getDescription(int32_t lookDistance) const override;
 
-		bool isImmune(CombatType_t) const final {
+		bool isImmune(CombatType_t) const override {
 			return !attackable;
 		}
-		bool isImmune(ConditionType_t) const final {
+		bool isImmune(ConditionType_t) const override {
 			return !attackable;
 		}
-		bool isAttackable() const final {
+		bool isAttackable() const override {
 			return attackable;
 		}
-		bool getNextStep(Direction& dir, uint32_t& flags) final;
+		bool getNextStep(Direction& dir, uint32_t& flags) override;
 
 		void setIdle(bool idle);
 		void updateIdleStatus();

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -57,7 +57,7 @@ void startupErrorMessage(const std::string& errorStr)
 
 void mainLoader(int argc, char* argv[], ServiceManager* servicer);
 
-void badAllocationHandler()
+[[noreturn]] void badAllocationHandler()
 {
 	// Use functions that only use stack allocation
 	puts("Allocation failed, server out of memory.\nDecrease the size of your map or compile in 64 bits mode.\n");

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -65,7 +65,7 @@ class OutputMessage : public NetworkMessage
 			info.position += msgLen;
 		}
 
-	protected:
+	private:
 		template <typename T>
 		void add_header(T add) {
 			assert(outputBufferStart >= sizeof(T));

--- a/src/party.h
+++ b/src/party.h
@@ -83,7 +83,7 @@ class Party
 		void updatePlayerTicks(Player* player, uint32_t points);
 		void clearPlayerPoints(Player* player);
 
-	protected:
+	private:
 		bool canEnableSharedExperience();
 
 		std::map<uint32_t, int64_t> ticksMap;

--- a/src/player.h
+++ b/src/player.h
@@ -118,14 +118,14 @@ class Player final : public Creature, public Cylinder
 		Player(const Player&) = delete;
 		Player& operator=(const Player&) = delete;
 
-		Player* getPlayer() final {
+		Player* getPlayer() override {
 			return this;
 		}
-		const Player* getPlayer() const final {
+		const Player* getPlayer() const override {
 			return this;
 		}
 
-		void setID() final {
+		void setID() override {
 			if (id == 0) {
 				id = playerAutoID++;
 			}
@@ -133,18 +133,18 @@ class Player final : public Creature, public Cylinder
 
 		static MuteCountMap muteCountMap;
 
-		const std::string& getName() const final {
+		const std::string& getName() const override {
 			return name;
 		}
 		void setName(std::string name) {
 			this->name = std::move(name);
 		}
-		const std::string& getNameDescription() const final {
+		const std::string& getNameDescription() const override {
 			return name;
 		}
-		std::string getDescription(int32_t lookDistance) const final;
+		std::string getDescription(int32_t lookDistance) const override;
 
-		CreatureType_t getType() const final {
+		CreatureType_t getType() const override {
 			return CREATURETYPE_PLAYER;
 		}
 
@@ -171,12 +171,12 @@ class Player final : public Creature, public Cylinder
 		uint32_t getGUID() const {
 			return guid;
 		}
-		bool canSeeInvisibility() const final {
+		bool canSeeInvisibility() const override {
 			return hasFlag(PlayerFlag_CanSenseInvisibility) || group->access;
 		}
 
-		void removeList() final;
-		void addList() final;
+		void removeList() override;
+		void addList() override;
 		void kickPlayer(bool displayEffect);
 
 		static uint64_t getExpForLevel(int32_t lv) {
@@ -368,7 +368,7 @@ class Player final : public Creature, public Cylinder
 			idleTime = 0;
 		}
 
-		bool isInGhostMode() const {
+		bool isInGhostMode() const override {
 			return ghostMode;
 		}
 		void switchGhostMode() {
@@ -445,7 +445,7 @@ class Player final : public Creature, public Cylinder
 		bool hasModalWindowOpen(uint32_t modalWindowId) const;
 		void onModalWindowHandled(uint32_t modalWindowId);
 
-		bool isPushable() const final;
+		bool isPushable() const override;
 		uint32_t isMuted() const;
 		void addMessageBuffer();
 		void removeMessageBuffer();
@@ -471,7 +471,7 @@ class Player final : public Creature, public Cylinder
 			}
 		}
 
-		int32_t getMaxHealth() const final {
+		int32_t getMaxHealth() const override {
 			return std::max<int32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS]);
 		}
 		uint32_t getMana() const {
@@ -505,13 +505,13 @@ class Player final : public Creature, public Cylinder
 		void onReceiveMail() const;
 		bool isNearDepotBox() const;
 
-		bool canSee(const Position& pos) const final;
-		bool canSeeCreature(const Creature* creature) const final;
+		bool canSee(const Position& pos) const override;
+		bool canSeeCreature(const Creature* creature) const override;
 
 		bool canWalkthrough(const Creature* creature) const;
 		bool canWalkthroughEx(const Creature* creature) const;
 
-		RaceType_t getRace() const final {
+		RaceType_t getRace() const override {
 			return RACE_BLOOD;
 		}
 
@@ -555,16 +555,16 @@ class Player final : public Creature, public Cylinder
 		bool editVIP(uint32_t vipGuid, const std::string& description, uint32_t icon, bool notify);
 
 		//follow functions
-		bool setFollowCreature(Creature* creature) final;
-		void goToFollowCreature() final;
+		bool setFollowCreature(Creature* creature) override;
+		void goToFollowCreature() override;
 
 		//follow events
-		void onFollowCreature(const Creature* creature) final;
+		void onFollowCreature(const Creature* creature) override;
 
 		//walk events
-		void onWalk(Direction& dir) final;
-		void onWalkAborted() final;
-		void onWalkComplete() final;
+		void onWalk(Direction& dir) override;
+		void onWalkAborted() override;
+		void onWalkComplete() override;
 
 		void stopWalk();
 		void openShopWindow(Npc* npc, const std::list<ShopInfo>& shop);
@@ -581,14 +581,14 @@ class Player final : public Creature, public Cylinder
 		}
 
 		//combat functions
-		bool setAttackedCreature(Creature* creature) final;
-		bool isImmune(CombatType_t type) const final;
-		bool isImmune(ConditionType_t type) const final;
+		bool setAttackedCreature(Creature* creature) override;
+		bool isImmune(CombatType_t type) const override;
+		bool isImmune(ConditionType_t type) const override;
 		bool hasShield() const;
-		bool isAttackable() const final;
+		bool isAttackable() const override;
 		static bool lastHitIsPlayer(Creature* lastHitCreature);
 
-		void changeHealth(int32_t healthChange, bool sendHealthChange = true) final;
+		void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
 		void changeMana(int32_t manaChange);
 		void changeSoul(int32_t soulChange);
 
@@ -596,9 +596,9 @@ class Player final : public Creature, public Cylinder
 			return pzLocked;
 		}
 		BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
-		                             bool checkDefense = false, bool checkArmor = false, bool field = false) final;
-		void doAttacking(uint32_t interval) final;
-		bool hasExtraSwing() final {
+		                             bool checkDefense = false, bool checkArmor = false, bool field = false) override;
+		void doAttacking(uint32_t interval) override;
+		bool hasExtraSwing() override {
 			return lastAttack > 0 && ((OTSYS_TIME() - lastAttack) >= getAttackSpeed());
 		}
 
@@ -625,43 +625,43 @@ class Player final : public Creature, public Cylinder
 		int32_t getWeaponSkill(const Item* item) const;
 		void getShieldAndWeapon(const Item*& shield, const Item*& weapon) const;
 
-		void drainHealth(Creature* attacker, int32_t damage) final;
+		void drainHealth(Creature* attacker, int32_t damage) override;
 		void drainMana(Creature* attacker, int32_t manaLoss);
 		void addManaSpent(uint64_t amount);
 		void addSkillAdvance(skills_t skill, uint64_t count);
 
-		int32_t getArmor() const final;
-		int32_t getDefense() const final;
-		float getAttackFactor() const final;
-		float getDefenseFactor() const final;
+		int32_t getArmor() const override;
+		int32_t getDefense() const override;
+		float getAttackFactor() const override;
+		float getDefenseFactor() const override;
 
 		void addInFightTicks(bool pzlock = false);
 
-		uint64_t getGainedExperience(Creature* attacker) const final;
+		uint64_t getGainedExperience(Creature* attacker) const override;
 
 		//combat event functions
-		void onAddCondition(ConditionType_t type) final;
-		void onAddCombatCondition(ConditionType_t type) final;
-		void onEndCondition(ConditionType_t type) final;
-		void onCombatRemoveCondition(Condition* condition) final;
-		void onAttackedCreature(Creature* target) final;
-		void onAttacked() final;
-		void onAttackedCreatureDrainHealth(Creature* target, int32_t points) final;
-		void onTargetCreatureGainHealth(Creature* target, int32_t points) final;
-		bool onKilledCreature(Creature* target, bool lastHit = true) final;
-		void onGainExperience(uint64_t gainExp, Creature* target) final;
+		void onAddCondition(ConditionType_t type) override;
+		void onAddCombatCondition(ConditionType_t type) override;
+		void onEndCondition(ConditionType_t type) override;
+		void onCombatRemoveCondition(Condition* condition) override;
+		void onAttackedCreature(Creature* target) override;
+		void onAttacked() override;
+		void onAttackedCreatureDrainHealth(Creature* target, int32_t points) override;
+		void onTargetCreatureGainHealth(Creature* target, int32_t points) override;
+		bool onKilledCreature(Creature* target, bool lastHit = true) override;
+		void onGainExperience(uint64_t gainExp, Creature* target) override;
 		void onGainSharedExperience(uint64_t gainExp, Creature* source);
-		void onAttackedCreatureBlockHit(BlockType_t blockType) final;
-		void onBlockHit() final;
-		void onChangeZone(ZoneType_t zone) final;
-		void onAttackedCreatureChangeZone(ZoneType_t zone) final;
-		void onIdleStatus() final;
-		void onPlacedCreature() final;
+		void onAttackedCreatureBlockHit(BlockType_t blockType) override;
+		void onBlockHit() override;
+		void onChangeZone(ZoneType_t zone) override;
+		void onAttackedCreatureChangeZone(ZoneType_t zone) override;
+		void onIdleStatus() override;
+		void onPlacedCreature() override;
 
-		LightInfo getCreatureLight() const final;
+		LightInfo getCreatureLight() const override;
 
-		Skulls_t getSkull() const final;
-		Skulls_t getSkullClient(const Creature* creature) const final;
+		Skulls_t getSkull() const override;
+		Skulls_t getSkullClient(const Creature* creature) const override;
 		int64_t getSkullTicks() const { return skullTicks; }
 		void setSkullTicks(int64_t ticks) { skullTicks = ticks; }
 
@@ -848,17 +848,17 @@ class Player final : public Creature, public Cylinder
 
 		//event methods
 		void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem,
-		                              const ItemType& oldType, const Item* newItem, const ItemType& newType) final;
+		                              const ItemType& oldType, const Item* newItem, const ItemType& newType) override;
 		void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType,
-		                              const Item* item) final;
+		                              const Item* item) override;
 
-		void onCreatureAppear(Creature* creature, bool isLogin) final;
-		void onRemoveCreature(Creature* creature, bool isLogout) final;
+		void onCreatureAppear(Creature* creature, bool isLogin) override;
+		void onRemoveCreature(Creature* creature, bool isLogout) override;
 		void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos,
-		                            const Tile* oldTile, const Position& oldPos, bool teleport) final;
+		                            const Tile* oldTile, const Position& oldPos, bool teleport) override;
 
-		void onAttackedCreatureDisappear(bool isLogout) final;
-		void onFollowCreatureDisappear(bool isLogout) final;
+		void onAttackedCreatureDisappear(bool isLogout) override;
+		void onFollowCreatureDisappear(bool isLogout) override;
 
 		//container
 		void onAddContainerItem(const Item* item);
@@ -1105,10 +1105,10 @@ class Player final : public Creature, public Cylinder
 			lastPong = OTSYS_TIME();
 		}
 
-		void onThink(uint32_t interval) final;
+		void onThink(uint32_t interval) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		void setNextAction(int64_t time) {
 			if (time > nextAction) {
@@ -1130,7 +1130,7 @@ class Player final : public Creature, public Cylinder
 		void forgetInstantSpell(const std::string& spellName);
 		bool hasLearnedInstantSpell(const std::string& spellName) const;
 
-	protected:
+	private:
 		std::forward_list<Condition*> getMuteConditions() const;
 
 		void checkTradeState(const Item* item);
@@ -1146,36 +1146,36 @@ class Player final : public Creature, public Cylinder
 		void setNextWalkTask(SchedulerTask* task);
 		void setNextActionTask(SchedulerTask* task);
 
-		void death(Creature* lastHitCreature) final;
-		bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified) final;
-		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) final;
+		void death(Creature* lastHitCreature) override;
+		bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified) override;
+		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) override;
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const final;
+				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-				uint32_t flags) const final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const final;
+				uint32_t flags) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const override;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) final;
+				uint32_t& flags) override;
 
-		void addThing(Thing*) final {}
-		void addThing(int32_t index, Thing* thing) final;
+		void addThing(Thing*) override {}
+		void addThing(int32_t index, Thing* thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) final;
-		void replaceThing(uint32_t index, Thing* thing) final;
+		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, Thing* thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) final;
+		void removeThing(Thing* thing, uint32_t count) override;
 
-		int32_t getThingIndex(const Thing* thing) const final;
-		size_t getFirstIndex() const final;
-		size_t getLastIndex() const final;
-		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const final;
-		std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const final;
-		Thing* getThing(size_t index) const final;
+		int32_t getThingIndex(const Thing* thing) const override;
+		size_t getFirstIndex() const override;
+		size_t getLastIndex() const override;
+		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override;
+		std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const override;
+		Thing* getThing(size_t index) const override;
 
-		void internalAddThing(Thing* thing) final;
-		void internalAddThing(uint32_t index, Thing* thing) final;
+		void internalAddThing(Thing* thing) override;
+		void internalAddThing(uint32_t index, Thing* thing) override;
 
 		std::unordered_set<uint32_t> attackedSet;
 		std::unordered_set<uint32_t> VIPList;
@@ -1296,7 +1296,7 @@ class Player final : public Creature, public Cylinder
 		static uint32_t playerAutoID;
 
 		void updateItemsLight(bool internal = false);
-		int32_t getStepSpeed() const final {
+		int32_t getStepSpeed() const override {
 			return std::max<int32_t>(PLAYER_MIN_SPEED, std::min<int32_t>(PLAYER_MAX_SPEED, getSpeed()));
 		}
 		void updateBaseSpeed() {
@@ -1315,20 +1315,20 @@ class Player final : public Creature, public Cylinder
 
 		static uint8_t getPercentLevel(uint64_t count, uint64_t nextLevelCount);
 		double getLostPercent() const;
-		uint64_t getLostExperience() const final {
+		uint64_t getLostExperience() const override {
 			return skillLoss ? static_cast<uint64_t>(experience * getLostPercent()) : 0;
 		}
-		uint32_t getDamageImmunities() const final {
+		uint32_t getDamageImmunities() const override {
 			return damageImmunities;
 		}
-		uint32_t getConditionImmunities() const final {
+		uint32_t getConditionImmunities() const override {
 			return conditionImmunities;
 		}
-		uint32_t getConditionSuppressions() const final {
+		uint32_t getConditionSuppressions() const override {
 			return conditionSuppressions;
 		}
-		uint16_t getLookCorpse() const final;
-		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const final;
+		uint16_t getLookCorpse() const override;
+		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
 
 		friend class Game;
 		friend class Npc;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -78,8 +78,6 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 			checksumEnabled = false;
 		}
 
-		void XTEA_encrypt(OutputMessage& msg) const;
-		bool XTEA_decrypt(NetworkMessage& msg) const;
 		static bool RSA_decrypt(NetworkMessage& msg);
 
 		void setRawMessages(bool value) {
@@ -87,10 +85,15 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		}
 
 		virtual void release() {}
+
+	private:
+		void XTEA_encrypt(OutputMessage& msg) const;
+		bool XTEA_decrypt(NetworkMessage& msg) const;
+
 		friend class Connection;
 
 		OutputMessage_ptr outputBuffer;
-	private:
+
 		const ConnectionWeak_ptr connection;
 		uint32_t key[4] = {};
 		bool encryptionEnabled = false;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -81,7 +81,7 @@ class ProtocolGame final : public Protocol
 		void disconnectClient(const std::string& message) const;
 		void writeToOutputBuffer(const NetworkMessage& msg);
 
-		void release() final;
+		void release() override;
 
 		void checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown);
 
@@ -90,9 +90,9 @@ class ProtocolGame final : public Protocol
 		bool canSee(const Position& pos) const;
 
 		// we have all the parse methods
-		void parsePacket(NetworkMessage& msg) final;
-		void onRecvFirstMessage(NetworkMessage& msg) final;
-		void onConnect() final;
+		void parsePacket(NetworkMessage& msg) override;
+		void onRecvFirstMessage(NetworkMessage& msg) override;
+		void onConnect() override;
 
 		//Parse methods
 		void parseAutoWalk(NetworkMessage& msg);

--- a/src/protocollogin.h
+++ b/src/protocollogin.h
@@ -38,9 +38,9 @@ class ProtocolLogin : public Protocol
 
 		explicit ProtocolLogin(Connection_ptr connection) : Protocol(connection) {}
 
-		void onRecvFirstMessage(NetworkMessage& msg);
+		void onRecvFirstMessage(NetworkMessage& msg) override;
 
-	protected:
+	private:
 		void disconnectClient(const std::string& message, uint16_t version);
 
 		void getCharacterList(const std::string& accountName, const std::string& password, const std::string& token, uint16_t version);

--- a/src/protocolold.h
+++ b/src/protocolold.h
@@ -37,9 +37,9 @@ class ProtocolOld final : public Protocol
 
 		explicit ProtocolOld(Connection_ptr connection) : Protocol(connection) {}
 
-		void onRecvFirstMessage(NetworkMessage& msg) final;
+		void onRecvFirstMessage(NetworkMessage& msg) override;
 
-	protected:
+	private:
 		void disconnectClient(const std::string& message);
 };
 

--- a/src/protocolstatus.h
+++ b/src/protocolstatus.h
@@ -36,14 +36,14 @@ class ProtocolStatus final : public Protocol
 
 		explicit ProtocolStatus(Connection_ptr connection) : Protocol(connection) {}
 
-		void onRecvFirstMessage(NetworkMessage& msg) final;
+		void onRecvFirstMessage(NetworkMessage& msg) override;
 
 		void sendStatusString();
 		void sendInfo(uint16_t requestedInfo, const std::string& characterName);
 
 		static const uint64_t start;
 
-	protected:
+	private:
 		static std::map<uint32_t, int64_t> ipConnectMap;
 };
 

--- a/src/raids.h
+++ b/src/raids.h
@@ -176,9 +176,9 @@ class AnnounceEvent final : public RaidEvent
 	public:
 		AnnounceEvent() = default;
 
-		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
+		bool configureRaidEvent(const pugi::xml_node& eventNode) override;
 
-		bool executeEvent() final;
+		bool executeEvent() override;
 
 	private:
 		std::string message;
@@ -188,9 +188,9 @@ class AnnounceEvent final : public RaidEvent
 class SingleSpawnEvent final : public RaidEvent
 {
 	public:
-		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
+		bool configureRaidEvent(const pugi::xml_node& eventNode) override;
 
-		bool executeEvent() final;
+		bool executeEvent() override;
 
 	private:
 		std::string monsterName;
@@ -200,9 +200,9 @@ class SingleSpawnEvent final : public RaidEvent
 class AreaSpawnEvent final : public RaidEvent
 {
 	public:
-		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
+		bool configureRaidEvent(const pugi::xml_node& eventNode) override;
 
-		bool executeEvent() final;
+		bool executeEvent() override;
 
 	private:
 		std::list<MonsterSpawn> spawnList;
@@ -214,15 +214,15 @@ class ScriptEvent final : public RaidEvent, public Event
 	public:
 		explicit ScriptEvent(LuaScriptInterface* interface) : Event(interface) {}
 
-		bool configureRaidEvent(const pugi::xml_node& eventNode) final;
-		bool configureEvent(const pugi::xml_node&) final {
+		bool configureRaidEvent(const pugi::xml_node& eventNode) override;
+		bool configureEvent(const pugi::xml_node&) override {
 			return false;
 		}
 
-		bool executeEvent() final;
+		bool executeEvent() override;
 
-	protected:
-		std::string getScriptEventName() const final;
+	private:
+		std::string getScriptEventName() const override;
 };
 
 #endif

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -42,7 +42,7 @@ class SchedulerTask : public Task
 			return expiration;
 		}
 
-	protected:
+	private:
 		SchedulerTask(uint32_t delay, std::function<void (void)>&& f) : Task(delay, std::move(f)) {}
 
 		uint32_t eventId = 0;
@@ -67,7 +67,8 @@ class Scheduler : public ThreadHolder<Scheduler>
 		void shutdown();
 
 		void threadMain();
-	protected:
+
+	private:
 		std::thread thread;
 		std::mutex eventLock;
 		std::condition_variable eventSignal;

--- a/src/server.h
+++ b/src/server.h
@@ -41,20 +41,20 @@ template <typename ProtocolType>
 class Service final : public ServiceBase
 {
 	public:
-		bool is_single_socket() const final {
+		bool is_single_socket() const override {
 			return ProtocolType::server_sends_first;
 		}
-		bool is_checksummed() const final {
+		bool is_checksummed() const override {
 			return ProtocolType::use_checksum;
 		}
-		uint8_t get_protocol_identifier() const final {
+		uint8_t get_protocol_identifier() const override {
 			return ProtocolType::protocol_identifier;
 		}
-		const char* get_protocol_name() const final {
+		const char* get_protocol_name() const override {
 			return ProtocolType::protocol_name();
 		}
 
-		Protocol_ptr make_protocol(const Connection_ptr& c) const final {
+		Protocol_ptr make_protocol(const Connection_ptr& c) const override {
 			return std::make_shared<ProtocolType>(c);
 		}
 };

--- a/src/server.h
+++ b/src/server.h
@@ -81,7 +81,7 @@ class ServicePort : public std::enable_shared_from_this<ServicePort>
 		void onStopServer();
 		void onAccept(Connection_ptr connection, const boost::system::error_code& error);
 
-	protected:
+	private:
 		void accept();
 
 		boost::asio::io_service& io_service;
@@ -112,7 +112,7 @@ class ServiceManager
 			return acceptors.empty() == false;
 		}
 
-	protected:
+	private:
 		void die();
 
 		std::unordered_map<uint16_t, ServicePort_ptr> acceptors;

--- a/src/spells.h
+++ b/src/spells.h
@@ -54,17 +54,17 @@ class Spells final : public BaseEvents
 		TalkActionResult_t playerSaySpell(Player* player, std::string& words);
 
 		static Position getCasterPosition(Creature* creature, Direction dir);
-		std::string getScriptBaseName() const final;
+		std::string getScriptBaseName() const override;
 
 		const std::map<std::string, InstantSpell*>& getInstantSpells() const {
 			return instants;
 		};
 
-	protected:
-		void clear() final;
-		LuaScriptInterface& getScriptInterface() final;
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
+	private:
+		void clear() override;
+		LuaScriptInterface& getScriptInterface() override;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
 
 		std::map<uint16_t, RuneSpell*> runes;
 		std::map<std::string, InstantSpell*> instants;
@@ -95,9 +95,9 @@ class CombatSpell final : public Event, public BaseSpell
 		CombatSpell(const CombatSpell&) = delete;
 		CombatSpell& operator=(const CombatSpell&) = delete;
 
-		bool castSpell(Creature* creature) final;
-		bool castSpell(Creature* creature, Creature* target) final;
-		bool configureEvent(const pugi::xml_node&) final {
+		bool castSpell(Creature* creature) override;
+		bool castSpell(Creature* creature, Creature* target) override;
+		bool configureEvent(const pugi::xml_node&) override {
 			return true;
 		}
 
@@ -109,8 +109,8 @@ class CombatSpell final : public Event, public BaseSpell
 			return combat;
 		}
 
-	protected:
-		std::string getScriptEventName() const final {
+	private:
+		std::string getScriptEventName() const override {
 			return "onCastSpell";
 		}
 
@@ -201,7 +201,7 @@ class Spell : public BaseSpell
 		std::string name;
 };
 
-class InstantSpell : public TalkAction, public Spell
+class InstantSpell final : public TalkAction, public Spell
 {
 	public:
 		explicit InstantSpell(LuaScriptInterface* interface) : TalkAction(interface) {}
@@ -216,7 +216,7 @@ class InstantSpell : public TalkAction, public Spell
 		//scripting
 		bool executeCastSpell(Creature* creature, const LuaVariant& var);
 
-		bool isInstant() const final {
+		bool isInstant() const override {
 			return true;
 		}
 		bool getHasParam() const {
@@ -228,7 +228,7 @@ class InstantSpell : public TalkAction, public Spell
 		bool canCast(const Player* player) const;
 		bool canThrowSpell(const Creature* creature, const Creature* target) const;
 
-	protected:
+	private:
 		std::string getScriptEventName() const override;
 
 		bool internalCastSpell(Creature* creature, const LuaVariant& var);
@@ -245,34 +245,34 @@ class RuneSpell final : public Action, public Spell
 	public:
 		explicit RuneSpell(LuaScriptInterface* interface) : Action(interface) {}
 
-		bool configureEvent(const pugi::xml_node& node) final;
-		bool loadFunction(const pugi::xml_attribute& attr) final;
+		bool configureEvent(const pugi::xml_node& node) override;
+		bool loadFunction(const pugi::xml_attribute& attr) override;
 
-		ReturnValue canExecuteAction(const Player* player, const Position& toPos) final;
-		bool hasOwnErrorHandler() final {
+		ReturnValue canExecuteAction(const Player* player, const Position& toPos) override;
+		bool hasOwnErrorHandler() override {
 			return true;
 		}
-		Thing* getTarget(Player*, Creature* targetCreature, const Position&, uint8_t) const final {
+		Thing* getTarget(Player*, Creature* targetCreature, const Position&, uint8_t) const override {
 			return targetCreature;
 		}
 
-		bool executeUse(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition, bool isHotkey) final;
+		bool executeUse(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition, bool isHotkey) override;
 
-		bool castSpell(Creature* creature) final;
-		bool castSpell(Creature* creature, Creature* target) final;
+		bool castSpell(Creature* creature) override;
+		bool castSpell(Creature* creature, Creature* target) override;
 
 		//scripting
 		bool executeCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
 
-		bool isInstant() const final {
+		bool isInstant() const override {
 			return false;
 		}
 		uint16_t getRuneItemId() const {
 			return runeId;
 		}
 
-	protected:
-		std::string getScriptEventName() const final;
+	private:
+		std::string getScriptEventName() const override;
 
 		bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -171,23 +171,30 @@ class Spell : public BaseSpell
 		bool playerInstantSpellCheck(Player* player, const Position& toPos);
 		bool playerRuneSpellCheck(Player* player, const Position& toPos);
 
-		uint8_t spellId = 0;
-		SpellGroup_t group = SPELLGROUP_NONE;
-		uint32_t groupCooldown = 1000;
-		SpellGroup_t secondaryGroup = SPELLGROUP_NONE;
-		uint32_t secondaryGroupCooldown = 0;
+		VocSpellMap vocSpellMap;
 
-		uint32_t mana = 0;
-		uint32_t manaPercent = 0;
-		uint32_t soul = 0;
+		SpellGroup_t group = SPELLGROUP_NONE;
+		SpellGroup_t secondaryGroup = SPELLGROUP_NONE;
+
 		uint32_t cooldown = 1000;
+		uint32_t groupCooldown = 1000;
+		uint32_t secondaryGroupCooldown = 0;
 		uint32_t level = 0;
 		uint32_t magLevel = 0;
 		int32_t range = -1;
 
-		bool needTarget = false;
-		bool needWeapon = false;
+		uint8_t spellId = 0;
+
 		bool selfTarget = false;
+		bool needTarget = false;
+
+	private:
+
+		uint32_t mana = 0;
+		uint32_t manaPercent = 0;
+		uint32_t soul = 0;
+
+		bool needWeapon = false;
 		bool blockingSolid = false;
 		bool blockingCreature = false;
 		bool aggressive = true;
@@ -195,7 +202,6 @@ class Spell : public BaseSpell
 		bool enabled = true;
 		bool premium = false;
 
-		VocSpellMap vocSpellMap;
 
 	private:
 		std::string name;

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -48,14 +48,14 @@ class TalkAction : public Event
 		bool executeSay(Player* player, const std::string& param, SpeakClasses type) const;
 		//
 
-	protected:
+	private:
 		std::string getScriptEventName() const override;
 
 		std::string words;
 		char separator = '"';
 };
 
-class TalkActions : public BaseEvents
+class TalkActions final : public BaseEvents
 {
 	public:
 		TalkActions();
@@ -67,12 +67,12 @@ class TalkActions : public BaseEvents
 
 		TalkActionResult_t playerSaySpell(Player* player, SpeakClasses type, const std::string& words) const;
 
-	protected:
-		LuaScriptInterface& getScriptInterface() final;
-		std::string getScriptBaseName() const final;
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
-		void clear() final;
+	private:
+		LuaScriptInterface& getScriptInterface() override;
+		std::string getScriptBaseName() const override;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
+		void clear() override;
 
 		std::forward_list<TalkAction> talkActions;
 

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -52,10 +52,12 @@ class Task
 		}
 
 	protected:
+		std::chrono::system_clock::time_point expiration = SYSTEM_TIME_ZERO;
+
+	private:
 		// Expiration has another meaning for scheduler tasks,
 		// then it is the time the task should be added to the
 		// dispatcher
-		std::chrono::system_clock::time_point expiration = SYSTEM_TIME_ZERO;
 		std::function<void (void)> func;
 };
 
@@ -74,7 +76,7 @@ class Dispatcher : public ThreadHolder<Dispatcher> {
 
 		void threadMain();
 
-	protected:
+	private:
 		std::thread thread;
 		std::mutex taskLock;
 		std::condition_variable taskSignal;

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -27,16 +27,16 @@ class Teleport final : public Item, public Cylinder
 	public:
 		explicit Teleport(uint16_t type) : Item(type) {};
 
-		Teleport* getTeleport() final {
+		Teleport* getTeleport() override {
 			return this;
 		}
-		const Teleport* getTeleport() const final {
+		const Teleport* getTeleport() const override {
 			return this;
 		}
 
 		//serialization
-		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) final;
-		void serializeAttr(PropWriteStream& propWriteStream) const final;
+		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
+		void serializeAttr(PropWriteStream& propWriteStream) const override;
 
 		const Position& getDestPos() const {
 			return destPos;
@@ -47,23 +47,23 @@ class Teleport final : public Item, public Cylinder
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const final;
+				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t& maxQueryCount, uint32_t flags) const final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const final;
+				uint32_t& maxQueryCount, uint32_t flags) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const override;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) final;
+				uint32_t& flags) override;
 
-		void addThing(Thing* thing) final;
-		void addThing(int32_t index, Thing* thing) final;
+		void addThing(Thing* thing) override;
+		void addThing(int32_t index, Thing* thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) final;
-		void replaceThing(uint32_t index, Thing* thing) final;
+		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, Thing* thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) final;
+		void removeThing(Thing* thing, uint32_t count) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 	private:
 		Position destPos;

--- a/src/thing.h
+++ b/src/thing.h
@@ -30,11 +30,10 @@ class Container;
 
 class Thing
 {
-	protected:
-		constexpr Thing() = default;
-		~Thing() = default;
-
 	public:
+		constexpr Thing() = default;
+		virtual ~Thing() = default;
+
 		// non-copyable
 		Thing(const Thing&) = delete;
 		Thing& operator=(const Thing&) = delete;

--- a/src/tile.h
+++ b/src/tile.h
@@ -293,7 +293,6 @@ class Tile : public Cylinder
 		void setTileFlags(const Item* item);
 		void resetTileFlags(const Item* item);
 
-	protected:
 		Item* ground = nullptr;
 		Position tilePos;
 		uint32_t flags = 0;

--- a/src/tile.h
+++ b/src/tile.h
@@ -168,10 +168,10 @@ class Tile : public Cylinder
 		virtual const CreatureVector* getCreatures() const = 0;
 		virtual CreatureVector* makeCreatures() = 0;
 
-		int32_t getThrowRange() const final {
+		int32_t getThrowRange() const override final {
 			return 0;
 		}
-		bool isPushable() const final {
+		bool isPushable() const override final {
 			return false;
 		}
 
@@ -231,7 +231,7 @@ class Tile : public Cylinder
 
 		bool hasHeight(uint32_t n) const;
 
-		std::string getDescription(int32_t lookDistance) const final;
+		std::string getDescription(int32_t lookDistance) const override final;
 
 		int32_t getClientIndexOfCreature(const Player* player, const Creature* creature) const;
 		int32_t getStackposOfCreature(const Player* player, const Creature* creature) const;
@@ -241,37 +241,37 @@ class Tile : public Cylinder
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t& maxQueryCount, uint32_t flags) const final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const final;
+				uint32_t& maxQueryCount, uint32_t flags) const override final;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const override final;
 		Tile* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override;
 
-		void addThing(Thing* thing) final;
+		void addThing(Thing* thing) override final;
 		void addThing(int32_t index, Thing* thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) final;
-		void replaceThing(uint32_t index, Thing* thing) final;
+		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override final;
+		void replaceThing(uint32_t index, Thing* thing) override final;
 
-		void removeThing(Thing* thing, uint32_t count) final;
+		void removeThing(Thing* thing, uint32_t count) override final;
 
 		void removeCreature(Creature* creature);
 
-		int32_t getThingIndex(const Thing* thing) const final;
-		size_t getFirstIndex() const final;
-		size_t getLastIndex() const final;
-		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const final;
-		Thing* getThing(size_t index) const final;
+		int32_t getThingIndex(const Thing* thing) const override final;
+		size_t getFirstIndex() const override final;
+		size_t getLastIndex() const override final;
+		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override final;
+		Thing* getThing(size_t index) const override final;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override final;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override final;
 
-		void internalAddThing(Thing* thing) final;
+		void internalAddThing(Thing* thing) override final;
 		void internalAddThing(uint32_t index, Thing* thing) override;
 
-		const Position& getPosition() const final {
+		const Position& getPosition() const override final {
 			return tilePos;
 		}
 
-		bool isRemoved() const final {
+		bool isRemoved() const override final {
 			return false;
 		}
 
@@ -319,23 +319,23 @@ class DynamicTile : public Tile
 		DynamicTile(const DynamicTile&) = delete;
 		DynamicTile& operator=(const DynamicTile&) = delete;
 
-		TileItemVector* getItemList() final {
+		TileItemVector* getItemList() override {
 			return &items;
 		}
-		const TileItemVector* getItemList() const final {
+		const TileItemVector* getItemList() const override {
 			return &items;
 		}
-		TileItemVector* makeItemList() final {
+		TileItemVector* makeItemList() override {
 			return &items;
 		}
 
-		CreatureVector* getCreatures() final {
+		CreatureVector* getCreatures() override {
 			return &creatures;
 		}
-		const CreatureVector* getCreatures() const final {
+		const CreatureVector* getCreatures() const override {
 			return &creatures;
 		}
-		CreatureVector* makeCreatures() final {
+		CreatureVector* makeCreatures() override {
 			return &creatures;
 		}
 };
@@ -361,26 +361,26 @@ class StaticTile final : public Tile
 		StaticTile(const StaticTile&) = delete;
 		StaticTile& operator=(const StaticTile&) = delete;
 
-		TileItemVector* getItemList() final {
+		TileItemVector* getItemList() override {
 			return items.get();
 		}
-		const TileItemVector* getItemList() const final {
+		const TileItemVector* getItemList() const override {
 			return items.get();
 		}
-		TileItemVector* makeItemList() final {
+		TileItemVector* makeItemList() override {
 			if (!items) {
 				items.reset(new TileItemVector);
 			}
 			return items.get();
 		}
 
-		CreatureVector* getCreatures() final {
+		CreatureVector* getCreatures() override {
 			return creatures.get();
 		}
-		const CreatureVector* getCreatures() const final {
+		const CreatureVector* getCreatures() const override {
 			return creatures.get();
 		}
-		CreatureVector* makeCreatures() final {
+		CreatureVector* makeCreatures() override {
 			if (!creatures) {
 				creatures.reset(new CreatureVector);
 			}

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -29,29 +29,29 @@ class TrashHolder final : public Item, public Cylinder
 	public:
 		explicit TrashHolder(uint16_t itemId) : Item(itemId) {}
 
-		TrashHolder* getTrashHolder() final {
+		TrashHolder* getTrashHolder() override {
 			return this;
 		}
-		const TrashHolder* getTrashHolder() const final {
+		const TrashHolder* getTrashHolder() const override {
 			return this;
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const final;
-		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount, uint32_t flags) const final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const final;
-		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) final;
+		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount, uint32_t flags) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags) const override;
+		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override;
 
-		void addThing(Thing* thing) final;
-		void addThing(int32_t index, Thing* thing) final;
+		void addThing(Thing* thing) override;
+		void addThing(int32_t index, Thing* thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) final;
-		void replaceThing(uint32_t index, Thing* thing) final;
+		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, Thing* thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) final;
+		void removeThing(Thing* thing, uint32_t count) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) final;
+		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 };
 
 #endif

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -91,7 +91,7 @@ class Vocation
 		float defenseMultiplier = 1.0f;
 		float armorMultiplier = 1.0f;
 
-	protected:
+	private:
 		friend class Vocations;
 
 		std::map<uint32_t, uint64_t> cacheMana;

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -47,12 +47,12 @@ class Weapons final : public BaseEvents
 		static int32_t getMaxMeleeDamage(int32_t attackSkill, int32_t attackValue);
 		static int32_t getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t attackValue, float attackFactor);
 
-	protected:
-		void clear() final;
-		LuaScriptInterface& getScriptInterface() final;
-		std::string getScriptBaseName() const final;
-		Event* getEvent(const std::string& nodeName) final;
-		bool registerEvent(Event* event, const pugi::xml_node& node) final;
+	private:
+		void clear() override;
+		LuaScriptInterface& getScriptInterface() override;
+		std::string getScriptBaseName() const override;
+		Event* getEvent(const std::string& nodeName) override;
+		bool registerEvent(Event* event, const pugi::xml_node& node) override;
 
 		std::map<uint32_t, Weapon*> weapons;
 
@@ -65,7 +65,7 @@ class Weapon : public Event
 		explicit Weapon(LuaScriptInterface* interface) : Event(interface) {}
 
 		bool configureEvent(const pugi::xml_node& node) override;
-		bool loadFunction(const pugi::xml_attribute&) final {
+		bool loadFunction(const pugi::xml_attribute&) override final {
 			return true;
 		}
 		virtual void configureWeapon(const ItemType& it);
@@ -99,13 +99,8 @@ class Weapon : public Event
 		}
 
 	protected:
-		std::string getScriptEventName() const final;
-
-		bool executeUseWeapon(Player* player, const LuaVariant& var) const;
 		void internalUseWeapon(Player* player, Item* item, Creature* target, int32_t damageModifier) const;
 		void internalUseWeapon(Player* player, Item* item, Tile* tile) const;
-
-		void onUsedWeapon(Player* player, Item* item, Tile* destTile) const;
 		virtual bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const {
 			return false;
 		}
@@ -127,6 +122,11 @@ class Weapon : public Event
 		bool wieldUnproperly = false;
 
 	private:
+		std::string getScriptEventName() const override final;
+
+		bool executeUseWeapon(Player* player, const LuaVariant& var) const;
+		void onUsedWeapon(Player* player, Item* item, Tile* destTile) const;
+
 		static void decrementItemCount(Item* item);
 
 		std::map<uint16_t, bool> vocWeaponMap;
@@ -138,16 +138,16 @@ class WeaponMelee final : public Weapon
 	public:
 		explicit WeaponMelee(LuaScriptInterface* interface);
 
-		void configureWeapon(const ItemType& it) final;
+		void configureWeapon(const ItemType& it) override;
 
-		bool useWeapon(Player* player, Item* item, Creature* target) const final;
+		bool useWeapon(Player* player, Item* item, Creature* target) const override;
 
-		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const final;
-		int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const final;
-		CombatType_t getElementType() const final { return elementType; }
+		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const override;
+		int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const override;
+		CombatType_t getElementType() const override { return elementType; }
 
-	protected:
-		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const final;
+	private:
+		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const override;
 
 		CombatType_t elementType = COMBAT_NONE;
 		uint16_t elementDamage = 0;
@@ -158,19 +158,19 @@ class WeaponDistance final : public Weapon
 	public:
 		explicit WeaponDistance(LuaScriptInterface* interface);
 
-		void configureWeapon(const ItemType& it) final;
-		bool interruptSwing() const final {
+		void configureWeapon(const ItemType& it) override;
+		bool interruptSwing() const override {
 			return true;
 		}
 
-		bool useWeapon(Player* player, Item* item, Creature* target) const final;
+		bool useWeapon(Player* player, Item* item, Creature* target) const override;
 
-		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const final;
-		int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const final;
-		CombatType_t getElementType() const final { return elementType; }
+		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const override;
+		int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const override;
+		CombatType_t getElementType() const override { return elementType; }
 
-	protected:
-		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const final;
+	private:
+		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const override;
 
 		CombatType_t elementType = COMBAT_NONE;
 		uint16_t elementDamage = 0;
@@ -181,15 +181,15 @@ class WeaponWand final : public Weapon
 	public:
 		explicit WeaponWand(LuaScriptInterface* interface) : Weapon(interface) {}
 
-		bool configureEvent(const pugi::xml_node& node) final;
-		void configureWeapon(const ItemType& it) final;
+		bool configureEvent(const pugi::xml_node& node) override;
+		void configureWeapon(const ItemType& it) override;
 
-		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const final;
-		int32_t getElementDamage(const Player*, const Creature*, const Item*) const final { return 0; }
-		CombatType_t getElementType() const final { return COMBAT_NONE; }
+		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const override;
+		int32_t getElementDamage(const Player*, const Creature*, const Item*) const override { return 0; }
+		CombatType_t getElementType() const override { return COMBAT_NONE; }
 
-	protected:
-		bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const final {
+	private:
+		bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const override {
 			return false;
 		}
 

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -101,20 +101,23 @@ class Weapon : public Event
 	protected:
 		void internalUseWeapon(Player* player, Item* item, Creature* target, int32_t damageModifier) const;
 		void internalUseWeapon(Player* player, Item* item, Tile* tile) const;
+
+		CombatParams params;
+
+		uint16_t id = 0;
+
+	private:
 		virtual bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const {
 			return false;
 		}
 
 		uint32_t getManaCost(const Player* player) const;
 
-		CombatParams params;
-
 		uint32_t level = 0;
 		uint32_t magLevel = 0;
 		uint32_t mana = 0;
 		uint32_t manaPercent = 0;
 		uint32_t soul = 0;
-		uint16_t id = 0;
 		WeaponAction_t action = WEAPONACTION_NONE;
 		uint8_t breakChance = 0;
 		bool enabled = true;


### PR DESCRIPTION
- Replace `protected` visibility with `private` for `final` classes
- Remove `final` attribute from `final` class methods
- Add `override` attribute when applicable
- Add `[[noreturn]]` attribute where applicable

Also removes an unused attribute clang has discovered after changing its visibility.