### PR TITLE
Catch the exception when loading map fragments in lua

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3991,7 +3991,15 @@ int LuaScriptInterface::luaGameLoadMap(lua_State* L)
 {
 	// Game.loadMap(path)
 	const std::string& path = getString(L, 1);
-	g_dispatcher.addTask(createTask(std::bind(&Game::loadMap, &g_game, path)));
+	g_dispatcher.addTask(createTask( [path]() {
+		try {
+			g_game.loadMap(path);
+		} catch (const std::exception& e) {
+			// FIXME: Should only catch some exceptions
+			std::cout << "[Error - LuaScriptInterface::luaGameLoadMap] Failed to load map: "
+				<< e.what() << std::endl;
+		}
+	}));
 	return 0;
 }
 


### PR DESCRIPTION
The server should not crash if the loading process failed, since the server is left in a valid state.

Resolves: #2018 