### PR TITLE
Improve players spectator cache hit rate

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -451,6 +451,10 @@ void Map::getSpectators(SpectatorHashSet& spectators, const Position& centerPos,
 void Map::clearSpectatorCache()
 {
 	spectatorCache.clear();
+}
+
+void Map::clearPlayersSpectatorCache()
+{
 	playersSpectatorCache.clear();
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -225,6 +225,7 @@ class Map
 		                   int32_t minRangeY = 0, int32_t maxRangeY = 0);
 
 		void clearSpectatorCache();
+		void clearPlayersSpectatorCache();
 
 		/**
 		  * Checks if you can throw an object to that position

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -830,6 +830,10 @@ void Tile::addThing(int32_t, Thing* thing)
 	Creature* creature = thing->getCreature();
 	if (creature) {
 		g_game.map.clearSpectatorCache();
+		if (creature->getPlayer()) {
+			g_game.map.clearPlayersSpectatorCache();
+		}
+
 		creature->setParent(this);
 		CreatureVector* creatures = makeCreatures();
 		creatures->insert(creatures->begin(), creature);
@@ -1035,6 +1039,10 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 			auto it = std::find(creatures->begin(), creatures->end(), thing);
 			if (it != creatures->end()) {
 				g_game.map.clearSpectatorCache();
+				if (creature->getPlayer()) {
+					g_game.map.clearPlayersSpectatorCache();
+				}
+
 				creatures->erase(it);
 			}
 		}
@@ -1432,6 +1440,10 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 	Creature* creature = thing->getCreature();
 	if (creature) {
 		g_game.map.clearSpectatorCache();
+		if (creature->getPlayer()) {
+			g_game.map.clearPlayersSpectatorCache();
+		}
+
 		CreatureVector* creatures = makeCreatures();
 		creatures->insert(creatures->begin(), creature);
 	} else {


### PR DESCRIPTION
There is no need to clear the players spectator cache when a non-player Creature has been added/moved/removed. This comes at the cost of checking if the creature is a player in those functions though, but hopefully that is negligible.