### PR TITLE
Fix luaGameReload not working with RELOAD_TYPE_ALL param

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4283,11 +4283,6 @@ int LuaScriptInterface::luaGameReload(lua_State* L)
 {
 	// Game.reload(reloadType)
 	ReloadTypes_t reloadType = getNumber<ReloadTypes_t>(L, 1);
-	if (!reloadType) {
-		lua_pushnil(L);
-		return 1;
-	}
-
 	if (reloadType == RELOAD_TYPE_GLOBAL) {
 		pushBoolean(L, g_luaEnvironment.loadFile("data/global.lua") == 0);
 	} else {


### PR DESCRIPTION
RELOAD_TYPE_ALL is equal to 0 which means Game.reload would never get past that check effectively making the type unusable.