### PR TITLE
Multi-stage Dockerfile to build and run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:edge AS build
+# pugixml-dev is in edge/testing
+RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+  binutils \
+  boost-dev \
+  build-base \
+  clang \
+  cmake \
+  gcc \
+  gmp-dev \
+  luajit-dev \
+  make \
+  mariadb-connector-c-dev \
+  pugixml-dev
+
+COPY cmake /usr/src/forgottenserver/cmake/
+COPY src /usr/src/forgottenserver/src/
+COPY CMakeLists.txt /usr/src/forgottenserver/
+WORKDIR /usr/src/forgottenserver/build
+RUN cmake .. && make
+
+FROM alpine:edge
+# pugixml-dev is in edge/testing
+RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+  boost-iostreams \
+  boost-system \
+  gmp \
+  luajit \
+  mariadb-connector-c \
+  pugixml
+
+COPY --from=build /usr/src/forgottenserver/build/tfs /bin/tfs
+COPY data /srv/data/
+COPY LICENSE README.md *.dist *.sql /srv/
+
+EXPOSE 7171 7172
+WORKDIR /srv
+VOLUME /srv
+ENTRYPOINT ["/bin/tfs"]

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -10,7 +10,7 @@
 find_path(LUA_INCLUDE_DIR luajit.h
   HINTS
     ENV LUA_DIR
-  PATH_SUFFIXES include/luajit-2.0 include
+  PATH_SUFFIXES include/luajit-2.0 include/luajit-2.1 include
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
This is a multi-staged Dockerfile, meaning that one Dockerfile produces two images: first one is intermediary (with build tools), second one is to run only.

See the size of images:
```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
tfs                 latest              dfdd18aa38f1        2 minutes ago       27.8MB
<none>              <none>              7310d26e0eb5        3 minutes ago       858MB
```

* 27 MB includes the Alpine OS, the `tfs` binary, and the whole stock `data/` directory.
* 858 MB is the build container image with build tools, and multiple layers. If you modify the source, the packages needed to compile won't need to be re-installed - they are already there in a previous layer and will be reused.

Explanation of Dockerfile:
* Only alpine:edge has pugixml and it still requires adding "testing"
* I explicitly copy source files used to compile (`cmake/`, `src/`, `CMakeLists.txt`) so that cache is not invalidated when you have created an extra file (or otherwise "touched" the repo)
* `/srv` is the workdir and a volume, when you start the container the stock data/ and config will be copied there if the volume is empty but your volume will persist with custom data/ and custom config.lua if you have one
* Entrypoint is set to the TFS executable, there's no way to interactively use the container with any sort of a shell (no point in doing so anyway)
* To run it, you probably have to mount (volume) the MySQL socket (recommended) or add this container to network namespace of a MySQL server, or add it to a common network

Try it yourself:
```bash
# build:
docker build -t tfs .
# run:
docker run --rm -it --name tfs-test tfs
# a volume with default data/ will be automatically created
```