### PR TITLE
vcxproj is missing WindowsTargetPlatformVersion

### DIFF
--- a/vc14/theforgottenserver.vcxproj
+++ b/vc14/theforgottenserver.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{A10F9657-129F-0FEF-14CB-CEE0B0E5AA3E}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
This is to prevent at least Windows 10 users from having to re-target the project. Right now everyone has to because the parameter is missing.
It is still possible to re-target in MSVS for older platforms.
Binary seems to be compatible with previous Win versions.

EOL is removed by MSVS :/