### PR TITLE
Fix crash when we remove a creaturescript (xml or revscriptsys), reloads and execute.

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1475,6 +1475,10 @@ CreatureEventList Creature::getCreatureEvents(CreatureEventType_t type)
 	}
 
 	for (CreatureEvent* creatureEvent : eventsList) {
+		if (!creatureEvent->isLoaded()) {
+			continue;
+		}
+		
 		if (creatureEvent->getEventType() == type) {
 			tmpEventList.push_back(creatureEvent);
 		}


### PR DESCRIPTION
To reproduce this crash, simply create an onThink script for example and register it on a creature, then remove from creaturescripts.xml or delete the file in data/scripts/creaturescripts, then use /reload creaturescripts or /reload scripts. When the creature executes the removed script, the server crashes.