### PR TITLE
Fix #2486

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1334,13 +1334,13 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 		cylinder->removeThing(item, count);
 
 		if (item->isRemoved()) {
+			item->onRemoved();
 			ReleaseItem(item);
 		}
 
 		cylinder->postRemoveNotification(item, nullptr, index);
 	}
 
-	item->onRemoved();
 	return RETURNVALUE_NOERROR;
 }
 


### PR DESCRIPTION
Since the test parameter is only used when internalRemoveItem is called by trade code i think nothing bad happened so far but i want to fix this since its still a bug.