### PR TITLE
Fix using vials by hotkeys

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -417,7 +417,7 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, Item* 
 	player->stopWalk();
 
 	if (isHotkey) {
-		showUseHotkeyMessage(player, item, player->getItemTypeCount(item->getID(), -1));
+		showUseHotkeyMessage(player, item, player->getItemTypeCount(item->getID(), item->getSubType()));
 	}
 
 	ReturnValue ret = internalUseItem(player, pos, index, item, isHotkey);
@@ -447,7 +447,7 @@ bool Actions::useItemEx(Player* player, const Position& fromPos, const Position&
 	}
 
 	if (isHotkey) {
-		showUseHotkeyMessage(player, item, player->getItemTypeCount(item->getID(), -1));
+		showUseHotkeyMessage(player, item, player->getItemTypeCount(item->getID(), item->getSubType()));
 	}
 
 	if (!action->executeUse(player, item, fromPos, action->getTarget(player, creature, toPos, toStackPos), toPos, isHotkey)) {


### PR DESCRIPTION
When using a vial it will return the message incorrectly.

Example: If I have 15 vials and 5 flasks it will return a message stating that I have 20 vials, but the other 5 are flasks.
The number will always remain fixed even when consuming the vials.