### PR TITLE
Update spells.cpp | fix very rare crash bug.

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -774,6 +774,7 @@ void Monster::doAttacking(uint32_t interval)
 
 	for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
 		bool inRange = false;
+		
 		if (attackedCreature == nullptr) {
 			break;
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -774,8 +774,10 @@ void Monster::doAttacking(uint32_t interval)
 
 	for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
 		bool inRange = false;
-
-		if (attackedCreature && canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
+		if (attackedCreature == nullptr) {
+			break;
+		}
+		if (canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
 			if (spellBlock.chance >= static_cast<uint32_t>(uniform_random(1, 100))) {
 				if (updateLook) {
 					updateLookDirection();

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -778,6 +778,7 @@ void Monster::doAttacking(uint32_t interval)
 		if (attackedCreature == nullptr) {
 			break;
 		}
+		
 		if (canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
 			if (spellBlock.chance >= static_cast<uint32_t>(uniform_random(1, 100))) {
 				if (updateLook) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -775,7 +775,7 @@ void Monster::doAttacking(uint32_t interval)
 	for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
 		bool inRange = false;
 
-		if (canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
+		if (attackedCreature && canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
 			if (spellBlock.chance >= static_cast<uint32_t>(uniform_random(1, 100))) {
 				if (updateLook) {
 					updateLookDirection();

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -257,8 +257,9 @@ bool CombatSpell::loadScriptCombat()
 
 bool CombatSpell::castSpell(Creature* creature)
 {
-	if (!creature)
+	if (!creature) {
 		return false;
+	}
 	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_POSITION;
@@ -285,8 +286,9 @@ bool CombatSpell::castSpell(Creature* creature)
 
 bool CombatSpell::castSpell(Creature* creature, Creature* target)
 {
-	if (!creature || !target)
+	if (!creature || !target) {
 		return false;
+	}
 	if (scripted) {
 		LuaVariant var;
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -257,6 +257,8 @@ bool CombatSpell::loadScriptCombat()
 
 bool CombatSpell::castSpell(Creature* creature)
 {
+	if (!creature)
+		return false;
 	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_POSITION;
@@ -283,6 +285,8 @@ bool CombatSpell::castSpell(Creature* creature)
 
 bool CombatSpell::castSpell(Creature* creature, Creature* target)
 {
+	if (!creature || !target)
+		return false;
 	if (scripted) {
 		LuaVariant var;
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -257,9 +257,6 @@ bool CombatSpell::loadScriptCombat()
 
 bool CombatSpell::castSpell(Creature* creature)
 {
-	if (!creature) {
-		return false;
-	}
 	if (scripted) {
 		LuaVariant var;
 		var.type = VARIANT_POSITION;
@@ -286,9 +283,6 @@ bool CombatSpell::castSpell(Creature* creature)
 
 bool CombatSpell::castSpell(Creature* creature, Creature* target)
 {
-	if (!creature || !target) {
-		return false;
-	}
 	if (scripted) {
 		LuaVariant var;
 


### PR DESCRIPTION
Fixing a very rare bug. In very specific situations, when the creature or target is removed, it can cause a crash, because in this part of the code the methods "creature->getPosition() and target->getPosition()" are used without first checking that they exist. This causes a bug in combat.cpp when trying to use a position that does not exist.