### PR TITLE
Use SIMD auto-vectorization for XTEA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ include(cotire)
 
 add_compile_options(-Wall -Werror -pipe -fvisibility=hidden)
 
+set(CMAKE_CXX_FLAGS_PERFORMANCE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options(-fno-strict-aliasing)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,5 +74,6 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/waitlist.cpp
 	${CMAKE_CURRENT_LIST_DIR}/weapons.cpp
 	${CMAKE_CURRENT_LIST_DIR}/wildcardtree.cpp
+	${CMAKE_CURRENT_LIST_DIR}/xtea.cpp
 	PARENT_SCOPE)
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -81,7 +81,7 @@ bool Protocol::XTEA_decrypt(NetworkMessage& msg) const
 	xtea::decrypt(buffer, msg.getLength() - 6, key);
 
 	uint16_t innerLength = msg.get<uint16_t>();
-	if (innerLength > msg.getLength() - 8) {
+	if (innerLength + 8 > msg.getLength()) {
 		return false;
 	}
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -21,6 +21,7 @@
 #define FS_PROTOCOL_H_D71405071ACF4137A4B1203899DE80E1
 
 #include "connection.h"
+#include "xtea.h"
 
 class Protocol : public std::enable_shared_from_this<Protocol>
 {
@@ -71,8 +72,8 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		void enableXTEAEncryption() {
 			encryptionEnabled = true;
 		}
-		void setXTEAKey(const uint32_t* key) {
-			memcpy(this->key, key, sizeof(*key) * 4);
+		void setXTEAKey(xtea::key key) {
+			this->key = std::move(key);
 		}
 		void disableChecksum() {
 			checksumEnabled = false;
@@ -95,7 +96,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		OutputMessage_ptr outputBuffer;
 
 		const ConnectionWeak_ptr connection;
-		uint32_t key[4] = {};
+		xtea::key key;
 		bool encryptionEnabled = false;
 		bool checksumEnabled = true;
 		bool rawMessages = false;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -252,13 +252,13 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	uint32_t key[4];
+	xtea::key key;
 	key[0] = msg.get<uint32_t>();
 	key[1] = msg.get<uint32_t>();
 	key[2] = msg.get<uint32_t>();
 	key[3] = msg.get<uint32_t>();
 	enableXTEAEncryption();
-	setXTEAKey(key);
+	setXTEAKey(std::move(key));
 
 	if (operatingSystem >= CLIENTOS_OTCLIENT_LINUX) {
 		NetworkMessage opcodeMessage;

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -150,13 +150,13 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	uint32_t key[4];
+	xtea::key key;
 	key[0] = msg.get<uint32_t>();
 	key[1] = msg.get<uint32_t>();
 	key[2] = msg.get<uint32_t>();
 	key[3] = msg.get<uint32_t>();
 	enableXTEAEncryption();
-	setXTEAKey(key);
+	setXTEAKey(std::move(key));
 
 	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {
 		std::ostringstream ss;

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -59,13 +59,13 @@ void ProtocolOld::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	uint32_t key[4];
+	xtea::key key;
 	key[0] = msg.get<uint32_t>();
 	key[1] = msg.get<uint32_t>();
 	key[2] = msg.get<uint32_t>();
 	key[3] = msg.get<uint32_t>();
 	enableXTEAEncryption();
-	setXTEAKey(key);
+	setXTEAKey(std::move(key));
 
 	if (version <= 822) {
 		disableChecksum();

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -1,0 +1,214 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2018  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "otpch.h"
+
+#include "xtea.h"
+
+#include <array>
+#include <assert.h>
+
+namespace xtea {
+
+namespace {
+
+// precalculated key schedule
+constexpr std::array<uint32_t, 33> sum = {{
+    0x00000000, 0x9e3779b9, 0x3c6ef372,
+    0xdaa66d2b, 0x78dde6e4, 0x1715609d,
+    0xb54cda56, 0x5384540f, 0xf1bbcdc8,
+    0x8ff34781, 0x2e2ac13a, 0xcc623af3,
+    0x6a99b4ac, 0x08d12e65, 0xa708a81e,
+    0x454021d7, 0xe3779b90, 0x81af1549,
+    0x1fe68f02, 0xbe1e08bb, 0x5c558274,
+    0xfa8cfc2d, 0x98c475e6, 0x36fbef9f,
+    0xd5336958, 0x736ae311, 0x11a25cca,
+    0xafd9d683, 0x4e11503c, 0xec48c9f5,
+    0x8a8043ae, 0x28b7bd67, 0xc6ef3720,
+}};
+
+template<size_t BLOCK_SIZE>
+void XTEA_encrypt(
+        uint8_t data[BLOCK_SIZE * 8],
+        const key& k)
+{
+    auto words = reinterpret_cast<uint32_t*>(data);
+    alignas(16) uint32_t left[BLOCK_SIZE], right[BLOCK_SIZE];
+
+    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
+        left[i] = words[2 * i];
+        right[i] = words[2 * i + 1];
+    }
+
+    for (auto i = 0u; i < 32u; ++i) {
+        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
+            left[j] += (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum[i] + k[sum[i] & 3]);
+            right[j] += (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum[i+1] + k[(sum[i+1] >> 11) & 3]);
+        }
+    }
+
+    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
+        words[2 * i] = left[i];
+        words[2 * i + 1] = right[i];
+    }
+}
+
+template<size_t BLOCK_SIZE>
+void XTEA_decrypt(
+        uint8_t data[BLOCK_SIZE * 8],
+        const key& k)
+{
+    auto words = reinterpret_cast<uint32_t*>(data);
+    alignas(16) uint32_t left[BLOCK_SIZE], right[BLOCK_SIZE];
+
+    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
+		left[i] = words[2 * i];
+		right[i] = words[2 * i + 1];
+    }
+
+    for (auto i = 32u; i > 0u; --i) {
+        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
+            right[j] -= (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum[i] + k[(sum[i] >> 11) & 3]);
+            left[j] -= (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum[i-1] + k[(sum[i-1]) & 3]);
+        }
+    }
+
+    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
+        words[2 * i] = left[i];
+        words[2 * i + 1] = right[i];
+    }
+}
+
+} // anonymous namespace
+
+void encrypt(uint8_t* data, size_t length, const key& k)
+{
+    assert(length % 8 == 0);
+
+#ifdef __AVX512F__
+    {
+        constexpr auto step = 64u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_encrypt<64>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __AVX512F__
+
+#ifdef __AVX__
+    {
+        constexpr auto step = 16u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_encrypt<16>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __AVX__
+
+#if defined(__SSE__) || defined(__ARM_FEATURE_SIMD32)
+    {
+        constexpr auto step = 4u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_encrypt<4>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __SSE__ || __ARM_FEATURE_SIMD32
+
+#ifdef __x86_64__
+    {
+        constexpr auto step = 2u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_encrypt<2>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __x86_64__
+
+    for (auto i = 0u; i < length; i += 8u) {
+        XTEA_encrypt<1>(data + i, k);
+    }
+}
+
+void decrypt(uint8_t* data, size_t length, const key& k)
+{
+    assert(length % 8 == 0);
+
+#ifdef __AVX512F__
+    {
+        constexpr auto step = 64u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_decrypt<64>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __AVX512F__
+
+#ifdef __AVX__
+    {
+        constexpr auto step = 16u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_decrypt<16>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __AVX__
+
+#if defined(__SSE__) || defined(__ARM_FEATURE_SIMD32)
+    {
+        constexpr auto step = 4u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_decrypt<4>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __SSE__ || __ARM_FEATURE_SIMD32
+
+#ifdef __x86_64__
+    {
+        constexpr auto step = 2u * 8u;
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            XTEA_decrypt<2>(data + i, k);
+        }
+        data += blocks;
+        length -= blocks;
+    }
+#endif // __x86_64__
+
+    for (auto i = 0u; i < length; i += 8u) {
+        XTEA_decrypt<1>(data + i, k);
+    }
+}
+
+} // namespace xtea

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -71,7 +71,7 @@ void XTEA_decrypt(uint8_t data[BLOCK_SIZE * 8], const key& k)
         right[i] = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
     }
 
-    uint32_t sum = 0u;
+    uint32_t sum = delta << 5;
     for (auto i = 0u; i < 32; ++i) {
         for (auto j = 0u; j < BLOCK_SIZE; ++j) {
             right[j] -= (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum + k[(sum >> 11) & 3]);

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -124,7 +124,7 @@ struct XTEA {
         length -= blocks;
 
         if (BlockSize != 1) {
-            XTEA<Encrypt, BlockSize / 2u>()(input, length, k);
+            XTEA<Encrypt, (BlockSize + 1u) / 2u>()(input, length, k);
         }
     }
 };

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -71,7 +71,7 @@ void XTEA_decrypt(uint8_t data[BLOCK_SIZE * 8], const key& k)
         right[i] = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
     }
 
-    uint32_t sum = delta * 32;
+    uint32_t sum = 0u;
     for (auto i = 0u; i < 32; ++i) {
         for (auto j = 0u; j < BLOCK_SIZE; ++j) {
             right[j] -= (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum + k[(sum >> 11) & 3]);

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -28,187 +28,113 @@ namespace xtea {
 
 namespace {
 
-// precalculated key schedule
-constexpr std::array<uint32_t, 33> sum = {{
-    0x00000000, 0x9e3779b9, 0x3c6ef372,
-    0xdaa66d2b, 0x78dde6e4, 0x1715609d,
-    0xb54cda56, 0x5384540f, 0xf1bbcdc8,
-    0x8ff34781, 0x2e2ac13a, 0xcc623af3,
-    0x6a99b4ac, 0x08d12e65, 0xa708a81e,
-    0x454021d7, 0xe3779b90, 0x81af1549,
-    0x1fe68f02, 0xbe1e08bb, 0x5c558274,
-    0xfa8cfc2d, 0x98c475e6, 0x36fbef9f,
-    0xd5336958, 0x736ae311, 0x11a25cca,
-    0xafd9d683, 0x4e11503c, 0xec48c9f5,
-    0x8a8043ae, 0x28b7bd67, 0xc6ef3720,
-}};
+constexpr uint32_t delta = 0x9E3779B9;
 
 template<size_t BLOCK_SIZE>
-void XTEA_encrypt(
-        uint8_t data[BLOCK_SIZE * 8],
-        const key& k)
+void XTEA_encrypt(uint8_t data[BLOCK_SIZE * 8], const key& k)
 {
-    auto words = reinterpret_cast<uint32_t*>(data);
     alignas(16) uint32_t left[BLOCK_SIZE], right[BLOCK_SIZE];
-
-    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
-        left[i] = words[2 * i];
-        right[i] = words[2 * i + 1];
+    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
+        left[i] = data[j] | data[j+1] << 8u | data[j+2] << 16u | data[j+3] << 24u;
+        right[i] = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
     }
 
-    for (auto i = 0u; i < 32u; ++i) {
+    uint32_t sum = 0u;
+    for (auto i = 0u; i < 32; ++i) {
         for (auto j = 0u; j < BLOCK_SIZE; ++j) {
-            left[j] += (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum[i] + k[sum[i] & 3]);
-            right[j] += (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum[i+1] + k[(sum[i+1] >> 11) & 3]);
+            left[j] += (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum + k[sum & 3]);
+        }
+        sum += delta;
+        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
+            right[j] += (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum + k[(sum >> 11) & 3]);
         }
     }
 
-    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
-        words[2 * i] = left[i];
-        words[2 * i + 1] = right[i];
+    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
+        data[j] = static_cast<uint8_t>(left[i]);
+        data[j+1] = static_cast<uint8_t>(left[i] >> 8u);
+        data[j+2] = static_cast<uint8_t>(left[i] >> 16u);
+        data[j+3] = static_cast<uint8_t>(left[i] >> 24u);
+        data[j+4] = static_cast<uint8_t>(right[i]);
+        data[j+5] = static_cast<uint8_t>(right[i] >> 8u);
+        data[j+6] = static_cast<uint8_t>(right[i] >> 16u);
+        data[j+7] = static_cast<uint8_t>(right[i] >> 24u);
     }
 }
 
 template<size_t BLOCK_SIZE>
-void XTEA_decrypt(
-        uint8_t data[BLOCK_SIZE * 8],
-        const key& k)
+void XTEA_decrypt(uint8_t data[BLOCK_SIZE * 8], const key& k)
 {
-    auto words = reinterpret_cast<uint32_t*>(data);
     alignas(16) uint32_t left[BLOCK_SIZE], right[BLOCK_SIZE];
-
-    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
-		left[i] = words[2 * i];
-		right[i] = words[2 * i + 1];
+    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
+        left[i] = data[j] | data[j+1] << 8u | data[j+2] << 16u | data[j+3] << 24u;
+        right[i] = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
     }
 
-    for (auto i = 32u; i > 0u; --i) {
+    uint32_t sum = delta * 32;
+    for (auto i = 0u; i < 32; ++i) {
         for (auto j = 0u; j < BLOCK_SIZE; ++j) {
-            right[j] -= (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum[i] + k[(sum[i] >> 11) & 3]);
-            left[j] -= (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum[i-1] + k[(sum[i-1]) & 3]);
+            right[j] -= (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum + k[(sum >> 11) & 3]);
+        }
+        sum -= delta;
+        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
+            left[j] -= (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum + k[(sum) & 3]);
         }
     }
 
-    for (auto i = 0u; i < BLOCK_SIZE; ++i) {
-        words[2 * i] = left[i];
-        words[2 * i + 1] = right[i];
+    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
+        data[j] = static_cast<uint8_t>(left[i]);
+        data[j+1] = static_cast<uint8_t>(left[i] >> 8u);
+        data[j+2] = static_cast<uint8_t>(left[i] >> 16u);
+        data[j+3] = static_cast<uint8_t>(left[i] >> 24u);
+        data[j+4] = static_cast<uint8_t>(right[i]);
+        data[j+5] = static_cast<uint8_t>(right[i] >> 8u);
+        data[j+6] = static_cast<uint8_t>(right[i] >> 16u);
+        data[j+7] = static_cast<uint8_t>(right[i] >> 24u);
     }
 }
+
+constexpr auto InitialBlockSize =
+#if defined(__AVX512F__)
+      128u;
+#elif defined(__AVX__)
+      32u;
+#elif defined(__SSE__) || defined(__ARM_FEATURE_SIMD32)
+      8u;
+#elif defined(__x86_64__)
+      2u;
+#else
+      1u;
+#endif
+
+template<bool Encrypt, size_t BlockSize>
+struct XTEA {
+    static constexpr auto step = BlockSize * 8u;
+
+    void operator()(uint8_t* input, size_t length, const key& k) const {
+        const auto blocks = (length & ~(step - 1));
+        for (auto i = 0u; i < blocks; i += step) {
+            if (Encrypt) {
+                XTEA_encrypt<BlockSize>(input + i, k);
+            } else {
+                XTEA_decrypt<BlockSize>(input + i, k);
+            }
+        }
+        input += blocks;
+        length -= blocks;
+
+        if (BlockSize != 1) {
+            XTEA<Encrypt, BlockSize / 2u>()(input, length, k);
+        }
+    }
+};
+
+constexpr auto encrypt_v = XTEA<true, InitialBlockSize>();
+constexpr auto decrypt_v = XTEA<false, InitialBlockSize>();
 
 } // anonymous namespace
 
-void encrypt(uint8_t* data, size_t length, const key& k)
-{
-    assert(length % 8 == 0);
-
-#ifdef __AVX512F__
-    {
-        constexpr auto step = 64u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_encrypt<64>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __AVX512F__
-
-#ifdef __AVX__
-    {
-        constexpr auto step = 16u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_encrypt<16>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __AVX__
-
-#if defined(__SSE__) || defined(__ARM_FEATURE_SIMD32)
-    {
-        constexpr auto step = 4u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_encrypt<4>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __SSE__ || __ARM_FEATURE_SIMD32
-
-#ifdef __x86_64__
-    {
-        constexpr auto step = 2u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_encrypt<2>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __x86_64__
-
-    for (auto i = 0u; i < length; i += 8u) {
-        XTEA_encrypt<1>(data + i, k);
-    }
-}
-
-void decrypt(uint8_t* data, size_t length, const key& k)
-{
-    assert(length % 8 == 0);
-
-#ifdef __AVX512F__
-    {
-        constexpr auto step = 64u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_decrypt<64>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __AVX512F__
-
-#ifdef __AVX__
-    {
-        constexpr auto step = 16u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_decrypt<16>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __AVX__
-
-#if defined(__SSE__) || defined(__ARM_FEATURE_SIMD32)
-    {
-        constexpr auto step = 4u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_decrypt<4>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __SSE__ || __ARM_FEATURE_SIMD32
-
-#ifdef __x86_64__
-    {
-        constexpr auto step = 2u * 8u;
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            XTEA_decrypt<2>(data + i, k);
-        }
-        data += blocks;
-        length -= blocks;
-    }
-#endif // __x86_64__
-
-    for (auto i = 0u; i < length; i += 8u) {
-        XTEA_decrypt<1>(data + i, k);
-    }
-}
+void encrypt(uint8_t* i, size_t l, const key& k) { encrypt_v(i, l, k); }
+void decrypt(uint8_t* i, size_t l, const key& k) { decrypt_v(i, l, k); }
 
 } // namespace xtea

--- a/src/xtea.h
+++ b/src/xtea.h
@@ -1,0 +1,32 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2018  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef TFS_XTEA_H
+#define TFS_XTEA_H
+
+namespace xtea {
+
+using key = std::array<uint32_t, 4>;
+
+void encrypt(uint8_t* data, size_t length, const key& k);
+void decrypt(uint8_t* data, size_t length, const key& k);
+
+} // namespace xtea
+
+#endif // TFS_XTEA_H

--- a/vc14/theforgottenserver.sln
+++ b/vc14/theforgottenserver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "theforgottenserver", "theforgottenserver.vcxproj", "{A10F9657-129F-0FEF-14CB-CEE0B0E5AA3E}"
 EndProject
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {81EB239E-6AEB-4015-9915-256C2C90D3FD}
 	EndGlobalSection
 EndGlobal

--- a/vc14/theforgottenserver.vcxproj
+++ b/vc14/theforgottenserver.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{A10F9657-129F-0FEF-14CB-CEE0B0E5AA3E}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -69,15 +69,26 @@
     <Import Project="release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>$(ProjectName)-$(Platform)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>$(ProjectName)-$(Platform)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>$(ProjectName)-$(Platform)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>$(ProjectName)-$(Platform)</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -89,6 +100,9 @@
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -100,6 +114,11 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -115,6 +134,11 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/vc14/theforgottenserver.vcxproj
+++ b/vc14/theforgottenserver.vcxproj
@@ -86,7 +86,6 @@
       <PreprocessorDefinitions>_CONSOLE;$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
@@ -100,7 +99,6 @@
     <ClCompile>
       <PreprocessorDefinitions>_CONSOLE;$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/vc14/theforgottenserver.vcxproj
+++ b/vc14/theforgottenserver.vcxproj
@@ -205,6 +205,7 @@
     <ClCompile Include="..\src\waitlist.cpp" />
     <ClCompile Include="..\src\weapons.cpp" />
     <ClCompile Include="..\src\wildcardtree.cpp" />
+    <ClCompile Include="..\src\xtea.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\account.h" />
@@ -290,6 +291,7 @@
     <ClInclude Include="..\src\waitlist.h" />
     <ClInclude Include="..\src\weapons.h" />
     <ClInclude Include="..\src\wildcardtree.h" />
+    <ClInclude Include="..\src\xtea.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
This patch enables auto-vectorization for XTEA encryption and decryption, exploring vector (SSE, AVX) instructions to be auto-enabled by the compiler. Should render up to 16x faster encryption/decryption throughput on AVX2, 8x on AVX and 4x on SSE/Neon.

Things to consider:
- Maybe find another way to enable without `#ifdef` hell
- Code can probably be cleaner

On my machine (third-gen i7), it's performing up to 8x better than current algorithm.