### PR TITLE
Force setLastDepotId on player:getDepotChest

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The Forgotten Server - a free and open-source MMORPG server emulator
  * Copyright (C) 2017  Mark Samman <mark.samman@gmail.com>
  *
@@ -7646,6 +7646,7 @@ int LuaScriptInterface::luaPlayerGetDepotChest(lua_State* L)
 	bool autoCreate = getBoolean(L, 3, false);
 	DepotChest* depotChest = player->getDepotChest(depotId, autoCreate);
 	if (depotChest) {
+		player->setLastDepotId(depotId); // FIXME: workaround for #2251
 		pushUserdata<Item>(L, depotChest);
 		setItemMetatable(L, -1, depotChest);
 	} else {


### PR DESCRIPTION
This is a workaround in case where Lua is used to save items to player's depot even if they never opened it (which is the condition we currently use to determine if we need to save).

Fixes #2251 