### PR TITLE
Correct a half dozen XML typos in the monsters folder

### DIFF
--- a/data/monster/Bosses/boogey.xml
+++ b/data/monster/Bosses/boogey.xml
@@ -29,7 +29,7 @@
 			<attribute key="shootEffect" value="fire" />
 			<attribute key="areaEffect" value="redspark" />
 		</attack>
-		<attack name="physical" interval="1500" chance="40" lenght="8" spread="3" min="-20" max="-30">
+		<attack name="physical" interval="1500" chance="40" length="8" spread="3" min="-20" max="-30">
 			<attribute key="shootEffect" value="suddendeath" />
 			<attribute key="areaEffect" value="mortarea" />
 		</attack>

--- a/data/monster/Bosses/chizzoron_the_distorter.xml
+++ b/data/monster/Bosses/chizzoron_the_distorter.xml
@@ -24,7 +24,7 @@
 			<attribute key="shootEffect" value="poison" />
 			<attribute key="areaEffect" value="poison" />
 		</attack>
-		<attack name="fire" interval="2000" chance="10" lenght="8" spread="3" max="-874">
+		<attack name="fire" interval="2000" chance="10" length="8" spread="3" max="-874">
 			<attribute key="shootEffect" value="fire" />
 			<attribute key="areaEffect" value="firearea" />
 		</attack>

--- a/data/monster/Bosses/incineron.xml
+++ b/data/monster/Bosses/incineron.xml
@@ -17,10 +17,10 @@
 		<flag runonhealth="0" />
 	</flags>
 	<attacks>
-		<attack name="fire" interval="2000" change="35" length="8" spread="1" min="0" max="-1000">
+		<attack name="fire" interval="2000" chance="35" length="8" spread="1" min="0" max="-1000">
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
-		<attack name="fire" interval="2000" change="35" range="7" radius="7" target="0" min="0" max="-395">
+		<attack name="fire" interval="2000" chance="35" range="7" radius="7" target="0" min="0" max="-395">
 			<attribute key="shootEffect" value="fire" />
 			<attribute key="areaEffect" value="firearea" />
 		</attack>

--- a/data/monster/Bosses/rocko.xml
+++ b/data/monster/Bosses/rocko.xml
@@ -3,7 +3,6 @@
 	<health now="10000" max="10000" />
 	<look type="67" corpse="6005" />
 	<targetchange interval="2000" chance="9" />
-	<strategy attack="100" defense="0" />
 	<flags>
 		<flag summonable="0" />
 		<flag attackable="1" />

--- a/data/monster/Bosses/tirecz.xml
+++ b/data/monster/Bosses/tirecz.xml
@@ -22,7 +22,7 @@
 			<attribute key="shootEffect" value="fire" />
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
-		<attack name="fire" interval="2000" chance="25" lenght="8" spread="3" min="-120" max="-460">
+		<attack name="fire" interval="2000" chance="25" length="8" spread="3" min="-120" max="-460">
 			<attribute key="shootEffect" value="fire" />
 			<attribute key="areaEffect" value="firearea" />
 		</attack>

--- a/data/monster/Bosses/tremorak.xml
+++ b/data/monster/Bosses/tremorak.xml
@@ -3,7 +3,6 @@
 	<health now="10000" max="10000" />
 	<look type="285" corpse="8933" />
 	<targetchange interval="2000" chance="5" />
-	<strategy attack="100" defense="0" />
 	<flags>
 		<flag summonable="0" />
 		<flag attackable="1" />

--- a/data/monster/Bosses/zevelon_duskbringer.xml
+++ b/data/monster/Bosses/zevelon_duskbringer.xml
@@ -31,7 +31,6 @@
 		<defense name="invisible" interval="3000" chance="25" duration="6000">
 			<attribute key="areaEffect" value="blueshimmer" />
 		<defense name="outfit" interval="4500" chance="30" monster="bat" duration="4000" />
-		</defense>
 	</defenses>
 	<elements>
 		<element physicalPercent="20" />

--- a/data/monster/Bosses/zevelon_duskbringer.xml
+++ b/data/monster/Bosses/zevelon_duskbringer.xml
@@ -30,6 +30,7 @@
 		</defense>
 		<defense name="invisible" interval="3000" chance="25" duration="6000">
 			<attribute key="areaEffect" value="blueshimmer" />
+		</defense>
 		<defense name="outfit" interval="4500" chance="30" monster="bat" duration="4000" />
 	</defenses>
 	<elements>

--- a/data/monster/Demons/gravedigger.xml
+++ b/data/monster/Demons/gravedigger.xml
@@ -63,7 +63,7 @@
 		<item name="platinum coin" chance="24470" />
 		<item name="yellow gem" chance="800" />
 		<item name="wand of inferno" chance="5590" />
-		<item name="sudden death rune" countmaxe="9" chance="7300" />
+		<item name="sudden death rune" countmax="9" chance="7300" />
 		<item name="skull staff" chance="130" />
 		<item name="mysterious voodoo skull" chance="100" />
 		<item name="hardened bone" chance="50" />

--- a/data/monster/Mutated/mutated_human.xml
+++ b/data/monster/Mutated/mutated_human.xml
@@ -23,7 +23,7 @@
 		<attack name="death" interval="2000" chance="15" length="3" spread="1" target="0" min="-50" max="-60">
 			<attribute key="areaEffect" value="poison" />
 		</attack>
-		<attack name="poisoncondition" interval="2000" chance="20" target="1" lenght="1" spread="0" min="-190" max="-280">
+		<attack name="poisoncondition" interval="2000" chance="20" target="1" length="1" spread="0" min="-190" max="-280">
 			<attribute key="areaeffect" value="greenspark" />
 		</attack>
 		<attack name="speed" interval="2000" chance="10" target="1" range="7" speedchange="-600" duration="30000">

--- a/data/monster/Skeletons/dreadbeast.xml
+++ b/data/monster/Skeletons/dreadbeast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Dreadbeast" species="undead" nameDescription="a dreadbeast" race="undead" experience="250" speed="200" manacost="800">
+<monster name="Dreadbeast" nameDescription="a dreadbeast" race="undead" experience="250" speed="200" manacost="800">
 	<health now="800" max="800" />
 	<look type="101" head="20" body="30" legs="40" feet="50" corpse="3031" />
 	<targetchange interval="60000" chance="10" />

--- a/data/monster/Undead_Humanoids/undead_prospector.xml
+++ b/data/monster/Undead_Humanoids/undead_prospector.xml
@@ -22,12 +22,11 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />
 	</attacks>
-	<defenses>
+	<defenses armor="15" defense="15">
 		<defense name="healing" interval="2000" chance="15" min="5" max="15">
 			<attribute key="areaEffect" value="blueshimmer" />
 		</defense>
 	</defenses>
-	<defenses armor="15" defense="15" />
 	<elements>
 		<element energyPercent="30" />
 		<element earthPercent="20" />


### PR DESCRIPTION
While working on a tool to convert XML monsters to revscriptsys I ran into a few errors with the XML monsters.

These errors are noncritical and the TFS engine was able to ignore them. Some nodes and attributes TFS doesn't understand where included. A few creatures had typos in attribute names. 