### PR TITLE
Increase Dispatcher throughput by not clearing spectator cache every task

### DIFF
--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -58,8 +58,6 @@ void Dispatcher::threadMain()
 				++dispatcherCycle;
 				// execute it
 				(*task)();
-
-				g_game.map.clearSpectatorCache();
 			}
 			delete task;
 		} else {


### PR DESCRIPTION
This could also increase the spectator cache hit rate since it is no longer cleared as often, but still cleared when necessary.

Further improvements that could be made for a higher cache hit rate would be to only clear the cache in map nodes where a creature has moved (or been added/removed) rather than clearing the entire cache, but that requires an efficient way to determine affected cache entries.