### PR TITLE
add docker-compose.yml to quick start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,16 @@ RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/test
   gmp \
   luajit \
   mariadb-connector-c \
+  mariadb-client \
   pugixml
 
 RUN ln -s /usr/lib/libcryptopp.so /usr/lib/libcryptopp.so.5.6
 COPY --from=build /usr/src/forgottenserver/build/tfs /bin/tfs
 COPY data /srv/data/
 COPY LICENSE README.md *.dist *.sql key.pem /srv/
+COPY entrypoint.sh /
 
 EXPOSE 7171 7172
 WORKDIR /srv
 VOLUME /srv
-ENTRYPOINT ["/bin/tfs"]
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM alpine:edge
 RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
   boost-iostreams \
   boost-system \
+  boost-filesystem \
   crypto++ \
   gmp \
   luajit \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.6"
+
+services:
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${TFS_MYSQL_ROOT_PASSWORD:-r00tp@ssword}
+      MYSQL_DATABASE: ${TFS_MYSQL_DATABASE:-forgottenserver}
+      MYSQL_USER: ${TFS_MYSQL_USER:-forgottenserver}
+      MYSQL_PASSWORD: ${TFS_MYSQL_PASS:-forgottenserver}
+    volumes:
+      - forgottenserver_db:/var/lib/mysql
+
+  forgottenserver:
+    image: otland/forgottenserver
+    environment:
+      TFS_MYSQL_HOST: ${TFS_MYSQL_HOST:-mysql}
+      TFS_MYSQL_DATABASE: ${TFS_MYSQL_DATABASE:-forgottenserver}
+      TFS_MYSQL_USER: ${TFS_MYSQL_USER:-forgottenserver}
+      TFS_MYSQL_PASS: ${TFS_MYSQL_PASS:-forgottenserver}
+    volumes:
+      - forgottenserver:/srv
+    ports:
+      - 7171:7171
+      - 7172:7172
+
+volumes:
+  forgottenserver:
+  forgottenserver_db:
+  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e 
+set -x
+
+TFS_MYSQL_HOST="${TFS_MYSQL_HOST:-127.0.0.1}"
+TFS_MYSQL_USER="${TFS_MYSQL_USER:-forgottenserver}"
+TFS_MYSQL_PASS="${TFS_MYSQL_PASS:-forgottenserver}"
+TFS_MYSQL_DATABASE="${TFS_MYSQL_DATABASE:-forgottenserver}"
+TFS_MYSQL_PORT="${TFS_MYSQL_PORT:-3306}"
+TFS_MYSQL_SOCK="${TFS_MYSQL_SOCK}"
+
+if [ -f "config.lua.dist" ]; then
+    sed -i "s/mysqlHost =.*/mysqlHost = \"${TFS_MYSQL_HOST}\"/" config.lua.dist
+    sed -i "s/mysqlUser =.*/mysqlUser = \"${TFS_MYSQL_USER}\"/" config.lua.dist
+    sed -i "s/mysqlPass =.*/mysqlPass = \"${TFS_MYSQL_PASS}\"/" config.lua.dist
+    sed -i "s/mysqlDatabase =.*/mysqlDatabase = \"${TFS_MYSQL_DATABASE}\"/" config.lua.dist
+    sed -i "s/mysqlPort =.*/mysqlPort = ${TFS_MYSQL_PORT}/" config.lua.dist
+    sed -i "s/mysqlSock =.*/mysqlSock = \"${TFS_MYSQL_Sock}\"/" config.lua.dist
+
+    mv config.lua.dist config.lua
+fi
+
+if [ "${@}" != "" ]; then
+    ${@}
+    exit $?
+fi
+
+if [ -f schema.sql ]; then
+    ln -s  /usr /usr/usr
+    mysql -h "${TFS_MYSQL_HOST}" -u "${TFS_MYSQL_USER}" "${TFS_MYSQL_DATABASE}" "-p${TFS_MYSQL_PASS}" < schema.sql || true
+    mv schema.sql schema.sql.bak
+fi
+
+/bin/tfs


### PR DESCRIPTION
- Fix boost-filesystem dependecy in original Dockerfile
- Add entrypoint.sh with automatic configuration of database
- Add docker-compose.yml for quick start of a new server

If you hado docker in swarm mode just run:

```bash
$ docker stack up -c docker-compose.yaml otserver
```