### PR TITLE
Changed item names to item ID in fishing script

### DIFF
--- a/data/actions/scripts/tools/fishing.lua
+++ b/data/actions/scripts/tools/fishing.lua
@@ -44,7 +44,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 
 	player:addSkillTries(SKILL_FISHING, 1)
 	if math.random(1, 100) <= math.min(math.max(10 + (player:getEffectiveSkillLevel(SKILL_FISHING) - 10) * 0.597, 10), 50) then
-		if useWorms and not player:removeItem("worm", 1) then
+		if useWorms and not player:removeItem(3976, 1) then
 			return true
 		end
 
@@ -72,7 +72,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 				return true
 			end
 		end
-		player:addItem("fish", 1)
+		player:addItem(2267, 1)
 	end
 	return true
 end


### PR DESCRIPTION
Like @TheSumm said in #2526 , it's not safe to use item names instead of their ID.