### PR TITLE
nameToItems overwriting

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -555,7 +555,12 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 	it.name = itemNode.attribute("name").as_string();
 
-	nameToItems.insert({ asLowerCaseString(it.name), id });
+	std::string lowerCaseItemName = asLowerCaseString(it.name);
+	auto itemFound = nameToItems.find(lowerCaseItemName);
+
+	if (itemFound == nameToItems.end()) {
+		nameToItems.insert({ lowerCaseItemName, id });
+	}
 
 	pugi::xml_attribute articleAttribute = itemNode.attribute("article");
 	if (articleAttribute) {


### PR DESCRIPTION
Hello. Recently I found that in newer protocols where are some items with the same name during items.xml parse they overwrite themselves. For example if regular shovel look like
```
	<item id="2554" article="a" name="shovel">
		<attribute key="weight" value="3500" />
	</item>
```
and below are some other "shovel" items which last entry ends with
```
<item id="18210" article="a" name="shovel" />
```
inside `nameToItems` will be only the last one. This will cause little confusion, because if you type `/i shovel` ingame or put `<item name="shovel" chance="4540" />` inside `loot` node of any monster the engine will create last occurence of that item (in this case 18210).

My change is not a bugfix, but will check if item with some name is already inside ItemMap, prevent overwriting and might help someone developing their server.