### PR TITLE
Handle token time parsing exceptions

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -281,7 +281,16 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	std::string& accountName = sessionArgs[0];
 	std::string& password = sessionArgs[1];
 	std::string& token = sessionArgs[2];
-	uint32_t tokenTime = std::stoul(sessionArgs[3]);
+	uint32_t tokenTime = 0;
+	try {
+		tokenTime = std::stoul(sessionArgs[3]);
+	} catch (const std::invalid_argument&) {
+		disconnectClient("Malformed token packet.");
+		return;
+	} catch (const std::out_of_range&) {
+		disconnectClient("Token time is too long.");
+		return;
+	}
 
 	if (accountName.empty()) {
 		disconnectClient("You must enter your account name.");


### PR DESCRIPTION
The current implementation of token time parsing can lead to a server crash using crafted packet.

`std::stoul` throws 2 types of exceptions: 
- one on an empty string and/or string not containing any numbers
- another if the parsed number would overflow the `long` type
http://en.cppreference.com/w/cpp/string/basic_string/stoul