### PR TITLE
Fix inconsistent parameter names

### DIFF
--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -24,15 +24,15 @@
 #include "databasetasks.h"
 #include "tools.h"
 
-bool Ban::acceptConnection(uint32_t clientip)
+bool Ban::acceptConnection(uint32_t clientIP)
 {
 	std::lock_guard<std::recursive_mutex> lockClass(lock);
 
 	uint64_t currentTime = OTSYS_TIME();
 
-	auto it = ipConnectMap.find(clientip);
+	auto it = ipConnectMap.find(clientIP);
 	if (it == ipConnectMap.end()) {
-		ipConnectMap.emplace(clientip, ConnectBlock(currentTime, 0, 1));
+		ipConnectMap.emplace(clientIP, ConnectBlock(currentTime, 0, 1));
 		return true;
 	}
 
@@ -89,16 +89,16 @@ bool IOBan::isAccountBanned(uint32_t accountId, BanInfo& banInfo)
 	return true;
 }
 
-bool IOBan::isIpBanned(uint32_t clientip, BanInfo& banInfo)
+bool IOBan::isIpBanned(uint32_t clientIP, BanInfo& banInfo)
 {
-	if (clientip == 0) {
+	if (clientIP == 0) {
 		return false;
 	}
 
 	Database& db = Database::getInstance();
 
 	std::ostringstream query;
-	query << "SELECT `reason`, `expires_at`, (SELECT `name` FROM `players` WHERE `id` = `banned_by`) AS `name` FROM `ip_bans` WHERE `ip` = " << clientip;
+	query << "SELECT `reason`, `expires_at`, (SELECT `name` FROM `players` WHERE `id` = `banned_by`) AS `name` FROM `ip_bans` WHERE `ip` = " << clientIP;
 
 	DBResult_ptr result = db.storeQuery(query.str());
 	if (!result) {
@@ -108,7 +108,7 @@ bool IOBan::isIpBanned(uint32_t clientip, BanInfo& banInfo)
 	int64_t expiresAt = result->getNumber<int64_t>("expires_at");
 	if (expiresAt != 0 && time(nullptr) > expiresAt) {
 		query.str(std::string());
-		query << "DELETE FROM `ip_bans` WHERE `ip` = " << clientip;
+		query << "DELETE FROM `ip_bans` WHERE `ip` = " << clientIP;
 		g_databaseTasks.addTask(query.str());
 		return false;
 	}

--- a/src/ban.h
+++ b/src/ban.h
@@ -40,7 +40,7 @@ using IpConnectMap = std::map<uint32_t, ConnectBlock>;
 class Ban
 {
 	public:
-		bool acceptConnection(uint32_t clientIp);
+		bool acceptConnection(uint32_t clientIP);
 
 	private:
 		IpConnectMap ipConnectMap;
@@ -51,7 +51,7 @@ class IOBan
 {
 	public:
 		static bool isAccountBanned(uint32_t accountId, BanInfo& banInfo);
-		static bool isIpBanned(uint32_t clientIp, BanInfo& banInfo);
+		static bool isIpBanned(uint32_t clientIP, BanInfo& banInfo);
 		static bool isPlayerNamelocked(uint32_t playerId);
 };
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -404,7 +404,7 @@ class LuaScriptInterface
 
 		void registerFunctions();
 
-		void registerMethod(const std::string& className, const std::string& methodName, lua_CFunction func);
+		void registerMethod(const std::string& globalName, const std::string& methodName, lua_CFunction func);
 
 		static std::string getErrorDesc(ErrorCode_t code);
 

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -134,7 +134,7 @@ constexpr auto decrypt_v = XTEA<false, InitialBlockSize>();
 
 } // anonymous namespace
 
-void encrypt(uint8_t* i, size_t l, const key& k) { encrypt_v(i, l, k); }
-void decrypt(uint8_t* i, size_t l, const key& k) { decrypt_v(i, l, k); }
+void encrypt(uint8_t* data, size_t length, const key& k) { encrypt_v(data, length, k); }
+void decrypt(uint8_t* data, size_t length, const key& k) { decrypt_v(data, length, k); }
 
 } // namespace xtea


### PR DESCRIPTION
Client IP was written as "clientIp" and "clientip", renamed all occurrences with "clientIP"

Renamed "className" to "globalName" in luascript.h to match the name used in the cpp file

Renamed "i, l" to "data, length" in xtea.cpp to match the names used in xtea.h
