### PR TITLE
Rename to avoid name conflict from boost::variant

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -191,13 +191,13 @@ bool ConfigManager::reload()
 	return result;
 }
 
-static std::string dummy;
+static std::string dummyStr;
 
 const std::string& ConfigManager::getString(string_config_t what) const
 {
 	if (what >= LAST_STRING_CONFIG) {
 		std::cout << "[Warning - ConfigManager::getString] Accessing invalid index: " << what << std::endl;
-		return dummy;
+		return dummyStr;
 	}
 	return string[what];
 }


### PR DESCRIPTION
Fixes the name conflict warning regarding to `dummy` in configmanager.cpp.
Warnings for reference:
```
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\detail\forced_return.hpp(40): warning C4459: declaration of 'dummy' hides global declaration (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\desktop\code\forgottenserver\src\configmanager.cpp(194): note: see declaration of 'dummy'
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\detail\visitation_impl.hpp(162): note: see reference to function template instantiation 'T boost::detail::variant::forced_return<result_type>(void)' being compiled
1>        with
1>        [
1>            T=result_type
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\detail\visitation_impl.hpp(231): note: see reference to function template instantiation 'void boost::detail::variant::visitation_impl_invoke<Visitor,VoidPtrCV,NoBackupFlag>(int,Visitor &,VoidPtrCV,boost::detail::variant::apply_visitor_unrolled *,NBF,long)' being compiled
1>        with
1>        [
1>            Visitor=boost::detail::variant::destroyer,
1>            VoidPtrCV=void *,
1>            NoBackupFlag=boost::variant<boost::blank,std::string,int64_t,double,bool>::has_fallback_type_,
1>            NBF=boost::variant<boost::blank,std::string,int64_t,double,bool>::has_fallback_type_
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(2339): note: see reference to function template instantiation 'void boost::detail::variant::visitation_impl<first_which,first_step,Visitor,VoidPtrCV,boost::variant<boost::blank,std::string,int64_t,double,bool>::has_fallback_type_>(const int,const int,Visitor &,VoidPtrCV,boost::mpl::false_,NoBackupFlag,Which *,step0 *)' being compiled
1>        with
1>        [
1>            Visitor=boost::detail::variant::destroyer,
1>            VoidPtrCV=void *,
1>            NoBackupFlag=boost::variant<boost::blank,std::string,int64_t,double,bool>::has_fallback_type_,
1>            Which=first_which,
1>            step0=first_step
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(2348): note: see reference to function template instantiation 'void boost::variant<boost::blank,std::string,int64_t,double,bool>::internal_apply_visitor_impl<Visitor,void*>(int,int,Visitor &,VoidPtrCV)' being compiled
1>        with
1>        [
1>            Visitor=boost::detail::variant::destroyer,
1>            VoidPtrCV=void *
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(2346): note: see reference to function template instantiation 'void boost::variant<boost::blank,std::string,int64_t,double,bool>::internal_apply_visitor_impl<Visitor,void*>(int,int,Visitor &,VoidPtrCV)' being compiled
1>        with
1>        [
1>            Visitor=boost::detail::variant::destroyer,
1>            VoidPtrCV=void *
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(1365): note: see reference to function template instantiation 'void boost::variant<boost::blank,std::string,int64_t,double,bool>::internal_apply_visitor<boost::detail::variant::destroyer>(Visitor &)' being compiled
1>        with
1>        [
1>            Visitor=boost::detail::variant::destroyer
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(1365): note: see reference to function template instantiation 'void boost::variant<boost::blank,std::string,int64_t,double,bool>::internal_apply_visitor<boost::detail::variant::destroyer>(Visitor &)' being compiled
1>        with
1>        [
1>            Visitor=boost::detail::variant::destroyer
1>        ] (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(1363): note: while compiling class template member function 'void boost::variant<boost::blank,std::string,int64_t,double,bool>::destroy_content(void) noexcept' (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\vcpkg\installed\x64-windows\include\boost\variant\variant.hpp(1372): note: see reference to function template instantiation 'void boost::variant<boost::blank,std::string,int64_t,double,bool>::destroy_content(void) noexcept' being compiled (compiling source file ..\src\configmanager.cpp)
1>c:\users\jacob\desktop\code\forgottenserver\src\item.h(219): note: see reference to class template instantiation 'boost::variant<boost::blank,std::string,int64_t,double,bool>' being compiled (compiling source file ..\src\configmanager.cpp)```