### PR TITLE
Fix crash when removing conditions in pre-death script

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1186,12 +1186,10 @@ void Creature::removeCondition(ConditionType_t type, bool force/* = false*/)
 			}
 		}
 
-		it = conditions.erase(it);
-
 		condition->endCondition(this);
-		delete condition;
-
 		onEndCondition(type);
+		toReleaseConditions.push_back(condition);
+		++it;
 	}
 }
 
@@ -1213,12 +1211,10 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 			}
 		}
 
-		it = conditions.erase(it);
-
 		condition->endCondition(this);
-		delete condition;
-
 		onEndCondition(type);
+		toReleaseConditions.push_back(condition);
+		++it;
 	}
 }
 
@@ -1251,11 +1247,9 @@ void Creature::removeCondition(Condition* condition, bool force/* = false*/)
 		}
 	}
 
-	conditions.erase(it);
-
 	condition->endCondition(this);
 	onEndCondition(condition->getType());
-	delete condition;
+	toReleaseConditions.push_back(condition);
 }
 
 Condition* Creature::getCondition(ConditionType_t type) const
@@ -1280,21 +1274,24 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(uint32_t interval)
 {
+	for (Condition* condition : toReleaseConditions) {
+		auto it = std::find(conditions.begin(), conditions.end(), condition);
+		if (it != conditions.end()) {
+			conditions.erase(it);
+		}
+		delete condition;
+	}
+	toReleaseConditions.clear();
+
 	auto it = conditions.begin(), end = conditions.end();
 	while (it != end) {
 		Condition* condition = *it;
 		if (!condition->executeCondition(this, interval)) {
-			ConditionType_t type = condition->getType();
-
-			it = conditions.erase(it);
-
 			condition->endCondition(this);
-			delete condition;
-
-			onEndCondition(type);
-		} else {
-			++it;
+			onEndCondition(condition->getType());
+			toReleaseConditions.push_back(condition);
 		}
+		++it;
 	}
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -480,6 +480,7 @@ class Creature : virtual public Thing
 		std::list<Creature*> summons;
 		CreatureEventList eventsList;
 		ConditionList conditions;
+		std::vector<Condition*> toReleaseConditions;
 
 		std::forward_list<Direction> listWalkDir;
 


### PR DESCRIPTION
Fixes #2024. I could 100% repeatedly reproduce the issue with the script @ninjalulz supplied. With this fix I can no longer reproduce it.

Please review, @Znote.