### PR TITLE
FIX string.split doesn't works correctly with space

### DIFF
--- a/data/global.lua
+++ b/data/global.lua
@@ -50,6 +50,14 @@ end
 string.split = function(str, sep)
 	local res = {}
 	for v in str:gmatch("([^" .. sep .. "]+)") do
+		res[#res + 1] = v
+	end
+	return res
+end
+
+string.splitTrimmed = function(str, sep)
+	local res = {}
+	for v in str:gmatch("([^" .. sep .. "]+)") do
 		res[#res + 1] = v:trim()
 	end
 	return res

--- a/data/global.lua
+++ b/data/global.lua
@@ -50,7 +50,7 @@ end
 string.split = function(str, sep)
 	local res = {}
 	for v in str:gmatch("([^" .. sep .. "]+)") do
-		res[#res + 1] = v
+		res[#res + 1] = v:trim()
 	end
 	return res
 end


### PR DESCRIPTION
If you use spaces after the first separator, you may return a bad result.

this command for example..
```Lua
function onSay(player, words, param)
	local split = param:split(',')
	if split[1] == 'check' then
		local player = Player(split[2])
		if player then
			print('exists')
		else
			print('doesn\'t exists')
		end
	end
	return false
end
```
`/command check, Playername`
```Lua
-- doesn't exists
```
` /command check,Playername`
```Lua
-- exit: exists
```

So now we can use with spaces normally.