### PR TITLE
Updates paidUntil according to rentPeriod on buying a house

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -88,8 +88,25 @@ void House::setOwner(uint32_t guid, bool updateDatabase/* = true*/, Player* play
 
 		//reset paid date
 		paidUntil = 0;
-		rentWarnings = 0;
-	}
+	} else {
+        std::string strRentPeriod = asLowerCaseString(g_config.getString(ConfigManager::HOUSE_RENT_PERIOD));
+        time_t currentTime = time(nullptr);
+        if (strRentPeriod == "yearly") {
+            currentTime += 24 * 60 * 60 * 365;
+        } else if (strRentPeriod == "monthly") {
+            currentTime += 24 * 60 * 60 * 30;
+        } else if (strRentPeriod == "weekly") {
+            currentTime += 24 * 60 * 60 * 7;
+        } else if (strRentPeriod == "daily") {
+            currentTime += 24 * 60 * 60;
+        } else {
+            currentTime = 0;
+        }
+
+        paidUntil = currentTime;
+    }
+
+    rentWarnings = 0;
 
 	if (guid != 0) {
 		std::string name = IOLoginData::getNameByGuid(guid);

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -89,21 +89,21 @@ void House::setOwner(uint32_t guid, bool updateDatabase/* = true*/, Player* play
 		//reset paid date
 		paidUntil = 0;
 	} else {
-        std::string strRentPeriod = asLowerCaseString(g_config.getString(ConfigManager::HOUSE_RENT_PERIOD));
-        time_t currentTime = time(nullptr);
-        if (strRentPeriod == "yearly") {
-            currentTime += 24 * 60 * 60 * 365;
-        } else if (strRentPeriod == "monthly") {
-            currentTime += 24 * 60 * 60 * 30;
-        } else if (strRentPeriod == "weekly") {
-            currentTime += 24 * 60 * 60 * 7;
-        } else if (strRentPeriod == "daily") {
-            currentTime += 24 * 60 * 60;
-        } else {
-            currentTime = 0;
-        }
+		std::string strRentPeriod = asLowerCaseString(g_config.getString(ConfigManager::HOUSE_RENT_PERIOD));
+		time_t currentTime = time(nullptr);
+		if (strRentPeriod == "yearly") {
+		    currentTime += 24 * 60 * 60 * 365;
+		} else if (strRentPeriod == "monthly") {
+		    currentTime += 24 * 60 * 60 * 30;
+		} else if (strRentPeriod == "weekly") {
+		    currentTime += 24 * 60 * 60 * 7;
+		} else if (strRentPeriod == "daily") {
+		    currentTime += 24 * 60 * 60;
+		} else {
+		    currentTime = 0;
+		}
 
-        paidUntil = currentTime;
+		paidUntil = currentTime;
     }
 
     rentWarnings = 0;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -85,9 +85,6 @@ void House::setOwner(uint32_t guid, bool updateDatabase/* = true*/, Player* play
 		for (Door* door : doorSet) {
 			door->setAccessList("");
 		}
-
-		//reset paid date
-		paidUntil = 0;
 	} else {
 		std::string strRentPeriod = asLowerCaseString(g_config.getString(ConfigManager::HOUSE_RENT_PERIOD));
 		time_t currentTime = time(nullptr);
@@ -104,9 +101,9 @@ void House::setOwner(uint32_t guid, bool updateDatabase/* = true*/, Player* play
 		}
 
 		paidUntil = currentTime;
-    }
+	}
 
-    rentWarnings = 0;
+	rentWarnings = 0;
 
 	if (guid != 0) {
 		std::string name = IOLoginData::getNameByGuid(guid);


### PR DESCRIPTION
House rents were charged twice since the money was removed when using !buyhouse and paidUntil was set to 0, so the warnings would start counting right away.