### PR TITLE
Use vcpkg for windows package management

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,12 @@ only_commits:
     - vc14/
     - appveyor.yml
 
-environment:
-  BOOST_ROOT: C:\Libraries\boost_1_65_1
-
 install:
-  - ps: if (-not (Test-Path tfs-sdk-3.2)) { Start-FileDownload https://static.otland.net/dl/tfs-sdk-3.2.zip; 7z x tfs-sdk-3.2.zip }
-  - set TFSSDKDir=%CD%\tfs-sdk-3.2
+  - cmd : vcpkg install boost:x64-windows
+  - cmd : vcpkg install luajit:x64-windows
+  - cmd : vcpkg install libmysql:x64-windows
+  - cmd : vcpkg install pugixml:x64-windows
+  - cmd : vcpkg install mpir:x64-windows
 
 build:
   parallel: true
@@ -31,7 +31,7 @@ build:
   #verbosity: detailed
 
 cache:
-  - tfs-sdk-3.2 -> appveyor.yml
+  - c:\tools\vcpkg\installed\
 
 artifacts:
   - path: vc14\**\theforgottenserver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,11 @@ only_commits:
     - appveyor.yml
 
 install:
-  - cmd : vcpkg install boost:x64-windows
+  - cmd : vcpkg install boost-iostreams:x64-windows
+  - cmd : vcpkg install boost-asio:x64-windows
+  - cmd : vcpkg install boost-system:x64-windows
+  - cmd : vcpkg install boost-variant:x64-windows
+  - cmd : vcpkg install boost-lockfree:x64-windows
   - cmd : vcpkg install luajit:x64-windows
   - cmd : vcpkg install libmysql:x64-windows
   - cmd : vcpkg install pugixml:x64-windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,4 +39,4 @@ cache:
 
 artifacts:
   - path: vc14\**\theforgottenserver.exe
-	- path: vc14\**\*.dll
+  - path: vc14\**\*.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,3 +39,4 @@ cache:
 
 artifacts:
   - path: vc14\**\theforgottenserver.exe
+	- path: vc14\**\*.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - cmd : vcpkg install boost-variant:x64-windows
   - cmd : vcpkg install boost-lockfree:x64-windows
   - cmd : vcpkg install luajit:x64-windows
-  - cmd : vcpkg install libmysql:x64-windows
+  - cmd : vcpkg install libmariadb:x64-windows
   - cmd : vcpkg install pugixml:x64-windows
   - cmd : vcpkg install mpir:x64-windows
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -22,7 +22,7 @@
 #include "configmanager.h"
 #include "database.h"
 
-#include <errmsg.h>
+#include <mysql/errmsg.h>
 
 extern ConfigManager g_config;
 
@@ -43,7 +43,7 @@ bool Database::connect()
 	}
 
 	// automatic reconnect
-	my_bool reconnect = true;
+	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
 
 	// connects to database

--- a/src/database.h
+++ b/src/database.h
@@ -22,7 +22,7 @@
 
 #include <boost/lexical_cast.hpp>
 
-#include <mysql.h>
+#include <mysql/mysql.h>
 
 class DBResult;
 using DBResult_ptr = std::shared_ptr<DBResult>;

--- a/vc14/arch32.props
+++ b/vc14/arch32.props
@@ -5,7 +5,6 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories>$(TFS_LIBS)</AdditionalLibraryDirectories>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>

--- a/vc14/arch64.props
+++ b/vc14/arch64.props
@@ -5,7 +5,6 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories>$(TFS_LIBS64)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/vc14/debug.props
+++ b/vc14/debug.props
@@ -13,9 +13,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <ObjectFileName>$(IntDir)\obj_d\</ObjectFileName>
     </ClCompile>
-    <Link>
-      <AdditionalDependencies>$(TFS_LIBDEPS_D)</AdditionalDependencies>
-    </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>

--- a/vc14/settings.props
+++ b/vc14/settings.props
@@ -2,23 +2,13 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <LUA_DIR>$(TFSSDKDir)\LuaJIT\</LUA_DIR>
-    <GMP_DIR>$(TFSSDKDir)\mpir\</GMP_DIR>
-    <MYSQLC_DIR>$(TFSSDKDir)\mysql-connector-c\</MYSQLC_DIR>
-	<PUGIXML_DIR>$(TFSSDKDir)\pugixml\</PUGIXML_DIR>
     <PREPROCESSOR_DEFS>_CRT_SECURE_NO_WARNINGS;</PREPROCESSOR_DEFS>
-    <TFS_INCLUDES>$(BOOST_ROOT);$(LUA_DIR)\include;$(GMP_DIR)\include;$(MYSQLC_DIR)\include;$(PUGIXML_DIR)\include;</TFS_INCLUDES>
-    <TFS_LIBS>$(BOOST_ROOT)\lib32-msvc-14.1;$(LUA_DIR)\lib;$(GMP_DIR)\lib;$(MYSQLC_DIR)\lib</TFS_LIBS>
-    <TFS_LIBS64>$(BOOST_ROOT)\lib64-msvc-14.1;$(LUA_DIR)\lib64;$(GMP_DIR)\lib64;$(MYSQLC_DIR)\lib64</TFS_LIBS64>
-    <TFS_LIBDEPS>lua51.lib;mpir.lib;libmysql.lib</TFS_LIBDEPS>
-    <TFS_LIBDEPS_D>lua51.lib;mpir.lib;libmysql.lib</TFS_LIBDEPS_D>
   </PropertyGroup>
   <PropertyGroup>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(TFS_INCLUDES)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -27,48 +17,10 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(TFS_LIBDEPS)</AdditionalDependencies>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>$(PREPROCESSOR_DEFS)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <BuildMacro Include="LUA_DIR">
-      <Value>$(LUA_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="GMP_DIR">
-      <Value>$(GMP_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="MYSQLC_DIR">
-      <Value>$(MYSQLC_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="PREPROCESSOR_DEFS">
-      <Value>$(PREPROCESSOR_DEFS)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="TFS_INCLUDES">
-      <Value>$(TFS_INCLUDES)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="TFS_LIBS">
-      <Value>$(TFS_LIBS)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="TFS_LIBS64">
-      <Value>$(TFS_LIBS64)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="TFS_LIBDEPS">
-      <Value>$(TFS_LIBDEPS)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="TFS_LIBDEPS_D">
-      <Value>$(TFS_LIBDEPS_D)</Value>
-    </BuildMacro>
-  </ItemGroup>
 </Project>

--- a/vc14/settings.props
+++ b/vc14/settings.props
@@ -23,4 +23,10 @@
       <PreprocessorDefinitions>$(PREPROCESSOR_DEFS)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="PREPROCESSOR_DEFS">
+      <Value>$(PREPROCESSOR_DEFS)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change would replace how the TFS SDK is currently generated. The TFS SDK zip would be updated with the output created by vcpkg export. I wasn't sure where to upload the vcpkg export so for now I have appveyor install the packages and cache them. In order to use [vcpkg](https://github.com/Microsoft/vcpkg) several libraries versions had to be altered.

Package | TFS SDK | VCPKG | vcpkgname | NOTES
--- | --- | --- | --- | ---
Boost | 1.66.0 | 1.67.0 | boost | 
GMP |  |  |  | N/A on windows use mpir
LuaJit | 2.1.0-beta1 | 2.0.5 | luajit | TFS needs lua or luajit
MySQL C Connector | 6.1.6 | 8.0.4-2 | libmysql | 
PugiXML | 1.7 | 1.9-1 | pugixml | 
mpir | 2.7.2 | 3.0.0-4 | mpir | This is a fork of GMP but can be compiled by MS Visual Studio
MariaDB C Connector |  | 3.0.2 | libmariadb | Can be used in place of MySQL C Connector

