### PR TITLE
Don't check if unsigned values are less than zero

### DIFF
--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -309,7 +309,7 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
 						std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID() << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y << ", z: " << z << "]." << std::endl;
 						delete item;
 					} else {
-						if (item->getItemCount() <= 0) {
+						if (item->getItemCount() == 0) {
 							item->setItemCount(1);
 						}
 
@@ -372,7 +372,7 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
 				std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID() << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y << ", z: " << z << "]." << std::endl;
 				delete item;
 			} else {
-				if (item->getItemCount() <= 0) {
+				if (item->getItemCount() == 0) {
 					item->setItemCount(1);
 				}
 


### PR DESCRIPTION
Unsigned values cannot be less than zero, so it's enough to check if getItemCount() equals zero in these two cases.