### PR TITLE
Revert 2097 fix reload error

### DIFF
--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -74,10 +74,9 @@ bool BaseEvents::loadFromXml()
 
 		if (!success || !registerEvent(event, node)) {
 			delete event;
-			loaded = false;
 		}
 	}
-	return loaded;
+	return true;
 }
 
 bool BaseEvents::reload()

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -182,11 +182,10 @@ bool Monsters::loadFromXml(bool reloading /*= false*/)
 		if (reloading && monsters.find(name) != monsters.end()) {
 			loadMonster(file, name, true);
 		} else {
-			loaded = false;
 			unloadedMonsters.emplace(name, file);
 		}
 	}
-	return loaded;
+	return true;
 }
 
 bool Monsters::reload()


### PR DESCRIPTION
That PR stops the stock server data from loading.
See: https://github.com/otland/forgottenserver/commit/5fbb12e44778560d9ce608c491772de484395802