### PR TITLE
Revscriptsys Spells

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -230,6 +230,17 @@ do
 	rawgetmetatable("Weapon").__newindex = WeaponNewIndex
 end
 
+do
+	local function SpellNewIndex(self, key, value)
+		if key == "onCastSpell" then
+			self:onCastSpell(value)
+			return
+		end
+		rawset(self, key, value)
+	end
+	rawgetmetatable("Spell").__newindex = SpellNewIndex
+end
+
 function pushThing(thing)
 	local t = {uid = 0, itemid = 0, type = 0, actionid = 0}
 	if thing then
@@ -1239,16 +1250,18 @@ end
 function doMoveCreature(cid, direction) local c = Creature(cid) return c ~= nil and c:move(direction) end
 
 function createFunctions(class)
-	local exclude = {"get", "set", "is", "add", "can"}
+	local exclude = {[2] = {"is"}, [3] = {"get", "set", "add", "can"}, [4] = {"need"}}
 	local temp = {}
 	for name, func in pairs(class) do
-		if not table.contains(exclude, name:sub(1,3)) then
-			local str = name:sub(1,1):upper()..name:sub(2)
-			local getFunc = function(self) return func(self) end
-			local setFunc = function(self, ...) return func(self, ...) end
-			local get = "get".. str
-			local set = "set".. str
-			table.insert(temp, {set, setFunc, get, getFunc})
+		for strLen, strTable in pairs(exclude) do
+			if not table.contains(strTable, name:sub(1,strLen)) then
+				local str = name:sub(1,1):upper()..name:sub(2)
+				local getFunc = function(self) return func(self) end
+				local setFunc = function(self, ...) return func(self, ...) end
+				local get = "get".. str
+				local set = "set".. str
+				table.insert(temp, {set, setFunc, get, getFunc})
+			end
 		end
 	end
 	for _,func in ipairs(temp) do

--- a/data/scripts/lib/create_functions.lua
+++ b/data/scripts/lib/create_functions.lua
@@ -1,1 +1,2 @@
 createFunctions(MonsterType) -- creates get/set functions for MonsterType
+createFunctions(Spell) -- creates get/set functions for Spell

--- a/data/scripts/spells/#example.lua
+++ b/data/scripts/spells/#example.lua
@@ -1,0 +1,52 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HEALING)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
+combat:setParameter(COMBAT_PARAM_DISPEL, CONDITION_PARALYZE)
+combat:setParameter(COMBAT_PARAM_TARGETCASTERORTOPMOST, true)
+combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
+
+function onGetFormulaValues(player, level, magicLevel)
+	local min = (level / 5) + (magicLevel * 3.2) + 20
+	local max = (level / 5) + (magicLevel * 5.4) + 40
+	return min, max
+end
+
+combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")
+
+local spell = Spell(SPELL_RUNE)
+
+function spell.onCastSpell(creature, variant, isHotkey)
+	return combat:execute(creature, variant)
+end
+
+spell:name("test rune")
+spell:runeId(2275)
+spell:id(220)
+spell:level(20)
+spell:magicLevel(5)
+spell:needTarget(true)
+spell:isAggressive(false)
+spell:allowFarUse(true)
+spell:charges(25)
+spell:register()
+
+local conjureRune = Spell(SPELL_INSTANT)
+
+function conjureRune.onCastSpell(creature, variant)
+	return creature:conjureItem(2260, 2275, 25)
+end
+
+conjureRune:name("Test")
+conjureRune:id(221)
+conjureRune:words("adori mas test")
+conjureRune:level(30)
+conjureRune:mana(530)
+conjureRune:group("support")
+conjureRune:soul(3)
+conjureRune:isAggressive(false)
+conjureRune:cooldown(2000)
+conjureRune:groupCooldown(2000)
+conjureRune:needLearn(false)
+conjureRune:vocation("sorcerer", true)
+conjureRune:vocation("master sorcerer")
+conjureRune:register()

--- a/src/enums.h
+++ b/src/enums.h
@@ -153,6 +153,12 @@ enum SpellGroup_t : uint8_t {
 	SPELLGROUP_SPECIAL = 4,
 };
 
+enum SpellType_t : uint8_t {
+	SPELL_UNDEFINED = 0,
+	SPELL_INSTANT = 1,
+	SPELL_RUNE = 2,
+};
+
 enum AccountType_t : uint8_t {
 	ACCOUNT_TYPE_NORMAL = 1,
 	ACCOUNT_TYPE_TUTOR = 2,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5736,7 +5736,6 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_talkActions->clear(true);
 			g_globalEvents->clear(true);
 			g_weapons->clear(true);
-			g_spells->clear(true);
 			g_weapons->loadDefaults();
 			g_spells->clear(true);
 			g_scripts->loadScripts("scripts", false, true);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5730,14 +5730,6 @@ bool Game::reload(ReloadTypes_t reloadType)
 
 		case RELOAD_TYPE_SCRIPTS: {
 			// commented out stuff is TODO, once we approach further in revscriptsys
-			if (!g_spells->reload()) {
-				std::cout << "[Error - Game::reload] Failed to reload spells." << std::endl;
-				std::terminate();
-			} else if (!g_monsters.reload()) {
-				std::cout << "[Error - Game::reload] Failed to reload monsters." << std::endl;
-				std::terminate();
-			}
-
 			g_actions->clear(true);
 			g_creatureEvents->clear(true);
 			g_moveEvents->clear(true);
@@ -5746,6 +5738,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_weapons->clear(true);
 			g_spells->clear(true);
 			g_weapons->loadDefaults();
+			g_spells->clear(true);
 			g_scripts->loadScripts("scripts", false, true);
 			/*
 			Npcs::reload();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5730,16 +5730,13 @@ bool Game::reload(ReloadTypes_t reloadType)
 
 		case RELOAD_TYPE_SCRIPTS: {
 			// commented out stuff is TODO, once we approach further in revscriptsys
-			/*
 			if (!g_spells->reload()) {
 				std::cout << "[Error - Game::reload] Failed to reload spells." << std::endl;
 				std::terminate();
-			}
-			else if (!g_monsters.reload()) {
+			} else if (!g_monsters.reload()) {
 				std::cout << "[Error - Game::reload] Failed to reload monsters." << std::endl;
 				std::terminate();
 			}
-			*/
 
 			g_actions->clear(true);
 			g_creatureEvents->clear(true);
@@ -5747,6 +5744,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_talkActions->clear(true);
 			g_globalEvents->clear(true);
 			g_weapons->clear(true);
+			g_spells->clear(true);
 			g_weapons->loadDefaults();
 			g_scripts->loadScripts("scripts", false, true);
 			/*
@@ -5793,6 +5791,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_moveEvents->clear(true);
 			g_talkActions->clear(true);
 			g_globalEvents->clear(true);
+			g_spells->clear(true);
 			g_scripts->loadScripts("scripts", false, true);
 			return true;
 		}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2781,24 +2781,30 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Spell", "manaPercent", LuaScriptInterface::luaSpellManaPercent);
 	registerMethod("Spell", "soul", LuaScriptInterface::luaSpellSoul);
 	registerMethod("Spell", "range", LuaScriptInterface::luaSpellRange);
-	registerMethod("Spell", "premium", LuaScriptInterface::luaSpellPremium);
-	registerMethod("Spell", "enabled", LuaScriptInterface::luaSpellEnabled);
+	registerMethod("Spell", "isPremium", LuaScriptInterface::luaSpellPremium);
+	registerMethod("Spell", "isEnabled", LuaScriptInterface::luaSpellEnabled);
 	registerMethod("Spell", "needTarget", LuaScriptInterface::luaSpellNeedTarget);
 	registerMethod("Spell", "needWeapon", LuaScriptInterface::luaSpellNeedWeapon);
 	registerMethod("Spell", "needLearn", LuaScriptInterface::luaSpellNeedLearn);
-	registerMethod("Spell", "selfTarget", LuaScriptInterface::luaSpellSelfTarget);
-	registerMethod("Spell", "blocking", LuaScriptInterface::luaSpellBlocking);
-	registerMethod("Spell", "aggressive", LuaScriptInterface::luaSpellAggressive);
+	registerMethod("Spell", "isSelfTarget", LuaScriptInterface::luaSpellSelfTarget);
+	registerMethod("Spell", "isBlocking", LuaScriptInterface::luaSpellBlocking);
+	registerMethod("Spell", "isAggressive", LuaScriptInterface::luaSpellAggressive);
 	registerMethod("Spell", "vocation", LuaScriptInterface::luaSpellVocation);
 
-	// only for instant spells
+	// only for InstantSpell
 	registerMethod("Spell", "words", LuaScriptInterface::luaSpellWords);
+	registerMethod("Spell", "needDirection", LuaScriptInterface::luaSpellNeedDirection);
+	registerMethod("Spell", "hasParams", LuaScriptInterface::luaSpellHasParams);
+	registerMethod("Spell", "hasPlayerNameParam", LuaScriptInterface::luaSpellHasPlayerNameParam);
+	registerMethod("Spell", "needCasterTargetOrDirection", LuaScriptInterface::luaSpellNeedCasterTargetOrDirection);
+	registerMethod("Spell", "isBlockingWalls", LuaScriptInterface::luaSpellIsBlockingWalls);
 
-	registerMethod("Spell", "getManaCost", LuaScriptInterface::luaSpellGetManaCost);
-	registerMethod("Spell", "getSoulCost", LuaScriptInterface::luaSpellGetSoulCost);
-
-	registerMethod("Spell", "isPremium", LuaScriptInterface::luaSpellIsPremium);
-	registerMethod("Spell", "isLearnable", LuaScriptInterface::luaSpellIsLearnable);
+	// only for RuneSpells
+	registerMethod("Spell", "runeId", LuaScriptInterface::luaSpellRuneId);
+	registerMethod("Spell", "charges", LuaScriptInterface::luaSpellCharges);
+	registerMethod("Spell", "allowFarUse", LuaScriptInterface::luaActionAllowFarUse);
+	registerMethod("Spell", "blockWalls", LuaScriptInterface::luaActionBlockWalls);
+	registerMethod("Spell", "checkFloor", LuaScriptInterface::luaActionCheckFloor);
 
 	// Action
 	registerClass("Action", "", LuaScriptInterface::luaCreateAction);
@@ -13815,9 +13821,9 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 				InstantSpell* spell = new InstantSpell(getScriptEnv()->getScriptInterface());
 				if (spell) {
 					spell->fromLua = true;
+					spell->type = SPELL_INSTANT;
 					pushUserdata<InstantSpell>(L, spell);
 					setMetatable(L, -1, "Spell");
-					spell->type = SPELL_INSTANT;
 				} else {
 					lua_pushnil(L);
 				}
@@ -13827,9 +13833,9 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 				RuneSpell* spell = new RuneSpell(getScriptEnv()->getScriptInterface());
 				if (spell) {
 					spell->fromLua = true;
+					spell->type = SPELL_RUNE;
 					pushUserdata<RuneSpell>(L, spell);
 					setMetatable(L, -1, "Spell");
-					spell->type = SPELL_RUNE;
 				} else {
 					lua_pushnil(L);
 				}
@@ -13843,28 +13849,50 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 		return 1;
 	}
 
-	Spell* userdata = getUserdata<Spell>(L, 2);
-	if (userdata) {
-		pushUserdata<Spell>(L, userdata);
+	Spell* spell = getUserdata<Spell>(L, 2);
+	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			pushUserdata<InstantSpell>(L, static_cast<InstantSpell*>(spell));
+		} else {
+			pushUserdata<RuneSpell>(L, static_cast<RuneSpell*>(spell));
+		}
 		setMetatable(L, -1, "Spell");
 		return 1;
 	}
 
-	InstantSpell* spell = nullptr;
 	if (isNumber(L, 2)) {
 		spell = g_spells->getInstantSpellById(getNumber<uint32_t>(L, 2));
-	} else {
-		std::string stringArgument = getString(L, 2);
-		spell = g_spells->getInstantSpellByName(stringArgument);
-		if (!spell) {
-			spell = g_spells->getInstantSpell(stringArgument);
+		if (spell) {
+			pushUserdata<InstantSpell>(L, static_cast<InstantSpell*>(spell));
+			setMetatable(L, -1, "Spell");
+			return 1;
 		}
-	}
-
-	if (spell) {
-		pushUserdata<InstantSpell>(L, spell);
-		setMetatable(L, -1, "Spell");
-		//pushInstantSpell(L, *spell);
+		spell = g_spells->getRuneSpell(getNumber<uint32_t>(L, 2));
+		if (spell) {
+			pushUserdata<RuneSpell>(L, static_cast<RuneSpell*>(spell));
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+	} else if (isString(L, 2)) {
+		std::string arg = getString(L, 2);
+		spell = g_spells->getInstantSpellByName(arg);
+		if (spell) {
+			pushUserdata<InstantSpell>(L, static_cast<InstantSpell*>(spell));
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+		spell = g_spells->getInstantSpell(arg);
+		if (spell) {
+			pushUserdata<InstantSpell>(L, static_cast<InstantSpell*>(spell));
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+		spell = g_spells->getRuneSpellByName(arg);
+		if (spell) {
+			pushUserdata<RuneSpell>(L, static_cast<RuneSpell*>(spell));
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
 	} else {
 		lua_pushnil(L);
 	}
@@ -13913,6 +13941,13 @@ int LuaScriptInterface::luaSpellRegister(lua_State* L)
 			pushBoolean(L, g_spells->registerInstantLuaEvent(instant));
 		} else {
 			RuneSpell* rune = getUserdata<RuneSpell>(L, 1);
+			if (rune->getMagicLevel() != 0 || rune->getLevel() != 0) {
+				//Change information in the ItemType to get accurate description
+				ItemType& iType = Item::items.getItemType(rune->getRuneItemId());
+				iType.runeMagLevel = rune->getMagicLevel();
+				iType.runeLevel = rune->getLevel();
+				iType.charges = rune->getCharges();
+			}
 			if (!rune->isScripted()) {
 				pushBoolean(L, false);
 				return 1;
@@ -13928,8 +13963,14 @@ int LuaScriptInterface::luaSpellRegister(lua_State* L)
 int LuaScriptInterface::luaSpellName(lua_State* L)
 {
 	// spell:name(name)
-	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
+	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushString(L, spell->getName());
 		} else {
@@ -13947,11 +13988,22 @@ int LuaScriptInterface::luaSpellId(lua_State* L)
 	// spell:id(id)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
-		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getId());
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+			if (lua_gettop(L) == 1) {
+				lua_pushnumber(L, spell->getId());
+			} else {
+				spell->setId(getNumber<uint8_t>(L, 2));
+				pushBoolean(L, true);
+			}
 		} else {
-			spell->setId(getNumber<uint8_t>(L, 2));
-			pushBoolean(L, true);
+			RuneSpell* rune = getUserdata<RuneSpell>(L, 1);
+			if (lua_gettop(L) == 1) {
+				lua_pushnumber(L, rune->getRuneItemId());
+			} else {
+				rune->setRuneItemId(getNumber<uint8_t>(L, 2));
+				pushBoolean(L, true);
+			}
 		}
 	} else {
 		lua_pushnil(L);
@@ -13964,8 +14016,16 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 	// spell:group(primaryGroup[, secondaryGroup])
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getGroup());
+			lua_pushnumber(L, spell->getSecondaryGroup());
+			return 2;
 		} else if (lua_gettop(L) == 2) {
 			SpellGroup_t group = getNumber<SpellGroup_t>(L, 2);
 			if (group) {
@@ -14052,9 +14112,16 @@ int LuaScriptInterface::luaSpellCooldown(lua_State* L)
 	// spell:cooldown(primaryGroupCd[, secondaryGroupCd])
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getCooldown());
 			lua_pushnumber(L, spell->getSecondaryCooldown());
+			return 2;
 		} else if (lua_gettop(L) == 2) {
 			spell->setCooldown(getNumber<uint32_t>(L, 2));
 			pushBoolean(L, true);
@@ -14074,6 +14141,12 @@ int LuaScriptInterface::luaSpellGroupCooldown(lua_State* L)
 	// spell:groupCooldown(cooldown)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getGroupCooldown());
 		} else {
@@ -14091,6 +14164,12 @@ int LuaScriptInterface::luaSpellLevel(lua_State* L)
 	// spell:level(lvl)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getLevel());
 		} else {
@@ -14108,6 +14187,12 @@ int LuaScriptInterface::luaSpellMagicLevel(lua_State* L)
 	// spell:magicLevel(lvl)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getMagicLevel());
 		} else {
@@ -14125,6 +14210,12 @@ int LuaScriptInterface::luaSpellMana(lua_State* L)
 	// spell:mana(mana)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getMana());
 		} else {
@@ -14142,6 +14233,12 @@ int LuaScriptInterface::luaSpellManaPercent(lua_State* L)
 	// spell:manaPercent(percent)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getManaPercent());
 		} else {
@@ -14159,6 +14256,12 @@ int LuaScriptInterface::luaSpellSoul(lua_State* L)
 	// spell:soul(soul)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getSoulCost());
 		} else {
@@ -14176,6 +14279,12 @@ int LuaScriptInterface::luaSpellRange(lua_State* L)
 	// spell:range(range)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getRange());
 		} else {
@@ -14190,9 +14299,15 @@ int LuaScriptInterface::luaSpellRange(lua_State* L)
 
 int LuaScriptInterface::luaSpellPremium(lua_State* L)
 {
-	// spell:premium(bool)
+	// spell:isPremium(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->isPremium());
 		} else {
@@ -14207,9 +14322,15 @@ int LuaScriptInterface::luaSpellPremium(lua_State* L)
 
 int LuaScriptInterface::luaSpellEnabled(lua_State* L)
 {
-	// spell:enabled(bool)
+	// spell:isEnabled(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->isEnabled());
 		} else {
@@ -14227,6 +14348,12 @@ int LuaScriptInterface::luaSpellNeedTarget(lua_State* L)
 	// spell:needTarget(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->getNeedTarget());
 		} else {
@@ -14244,6 +14371,12 @@ int LuaScriptInterface::luaSpellNeedWeapon(lua_State* L)
 	// spell:needWeapon(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->getNeedWeapon());
 		} else {
@@ -14261,6 +14394,12 @@ int LuaScriptInterface::luaSpellNeedLearn(lua_State* L)
 	// spell:needLearn(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->getNeedLearn());
 		} else {
@@ -14275,9 +14414,15 @@ int LuaScriptInterface::luaSpellNeedLearn(lua_State* L)
 
 int LuaScriptInterface::luaSpellSelfTarget(lua_State* L)
 {
-	// spell:selfTarget(bool)
+	// spell:isSelfTarget(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->getSelfTarget());
 		} else {
@@ -14292,12 +14437,19 @@ int LuaScriptInterface::luaSpellSelfTarget(lua_State* L)
 
 int LuaScriptInterface::luaSpellBlocking(lua_State* L)
 {
-	// spell:blocking(blockingSolid, blockingCreature)
+	// spell:isBlocking(blockingSolid, blockingCreature)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->getBlockingSolid());
 			pushBoolean(L, spell->getBlockingCreature());
+			return 2;
 		} else {
 			spell->setBlockingSolid(getBoolean(L, 2));
 			spell->setBlockingCreature(getBoolean(L, 3));
@@ -14311,9 +14463,15 @@ int LuaScriptInterface::luaSpellBlocking(lua_State* L)
 
 int LuaScriptInterface::luaSpellAggressive(lua_State* L)
 {
-	// spell:aggressive(bool)
+	// spell:isAggressive(bool)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, spell->getAggressive());
 		} else {
@@ -14331,6 +14489,12 @@ int LuaScriptInterface::luaSpellVocation(lua_State* L)
 	// spell:vocation(vocation[, showInDescription = false)
 	Spell* spell = getUserdata<Spell>(L, 1);
 	if (spell) {
+		if (spell->type == SPELL_INSTANT) {
+			spell = static_cast<InstantSpell*>(getUserdata<InstantSpell>(L, 1));
+		} else {
+			spell = static_cast<RuneSpell*>(getUserdata<RuneSpell>(L, 1));
+		}
+
 		if (lua_gettop(L) == 1) {
 			lua_createtable(L, 0, 0);
 			auto it = 0;
@@ -14338,7 +14502,8 @@ int LuaScriptInterface::luaSpellVocation(lua_State* L)
 				++it;
 				std::string s = std::to_string(it);
 				char const *pchar = s.c_str();
-				setField(L, pchar, voc.first);
+				std::string name = g_vocations.getVocation(voc.first)->getVocName();
+				setField(L, pchar, name);
 			}
 			setMetatable(L, -1, "Spell");
 		} else {
@@ -14358,6 +14523,7 @@ int LuaScriptInterface::luaSpellVocation(lua_State* L)
 	return 1;
 }
 
+// only for InstantSpells
 int LuaScriptInterface::luaSpellWords(lua_State* L)
 {
 	// spell:words(words[, separator = ""])
@@ -14365,6 +14531,8 @@ int LuaScriptInterface::luaSpellWords(lua_State* L)
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			pushString(L, spell->getWords());
+			pushString(L, spell->getSeparator());
+			return 2;
 		} else {
 			std::string sep = "";
 			if (lua_gettop(L) == 3) {
@@ -14380,46 +14548,181 @@ int LuaScriptInterface::luaSpellWords(lua_State* L)
 	return 1;
 }
 
-int LuaScriptInterface::luaSpellGetManaCost(lua_State* L)
+// only for InstantSpells
+int LuaScriptInterface::luaSpellNeedDirection(lua_State* L)
 {
-	// spell:getManaCost(player)
-	InstantSpell* spell = getInstantSpell(L, 1);
-	Player* player = getUserdata<Player>(L, 2);
-	if (spell && player) {
-		lua_pushnumber(L, spell->getManaCost(player));
+	// spell:needDirection(bool)
+	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getNeedDirection());
+		} else {
+			spell->setNeedDirection(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
 	} else {
 		lua_pushnil(L);
 	}
 	return 1;
 }
 
-int LuaScriptInterface::luaSpellGetSoulCost(lua_State* L)
+// only for InstantSpells
+int LuaScriptInterface::luaSpellHasParams(lua_State* L)
 {
-	// spell:getSoulCost()
-	if (InstantSpell* spell = getInstantSpell(L, 1)) {
-		lua_pushnumber(L, spell->getSoulCost());
+	// spell:hasParams(bool)
+	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getHasParam());
+		} else {
+			spell->setHasParam(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
 	} else {
 		lua_pushnil(L);
 	}
 	return 1;
 }
 
-int LuaScriptInterface::luaSpellIsPremium(lua_State* L)
+// only for InstantSpells
+int LuaScriptInterface::luaSpellHasPlayerNameParam(lua_State* L)
 {
-	// spell:isPremium()
-	if (InstantSpell* spell = getInstantSpell(L, 1)) {
-		pushBoolean(L, spell->isPremium());
+	// spell:hasPlayerNameParam(bool)
+	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getHasPlayerNameParam());
+		} else {
+			spell->setHasPlayerNameParam(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
 	} else {
 		lua_pushnil(L);
 	}
 	return 1;
 }
 
-int LuaScriptInterface::luaSpellIsLearnable(lua_State* L)
+// only for InstantSpells
+int LuaScriptInterface::luaSpellNeedCasterTargetOrDirection(lua_State* L)
 {
-	// spell:isLearnable()
-	if (InstantSpell* spell = getInstantSpell(L, 1)) {
-		pushBoolean(L, spell->isLearnable());
+	// spell:needCasterTargetOrDirection(bool)
+	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getNeedCasterTargetOrDirection());
+		} else {
+			spell->setNeedCasterTargetOrDirection(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+// only for InstantSpells
+int LuaScriptInterface::luaSpellIsBlockingWalls(lua_State* L)
+{
+	// spell:blockWalls(bool)
+	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getBlockWalls());
+		} else {
+			spell->setBlockWalls(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+// only for RuneSpells
+int LuaScriptInterface::luaSpellRuneId(lua_State* L)
+{
+	// spell:runeId(id)
+	RuneSpell* spell = getUserdata<RuneSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getRuneItemId());
+		} else {
+			spell->setRuneItemId(getNumber<uint16_t>(L, 2));
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+// only for RuneSpells
+int LuaScriptInterface::luaSpellCharges(lua_State* L)
+{
+	// spell:charges(bool)
+	RuneSpell* spell = getUserdata<RuneSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getCharges());
+		} else {
+			spell->setCharges(getNumber<uint32_t>(L, 2));
+			spell->setHasCharges(true);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+// only for RuneSpells
+int LuaScriptInterface::luaSpellAllowFarUse(lua_State* L)
+{
+	// spell:allowFarUse(bool)
+	RuneSpell* spell = getUserdata<RuneSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getAllowFarUse());
+		} else {
+			spell->setAllowFarUse(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+// only for RuneSpells
+int LuaScriptInterface::luaSpellBlockWalls(lua_State* L)
+{
+	// spell:blockWalls(bool)
+	RuneSpell* spell = getUserdata<RuneSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getCheckLineOfSight());
+		} else {
+			spell->setCheckLineOfSight(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+// only for RuneSpells
+int LuaScriptInterface::luaSpellCheckFloor(lua_State* L)
+{
+	// spell:checkFloor(bool)
+	RuneSpell* spell = getUserdata<RuneSpell>(L, 1);
+	if (spell) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, spell->getCheckFloor());
+		} else {
+			spell->setCheckFloor(getBoolean(L, 2));
+			pushBoolean(L, true);
+		}
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14646,7 +14646,7 @@ int LuaScriptInterface::luaSpellRuneId(lua_State* L)
 // only for RuneSpells
 int LuaScriptInterface::luaSpellCharges(lua_State* L)
 {
-	// spell:charges(bool)
+	// spell:charges(charges)
 	RuneSpell* spell = getUserdata<RuneSpell>(L, 1);
 	if (spell) {
 		// if spell == SPELL_UNDEFINED, it means that this actually is no RuneSpell, so we return nil
@@ -14656,10 +14656,9 @@ int LuaScriptInterface::luaSpellCharges(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			pushBoolean(L, spell->getCharges());
+			lua_pushnumber(L, spell->getCharges());
 		} else {
 			spell->setCharges(getNumber<uint32_t>(L, 2));
-			spell->setHasCharges(true);
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13866,7 +13866,7 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 			return 1;
 		}
 	} else if (isString(L, 2)) {
-		std::string& arg = getString(L, 2);
+		std::string arg = getString(L, 2);
 		InstantSpell* instant = g_spells->getInstantSpellByName(arg);
 		if (instant) {
 			pushUserdata<Spell>(L, instant);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13843,6 +13843,13 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 		return 1;
 	}
 
+	Spell* userdata = getUserdata<Spell>(L, 2);
+	if (userdata) {
+		pushUserdata<Spell>(L, userdata);
+		setMetatable(L, -1, "Spell");
+		return 1;
+	}
+
 	InstantSpell* spell = nullptr;
 	if (isNumber(L, 2)) {
 		spell = g_spells->getInstantSpellById(getNumber<uint32_t>(L, 2));
@@ -13855,7 +13862,9 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 	}
 
 	if (spell) {
-		pushInstantSpell(L, *spell);
+		pushUserdata<InstantSpell>(L, spell);
+		setMetatable(L, -1, "Spell");
+		//pushInstantSpell(L, *spell);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13919,7 +13928,7 @@ int LuaScriptInterface::luaSpellRegister(lua_State* L)
 int LuaScriptInterface::luaSpellName(lua_State* L)
 {
 	// spell:name(name)
-	Spell* spell = getUserdata<Spell>(L, 1);
+	InstantSpell* spell = getUserdata<InstantSpell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			pushString(L, spell->getName());

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13815,6 +13815,15 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 	// Spell(words, name or id) to get an existing spell
 	// Spell(type) ex: Spell(SPELL_INSTANT) or Spell(SPELL_RUNE) to create a new spell
 	SpellType_t type = getNumber<SpellType_t>(L, 2);
+	if (isString(L, 2)) {
+		std::string tmp = asLowerCaseString(getString(L, 2));
+		if (tmp == "instant") {
+			type = SPELL_INSTANT;
+		} else if (tmp == "rune") {
+			type = SPELL_RUNE;
+		}
+	}
+
 	if (type) {
 		switch (type) {
 			case SPELL_INSTANT: {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13814,7 +13814,14 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 {
 	// Spell(words, name or id) to get an existing spell
 	// Spell(type) ex: Spell(SPELL_INSTANT) or Spell(SPELL_RUNE) to create a new spell
+	if (lua_gettop(L) == 1) {
+		std::cout << "[Error - Spell::luaSpellCreate] There is no parameter set!" << std::endl;
+		lua_pushnil(L);
+		return 1;
+	}
+
 	SpellType_t type = getNumber<SpellType_t>(L, 2);
+
 	if (isString(L, 2)) {
 		std::string tmp = asLowerCaseString(getString(L, 2));
 		if (tmp == "instant") {
@@ -13824,35 +13831,24 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 		}
 	}
 
-	if (type) {
-		switch (type) {
-			case SPELL_INSTANT: {
-				InstantSpell* spell = new InstantSpell(getScriptEnv()->getScriptInterface());
-				spell->fromLua = true;
-				pushUserdata<Spell>(L, spell);
-				setMetatable(L, -1, "Spell");
-				spell->spellType = SPELL_INSTANT;
-				break;
-			}
-			case SPELL_RUNE: {
-				RuneSpell* spell = new RuneSpell(getScriptEnv()->getScriptInterface());
-				spell->fromLua = true;
-				pushUserdata<Spell>(L, spell);
-				setMetatable(L, -1, "Spell");
-				spell->spellType = SPELL_RUNE;
-				break;
-			}
-			case SPELL_UNDEFINED: {
-				std::cout << "[Error - Spell::luaSpellCreate] Invalid spellType: " << type << std::endl;
-				lua_pushnil(L);
-				break;
-			}
-		}
+	if (type == SPELL_INSTANT) {
+		InstantSpell* spell = new InstantSpell(getScriptEnv()->getScriptInterface());
+		spell->fromLua = true;
+		pushUserdata<Spell>(L, spell);
+		setMetatable(L, -1, "Spell");
+		spell->spellType = SPELL_INSTANT;
+		return 1;
+	} else if (type == SPELL_RUNE) {
+		RuneSpell* spell = new RuneSpell(getScriptEnv()->getScriptInterface());
+		spell->fromLua = true;
+		pushUserdata<Spell>(L, spell);
+		setMetatable(L, -1, "Spell");
+		spell->spellType = SPELL_RUNE;
 		return 1;
 	}
 
 	// isNumber(L, 2) doesn't work here for some reason, maybe a bug?
-	if (getNumber<int32_t>(L, 2)) {
+	if (getNumber<uint32_t>(L, 2)) {
 		InstantSpell* instant = g_spells->getInstantSpellById(getNumber<uint32_t>(L, 2));
 		if (instant) {
 			pushUserdata<Spell>(L, instant);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14035,17 +14035,9 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				spell->setGroup(group);
 				pushBoolean(L, true);
 			} else if (isString(L, 2)) {
-				std::string tmpStr = asLowerCaseString(getString(L, 2));
-				if (tmpStr == "none" || tmpStr == "0") {
-					spell->setGroup(SPELLGROUP_NONE);
-				} else if (tmpStr == "attack" || tmpStr == "1") {
-					spell->setGroup(SPELLGROUP_ATTACK);
-				} else if (tmpStr == "healing" || tmpStr == "2") {
-					spell->setGroup(SPELLGROUP_HEALING);
-				} else if (tmpStr == "support" || tmpStr == "3") {
-					spell->setGroup(SPELLGROUP_SUPPORT);
-				} else if (tmpStr == "special" || tmpStr == "4") {
-					spell->setGroup(SPELLGROUP_SPECIAL);
+				group = stringToSpellGroup(getString(L, 2));
+				if (group != SPELLGROUP_NONE) {
+					spell->setGroup(group);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown group: " << getString(L, 2) << std::endl;
 					pushBoolean(L, false);
@@ -14053,7 +14045,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				}
 				pushBoolean(L, true);
 			} else {
-				std::cout << "[Warning - Spell::group] Unknown group: " << group << std::endl;
+				std::cout << "[Warning - Spell::group] Unknown group: " << getString(L, 2) << std::endl;
 				pushBoolean(L, false);
 				return 1;
 			}
@@ -14065,33 +14057,17 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				spell->setSecondaryGroup(secondaryGroup);
 				pushBoolean(L, true);
 			} else if (isString(L, 2) && isString(L, 3)) {
-				std::string tmpStr = asLowerCaseString(getString(L, 2));
-				if (tmpStr == "none" || tmpStr == "0") {
-					spell->setGroup(SPELLGROUP_NONE);
-				} else if (tmpStr == "attack" || tmpStr == "1") {
-					spell->setGroup(SPELLGROUP_ATTACK);
-				} else if (tmpStr == "healing" || tmpStr == "2") {
-					spell->setGroup(SPELLGROUP_HEALING);
-				} else if (tmpStr == "support" || tmpStr == "3") {
-					spell->setGroup(SPELLGROUP_SUPPORT);
-				} else if (tmpStr == "special" || tmpStr == "4") {
-					spell->setGroup(SPELLGROUP_SPECIAL);
+				primaryGroup = stringToSpellGroup(getString(L, 2));
+				if (primaryGroup != SPELLGROUP_NONE) {
+					spell->setGroup(primaryGroup);
 				} else {
-					std::cout << "[Warning - Spell::group] Unknown group: " << getString(L, 2) << std::endl;
+					std::cout << "[Warning - Spell::group] Unknown primaryGroup: " << getString(L, 2) << std::endl;
 					pushBoolean(L, false);
 					return 1;
 				}
-				std::string tmpStr1 = asLowerCaseString(getString(L, 3));
-				if (tmpStr1 == "none" || tmpStr1 == "0") {
-					spell->setSecondaryGroup(SPELLGROUP_NONE);
-				} else if (tmpStr1 == "attack" || tmpStr1 == "1") {
-					spell->setSecondaryGroup(SPELLGROUP_ATTACK);
-				} else if (tmpStr1 == "healing" || tmpStr1 == "2") {
-					spell->setSecondaryGroup(SPELLGROUP_HEALING);
-				} else if (tmpStr1 == "support" || tmpStr1 == "3") {
-					spell->setSecondaryGroup(SPELLGROUP_SUPPORT);
-				} else if (tmpStr1 == "special" || tmpStr1 == "4") {
-					spell->setSecondaryGroup(SPELLGROUP_SPECIAL);
+				secondaryGroup = stringToSpellGroup(getString(L, 3));
+				if (secondaryGroup != SPELLGROUP_NONE) {
+					spell->setSecondaryGroup(secondaryGroup);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown secondaryGroup: " << getString(L, 3) << std::endl;
 					pushBoolean(L, false);
@@ -14099,7 +14075,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				}
 				pushBoolean(L, true);
 			} else {
-				std::cout << "[Warning - Spell::group] Unknown primaryGroup: " << primaryGroup << " or secondaryGroup: " << secondaryGroup << std::endl;
+				std::cout << "[Warning - Spell::group] Unknown primaryGroup: " << getString(L, 2) << " or secondaryGroup: " << getString(L, 3) << std::endl;
 				pushBoolean(L, false);
 				return 1;
 			}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1358,14 +1358,20 @@ class LuaScriptInterface
 		static int luaSpellAggressive(lua_State* L);
 		static int luaSpellVocation(lua_State* L);
 
-		// only for instant spells
+		// only for InstantSpells
 		static int luaSpellWords(lua_State* L);
+		static int luaSpellNeedDirection(lua_State* L);
+		static int luaSpellHasParams(lua_State* L);
+		static int luaSpellHasPlayerNameParam(lua_State* L);
+		static int luaSpellNeedCasterTargetOrDirection(lua_State* L);
+		static int luaSpellIsBlockingWalls(lua_State* L);
 
-		static int luaSpellGetManaCost(lua_State* L);
-		static int luaSpellGetSoulCost(lua_State* L);
-
-		static int luaSpellIsPremium(lua_State* L);
-		static int luaSpellIsLearnable(lua_State* L);
+		// only for RuneSpells
+		static int luaSpellRuneId(lua_State* L);
+		static int luaSpellCharges(lua_State* L);
+		static int luaSpellAllowFarUse(lua_State* L);
+		static int luaSpellBlockWalls(lua_State* L);
+		static int luaSpellCheckFloor(lua_State* L);
 
 		// Actions
 		static int luaCreateAction(lua_State* L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1335,6 +1335,32 @@ class LuaScriptInterface
 		// Spells
 		static int luaSpellCreate(lua_State* L);
 
+		static int luaSpellOnCastSpell(lua_State* L);
+		static int luaSpellRegister(lua_State* L);
+		static int luaSpellName(lua_State* L);
+		static int luaSpellId(lua_State* L);
+		static int luaSpellGroup(lua_State* L);
+		static int luaSpellCooldown(lua_State* L);
+		static int luaSpellGroupCooldown(lua_State* L);
+		static int luaSpellLevel(lua_State* L);
+		static int luaSpellMagicLevel(lua_State* L);
+		static int luaSpellMana(lua_State* L);
+		static int luaSpellManaPercent(lua_State* L);
+		static int luaSpellSoul(lua_State* L);
+		static int luaSpellRange(lua_State* L);
+		static int luaSpellPremium(lua_State* L);
+		static int luaSpellEnabled(lua_State* L);
+		static int luaSpellNeedTarget(lua_State* L);
+		static int luaSpellNeedWeapon(lua_State* L);
+		static int luaSpellNeedLearn(lua_State* L);
+		static int luaSpellSelfTarget(lua_State* L);
+		static int luaSpellBlocking(lua_State* L);
+		static int luaSpellAggressive(lua_State* L);
+		static int luaSpellVocation(lua_State* L);
+
+		// only for instant spells
+		static int luaSpellWords(lua_State* L);
+
 		static int luaSpellGetManaCost(lua_State* L);
 		static int luaSpellGetSoulCost(lua_State* L);
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -120,7 +120,7 @@ void Spells::clear(bool fromLua)
 {
 	clearMaps(fromLua);
 
-	scriptInterface.reInitState();
+	reInitState(fromLua);
 }
 
 LuaScriptInterface& Spells::getScriptInterface()

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -859,7 +859,7 @@ bool InstantSpell::configureEvent(const pugi::xml_node& node)
 		return false;
 	}
 
-	type = SPELL_INSTANT;
+	spellType = SPELL_INSTANT;
 
 	pugi::xml_attribute attr;
 	if ((attr = node.attribute("params"))) {
@@ -1138,7 +1138,7 @@ bool RuneSpell::configureEvent(const pugi::xml_node& node)
 		return false;
 	}
 
-	type = SPELL_RUNE;
+	spellType = SPELL_RUNE;
 
 	pugi::xml_attribute attr;
 	if (!(attr = node.attribute("id"))) {

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -859,6 +859,8 @@ bool InstantSpell::configureEvent(const pugi::xml_node& node)
 		return false;
 	}
 
+	type = SPELL_INSTANT;
+
 	pugi::xml_attribute attr;
 	if ((attr = node.attribute("params"))) {
 		hasParam = attr.as_bool();
@@ -1136,6 +1138,8 @@ bool RuneSpell::configureEvent(const pugi::xml_node& node)
 		return false;
 	}
 
+	type = SPELL_RUNE;
+
 	pugi::xml_attribute attr;
 	if (!(attr = node.attribute("id"))) {
 		std::cout << "[Error - RuneSpell::configureSpell] Rune spell without id." << std::endl;
@@ -1143,7 +1147,6 @@ bool RuneSpell::configureEvent(const pugi::xml_node& node)
 	}
 	runeId = pugi::cast<uint16_t>(attr.value());
 
-	uint32_t charges;
 	if ((attr = node.attribute("charges"))) {
 		charges = pugi::cast<uint32_t>(attr.value());
 	} else {

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -209,9 +209,9 @@ RuneSpell* Spells::getRuneSpell(uint32_t id)
 {
 	auto it = runes.find(id);
 	if (it == runes.end()) {
-		for (auto& it : runes) {
-			if (it.second.getId() == id) {
-				return &it.second;
+		for (auto& rune : runes) {
+			if (rune.second.getId() == id) {
+				return &rune.second;
 			}
 		}
 		return nullptr;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -169,8 +169,8 @@ bool Spells::registerEvent(Event_ptr event, const pugi::xml_node&)
 bool Spells::registerInstantLuaEvent(InstantSpell* event)
 {
 	InstantSpell_ptr instant { event };
-	std::string words = instant->getWords();
 	if (instant) {
+		std::string words = instant->getWords();
 		auto result = instants.emplace(instant->getWords(), std::move(*instant));
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerInstantLuaEvent] Duplicate registered instant spell with words: " << words << std::endl;
@@ -184,8 +184,8 @@ bool Spells::registerInstantLuaEvent(InstantSpell* event)
 bool Spells::registerRuneLuaEvent(RuneSpell* event)
 {
 	RuneSpell_ptr rune { event };
-	uint16_t id = rune->getRuneItemId();
 	if (rune) {
+		uint16_t id = rune->getRuneItemId();
 		auto result = runes.emplace(rune->getRuneItemId(), std::move(*rune));
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerRuneLuaEvent] Duplicate registered rune with id: " << id << std::endl;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -209,6 +209,11 @@ RuneSpell* Spells::getRuneSpell(uint32_t id)
 {
 	auto it = runes.find(id);
 	if (it == runes.end()) {
+		for (auto& it : runes) {
+			if (it.second.getId() == id) {
+				return &it.second;
+			}
+		}
 		return nullptr;
 	}
 	return &it->second;
@@ -261,9 +266,10 @@ InstantSpell* Spells::getInstantSpell(const std::string& words)
 
 InstantSpell* Spells::getInstantSpellById(uint32_t spellId)
 {
-	auto it = std::next(instants.begin(), std::min<uint32_t>(spellId, instants.size()));
-	if (it != instants.end()) {
-		return &it->second;
+	for (auto& it : instants) {
+		if (it.second.getId() == spellId) {
+			return &it.second;
+		}
 	}
 	return nullptr;
 }

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -169,10 +169,11 @@ bool Spells::registerEvent(Event_ptr event, const pugi::xml_node&)
 bool Spells::registerInstantLuaEvent(InstantSpell* event)
 {
 	InstantSpell_ptr instant { event };
+	std::string words = instant->getWords();
 	if (instant) {
 		auto result = instants.emplace(instant->getWords(), std::move(*instant));
 		if (!result.second) {
-			std::cout << "[Warning - Spells::registerInstantLuaEvent] Duplicate registered instant spell with words: " << instant->getWords() << std::endl;
+			std::cout << "[Warning - Spells::registerInstantLuaEvent] Duplicate registered instant spell with words: " << words << std::endl;
 		}
 		return result.second;
 	}
@@ -183,10 +184,11 @@ bool Spells::registerInstantLuaEvent(InstantSpell* event)
 bool Spells::registerRuneLuaEvent(RuneSpell* event)
 {
 	RuneSpell_ptr rune { event };
+	uint16_t id = rune->getRuneItemId();
 	if (rune) {
 		auto result = runes.emplace(rune->getRuneItemId(), std::move(*rune));
 		if (!result.second) {
-			std::cout << "[Warning - Spells::registerRuneLuaEvent] Duplicate registered rune with id: " << rune->getRuneItemId() << std::endl;
+			std::cout << "[Warning - Spells::registerRuneLuaEvent] Duplicate registered rune with id: " << id << std::endl;
 		}
 		return result.second;
 	}

--- a/src/spells.h
+++ b/src/spells.h
@@ -31,6 +31,8 @@ class RuneSpell;
 class Spell;
 
 using VocSpellMap = std::map<uint16_t, bool>;
+using InstantSpell_ptr = std::unique_ptr<InstantSpell>;
+using RuneSpell_ptr = std::unique_ptr<RuneSpell>;
 
 class Spells final : public BaseEvents
 {
@@ -60,8 +62,12 @@ class Spells final : public BaseEvents
 			return instants;
 		};
 
+		void clearMaps(bool fromLua);
+		void clear(bool fromLua) override final;
+		bool registerInstantLuaEvent(InstantSpell* event);
+		bool registerRuneLuaEvent(RuneSpell* event);
+
 	private:
-		void clear(bool) override final;
 		LuaScriptInterface& getScriptInterface() override;
 		Event_ptr getEvent(const std::string& nodeName) override;
 		bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
@@ -129,6 +135,15 @@ class Spell : public BaseSpell
 		const std::string& getName() const {
 			return name;
 		}
+		void setName(std::string n) {
+			name = n;
+		}
+		uint8_t getId() const {
+			return spellId;
+		}
+		void setId(uint8_t id) {
+			spellId = id;
+		}
 
 		void postCastSpell(Player* player, bool finishedCast = true, bool payCost = true) const;
 		static void postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost);
@@ -137,30 +152,144 @@ class Spell : public BaseSpell
 		uint32_t getSoulCost() const {
 			return soul;
 		}
+		void setSoulCost(uint32_t s) {
+			soul = s;
+		}
 		uint32_t getLevel() const {
 			return level;
+		}
+		void setLevel(uint32_t lvl) {
+			level = lvl;
 		}
 		uint32_t getMagicLevel() const {
 			return magLevel;
 		}
+		void setMagicLevel(uint32_t lvl) {
+			magLevel = lvl;
+		}
 		uint32_t getMana() const {
 			return mana;
+		}
+		void setMana(uint32_t m) {
+			mana = m;
 		}
 		uint32_t getManaPercent() const {
 			return manaPercent;
 		}
+		void setManaPercent(uint32_t m) {
+			manaPercent = m;
+		}
 		bool isPremium() const {
 			return premium;
+		}
+		void setPremium(bool p) {
+			premium = p;
+		}
+		bool isEnabled() const {
+			return enabled;
+		}
+		void setEnabled(bool e) {
+			enabled = e;
 		}
 
 		virtual bool isInstant() const = 0;
 		bool isLearnable() const {
 			return learnable;
 		}
+		void setLearnable(bool l) {
+			learnable = l;
+		}
 
 		const VocSpellMap& getVocMap() const {
 			return vocSpellMap;
 		}
+		void addVocMap(uint16_t n, bool b) {
+			vocSpellMap[n] = b;
+		}
+
+		const SpellGroup_t getGroup() const {
+			return group;
+		}
+		void setGroup(SpellGroup_t g) {
+			group = g;
+		}
+		const SpellGroup_t getSecondaryGroup() const {
+			return secondaryGroup;
+		}
+		void setSecondaryGroup(SpellGroup_t g) {
+			secondaryGroup = g;
+		}
+
+		uint32_t getCooldown() const {
+			return cooldown;
+		}
+		void setCooldown(uint32_t cd) {
+			cooldown = cd;
+		}
+		uint32_t getSecondaryCooldown() const {
+			return secondaryGroupCooldown;
+		}
+		void setSecondaryCooldown(uint32_t cd) {
+			secondaryGroupCooldown = cd;
+		}
+		uint32_t getGroupCooldown() const {
+			return groupCooldown;
+		}
+		void setGroupCooldown(uint32_t cd) {
+			groupCooldown = cd;
+		}
+
+		int32_t getRange() const {
+			return range;
+		}
+		void setRange(int32_t r) {
+			range = r;
+		}
+
+		bool getNeedTarget() const {
+			return needTarget;
+		}
+		void setNeedTarget(bool n) {
+			needTarget = n;
+		}
+		bool getNeedWeapon() const {
+			return needWeapon;
+		}
+		void setNeedWeapon(bool n) {
+			needWeapon = n;
+		}
+		bool getNeedLearn() const {
+			return learnable;
+		}
+		void setNeedLearn(bool n) {
+			learnable = n;
+		}
+		bool getSelfTarget() const {
+			return selfTarget;
+		}
+		void setSelfTarget(bool s) {
+			selfTarget = s;
+		}
+		bool getBlockingSolid() const {
+			return blockingSolid;
+		}
+		void setBlockingSolid(bool b) {
+			blockingSolid = b;
+		}
+		bool getBlockingCreature() const {
+			return blockingCreature;
+		}
+		void setBlockingCreature(bool b) {
+			blockingCreature = b;
+		}
+		bool getAggressive() const {
+			return aggressive;
+		}
+		void setAggressive(bool a) {
+			aggressive = a;
+		}
+
+		SpellType_t type = SPELL_UNDEFINED;
 
 	protected:
 		bool playerSpellCheck(Player* player) const;

--- a/src/spells.h
+++ b/src/spells.h
@@ -353,8 +353,32 @@ class InstantSpell final : public TalkAction, public Spell
 		bool getHasParam() const {
 			return hasParam;
 		}
+		void setHasParam(bool p) {
+			hasParam = p;
+		}
 		bool getHasPlayerNameParam() const {
 			return hasPlayerNameParam;
+		}
+		void setHasPlayerNameParam(bool p) {
+			hasPlayerNameParam = p;
+		}
+		bool getNeedDirection() const {
+			return needDirection;
+		}
+		void setNeedDirection(bool n) {
+			needDirection = n;
+		}
+		bool getNeedCasterTargetOrDirection() const {
+			return casterTargetOrDirection;
+		}
+		void setNeedCasterTargetOrDirection(bool d) {
+			casterTargetOrDirection = d;
+		}
+		bool getBlockWalls() const {
+			return checkLineOfSight;
+		}
+		void setBlockWalls(bool w) {
+			checkLineOfSight = w;
 		}
 		bool canCast(const Player* player) const;
 		bool canThrowSpell(const Creature* creature, const Creature* target) const;
@@ -400,6 +424,21 @@ class RuneSpell final : public Action, public Spell
 		uint16_t getRuneItemId() const {
 			return runeId;
 		}
+		void setRuneItemId(uint16_t i) {
+			runeId = i;
+		}
+		bool getHasCharges() const {
+			return hasCharges;
+		}
+		void setHasCharges(bool c) {
+			hasCharges = c;
+		}
+		uint32_t getCharges() const {
+			return charges;
+		}
+		void setCharges(uint32_t c) {
+			charges = c;
+		}
 
 	private:
 		std::string getScriptEventName() const override;
@@ -407,6 +446,7 @@ class RuneSpell final : public Action, public Spell
 		bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
 
 		uint16_t runeId = 0;
+		uint32_t charges = 0;
 		bool hasCharges = true;
 };
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -135,7 +135,7 @@ class Spell : public BaseSpell
 		const std::string& getName() const {
 			return name;
 		}
-		void setName(std::string& n) {
+		void setName(std::string n) {
 			name = n;
 		}
 		uint8_t getId() const {

--- a/src/spells.h
+++ b/src/spells.h
@@ -427,16 +427,13 @@ class RuneSpell final : public Action, public Spell
 		void setRuneItemId(uint16_t i) {
 			runeId = i;
 		}
-		bool getHasCharges() const {
-			return hasCharges;
-		}
-		void setHasCharges(bool c) {
-			hasCharges = c;
-		}
 		uint32_t getCharges() const {
 			return charges;
 		}
 		void setCharges(uint32_t c) {
+			if (c > 0) {
+				hasCharges = true;
+			}
 			charges = c;
 		}
 
@@ -447,7 +444,7 @@ class RuneSpell final : public Action, public Spell
 
 		uint16_t runeId = 0;
 		uint32_t charges = 0;
-		bool hasCharges = true;
+		bool hasCharges = false;
 };
 
 #endif

--- a/src/spells.h
+++ b/src/spells.h
@@ -289,7 +289,7 @@ class Spell : public BaseSpell
 			aggressive = a;
 		}
 
-		SpellType_t type = SPELL_UNDEFINED;
+		SpellType_t spellType = SPELL_UNDEFINED;
 
 	protected:
 		bool playerSpellCheck(Player* player) const;

--- a/src/spells.h
+++ b/src/spells.h
@@ -135,7 +135,7 @@ class Spell : public BaseSpell
 		const std::string& getName() const {
 			return name;
 		}
-		void setName(std::string n) {
+		void setName(std::string& n) {
 			name = n;
 		}
 		uint8_t getId() const {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1223,3 +1223,19 @@ int64_t OTSYS_TIME()
 {
 	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
+
+SpellGroup_t stringToSpellGroup(std::string value)
+{
+	std::string tmpStr = asLowerCaseString(value);
+	if (tmpStr == "attack" || tmpStr == "1") {
+		return SPELLGROUP_ATTACK;
+	} else if (tmpStr == "healing" || tmpStr == "2") {
+		return SPELLGROUP_HEALING;
+	} else if (tmpStr == "support" || tmpStr == "3") {
+		return SPELLGROUP_SUPPORT;
+	} else if (tmpStr == "special" || tmpStr == "4") {
+		return SPELLGROUP_SPECIAL;
+	}
+
+	return SPELLGROUP_NONE;
+}

--- a/src/tools.h
+++ b/src/tools.h
@@ -94,4 +94,6 @@ const char* getReturnMessage(ReturnValue value);
 
 int64_t OTSYS_TIME();
 
+SpellGroup_t stringToSpellGroup(std::string value);
+
 #endif


### PR DESCRIPTION
The basics are done, spells can be created by either.

instant:
```lua
local conjureRune = Spell(SPELL_INSTANT)

function conjureRune.onCastSpell(creature, variant)
	return creature:conjureItem(2260, 2304, 4)
end

conjureRune:name("Great Fireball")
conjureRune:words("adori mas flam")
conjureRune:level(30)
conjureRune:mana(530)
conjureRune:group("support")
conjureRune:soul(3)
conjureRune:isAggressive(false)
conjureRune:cooldown(2000)
conjureRune:groupCooldown(2000)
conjureRune:needLearn(false)
conjureRune:vocation("sorcerer", true)
conjureRune:vocation("master sorcerer")
conjureRune:register()
```
rune:
```lua
local combat = Combat()
combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_HEALING)
combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_BLUE)
combat:setParameter(COMBAT_PARAM_DISPEL, CONDITION_PARALYZE)
combat:setParameter(COMBAT_PARAM_TARGETCASTERORTOPMOST, true)
combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)

function onGetFormulaValues(player, level, magicLevel)
	local min = (level / 5) + (magicLevel * 3.2) + 20
	local max = (level / 5) + (magicLevel * 5.4) + 40
	return min, max
end

combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

local rune = Spell(SPELL_RUNE)

function rune.onCastSpell(creature, variant, isHotkey)
	return combat:execute(creature, variant)
end

rune:name("Test Rune")
rune:id(220)
rune:runeId(2275)
rune:level(20)
rune:magicLevel(5)
rune:needTarget(true)
rune:isAggressive(false)
rune:allowFarUse(true)
rune:charges(1)
rune:register()
```

todo:
- [x] convert all remaining `const_cast` into `dynamic_cast`
- [x] cleanup a few functions to make them smaller
- [x] `InstantSpell` and `RuneSpell` lua functions need to return nil, if they are not used appropriately instead of crashing the server (ex: using a `RuneSpell` function on an `InstantSpell`).