### PR TITLE
Setting default player capacity to 400

### DIFF
--- a/data/migrations/19.lua
+++ b/data/migrations/19.lua
@@ -1,3 +1,5 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 20 (setting default cap to 400)")
+	db.query("ALTER TABLE `players` CHANGE `cap` `cap` int(11) NOT NULL DEFAULT '400'")
+	return true
 end

--- a/data/migrations/20.lua
+++ b/data/migrations/20.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS `players` (
   `posy` int(11) NOT NULL DEFAULT '0',
   `posz` int(11) NOT NULL DEFAULT '0',
   `conditions` blob NOT NULL,
-  `cap` int(11) NOT NULL DEFAULT '0',
+  `cap` int(11) NOT NULL DEFAULT '400',
   `sex` int(11) NOT NULL DEFAULT '0',
   `lastlogin` bigint(20) unsigned NOT NULL DEFAULT '0',
   `lastip` int(10) unsigned NOT NULL DEFAULT '0',


### PR DESCRIPTION
Editing schema.sql, setting default player capacity to 400, like the official tibia.