### PR TITLE
Challenge creature stops monsters from running away.

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -866,11 +866,11 @@ void Monster::onThinkTarget(uint32_t interval)
 		if (mType->info.changeTargetSpeed != 0) {
 			bool canChangeTarget = true;
 
-			if (targetExetaCooldown > 0) {
-				targetExetaCooldown -= interval;
+			if (challengeFocusDuration > 0) {
+				challengeFocusDuration -= interval;
 
-				if (targetExetaCooldown <= 0) {
-					targetExetaCooldown = 0;
+				if (challengeFocusDuration <= 0) {
+					challengeFocusDuration = 0;
 				}
 			}
 
@@ -892,8 +892,8 @@ void Monster::onThinkTarget(uint32_t interval)
 					targetChangeTicks = 0;
 					targetChangeCooldown = mType->info.changeTargetSpeed;
 
-					if (targetExetaCooldown > 0) {
-						targetExetaCooldown = 0;
+					if (challengeFocusDuration > 0) {
+						challengeFocusDuration = 0;
 					}
 
 					if (mType->info.changeTargetChance >= uniform_random(1, 100)) {
@@ -1960,7 +1960,7 @@ bool Monster::challengeCreature(Creature* creature)
 	bool result = selectTarget(creature);
 	if (result) {
 		targetChangeCooldown = 8000;
-		targetExetaCooldown = targetChangeCooldown;
+		challengeFocusDuration = targetChangeCooldown;
 		targetChangeTicks = 0;
 	}
 	return result;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -866,6 +866,14 @@ void Monster::onThinkTarget(uint32_t interval)
 		if (mType->info.changeTargetSpeed != 0) {
 			bool canChangeTarget = true;
 
+			if (targetExetaCooldown > 0) {
+				targetExetaCooldown -= interval;
+
+				if (targetExetaCooldown <= 0) {
+					targetExetaCooldown = 0;
+				}
+			}
+
 			if (targetChangeCooldown > 0) {
 				targetChangeCooldown -= interval;
 
@@ -883,6 +891,10 @@ void Monster::onThinkTarget(uint32_t interval)
 				if (targetChangeTicks >= mType->info.changeTargetSpeed) {
 					targetChangeTicks = 0;
 					targetChangeCooldown = mType->info.changeTargetSpeed;
+
+					if (targetExetaCooldown > 0) {
+						targetExetaCooldown = 0;
+					}
 
 					if (mType->info.changeTargetChance >= uniform_random(1, 100)) {
 						if (mType->info.targetDistance <= 1) {
@@ -1948,6 +1960,7 @@ bool Monster::challengeCreature(Creature* creature)
 	bool result = selectTarget(creature);
 	if (result) {
 		targetChangeCooldown = 8000;
+		targetExetaCooldown = targetChangeCooldown;
 		targetChangeTicks = 0;
 	}
 	return result;

--- a/src/monster.h
+++ b/src/monster.h
@@ -163,7 +163,7 @@ class Monster final : public Creature
 
 		bool isTarget(const Creature* creature) const;
 		bool isFleeing() const {
-			return !isSummon() && getHealth() <= mType->info.runAwayHealth && targetExetaCooldown <= 0;
+			return !isSummon() && getHealth() <= mType->info.runAwayHealth && challengeFocusDuration <= 0;
 		}
 
 		bool getDistanceStep(const Position& targetPos, Direction& direction, bool flee = false);
@@ -198,7 +198,7 @@ class Monster final : public Creature
 		int32_t minCombatValue = 0;
 		int32_t maxCombatValue = 0;
 		int32_t targetChangeCooldown = 0;
-		int32_t targetExetaCooldown = 0;
+		int32_t challengeFocusDuration = 0;
 		int32_t stepDuration = 0;
 
 		Position masterPos;

--- a/src/monster.h
+++ b/src/monster.h
@@ -163,7 +163,7 @@ class Monster final : public Creature
 
 		bool isTarget(const Creature* creature) const;
 		bool isFleeing() const {
-			return !isSummon() && getHealth() <= mType->info.runAwayHealth;
+			return !isSummon() && getHealth() <= mType->info.runAwayHealth && targetExetaCooldown <= 0;
 		}
 
 		bool getDistanceStep(const Position& targetPos, Direction& direction, bool flee = false);
@@ -198,6 +198,7 @@ class Monster final : public Creature
 		int32_t minCombatValue = 0;
 		int32_t maxCombatValue = 0;
 		int32_t targetChangeCooldown = 0;
+		int32_t targetExetaCooldown = 0;
 		int32_t stepDuration = 0;
 
 		Position masterPos;


### PR DESCRIPTION
When a creature, like Dragon or Troll gets low on health, (treshhold specified in runonhealth), they will try to run away from the target.

This PR stops that from happening while they are under the influence of challenge creature (exeta res - Elite Knight spell). 

I became aware of this issue here:
https://otland.net/threads/exeta-res.267163/

and @EPuncker linked to a merged PR that solves this issue in the OTservBR-Global repository. 
Originally committed by @LucasCPrazeres 
https://github.com/opentibiabr/OTServBR-Global/pull/276

The code looks clean so I figured I would try to apply it to TFS. 
Tested locally, it works. 

Verified from TibiaWiki that the spell is suppose to prevent creatures from running away at low health. https://tibia.fandom.com/wiki/Challenge

So figured why not create a PR to this repository as well. 