### PR TITLE
fix: MonsterType:isSummonable

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12262,7 +12262,7 @@ int LuaScriptInterface::luaMonsterTypeIsSummonable(lua_State* L)
 		if (lua_gettop(L) == 1) {
 			pushBoolean(L, monsterType->info.isSummonable);
 		} else {
-			monsterType->info.isAttackable = getBoolean(L, 2);
+			monsterType->info.isSummonable = getBoolean(L, 2);
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12260,7 +12260,7 @@ int LuaScriptInterface::luaMonsterTypeIsSummonable(lua_State* L)
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			pushBoolean(L, monsterType->info.isAttackable);
+			pushBoolean(L, monsterType->info.isSummonable);
 		} else {
 			monsterType->info.isAttackable = getBoolean(L, 2);
 			pushBoolean(L, true);


### PR DESCRIPTION
i received an issue via whatsapp on my project [opentibiabr/OTServBR-Global](https://github.com/opentibiabr/OTServBR-Global), saying players can summon all monsters (including bosses)...

i have checked:
- player has flag to summon all **(fail)**
https://github.com/opentibiabr/OTServBR-Global/blob/master/data/XML/groups.xml#L3
- default summon all flag **(fail)**
https://github.com/opentibiabr/OTServBR-Global/blob/master/src/groups.cpp#L85-L97
- monster summonable flag  **(fail)**
https://github.com/opentibiabr/OTServBR-Global/blob/master/data/monster/Bosses/ferumbras.xml#L9
- default summonable flag  **(fail)**
https://github.com/opentibiabr/OTServBR-Global/blob/master/src/monsters.h#L169
- finally reached on this PoC  **(gg)**
https://github.com/opentibiabr/OTServBR-Global/blob/2bc0a0e326a4d854db33b50e9c83df1ee57cfcb4/src/luascript.cpp#L13228-L13243

doesnt make sense `Monster::isSummonable` read another value flag.