### PR TITLE
Fix #2440 UID Reset

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -66,7 +66,6 @@ void ScriptEnvironment::resetEnv()
 	callbackId = 0;
 	timerEvent = false;
 	interface = nullptr;
-	localMap.clear();
 	tempResults.clear();
 
 	auto pair = tempItems.equal_range(this);


### PR DESCRIPTION
Fix error on localMap reset everytimes and is impossible get the actual uniqueId of created items.