### PR TITLE
Corrections to spider's damage and weakness to fire

### DIFF
--- a/data/monster/Arachnids/spider.xml
+++ b/data/monster/Arachnids/spider.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="2000" min="0" max="-25" />
+		<attack name="melee" interval="2000" min="0" max="-9" />
 	</attacks>
 	<defenses armor="5" defense="5" />
 	<elements>

--- a/data/monster/Arachnids/spider.xml
+++ b/data/monster/Arachnids/spider.xml
@@ -24,7 +24,7 @@
 	</attacks>
 	<defenses armor="5" defense="5" />
 	<elements>
-		<element firePercent="-1" />
+		<element firePercent="-20" />
 	</elements>
 	<loot>
 		<item name="gold coin" countmax="5" chance="63333" />


### PR DESCRIPTION
Spider's damage was incorrect (it should be 0–9 instead of 0–25).
I've just done a test which confirms the 0–9 range with at least 99.75% certainity (with a few assumptions, such as that damage is a uniform random variable):

Wearing a bow (which has defense 0) and no armor I got hit by a spider at least 63 times, and the maximum hit was 9. If spider's damage was higher than 0–9, it would mean it's at least 0–10. So there would be at least 11 different results, but only 10 of them appeared in the test. The odds of this _not_ happening are at least `1 - (10/11)^63 >= 99.75%`.

Its weakness to fire was also incorrect. Instead of taking 101% of fire damage, it takes 120% (source: https://tibia.fandom.com/wiki/Spider and this value was taken from the Bestiary).