### PR TITLE
Handle SIGBREAK (Windows console close)

### DIFF
--- a/src/signals.h
+++ b/src/signals.h
@@ -32,6 +32,7 @@ class Signals
 		void asyncWait();
 		static void dispatchSignalHandler(int signal);
 
+		static void sigbreakHandler();
 		static void sigintHandler();
 		static void sighupHandler();
 		static void sigtermHandler();


### PR DESCRIPTION
SetConsoleCtrlHandler is not needed because SIGBREAK is also sent
on window close. The process is killed when the thread handling
SIGBREAK returns. That's why we must handle it synchronously
and wait for other threads to finish first. The Windows-defined
timeout is only 5 seconds but there is no way to change that.

https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals

Fixes #1277
Fixes #1853