### PR TITLE
Fix #2591

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -11895,6 +11895,14 @@ int LuaScriptInterface::luaCombatExecute(lua_State* L)
 		return 1;
 	}
 
+	if (isUserdata(L, 2)) {
+		LuaDataType type = getUserdataType(L, 2);
+		if (type != LuaData_Player && type != LuaData_Monster && type != LuaData_Npc) {
+			pushBoolean(L, false);
+			return 1;
+		}
+	}
+
 	Creature* creature = getCreature(L, 2);
 
 	const LuaVariant& variant = getVariant(L, 3);


### PR DESCRIPTION
Fixes #2591 

I'm not entirely sure how often end-users manages to do this mistake but modifying `LuaScriptInterface::getCreature` & `LuaScriptInterface::getPlayer` to check for appropriate Userdata type(s) seems a bit redundant at the moment.