### PR TITLE
Fix party extraExpRate

### DIFF
--- a/src/party.cpp
+++ b/src/party.cpp
@@ -375,11 +375,7 @@ void Party::updateVocationsList()
 	}
 
 	size_t size = vocationIds.size();
-	if (size > 1) {
-		extraExpRate = static_cast<float>(size * (10 + (size - 1) * 5)) / 100.f;
-	} else {
-		extraExpRate = 0.20f;
-	}
+	extraExpRate = size > 1 ? static_cast<float>(size * (10 + (size - 1) * 5)) / 100.f : 0.20f;
 }
 
 bool Party::setSharedExperience(Player* player, bool sharedExpActive)

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -127,7 +127,7 @@ bool Party::leaveParty(Player* player)
 	player->sendTextMessage(MESSAGE_INFO_DESCR, "You have left the party.");
 
 	updateSharedExperience();
-	updateVocationsList();
+	updateSharedExperienceBonus();
 
 	clearPlayerPoints(player);
 
@@ -218,7 +218,7 @@ bool Party::joinParty(Player& player)
 
 	player.removePartyInvitation(this);
 	updateSharedExperience();
-	updateVocationsList();
+	updateSharedExperienceBonus();
 
 	const std::string& leaderName = leader->getName();
 	ss.str(std::string());
@@ -358,7 +358,7 @@ void Party::updateSharedExperience()
 	}
 }
 
-void Party::updateVocationsList()
+void Party::updateSharedExperienceBonus()
 {
 	std::set<uint32_t> vocationIds;
 
@@ -375,7 +375,7 @@ void Party::updateVocationsList()
 	}
 
 	size_t size = vocationIds.size();
-	extraExpRate = size > 1 ? static_cast<float>(size * (10 + (size - 1) * 5)) / 100.f : 0.20f;
+	sharedExpBonus = size > 1 ? static_cast<float>(size * (10 + (size - 1) * 5)) / 100.f : 0.20f;
 }
 
 bool Party::setSharedExperience(Player* player, bool sharedExpActive)
@@ -408,7 +408,7 @@ bool Party::setSharedExperience(Player* player, bool sharedExpActive)
 
 void Party::shareExperience(uint64_t experience, Creature* source/* = nullptr*/)
 {
-	uint64_t shareExperience = static_cast<uint64_t>(std::ceil((static_cast<double>(experience) * (extraExpRate + 1)) / (memberList.size() + 1)));
+	uint64_t shareExperience = static_cast<uint64_t>(std::ceil((static_cast<double>(experience) * (sharedExpBonus + 1)) / (memberList.size() + 1)));
 	for (Player* member : memberList) {
 		member->onGainSharedExperience(shareExperience, source);
 	}

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -375,7 +375,7 @@ void Party::updateSharedExperienceBonus()
 	}
 
 	size_t size = vocationIds.size();
-	sharedExpBonus = size > 1 ? static_cast<float>(size * (10 + (size - 1) * 5)) / 100.f : 0.20f;
+	sharedExpBonus = std::max(0.20f, (size * (5 * (size - 1) + 10)) / 100.f);
 }
 
 bool Party::setSharedExperience(Player* player, bool sharedExpActive)

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -279,7 +279,7 @@ bool Party::invitePlayer(Player& player)
 	std::ostringstream ss;
 	ss << player.getName() << " has been invited.";
 
-	if (memberList.empty() && inviteList.empty()) {
+	if (empty()) {
 		ss << " Open the party channel to communicate with your members.";
 		g_game.updatePlayerShield(leader);
 		leader->sendCreatureSkull(leader);

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -375,7 +375,7 @@ void Party::updateSharedExperienceBonus()
 	}
 
 	size_t size = vocationIds.size();
-	sharedExpBonus = std::max(0.20f, (size * (5 * (size - 1) + 10)) / 100.f);
+	sharedExpBonus = std::max(0.2, (size * (5 * (size - 1) + 10)) / 100.);
 }
 
 bool Party::setSharedExperience(Player* player, bool sharedExpActive)

--- a/src/party.h
+++ b/src/party.h
@@ -78,7 +78,7 @@ class Party
 		bool canUseSharedExperience(const Player* player) const;
 		void updateSharedExperience();
 
-		void updateVocationsList();
+		void updateSharedExperienceBonus();
 
 		void updatePlayerTicks(Player* player, uint32_t points);
 		void clearPlayerPoints(Player* player);
@@ -93,7 +93,7 @@ class Party
 
 		Player* leader;
 
-		float extraExpRate;
+		float sharedExpBonus;
 
 		bool sharedExpActive = false;
 		bool sharedExpEnabled = false;

--- a/src/party.h
+++ b/src/party.h
@@ -93,7 +93,7 @@ class Party
 
 		Player* leader;
 
-		float extraExpRate = 0.20f;
+		float extraExpRate;
 
 		bool sharedExpActive = false;
 		bool sharedExpEnabled = false;

--- a/src/party.h
+++ b/src/party.h
@@ -93,7 +93,7 @@ class Party
 
 		Player* leader;
 
-		float sharedExpBonus;
+		double sharedExpBonus;
 
 		bool sharedExpActive = false;
 		bool sharedExpEnabled = false;


### PR DESCRIPTION
This data member is [initialized](https://github.com/otland/forgottenserver/pull/2368/files#diff-bca280ff47a20e24267a1c6b5caf6139L96) on Party class instantiation and _possibly_ assigned the same value [``0.20f``](https://github.com/otland/forgottenserver/pull/2368/files#diff-c5af55d870b9bc2502667c495bad41f7L381), once a new member [leaves](https://github.com/raymondtfr/forgottenserver/blob/31a16d765b403767eba0d7c83bedce9be81c817e/src/party.cpp#L130) or [join](https://github.com/raymondtfr/forgottenserver/blob/31a16d765b403767eba0d7c83bedce9be81c817e/src/party.cpp#L221) a party.

Am I right about this? 🙄 