### PR TITLE
[Fix #2323] Fix skull ticks overflow

### DIFF
--- a/data/migrations/22.lua
+++ b/data/migrations/22.lua
@@ -1,3 +1,5 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 23 (Fix skulltime)")
+	db.query("ALTER TABLE players MODIFY skulltime BIGINT(20) NOT NULL DEFAULT '0'")
+	return true
 end

--- a/data/migrations/22.lua
+++ b/data/migrations/22.lua
@@ -1,5 +1,5 @@
 function onUpdateDatabase()
 	print("> Updating database to version 23 (Fix skulltime)")
-	db.query("ALTER TABLE players MODIFY skulltime BIGINT(20) NOT NULL DEFAULT '0'")
+	db.query("ALTER TABLE players MODIFY skulltime BIGINT(20) NOT NULL DEFAULT 0")
 	return true
 end

--- a/data/migrations/23.lua
+++ b/data/migrations/23.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/data/talkactions/scripts/kills.lua
+++ b/data/talkactions/scripts/kills.lua
@@ -12,7 +12,7 @@ function onSay(player, words, param)
 	end
 
 	local kills = math.ceil(skullTime / fragTime)
-	local remainingSeconds = math.floor((skullTime % fragTime) / 1000)
+	local remainingSeconds = math.floor(skullTime % fragTime)
 
 	local hours = math.floor(remainingSeconds / 3600)
 	local minutes = math.floor((remainingSeconds % 3600) / 60)

--- a/schema.sql
+++ b/schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS `players` (
   `lastip` int(10) unsigned NOT NULL DEFAULT '0',
   `save` tinyint(1) NOT NULL DEFAULT '1',
   `skull` tinyint(1) NOT NULL DEFAULT '0',
-  `skulltime` int(11) NOT NULL DEFAULT '0',
+  `skulltime` bigint(20) NOT NULL DEFAULT '0',
   `lastlogout` bigint(20) unsigned NOT NULL DEFAULT '0',
   `blessings` tinyint(2) NOT NULL DEFAULT '0',
   `onlinetime` int(11) NOT NULL DEFAULT '0',

--- a/schema.sql
+++ b/schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS `players` (
   `lastip` int(10) unsigned NOT NULL DEFAULT '0',
   `save` tinyint(1) NOT NULL DEFAULT '1',
   `skull` tinyint(1) NOT NULL DEFAULT '0',
-  `skulltime` bigint(20) NOT NULL DEFAULT '0',
+  `skulltime` int(11) NOT NULL DEFAULT '0',
   `lastlogout` bigint(20) unsigned NOT NULL DEFAULT '0',
   `blessings` tinyint(2) NOT NULL DEFAULT '0',
   `onlinetime` int(11) NOT NULL DEFAULT '0',

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -348,7 +348,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 		const time_t skullSeconds = result->getNumber<time_t>("skulltime") - time(nullptr);
 		if (skullSeconds > 0) {
 			//ensure that we round up the number of ticks
-			player->skullTicks = (skullSeconds + 2) * 1000;
+			player->skullTicks = (skullSeconds + 2);
 
 			uint16_t skull = result->getNumber<uint16_t>("skull");
 			if (skull == SKULL_RED) {
@@ -698,12 +698,11 @@ bool IOLoginData::savePlayer(Player* player)
 	query << "`conditions` = " << db.escapeBlob(conditions, conditionsSize) << ',';
 
 	if (g_game.getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
-		int32_t skullTime = 0;
+		int64_t skullTime = 0;
 
 		if (player->skullTicks > 0) {
-			skullTime = time(nullptr) + player->skullTicks / 1000;
+			skullTime = time(nullptr) + player->skullTicks;
 		}
-
 		query << "`skulltime` = " << skullTime << ',';
 
 		Skulls_t skull = SKULL_NONE;
@@ -712,7 +711,7 @@ bool IOLoginData::savePlayer(Player* player)
 		} else if (player->skull == SKULL_BLACK) {
 			skull = SKULL_BLACK;
 		}
-		query << "`skull` = " << static_cast<uint32_t>(skull) << ',';
+		query << "`skull` = " << static_cast<int64_t>(skull) << ',';
 	}
 
 	query << "`lastlogout` = " << player->getLastLogout() << ',';

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1444,7 +1444,7 @@ void Player::onThink(uint32_t interval)
 	}
 
 	if (g_game.getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
-		checkSkullTicks(interval);
+		checkSkullTicks(interval / 1000);
 	}
 
 	addOfflineTrainingTime(interval);
@@ -3823,16 +3823,16 @@ void Player::addUnjustifiedDead(const Player* attacked)
 	}
 }
 
-void Player::checkSkullTicks(int32_t ticks)
+void Player::checkSkullTicks(int64_t ticks)
 {
-	int32_t newTicks = skullTicks - ticks;
+	int64_t newTicks = skullTicks - ticks;
 	if (newTicks < 0) {
 		skullTicks = 0;
 	} else {
 		skullTicks = newTicks;
 	}
 
-	if ((skull == SKULL_RED || skull == SKULL_BLACK) && skullTicks < 1000 && !hasCondition(CONDITION_INFIGHT)) {
+	if ((skull == SKULL_RED || skull == SKULL_BLACK) && skullTicks < 1 && !hasCondition(CONDITION_INFIGHT)) {
 		setSkull(SKULL_NONE);
 	}
 }

--- a/src/player.h
+++ b/src/player.h
@@ -682,7 +682,7 @@ class Player final : public Creature, public Cylinder
 				client->sendCreatureSkull(creature);
 			}
 		}
-		void checkSkullTicks(int32_t ticks);
+		void checkSkullTicks(int64_t ticks);
 
 		bool canWear(uint32_t lookType, uint8_t addons) const;
 		void addOutfit(uint16_t lookType, uint8_t addons);


### PR DESCRIPTION
●The reason for the change:

When a player's skull time exceeds 35 days, the skull time overflows as it's stored as milliseconds which has no better value than seconds

●Reproducing Bug

1-Let Player A gets 35 kills(which is equal of 35 days) 
2-35 days calculated in milliseconds -> 3024000000
3-Maximum value for int32 -> 2147483648
4-by calculating the difference = -876516352
5-By next login the player will have 0 skull time
6-Major problem Lied in [here](https://github.com/otland/forgottenserver/blob/master/src/player.cpp#L3828)

●Changes:

Changed skull ticks from millisecond to seconds to avoid overflow and
preserve performance because there's no need for using milliseconds.

●Test:
1-Player A Killed Player B 35 times
2-Player A now has a black skull
3-Player A logged out showing the following information(skull time:3020086 seconds)
4-Player A logged in after few seconds showing the following information(skull time:3020082 seconds)
