### PR TITLE
Missions within the same storage

### DIFF
--- a/data/XML/quests.xml
+++ b/data/XML/quests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <quests>
 	<quest name="Example Quest I" startstorageid="1001" startstoragevalue="1">
-		<mission name="Example Mission 1" storageid="1001" startvalue="1" endvalue="3">
+		<mission name="Example Mission 1" storageid="1001" startvalue="1" endvalue="3" ignoreendvalue="true">
 			<missionstate id="1" description="Example description 1" />
 			<missionstate id="2" description="Example description 2" />
 			<missionstate id="3" description="Example description 3" />


### PR DESCRIPTION
While using the same storage in multiple missions in one quest having:
- `storage = 3` first mission is completed - OK
- `storage = 4` first mission disappear, second shows - not OK

Adding `ignoreendvalue="true"` in first mission causes:
- `storage = 3` first mission is completed - OK
- `storage = 4` first mission is still completed, second shows - OK