### PR TITLE
Fixed displaying Premium Account (status) in client

### DIFF
--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -107,7 +107,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 		output->addByte(1);
 		output->add<uint32_t>(0);
 	} else {
-		output->addByte(0);
+		output->addByte(account.premiumDays > 0 ? 1 : 0);
 		output->add<uint32_t>(time(nullptr) + (account.premiumDays * 86400));
 	}
 


### PR DESCRIPTION
After Mark update Premium Status stopped showing in Tibia Client.

This push fixes it.
Now client displays correct Premium Status (either free or premium with days).