### PR TITLE
Fix error using classicEquipmentSlots

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -103,7 +103,7 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 
 		if moveItem then
 			local parent = item:getParent()
-			if parent:getSize() == parent:getCapacity() then
+			if parent:isContainer() and parent:getSize() == parent:getCapacity() then
 				self:sendTextMessage(MESSAGE_STATUS_SMALL, Game.getReturnMessage(RETURNVALUE_CONTAINERNOTENOUGHROOM))
 				return false
 			else


### PR DESCRIPTION
The problem occurs when you use classicEquipmentSlots, it happens as follows.

1 item in the left hand of two hands.
1 item in the arrow slot.

I try to move this item on the arrow to the right hand and the error in the `getSize()` function occurs, as it tries to pick up from a parent that is not a container.