### PR TITLE
prevent crafted packets from inviting yourself to a party

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4822,6 +4822,10 @@ bool Game::loadExperienceStages()
 
 void Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 {
+	if (playerId == invitedId) {
+		return;
+	}
+	
 	Player* player = getPlayerByID(playerId);
 	if (!player) {
 		return;


### PR DESCRIPTION
could potentially cause issues