### PR TITLE
Correct way to random step

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1106,7 +1106,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 
 	bool result = false;
 	if ((!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
-		if (getWalkDelay() <= 0) {
+		if (getTimeSinceLastMove() - getStepDuration() > 600) {
 			randomStepping = true;
 			//choose a random direction
 			result = getRandomStep(getPosition(), direction);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1106,7 +1106,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 
 	bool result = false;
 	if ((!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
-		if (getTimeSinceLastMove() - getStepDuration() > 600) {
+		if (getTimeSinceLastMove() >= 1000) {
 			randomStepping = true;
 			//choose a random direction
 			result = getRandomStep(getPosition(), direction);


### PR DESCRIPTION
Monsters dont random step while no target like they should right now, this pr should fix the behaviour to the correct one.