### PR TITLE
getItemIdByName fix

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -1338,10 +1338,15 @@ const ItemType& Items::getItemIdByClientId(uint16_t spriteId) const
 
 uint16_t Items::getItemIdByName(const std::string& name)
 {
-	auto result = nameToItems.find(asLowerCaseString(name));
+	auto ids = nameToItems.equal_range(asLowerCaseString(name));
 
-	if (result == nameToItems.end())
+	if (ids.first == nameToItems.cend())
 		return 0;
 
-	return result->second;
+	NameMap::iterator id;
+	for (NameMap::iterator it = ids.first; it != ids.second; ++it) {
+		id = it;
+	}
+
+	return id->second;
 }


### PR DESCRIPTION
Hello. When server is parsing items.xml it uses `std::unordered_multimap` to store item names. That means if different items have the same name (shovel, fish, rope, torch) calling `Items::getItemIdByName` will return only one of these (#2524).

The thing is, on newer protocols it may cause little confusion and here is an example - https://github.com/otland/forgottenserver/blob/master/data/actions/scripts/tools/fishing.lua#L75. A player uses his fishing rod so on newer protocols (like that which support https://github.com/otland/forgottenserver/blob/master/data/items/items.xml) instead of fish (ID 2667) he will get ID 11163 (which also are fish but not moveable/eatable item). My solution is using `equal_range` and I'm sure in all cases returns item which script author had on his mind.