### PR TITLE
windows <luajit/lua.hpp> include

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -19,7 +19,11 @@
 
 #include "otpch.h"
 
+#ifdef _WIN32
+#include <luajit/lua.hpp>
+#else
 #include <lua.hpp>
+#endif
 
 #include "configmanager.h"
 #include "game.h"

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -20,7 +20,11 @@
 #ifndef FS_LUASCRIPT_H_5344B2BC907E46E3943EA78574A212D8
 #define FS_LUASCRIPT_H_5344B2BC907E46E3943EA78574A212D8
 
+#ifdef _WIN32
+#include <luajit/lua.hpp>
+#else
 #include <lua.hpp>
+#endif
 
 #if LUA_VERSION_NUM >= 502
 #ifndef LUA_COMPAT_ALL


### PR DESCRIPTION
This fixes the problem on windows that lua.hpp cannot be found, because vcpkg by default installs luajit, which results in <luajit/lua.hpp>
#2603