### PR TITLE
Revert "Fixes wrong position"

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1411,7 +1411,7 @@ void Tile::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32
 	//calling movement scripts
 	Creature* creature = thing->getCreature();
 	if (creature) {
-		g_moveEvents->onCreatureMove(creature, newParent->getTile(), MOVE_EVENT_STEP_OUT);
+		g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_OUT);
 	} else {
 		Item* item = thing->getItem();
 		if (item) {


### PR DESCRIPTION
Reverts otland/forgottenserver#2587

#2587 has been merged faster than anyone could possibly check it.
It breaks onStepOut scripts. The onStepOut scripts will trigger when you step onto the tile now.
Also, note that changing the value of the parameter `fromPosition` will break scripts that rely on it.