### PR TITLE
Fixed zero in key number

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1290,7 +1290,7 @@ std::string Item::getDescription(const ItemType& it, int32_t lookDistance,
 
 		if (!found) {
 			if (it.isKey()) {
-				s << " (Key:" << (item ? item->getActionId() : 0) << ')';
+				s << " (Key:" << std::setfill('0') << std::setw(4) << (item ? item->getActionId() : 0) << ')';
 			} else if (it.isFluidContainer()) {
 				if (subType > 0) {
 					const std::string& itemName = items[subType].name;


### PR DESCRIPTION
Now keys will display (Key:0021) instead of (Key:21) as it is on current RL tibia

more info on this thread: https://otland.net/threads/how-fix-the-this-key-number-tfs-1-2.266312/
code by fabian766 on otland