### PR TITLE
Halt instant exit when failing to load the server

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -93,6 +93,7 @@ int main(int argc, char* argv[])
 	g_scheduler.join();
 	g_databaseTasks.join();
 	g_dispatcher.join();
+	std::cin.get();
 	return 0;
 }
 


### PR DESCRIPTION
annoying to have to use a console to view the errors since it instantly closes if you have an error while loading server resources