### PR TITLE
complement to getTileInfo

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -765,6 +765,8 @@ function getTileInfo(position)
 
 	local ret = pushThing(t:getGround())
 	ret.protection = t:hasFlag(TILESTATE_PROTECTIONZONE)
+	ret.pvp = t:hasFlag(TILESTATE_PVPZONE)
+	ret.nopvp = t:hasFlag(TILESTATE_NOPVPZONE)
 	ret.nopz = ret.protection
 	ret.nologout = t:hasFlag(TILESTATE_NOLOGOUT)
 	ret.refresh = t:hasFlag(TILESTATE_REFRESH)


### PR DESCRIPTION
Without it we need to do a hasFlag after already getting the ret if we wanna check for pvp and nopvp flags too after calling the function.