### PR TITLE
Fix #2024, #2549, and #2550

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1280,20 +1280,21 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(uint32_t interval)
 {
-	auto it = conditions.begin(), end = conditions.end();
-	while (it != end) {
-		Condition* condition = *it;
+	ConditionList tempConditions{ conditions };
+	for (Condition* condition : tempConditions) {
+		auto it = std::find(conditions.begin(), conditions.end(), condition);
+		if (it == conditions.end()) {
+			continue;
+		}
+
 		if (!condition->executeCondition(this, interval)) {
-			ConditionType_t type = condition->getType();
-
-			it = conditions.erase(it);
-
-			condition->endCondition(this);
-			delete condition;
-
-			onEndCondition(type);
-		} else {
-			++it;
+			it = std::find(conditions.begin(), conditions.end(), condition);
+			if (it != conditions.end()) {
+				conditions.erase(it);
+				condition->endCondition(this);
+				onEndCondition(condition->getType());
+				delete condition;
+			}
 		}
 	}
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1186,10 +1186,12 @@ void Creature::removeCondition(ConditionType_t type, bool force/* = false*/)
 			}
 		}
 
+		it = conditions.erase(it);
+
 		condition->endCondition(this);
+		delete condition;
+
 		onEndCondition(type);
-		toReleaseConditions.push_back(condition);
-		++it;
 	}
 }
 
@@ -1211,10 +1213,12 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 			}
 		}
 
+		it = conditions.erase(it);
+
 		condition->endCondition(this);
+		delete condition;
+
 		onEndCondition(type);
-		toReleaseConditions.push_back(condition);
-		++it;
 	}
 }
 
@@ -1247,9 +1251,11 @@ void Creature::removeCondition(Condition* condition, bool force/* = false*/)
 		}
 	}
 
+	conditions.erase(it);
+
 	condition->endCondition(this);
 	onEndCondition(condition->getType());
-	toReleaseConditions.push_back(condition);
+	delete condition;
 }
 
 Condition* Creature::getCondition(ConditionType_t type) const
@@ -1274,24 +1280,21 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(uint32_t interval)
 {
-	for (Condition* condition : toReleaseConditions) {
-		auto it = std::find(conditions.begin(), conditions.end(), condition);
-		if (it != conditions.end()) {
-			conditions.erase(it);
-		}
-		delete condition;
-	}
-	toReleaseConditions.clear();
-
 	auto it = conditions.begin(), end = conditions.end();
 	while (it != end) {
 		Condition* condition = *it;
 		if (!condition->executeCondition(this, interval)) {
+			ConditionType_t type = condition->getType();
+
+			it = conditions.erase(it);
+
 			condition->endCondition(this);
-			onEndCondition(condition->getType());
-			toReleaseConditions.push_back(condition);
+			delete condition;
+
+			onEndCondition(type);
+		} else {
+			++it;
 		}
-		++it;
 	}
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -480,7 +480,6 @@ class Creature : virtual public Thing
 		std::list<Creature*> summons;
 		CreatureEventList eventsList;
 		ConditionList conditions;
-		std::vector<Condition*> toReleaseConditions;
 
 		std::forward_list<Direction> listWalkDir;
 


### PR DESCRIPTION
My fix for #2024 (#2541) introduced issues with conditions (#2549 and #2550). Commit 9c2f11c reverts my original fix, and commit e21523e implements a better way to resolve the original issue while fixing the new ones.

Basically, before executing conditions, the current condition list is copied to a new one, and that new list is iterated through instead. Checks are done against the original condition list to ensure the current iteration is valid.

@gregorecruzeiro and @raymondtfr, please test and confirm this fixes the mentioned issues.