### PR TITLE
Monsters update

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -1494,7 +1494,7 @@
 		<attribute key="writeOnceItemId" value="1960" />
 		<attribute key="weight" value="1300" />
 	</item>
-	<item id="1976" article="a" name="gemmed book">
+	<item id="1976" article="a" name="book">
 		<attribute key="writeable" value="1" />
 		<attribute key="maxTextLen" value="1100" />
 		<attribute key="weight" value="1300" />

--- a/data/monster/Arachnids/giant_spider.xml
+++ b/data/monster/Arachnids/giant_spider.xml
@@ -26,7 +26,7 @@
 			<attribute key="shootEffect" value="poison" />
 		</attack>
 	</attacks>
-	<defenses armor="25" defense="25">
+	<defenses armor="30" defense="30">
 		<defense name="speed" interval="2000" chance="15" speedchange="390" duration="5000">
 			<attribute key="areaEffect" value="redshimmer" />
 		</defense>
@@ -46,19 +46,18 @@
 		<summon name="Poison Spider" interval="2000" chance="10" max="2" />
 	</summons>
 	<loot>
-		<item name="gold coin" countmax="100" chance="50000" />
-		<item name="gold coin" countmax="95" chance="50000" />
-		<item id="2169" chance="710" /><!-- time ring -->
-		<item name="platinum amulet" chance="280" />
-		<item name="two handed sword" chance="5000" />
-		<item name="steel helmet" chance="4545" />
-		<item name="plate armor" chance="8333" />
-		<item name="knight armor" chance="530" />
-		<item name="knight legs" chance="870" />
+		<item name="gold coin" countmax="195" chance="100000" />
 		<item name="poison arrow" countmax="12" chance="12500" />
-		<item name="plate legs" chance="8333" />
-		<item name="spider silk" chance="2140" />
+		<item name="plate armor" chance="10000" />
+		<item name="plate legs" chance="8000" />
+		<item name="two handed sword" chance="5000" />
+		<item name="steel helmet" chance="5000" />
 		<item name="strong health potion" chance="3571" />
-		<item name="lightning headband" chance="220" />
+		<item name="spider silk" chance="2000" />
+		<item name="knight legs" chance="870" />
+		<item id="2169" chance="710" /><!-- time ring -->
+		<item name="knight armor" chance="500" />
+		<item name="platinum amulet" chance="280" />
+		<item name="lightning headband" chance="270" />
 	</loot>
 </monster>

--- a/data/monster/Arachnids/giant_spider_wyda.xml
+++ b/data/monster/Arachnids/giant_spider_wyda.xml
@@ -1,31 +1,33 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Giant Spider" nameDescription="a giant spider" race="venom" experience="12" speed="152" manacost="210">
+<monster name="Giant Spider" nameDescription="a giant spider" race="venom" experience="12" speed="152">
 	<health now="20" max="20" />
 	<look type="38" corpse="5977" />
 	<targetchange interval="2000" chance="0" />
 	<flags>
-		<flag summonable="1" />
+		<flag summonable="0" />
 		<flag attackable="1" />
 		<flag hostile="1" />
-		<flag illusionable="1" />
-		<flag convinceable="1" />
+		<flag illusionable="0" />
+		<flag convinceable="0" />
 		<flag pushable="1" />
 		<flag canpushitems="0" />
 		<flag canpushcreatures="0" />
 		<flag targetdistance="1" />
 		<flag staticattack="90" />
 		<flag runonhealth="6" />
+		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
+		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-9" />
 	</attacks>
-	<defenses armor="5" defense="5" />
+	<defenses armor="2" defense="2" />
 	<elements>
 		<element firePercent="-20" />
 	</elements>
 	<loot>
-		<item name="gold coin" countmax="5" chance="63333" />
-		<item name="spider fangs" chance="810" />
+		<item name="gold coin" countmax="5" chance="65000" />
+		<item name="spider fangs" chance="950" />
 	</loot>
 </monster>

--- a/data/monster/Arachnids/giant_spider_wyda.xml
+++ b/data/monster/Arachnids/giant_spider_wyda.xml
@@ -18,13 +18,14 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="2000" min="0" max="-20" />
+		<attack name="melee" interval="2000" min="0" max="-9" />
 	</attacks>
-	<defenses armor="2" defense="2" />
+	<defenses armor="5" defense="5" />
 	<elements>
-		<element firePercent="-10" />
+		<element firePercent="-20" />
 	</elements>
 	<loot>
-		<item name="gold coin" countmax="5" chance="100000" />
+		<item name="gold coin" countmax="5" chance="63333" />
+		<item name="spider fangs" chance="810" />
 	</loot>
 </monster>

--- a/data/monster/Arachnids/spider.xml
+++ b/data/monster/Arachnids/spider.xml
@@ -22,12 +22,12 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-9" />
 	</attacks>
-	<defenses armor="5" defense="5" />
+	<defenses armor="2" defense="2" />
 	<elements>
 		<element firePercent="-20" />
 	</elements>
 	<loot>
-		<item name="gold coin" countmax="5" chance="63333" />
-		<item name="spider fangs" chance="810" />
+		<item name="gold coin" countmax="5" chance="65000" />
+		<item name="spider fangs" chance="950" />
 	</loot>
 </monster>

--- a/data/monster/Arachnids/spider.xml
+++ b/data/monster/Arachnids/spider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Spider" nameDescription="a spider" race="venom" experience="12" speed="165" manacost="210">
+<monster name="Spider" nameDescription="a spider" race="venom" experience="12" speed="152" manacost="210">
 	<health now="20" max="20" />
 	<look type="30" corpse="5961" />
 	<targetchange interval="4000" chance="0" />

--- a/data/monster/Bears/bear.xml
+++ b/data/monster/Bears/bear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bear" namedescription="a bear" race="blood" experience="23" speed="145" manacost="300">
+<monster name="Bear" namedescription="a bear" race="blood" experience="23" speed="156" manacost="300">
 	<health now="80" max="80" />
 	<look type="16" corpse="5975" />
 	<targetchange interval="4000" chance="0" />
@@ -22,7 +22,7 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />
 	</attacks>
-	<defenses armor="10" defense="10" />
+	<defenses armor="6" defense="6" />
 	<elements>
 		<element holyPercent="10" />
 		<element icePercent="-10" />

--- a/data/monster/Bio-Elementals/wilting_leaf_golem.xml
+++ b/data/monster/Bio-Elementals/wilting_leaf_golem.xml
@@ -18,7 +18,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="1500" min="0" max="-120" poison="300" />
+		<attack name="melee" interval="2000" min="0" max="-120" poison="300" />
 		<attack name="physical" interval="2000" chance="20" radius="1" range="7" target="1" min="0" max="-50">
 			<attribute key="shootEffect" value="largerock" />
 			<attribute key="areaEffect" value="explosion" />

--- a/data/monster/Birds/chicken.xml
+++ b/data/monster/Birds/chicken.xml
@@ -28,6 +28,6 @@
 		<item name="meat" countmax="2" chance="2120" />
 		<item id="2695" chance="950" /><!-- egg -->
 		<item name="worm" countmax="3" chance="10000" />
-		<item name="chicken feather" countmax="1" chance="20000" />
+		<item name="chicken feather" chance="20000" />
 	</loot>
 </monster>

--- a/data/monster/Bonelords/bonelord.xml
+++ b/data/monster/Bonelords/bonelord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Bonelord" nameDescription="a bonelord" race="venom" experience="170" speed="170">
+<monster name="Bonelord" nameDescription="a bonelord" race="venom" experience="170" speed="150">
 	<health now="260" max="260" />
 	<look type="17" corpse="5992" />
 	<targetchange interval="4000" chance="10" />
@@ -42,7 +42,7 @@
 		</attack>
 		<attack name="manadrain" interval="2000" chance="5" range="7" min="-5" max="-35" />
 	</attacks>
-	<defenses armor="10" defense="10" />
+	<defenses armor="5" defense="5" />
 	<elements>
 		<element icePercent="20" />
 		<element firePercent="-10" />
@@ -60,18 +60,19 @@
 		<voice sentence="Here's looking at you!" />
 		<voice sentence="Let me take a look at you!" />
 		<voice sentence="You've got the look!" />
+		<voice sentence="I've got to look!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="48" chance="65000" />
-		<item id="2175" chance="4650" /><!-- spellbook -->
-		<item name="terra rod" chance="570" />
-		<item name="two handed sword" chance="3840" />
-		<item name="morning star" chance="6950" />
-		<item name="longsword" chance="8980" />
-		<item name="steel shield" chance="4001" />
-		<item name="bonelord shield" chance="80" />
-		<item name="bonelord eye" chance="940" />
-		<item name="mana potion" chance="280" />
-		<item name="small flask of eyedrops" chance="4940" />
+		<item name="gold coin" countmax="48" chance="99000" />
+		<item name="longsword" chance="9000" />
+		<item name="morning star" chance="7000" />
+		<item name="small flask of eyedrops" chance="5000" />
+		<item id="2175" chance="5000" /><!-- spellbook -->
+		<item name="steel shield" chance="4000" />
+		<item name="two handed sword" chance="3950" />
+		<item name="bonelord eye" chance="1000" />
+		<item name="terra rod" chance="510" />
+		<item name="mana potion" chance="300" />
+		<item name="bonelord shield" chance="110" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/apocalypse.xml
+++ b/data/monster/Bosses/apocalypse.xml
@@ -69,13 +69,13 @@
 		<voice sentence="DEATH TO ALL!" yell="1" />
 	</voices>
 	<loot>
-		<item name="purple tome" countmax="1" chance="2600" />
-		<item name="golden mug" countmax="1" chance="7500" />
-		<item name="teddy bear" countmax="1" chance="14500" />
-		<item name="ring of the sky" countmax="1" chance="3500" />
-		<item id="2124" countmax="1" chance="5500" />
-		<item name="crystal necklace" countmax="1" chance="1500" />
-		<item name="ancient amulet" countmax="1" chance="3500" />
+		<item name="purple tome" chance="2600" />
+		<item name="golden mug" chance="7500" />
+		<item name="teddy bear" chance="14500" />
+		<item name="ring of the sky" chance="3500" />
+		<item id="2124" chance="5500" />
+		<item name="crystal necklace" chance="1500" />
+		<item name="ancient amulet" chance="3500" />
 		<item name="white pearl" countmax="15" chance="12500" />
 		<item name="black pearl" countmax="15" chance="15000" />
 		<item name="small diamond" countmax="5" chance="9500" />
@@ -87,44 +87,44 @@
 		<item name="small emerald" countmax="10" chance="15500" />
 		<item name="small amethyst" countmax="20" chance="13500" />
 		<item name="talon" countmax="7" chance="14000" />
-		<item name="green gem" countmax="1" chance="1500" />
-		<item name="blue gem" countmax="1" chance="1500" />
-		<item id="2162" countmax="1" chance="11500" />
-		<item name="might ring" countmax="1" chance="5000" />
-		<item name="stealth ring" countmax="1" chance="9500" />
-		<item name="energy ring" countmax="1" chance="13500" />
-		<item name="silver amulet" countmax="1" chance="13000" />
-		<item name="platinum amulet" countmax="1" chance="4500" />
-		<item name="strange symbol" countmax="1" chance="2500" />
-		<item name="orb" countmax="1" chance="12000" />
-		<item name="life crystal" countmax="1" chance="1000" />
-		<item name="mind stone" countmax="1" chance="4000" />
-		<item name="gold ring" countmax="1" chance="8000" />
-		<item name="snakebite rod" countmax="1" chance="3500" />
-		<item name="necrotic rod" countmax="1" chance="3500" />
-		<item name="moonlight rod" countmax="1" chance="3500" />
-		<item name="wand of decay" countmax="1" chance="2500" />
-		<item id="2192" countmax="1" chance="2500" />
-		<item name="boots of haste" countmax="1" chance="4000" />
-		<item name="stone skin amulet" countmax="1" chance="4000" />
-		<item name="protection amulet" countmax="1" chance="4500" />
-		<item name="ring of healing" countmax="1" chance="13000" />
-		<item id="2231" countmax="1" chance="9000" />
-		<item name="two handed sword" countmax="1" chance="20000" />
-		<item name="double axe" countmax="1" chance="20000" />
-		<item name="giant sword" countmax="1" chance="12500" />
-		<item name="ice rapier" countmax="1" chance="7500" />
-		<item name="silver dagger" countmax="1" chance="15500" />
-		<item name="golden sickle" countmax="1" chance="4500" />
-		<item name="thunder hammer" countmax="1" chance="13500" />
-		<item name="fire axe" countmax="1" chance="17000" />
-		<item name="dragon hammer" countmax="1" chance="4500" />
-		<item name="skull staff" countmax="1" chance="5000" />
-		<item name="devil helmet" countmax="1" chance="11000" />
-		<item name="golden legs" countmax="1" chance="5000" />
-		<item name="magic plate armor" countmax="1" chance="3000" />
-		<item name="mastermind shield" countmax="1" chance="7500" />
-		<item name="demon shield" countmax="1" chance="15500" />
-		<item id="3955" countmax="1" chance="100" />
+		<item name="green gem" chance="1500" />
+		<item name="blue gem" chance="1500" />
+		<item id="2162" chance="11500" />
+		<item name="might ring" chance="5000" />
+		<item name="stealth ring" chance="9500" />
+		<item name="energy ring" chance="13500" />
+		<item name="silver amulet" chance="13000" />
+		<item name="platinum amulet" chance="4500" />
+		<item name="strange symbol" chance="2500" />
+		<item name="orb" chance="12000" />
+		<item name="life crystal" chance="1000" />
+		<item name="mind stone" chance="4000" />
+		<item name="gold ring" chance="8000" />
+		<item name="snakebite rod" chance="3500" />
+		<item name="necrotic rod" chance="3500" />
+		<item name="moonlight rod" chance="3500" />
+		<item name="wand of decay" chance="2500" />
+		<item id="2192" chance="2500" />
+		<item name="boots of haste" chance="4000" />
+		<item name="stone skin amulet" chance="4000" />
+		<item name="protection amulet" chance="4500" />
+		<item name="ring of healing" chance="13000" />
+		<item id="2231" chance="9000" />
+		<item name="two handed sword" chance="20000" />
+		<item name="double axe" chance="20000" />
+		<item name="giant sword" chance="12500" />
+		<item name="ice rapier" chance="7500" />
+		<item name="silver dagger" chance="15500" />
+		<item name="golden sickle" chance="4500" />
+		<item name="thunder hammer" chance="13500" />
+		<item name="fire axe" chance="17000" />
+		<item name="dragon hammer" chance="4500" />
+		<item name="skull staff" chance="5000" />
+		<item name="devil helmet" chance="11000" />
+		<item name="golden legs" chance="5000" />
+		<item name="magic plate armor" chance="3000" />
+		<item name="mastermind shield" chance="7500" />
+		<item name="demon shield" chance="15500" />
+		<item id="3955" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/arachir_the_ancient_one.xml
+++ b/data/monster/Bosses/arachir_the_ancient_one.xml
@@ -55,9 +55,9 @@
 		<voice sentence="Can you feel the passage of time, mortal?" />
 	</voices>
 	<loot>
-		<item name="black pearl" chance="8980" countmax="1" />
-		<item name="gold coin" chance="100000" countmax="98" />
-		<item name="platinum coin" chance="50000" countmax="5" />
+		<item name="black pearl" chance="8980" />
+		<item name="gold coin" countmax="98" chance="100000" />
+		<item name="platinum coin" countmax="5" chance="50000" />
 		<item name="ring of healing (faster regeneration)" chance="11111" />
 		<item id="2229" chance="10000" />
 		<item name="vampire shield" chance="6300" />

--- a/data/monster/Bosses/bazir.xml
+++ b/data/monster/Bosses/bazir.xml
@@ -95,13 +95,13 @@
 		<voice sentence="DON'T BE AFRAID! I AM COMING IN PEACE!" yell="1" />
 	</voices>
 	<loot>
-		<item name="purple tome" countmax="1" chance="2600" />
-		<item name="golden mug" countmax="1" chance="7500" />
-		<item name="teddy bear" countmax="1" chance="14500" />
-		<item name="ring of the sky" countmax="1" chance="3500" />
-		<item id="2124" countmax="1" chance="5500" />
-		<item name="crystal necklace" countmax="1" chance="1500" />
-		<item name="ancient amulet" countmax="1" chance="3500" />
+		<item name="purple tome" chance="2600" />
+		<item name="golden mug" chance="7500" />
+		<item name="teddy bear" chance="14500" />
+		<item name="ring of the sky" chance="3500" />
+		<item id="2124" chance="5500" />
+		<item name="crystal necklace" chance="1500" />
+		<item name="ancient amulet" chance="3500" />
 		<item name="white pearl" countmax="15" chance="12500" />
 		<item name="black pearl" countmax="15" chance="15000" />
 		<item name="small diamond" countmax="5" chance="9500" />
@@ -113,44 +113,44 @@
 		<item name="small emerald" countmax="10" chance="15500" />
 		<item name="small amethyst" countmax="20" chance="13500" />
 		<item name="talon" countmax="7" chance="14000" />
-		<item name="green gem" countmax="1" chance="1500" />
-		<item name="blue gem" countmax="1" chance="1500" />
-		<item id="2162" countmax="1" chance="11500" />
-		<item name="might ring" countmax="1" chance="5000" />
-		<item name="stealth ring" countmax="1" chance="9500" />
-		<item name="energy ring" countmax="1" chance="13500" />
-		<item name="silver amulet" countmax="1" chance="13000" />
-		<item name="platinum amulet" countmax="1" chance="4500" />
-		<item name="strange symbol" countmax="1" chance="2500" />
-		<item name="orb" countmax="1" chance="12000" />
-		<item name="life crystal" countmax="1" chance="1000" />
-		<item name="mind stone" countmax="1" chance="4000" />
-		<item name="gold ring" countmax="1" chance="8000" />
-		<item name="snakebite rod" countmax="1" chance="3500" />
-		<item name="necrotic rod" countmax="1" chance="3500" />
-		<item name="moonlight rod" countmax="1" chance="3500" />
-		<item name="wand of decay" countmax="1" chance="2500" />
-		<item id="2192" countmax="1" chance="2500" />
-		<item name="boots of haste" countmax="1" chance="4000" />
-		<item name="stone skin amulet" countmax="1" chance="4000" />
-		<item name="protection amulet" countmax="1" chance="4500" />
-		<item name="ring of healing" countmax="1" chance="13000" />
-		<item id="2231" countmax="1" chance="9000" />
-		<item name="two handed sword" countmax="1" chance="20000" />
-		<item name="double axe" countmax="1" chance="20000" />
-		<item name="giant sword" countmax="1" chance="12500" />
-		<item name="ice rapier" countmax="1" chance="7500" />
-		<item name="silver dagger" countmax="1" chance="15500" />
-		<item name="golden sickle" countmax="1" chance="4500" />
-		<item name="thunder hammer" countmax="1" chance="13500" />
-		<item name="fire axe" countmax="1" chance="17000" />
-		<item name="dragon hammer" countmax="1" chance="4500" />
-		<item name="skull staff" countmax="1" chance="5000" />
-		<item name="devil helmet" countmax="1" chance="11000" />
-		<item name="golden legs" countmax="1" chance="5000" />
-		<item name="magic plate armor" countmax="1" chance="3000" />
-		<item name="mastermind shield" countmax="1" chance="7500" />
-		<item name="demon shield" countmax="1" chance="15500" />
-		<item id="3955" countmax="1" chance="100" />
+		<item name="green gem" chance="1500" />
+		<item name="blue gem" chance="1500" />
+		<item id="2162" chance="11500" />
+		<item name="might ring" chance="5000" />
+		<item name="stealth ring" chance="9500" />
+		<item name="energy ring" chance="13500" />
+		<item name="silver amulet" chance="13000" />
+		<item name="platinum amulet" chance="4500" />
+		<item name="strange symbol" chance="2500" />
+		<item name="orb" chance="12000" />
+		<item name="life crystal" chance="1000" />
+		<item name="mind stone" chance="4000" />
+		<item name="gold ring" chance="8000" />
+		<item name="snakebite rod" chance="3500" />
+		<item name="necrotic rod" chance="3500" />
+		<item name="moonlight rod" chance="3500" />
+		<item name="wand of decay" chance="2500" />
+		<item id="2192" chance="2500" />
+		<item name="boots of haste" chance="4000" />
+		<item name="stone skin amulet" chance="4000" />
+		<item name="protection amulet" chance="4500" />
+		<item name="ring of healing" chance="13000" />
+		<item id="2231" chance="9000" />
+		<item name="two handed sword" chance="20000" />
+		<item name="double axe" chance="20000" />
+		<item name="giant sword" chance="12500" />
+		<item name="ice rapier" chance="7500" />
+		<item name="silver dagger" chance="15500" />
+		<item name="golden sickle" chance="4500" />
+		<item name="thunder hammer" chance="13500" />
+		<item name="fire axe" chance="17000" />
+		<item name="dragon hammer" chance="4500" />
+		<item name="skull staff" chance="5000" />
+		<item name="devil helmet" chance="11000" />
+		<item name="golden legs" chance="5000" />
+		<item name="magic plate armor" chance="3000" />
+		<item name="mastermind shield" chance="7500" />
+		<item name="demon shield" chance="15500" />
+		<item id="3955" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/demodras.xml
+++ b/data/monster/Bosses/demodras.xml
@@ -48,7 +48,7 @@
 		<voice sentence="I WILL PROTECT MY BROOD!" yell="1" />
 	</voices>
 	<loot>
-		<item name="gemmed book" chance="3333" />
+		<item id="1976" chance="3333" /><!-- book (gemmed) -->
 		<item name="golden mug" chance="1818" />
 		<item name="small sapphire" countmax="2" chance="2222" />
 		<item name="gold coin" countmax="100" chance="100000" />
@@ -62,10 +62,10 @@
 		<item name="burst arrow" countmax="5" chance="2222" />
 		<item name="power bolt" countmax="10" chance="2222" />
 		<item name="dragon ham" countmax="2" chance="20000" />
-		<item name="green mushroom" countmax="1" chance="6666" />
+		<item name="green mushroom" chance="6666" />
 		<item name="worm" countmax="10" chance="50000" />
-		<item name="red dragon scale" countmax="1" chance="5000" />
+		<item name="red dragon scale" chance="5000" />
 		<item id="5919" chance="100000" /><!-- dragon claw -->
-		<item name="red dragon leather" countmax="1" chance="5000" />
+		<item name="red dragon leather" chance="5000" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/dharalion.xml
+++ b/data/monster/Bosses/dharalion.xml
@@ -73,7 +73,7 @@
 		<item name="green tunic" chance="5000" />
 		<item name="melon" chance="6666" />
 		<item name="bread" countmax="3" chance="20000" />
-		<item name="sling herb" countmax="1" chance="10000" />
+		<item name="sling herb" chance="10000" />
 		<item name="worm" countmax="10" chance="50000" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/freegoiz.xml
+++ b/data/monster/Bosses/freegoiz.xml
@@ -69,13 +69,13 @@
 		<voice sentence="DEATH TO ALL!" yell="1" />
 	</voices>
 	<loot>
-		<item name="purple tome" countmax="1" chance="2600" />
-		<item name="golden mug" countmax="1" chance="7500" />
-		<item name="teddy bear" countmax="1" chance="14500" />
-		<item name="ring of the sky" countmax="1" chance="3500" />
-		<item id="2124" countmax="1" chance="5500" />
-		<item name="crystal necklace" countmax="1" chance="1500" />
-		<item name="ancient amulet" countmax="1" chance="3500" />
+		<item name="purple tome" chance="2600" />
+		<item name="golden mug" chance="7500" />
+		<item name="teddy bear" chance="14500" />
+		<item name="ring of the sky" chance="3500" />
+		<item id="2124" chance="5500" />
+		<item name="crystal necklace" chance="1500" />
+		<item name="ancient amulet" chance="3500" />
 		<item name="white pearl" countmax="15" chance="12500" />
 		<item name="black pearl" countmax="15" chance="15000" />
 		<item name="small diamond" countmax="5" chance="9500" />
@@ -87,44 +87,44 @@
 		<item name="small emerald" countmax="10" chance="15500" />
 		<item name="small amethyst" countmax="20" chance="13500" />
 		<item name="talon" countmax="7" chance="14000" />
-		<item name="green gem" countmax="1" chance="1500" />
-		<item name="blue gem" countmax="1" chance="1500" />
-		<item id="2162" countmax="1" chance="11500" />
-		<item name="might ring" countmax="1" chance="5000" />
-		<item name="stealth ring" countmax="1" chance="9500" />
-		<item name="energy ring" countmax="1" chance="13500" />
-		<item name="silver amulet" countmax="1" chance="13000" />
-		<item name="platinum amulet" countmax="1" chance="4500" />
-		<item name="strange symbol" countmax="1" chance="2500" />
-		<item name="orb" countmax="1" chance="12000" />
-		<item name="life crystal" countmax="1" chance="1000" />
-		<item name="mind stone" countmax="1" chance="4000" />
-		<item name="gold ring" countmax="1" chance="8000" />
-		<item name="snakebite rod" countmax="1" chance="3500" />
-		<item name="necrotic rod" countmax="1" chance="3500" />
-		<item name="moonlight rod" countmax="1" chance="3500" />
-		<item name="wand of decay" countmax="1" chance="2500" />
-		<item id="2192" countmax="1" chance="2500" />
-		<item name="boots of haste" countmax="1" chance="4000" />
-		<item name="stone skin amulet" countmax="1" chance="4000" />
-		<item name="protection amulet" countmax="1" chance="4500" />
-		<item name="ring of healing" countmax="1" chance="13000" />
-		<item id="2231" countmax="1" chance="9000" />
-		<item name="two handed sword" countmax="1" chance="20000" />
-		<item name="double axe" countmax="1" chance="20000" />
-		<item name="giant sword" countmax="1" chance="12500" />
-		<item name="ice rapier" countmax="1" chance="7500" />
-		<item name="silver dagger" countmax="1" chance="15500" />
-		<item name="golden sickle" countmax="1" chance="4500" />
-		<item name="thunder hammer" countmax="1" chance="13500" />
-		<item name="fire axe" countmax="1" chance="17000" />
-		<item name="dragon hammer" countmax="1" chance="4500" />
-		<item name="skull staff" countmax="1" chance="5000" />
-		<item name="devil helmet" countmax="1" chance="11000" />
-		<item name="golden legs" countmax="1" chance="5000" />
-		<item name="magic plate armor" countmax="1" chance="3000" />
-		<item name="mastermind shield" countmax="1" chance="7500" />
-		<item name="demon shield" countmax="1" chance="15500" />
-		<item id="3955" countmax="1" chance="100" />
+		<item name="green gem" chance="1500" />
+		<item name="blue gem" chance="1500" />
+		<item id="2162" chance="11500" />
+		<item name="might ring" chance="5000" />
+		<item name="stealth ring" chance="9500" />
+		<item name="energy ring" chance="13500" />
+		<item name="silver amulet" chance="13000" />
+		<item name="platinum amulet" chance="4500" />
+		<item name="strange symbol" chance="2500" />
+		<item name="orb" chance="12000" />
+		<item name="life crystal" chance="1000" />
+		<item name="mind stone" chance="4000" />
+		<item name="gold ring" chance="8000" />
+		<item name="snakebite rod" chance="3500" />
+		<item name="necrotic rod" chance="3500" />
+		<item name="moonlight rod" chance="3500" />
+		<item name="wand of decay" chance="2500" />
+		<item id="2192" chance="2500" />
+		<item name="boots of haste" chance="4000" />
+		<item name="stone skin amulet" chance="4000" />
+		<item name="protection amulet" chance="4500" />
+		<item name="ring of healing" chance="13000" />
+		<item id="2231" chance="9000" />
+		<item name="two handed sword" chance="20000" />
+		<item name="double axe" chance="20000" />
+		<item name="giant sword" chance="12500" />
+		<item name="ice rapier" chance="7500" />
+		<item name="silver dagger" chance="15500" />
+		<item name="golden sickle" chance="4500" />
+		<item name="thunder hammer" chance="13500" />
+		<item name="fire axe" chance="17000" />
+		<item name="dragon hammer" chance="4500" />
+		<item name="skull staff" chance="5000" />
+		<item name="devil helmet" chance="11000" />
+		<item name="golden legs" chance="5000" />
+		<item name="magic plate armor" chance="3000" />
+		<item name="mastermind shield" chance="7500" />
+		<item name="demon shield" chance="15500" />
+		<item id="3955" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/general_murius.xml
+++ b/data/monster/Bosses/general_murius.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <monster name="General Murius" nameDescription="General Murius" race="blood" experience="450" speed="240">
 	<health now="550" max="550" />
-	<look type="202" corpse="5983" />
+	<look type="611" corpse="23462"/>
 	<targetchange interval="5000" chance="8" />
 	<flags>
 		<flag summonable="0" />
@@ -41,24 +41,21 @@
 		<voice sentence="Feel the power of the Mooh'Tah!" />
 		<voice sentence="You will get what you deserve!" />
 		<voice sentence="For the king!" />
+		<voice sentence="Guards!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="30" chance="100000" />
-		<item name="gold coin" chance="2857" />
-		<item name="sword ring" chance="2000" />
-		<item name="dagger" chance="6666" />
-		<item name="longsword" chance="10000" />
-		<item name="throwing knife" countmax="2" chance="50000" />
-		<item name="broadsword" chance="2857" />
-		<item id="2419" chance="10000" /><!-- scimitar -->
-		<item name="plate armor" chance="1818" />
-		<item name="warrior helmet" chance="1000" />
-		<item name="brass legs" chance="2857" />
-		<item name="plate shield" chance="5000" />
-		<item name="plate legs" chance="1818" />
-		<item name="green tunic" chance="2500" />
-		<item name="meat" countmax="2" chance="33333" />
-		<item id="2667" chance="20000" /><!-- fish -->
-		<item name="worm" countmax="10" chance="50000" />
+		<item name="minotaur horn" countmax="2" chance="100000" />
+		<item name="minotaur leather" chance="100000" />
+		<item name="gold coin" countmax="97" chance="92000" />
+		<item name="platinum coin" countmax="3" chance="92000" />
+		<item name="brass armor" chance="76000" />
+		<item name="double axe" chance="76000" />
+		<item name="piercing bolt" countmax="7" chance="40000"/>
+		<item name="meat" countmax="2" chance="30000" />
+		<item name="battle shield" chance="23000" />
+		<item name="chain legs" chance="23000" />
+		<item id="7401" chance="23000"/><!-- minotaur trophy -->
+		<item name="power bolt" countmax="7" chance="23000"/>
+		<item name="dwarven helmet" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/general_murius.xml
+++ b/data/monster/Bosses/general_murius.xml
@@ -44,7 +44,7 @@
 	</voices>
 	<loot>
 		<item name="gold coin" countmax="30" chance="100000" />
-		<item name="gold coin" countmax="1" chance="2857" />
+		<item name="gold coin" chance="2857" />
 		<item name="sword ring" chance="2000" />
 		<item name="dagger" chance="6666" />
 		<item name="longsword" chance="10000" />
@@ -58,7 +58,7 @@
 		<item name="plate legs" chance="1818" />
 		<item name="green tunic" chance="2500" />
 		<item name="meat" countmax="2" chance="33333" />
-		<item id="2667" countmax="1" chance="20000" /><!-- fish -->
+		<item id="2667" chance="20000" /><!-- fish -->
 		<item name="worm" countmax="10" chance="50000" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/infernatil.xml
+++ b/data/monster/Bosses/infernatil.xml
@@ -74,13 +74,13 @@
 		<voice sentence="BOW TO THE POWER OF THE RUTHLESS SEVEN!" yell="1" />
 	</voices>
 	<loot>
-		<item name="purple tome" countmax="1" chance="2600" />
-		<item name="golden mug" countmax="1" chance="7500" />
-		<item name="teddy bear" countmax="1" chance="14500" />
-		<item name="ring of the sky" countmax="1" chance="3500" />
-		<item id="2124" countmax="1" chance="5500" />
-		<item name="crystal necklace" countmax="1" chance="1500" />
-		<item name="ancient amulet" countmax="1" chance="3500" />
+		<item name="purple tome" chance="2600" />
+		<item name="golden mug" chance="7500" />
+		<item name="teddy bear" chance="14500" />
+		<item name="ring of the sky" chance="3500" />
+		<item id="2124" chance="5500" />
+		<item name="crystal necklace" chance="1500" />
+		<item name="ancient amulet" chance="3500" />
 		<item name="white pearl" countmax="15" chance="12500" />
 		<item name="black pearl" countmax="15" chance="15000" />
 		<item name="small diamond" countmax="5" chance="9500" />
@@ -92,44 +92,44 @@
 		<item name="small emerald" countmax="10" chance="15500" />
 		<item name="small amethyst" countmax="20" chance="13500" />
 		<item name="talon" countmax="7" chance="14000" />
-		<item name="green gem" countmax="1" chance="1500" />
-		<item name="blue gem" countmax="1" chance="1500" />
-		<item id="2162" countmax="1" chance="11500" />
-		<item name="might ring" countmax="1" chance="5000" />
-		<item name="stealth ring" countmax="1" chance="9500" />
-		<item name="energy ring" countmax="1" chance="13500" />
-		<item name="silver amulet" countmax="1" chance="13000" />
-		<item name="platinum amulet" countmax="1" chance="4500" />
-		<item name="strange symbol" countmax="1" chance="2500" />
-		<item name="orb" countmax="1" chance="12000" />
-		<item name="life crystal" countmax="1" chance="1000" />
-		<item name="mind stone" countmax="1" chance="4000" />
-		<item name="gold ring" countmax="1" chance="8000" />
-		<item name="snakebite rod" countmax="1" chance="3500" />
-		<item name="necrotic rod" countmax="1" chance="3500" />
-		<item name="moonlight rod" countmax="1" chance="3500" />
-		<item name="wand of decay" countmax="1" chance="2500" />
-		<item id="2192" countmax="1" chance="2500" />
-		<item name="boots of haste" countmax="1" chance="4000" />
-		<item name="stone skin amulet" countmax="1" chance="4000" />
-		<item name="protection amulet" countmax="1" chance="4500" />
-		<item name="ring of healing" countmax="1" chance="13000" />
-		<item id="2231" countmax="1" chance="9000" />
-		<item name="two handed sword" countmax="1" chance="20000" />
-		<item name="double axe" countmax="1" chance="20000" />
-		<item name="giant sword" countmax="1" chance="12500" />
-		<item name="ice rapier" countmax="1" chance="7500" />
-		<item name="silver dagger" countmax="1" chance="15500" />
-		<item name="golden sickle" countmax="1" chance="4500" />
-		<item name="thunder hammer" countmax="1" chance="13500" />
-		<item name="fire axe" countmax="1" chance="17000" />
-		<item name="dragon hammer" countmax="1" chance="4500" />
-		<item name="skull staff" countmax="1" chance="5000" />
-		<item name="devil helmet" countmax="1" chance="11000" />
-		<item name="golden legs" countmax="1" chance="5000" />
-		<item name="magic plate armor" countmax="1" chance="3000" />
-		<item name="mastermind shield" countmax="1" chance="7500" />
-		<item name="demon shield" countmax="1" chance="15500" />
-		<item id="3955" countmax="1" chance="100" />
+		<item name="green gem" chance="1500" />
+		<item name="blue gem" chance="1500" />
+		<item id="2162" chance="11500" />
+		<item name="might ring" chance="5000" />
+		<item name="stealth ring" chance="9500" />
+		<item name="energy ring" chance="13500" />
+		<item name="silver amulet" chance="13000" />
+		<item name="platinum amulet" chance="4500" />
+		<item name="strange symbol" chance="2500" />
+		<item name="orb" chance="12000" />
+		<item name="life crystal" chance="1000" />
+		<item name="mind stone" chance="4000" />
+		<item name="gold ring" chance="8000" />
+		<item name="snakebite rod" chance="3500" />
+		<item name="necrotic rod" chance="3500" />
+		<item name="moonlight rod" chance="3500" />
+		<item name="wand of decay" chance="2500" />
+		<item id="2192" chance="2500" />
+		<item name="boots of haste" chance="4000" />
+		<item name="stone skin amulet" chance="4000" />
+		<item name="protection amulet" chance="4500" />
+		<item name="ring of healing" chance="13000" />
+		<item id="2231" chance="9000" />
+		<item name="two handed sword" chance="20000" />
+		<item name="double axe" chance="20000" />
+		<item name="giant sword" chance="12500" />
+		<item name="ice rapier" chance="7500" />
+		<item name="silver dagger" chance="15500" />
+		<item name="golden sickle" chance="4500" />
+		<item name="thunder hammer" chance="13500" />
+		<item name="fire axe" chance="17000" />
+		<item name="dragon hammer" chance="4500" />
+		<item name="skull staff" chance="5000" />
+		<item name="devil helmet" chance="11000" />
+		<item name="golden legs" chance="5000" />
+		<item name="magic plate armor" chance="3000" />
+		<item name="mastermind shield" chance="7500" />
+		<item name="demon shield" chance="15500" />
+		<item id="3955" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/lethal_lissy.xml
+++ b/data/monster/Bosses/lethal_lissy.xml
@@ -34,7 +34,7 @@
 	<loot>
 		<item name="small diamond" chance="100000" />
 		<item name="gold coin" countmax="40" chance="100000" />
-		<item name="skull of Ratha" countmax="1" chance="100000" />
+		<item name="skull of Ratha" chance="100000" />
 		<item name="double axe" chance="1500" />
 		<item name="plate armor" chance="4000" />
 		<item name="knight armor" chance="1200" />

--- a/data/monster/Bosses/munster.xml
+++ b/data/monster/Bosses/munster.xml
@@ -31,7 +31,7 @@
 		<item name="gold coin" countmax="16" chance="100000" />
 		<item name="bone club" chance="5000" />
 		<item name="jacket" chance="50000" />
-		<item name="cookie" countmax="1" chance="5000" />
+		<item name="cookie" chance="5000" />
 		<item id="2696" chance="50000" /><!-- cheese -->
 	</loot>
 </monster>

--- a/data/monster/Bosses/necropharus.xml
+++ b/data/monster/Bosses/necropharus.xml
@@ -53,18 +53,18 @@
 		<item name="moonlight rod" chance="500" />
 		<item name="boots of haste" chance="666" />
 		<item id="2229" countmax="3" chance="20000" /><!-- skull -->
-		<item id="2230" countmax="1" chance="30000" /><!-- bone -->
-		<item id="2231" countmax="1" chance="6000" /><!-- big bone -->
+		<item id="2230" chance="30000" /><!-- bone -->
+		<item id="2231" chance="6000" /><!-- big bone -->
 		<item name="fire sword" chance="220" />
 		<item name="katana" chance="10000" />
 		<item name="clerical mace" chance="5000" />
 		<item name="skull staff" chance="833" />
-		<item name="bone club" countmax="1" chance="19900" />
-		<item name="scale armor" countmax="1" chance="8500" />
+		<item name="bone club" chance="19900" />
+		<item name="scale armor" chance="8500" />
 		<item name="bone shield" chance="7500" />
 		<item name="mystic turban" chance="909" />
 		<item name="grave flower" chance="20000" />
-		<item name="green mushroom" countmax="1" chance="22500" />
+		<item name="green mushroom" chance="22500" />
 		<item name="shadow herb" countmax="2" chance="20000" />
 		<item name="horseman helmet" chance="150" />
 		<item name="worm" countmax="10" chance="50000" />

--- a/data/monster/Bosses/the_abomination.xml
+++ b/data/monster/Bosses/the_abomination.xml
@@ -50,6 +50,6 @@
 		<item name="gold coin" countmax="100" chance="100000" />
 		<item name="platinum coin" countmax="3" chance="10000" />
 		<item name="soul orb" chance="2500" />
-		<item name="demonic essence" countmax="1" chance="2857" />
+		<item name="demonic essence" chance="2857" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/the_evil_eye.xml
+++ b/data/monster/Bosses/the_evil_eye.xml
@@ -74,6 +74,6 @@
 		<item name="crystal mace" chance="1000" />
 		<item name="djinn blade" chance="800" />
 		<item name="worm" countmax="10" chance="50000" />
-		<item name="bonelord eye" countmax="1" chance="5000" />
+		<item name="bonelord eye" chance="5000" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/the_horned_fox.xml
+++ b/data/monster/Bosses/the_horned_fox.xml
@@ -63,7 +63,7 @@
 		<item name="plate legs" chance="1818" />
 		<item name="green tunic" chance="2500" />
 		<item name="meat" countmax="2" chance="33333" />
-		<item id="2667" countmax="1" chance="20000" /><!-- fish -->
+		<item id="2667" chance="20000" /><!-- fish -->
 		<item name="worm" countmax="10" chance="50000" />
 		<item name="nose ring" chance="100000" />
 	</loot>

--- a/data/monster/Bosses/the_imperor.xml
+++ b/data/monster/Bosses/the_imperor.xml
@@ -66,7 +66,7 @@
 	<loot>
 		<item id="2050" chance="15000" /><!-- torch -->
 		<item name="gold coin" countmax="79" chance="100000" />
-		<item name="small amethyst" countmax="1" chance="8888" />
+		<item name="small amethyst" chance="8888" />
 		<item name="stealth ring" chance="4555" />
 		<item name="necrotic rod" chance="833" />
 		<item name="blank rune" chance="18000" />
@@ -76,7 +76,7 @@
 		<item name="pitchfork" chance="20000" />
 		<item name="soul orb" chance="5666" />
 		<item id="6300" chance="999" /><!-- death ring -->
-		<item name="demonic essence" countmax="1" chance="7777" />
+		<item name="demonic essence" chance="7777" />
 		<item name="infernal bolt" countmax="5" chance="5000" />
 		<item name="the Imperor's trident" chance="100000" />
 		<item name="concentrated demonic blood" chance="2222" />

--- a/data/monster/Bosses/verminor.xml
+++ b/data/monster/Bosses/verminor.xml
@@ -69,13 +69,13 @@
 		<voice sentence="DEATH TO ALL!" yell="1" />
 	</voices>
 	<loot>
-		<item name="purple tome" countmax="1" chance="2600" />
-		<item name="golden mug" countmax="1" chance="7500" />
-		<item name="teddy bear" countmax="1" chance="14500" />
-		<item name="ring of the sky" countmax="1" chance="3500" />
-		<item id="2124" countmax="1" chance="5500" />
-		<item name="crystal necklace" countmax="1" chance="1500" />
-		<item name="ancient amulet" countmax="1" chance="3500" />
+		<item name="purple tome" chance="2600" />
+		<item name="golden mug" chance="7500" />
+		<item name="teddy bear" chance="14500" />
+		<item name="ring of the sky" chance="3500" />
+		<item id="2124" chance="5500" />
+		<item name="crystal necklace" chance="1500" />
+		<item name="ancient amulet" chance="3500" />
 		<item name="white pearl" countmax="15" chance="12500" />
 		<item name="black pearl" countmax="15" chance="15000" />
 		<item name="small diamond" countmax="5" chance="9500" />
@@ -87,44 +87,44 @@
 		<item name="small emerald" countmax="10" chance="15500" />
 		<item name="small amethyst" countmax="20" chance="13500" />
 		<item name="talon" countmax="7" chance="14000" />
-		<item name="green gem" countmax="1" chance="1500" />
-		<item name="blue gem" countmax="1" chance="1500" />
-		<item id="2162" countmax="1" chance="11500" />
-		<item name="might ring" countmax="1" chance="5000" />
-		<item name="stealth ring" countmax="1" chance="9500" />
-		<item name="energy ring" countmax="1" chance="13500" />
-		<item name="silver amulet" countmax="1" chance="13000" />
-		<item name="platinum amulet" countmax="1" chance="4500" />
-		<item name="strange symbol" countmax="1" chance="2500" />
-		<item name="orb" countmax="1" chance="12000" />
-		<item name="life crystal" countmax="1" chance="1000" />
-		<item name="mind stone" countmax="1" chance="4000" />
-		<item name="gold ring" countmax="1" chance="8000" />
-		<item name="snakebite rod" countmax="1" chance="3500" />
-		<item name="necrotic rod" countmax="1" chance="3500" />
-		<item name="moonlight rod" countmax="1" chance="3500" />
-		<item name="wand of decay" countmax="1" chance="2500" />
-		<item id="2192" countmax="1" chance="2500" />
-		<item name="boots of haste" countmax="1" chance="4000" />
-		<item name="stone skin amulet" countmax="1" chance="4000" />
-		<item name="protection amulet" countmax="1" chance="4500" />
-		<item name="ring of healing" countmax="1" chance="13000" />
-		<item id="2231" countmax="1" chance="9000" />
-		<item name="two handed sword" countmax="1" chance="20000" />
-		<item name="double axe" countmax="1" chance="20000" />
-		<item name="giant sword" countmax="1" chance="12500" />
-		<item name="ice rapier" countmax="1" chance="7500" />
-		<item name="silver dagger" countmax="1" chance="15500" />
-		<item name="golden sickle" countmax="1" chance="4500" />
-		<item name="thunder hammer" countmax="1" chance="13500" />
-		<item name="fire axe" countmax="1" chance="17000" />
-		<item name="dragon hammer" countmax="1" chance="4500" />
-		<item name="skull staff" countmax="1" chance="5000" />
-		<item name="devil helmet" countmax="1" chance="11000" />
-		<item name="golden legs" countmax="1" chance="5000" />
-		<item name="magic plate armor" countmax="1" chance="3000" />
-		<item name="mastermind shield" countmax="1" chance="7500" />
-		<item name="demon shield" countmax="1" chance="15500" />
-		<item id="3955" countmax="1" chance="100" />
+		<item name="green gem" chance="1500" />
+		<item name="blue gem" chance="1500" />
+		<item id="2162" chance="11500" />
+		<item name="might ring" chance="5000" />
+		<item name="stealth ring" chance="9500" />
+		<item name="energy ring" chance="13500" />
+		<item name="silver amulet" chance="13000" />
+		<item name="platinum amulet" chance="4500" />
+		<item name="strange symbol" chance="2500" />
+		<item name="orb" chance="12000" />
+		<item name="life crystal" chance="1000" />
+		<item name="mind stone" chance="4000" />
+		<item name="gold ring" chance="8000" />
+		<item name="snakebite rod" chance="3500" />
+		<item name="necrotic rod" chance="3500" />
+		<item name="moonlight rod" chance="3500" />
+		<item name="wand of decay" chance="2500" />
+		<item id="2192" chance="2500" />
+		<item name="boots of haste" chance="4000" />
+		<item name="stone skin amulet" chance="4000" />
+		<item name="protection amulet" chance="4500" />
+		<item name="ring of healing" chance="13000" />
+		<item id="2231" chance="9000" />
+		<item name="two handed sword" chance="20000" />
+		<item name="double axe" chance="20000" />
+		<item name="giant sword" chance="12500" />
+		<item name="ice rapier" chance="7500" />
+		<item name="silver dagger" chance="15500" />
+		<item name="golden sickle" chance="4500" />
+		<item name="thunder hammer" chance="13500" />
+		<item name="fire axe" chance="17000" />
+		<item name="dragon hammer" chance="4500" />
+		<item name="skull staff" chance="5000" />
+		<item name="devil helmet" chance="11000" />
+		<item name="golden legs" chance="5000" />
+		<item name="magic plate armor" chance="3000" />
+		<item name="mastermind shield" chance="7500" />
+		<item name="demon shield" chance="15500" />
+		<item id="3955" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Bosses/warlord_ruzad.xml
+++ b/data/monster/Bosses/warlord_ruzad.xml
@@ -46,6 +46,6 @@
 		<item name="brass legs" chance="3333" />
 		<item name="crusader helmet" chance="6670" />
 		<item name="meat" chance="20000" countmax="3" />
-		<item id="2667" chance="6667" countmax="1" /><!-- fish -->
+		<item id="2667" chance="6667" /><!-- fish -->
 	</loot>
 </monster>

--- a/data/monster/Canines/dog.xml
+++ b/data/monster/Canines/dog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Dog" nameDescription="a dog" race="blood" experience="0" speed="140" manacost="220">
+<monster name="Dog" nameDescription="a dog" race="blood" experience="0" speed="124" manacost="220">
 	<health now="20" max="20" />
 	<look type="32" corpse="5971" />
 	<targetchange interval="4000" chance="0" />
@@ -19,8 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
-	<defenses armor="5" defense="5" />
+	<defenses armor="1" defense="1" />
 	<voices interval="5000" chance="10">
-		<voice sentence="Wuff! Wuff!" />
+		<voice sentence="Wuff wuff" />
 	</voices>
 </monster>

--- a/data/monster/Canines/wolf.xml
+++ b/data/monster/Canines/wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wolf" nameDescription="a wolf" race="blood" experience="18" speed="160" manacost="255">
+<monster name="Wolf" nameDescription="a wolf" race="blood" experience="18" speed="164" manacost="255">
 	<health now="25" max="25" />
 	<look type="27" corpse="5968" />
 	<targetchange interval="4000" chance="0" />
@@ -20,21 +20,20 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="2000" min="0" max="-20" />
+		<attack name="melee" interval="2000" min="0" max="-17" />
 	</attacks>
-	<defenses armor="5" defense="5" />
+	<defenses armor="1" defense="1" />
 	<elements>
-		<element earthPercent="5" />
-		<element holyPercent="5" />
-		<element icePercent="-5" />
+		<element holyPercent="30" />
+		<element icePercent="-10" />
 		<element deathPercent="-5" />
 	</elements>
 	<voices interval="5000" chance="10">
-		<voice sentence="Yoooohhuuu!" />
-		<voice sentence="Grrrrrr" />
+		<voice sentence="Yoooohhuuuu!" />
+		<voice sentence="Grrrrrrr" />
 	</voices>
 	<loot>
-		<item name="meat" countmax="2" chance="55000" />
-		<item name="wolf paw" chance="980" />
+		<item name="meat" countmax="2" chance="70000" />
+		<item name="wolf paw" chance="1000" />
 	</loot>
 </monster>

--- a/data/monster/Demons/fire_devil.xml
+++ b/data/monster/Demons/fire_devil.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Fire Devil" nameDescription="a fire devil" race="blood" experience="145" speed="190" manacost="530">
+<monster name="Fire Devil" nameDescription="a fire devil" race="blood" experience="145" speed="180" manacost="530">
 	<health now="200" max="200" />
 	<look type="40" corpse="5985" />
 	<targetchange interval="4000" chance="10" />
@@ -29,7 +29,7 @@
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
 	</attacks>
-	<defenses armor="10" defense="10" />
+	<defenses armor="13" defense="13" />
 	<elements>
 		<element energyPercent="30" />
 		<element earthPercent="20" />
@@ -43,18 +43,17 @@
 	</immunities>
 	<voices interval="5000" chance="10">
 		<voice sentence="Hot, eh?" />
-		<voice sentence="Hell, oh hell!" />
+		<voice sentence="Hell, oh, hell!" />
 	</voices>
 	<loot>
-		<item id="2050" chance="10000" /><!-- torch -->
-		<item id="2050" countmax="2" chance="1420" /><!-- torch -->
-		<item name="small amethyst" chance="300" />
-		<item name="necrotic rod" chance="460" />
-		<item name="blank rune" chance="10950" />
-		<item name="double axe" chance="1500" />
-		<item id="2419" chance="3000" /><!-- scimitar -->
-		<item name="guardian shield" chance="210" />
-		<item name="cleaver" chance="1100" />
 		<item name="small pitchfork" chance="19770" />
+		<item name="blank rune" chance="11000" />
+		<item id="2419" chance="3000" /><!-- scimitar -->
+		<item id="2050" countmax="2" chance="1370" /><!-- torch -->
+		<item name="double axe" chance="1200" />
+		<item name="cleaver" chance="920" />
+		<item name="necrotic rod" chance="460" />
+		<item name="small amethyst" chance="280" />
+		<item name="guardian shield" chance="210" />
 	</loot>
 </monster>

--- a/data/monster/Demons/plaguesmith.xml
+++ b/data/monster/Demons/plaguesmith.xml
@@ -18,7 +18,7 @@
 		<flag canwalkonenergy="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="1500" min="0" max="-539" poison="200" />
+		<attack name="melee" interval="2000" min="0" max="-539" poison="200" />
 		<attack name="earth" interval="2000" chance="15" radius="4" target="0" min="-60" max="-114">
 			<attribute key="areaEffect" value="poison" />
 		</attack>

--- a/data/monster/Dragons/dragon.xml
+++ b/data/monster/Dragons/dragon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dragon" nameDescription="a dragon" race="blood" experience="700" speed="185">
+<monster name="Dragon" nameDescription="a dragon" race="blood" experience="700" speed="172">
 	<health now="1000" max="1000" />
 	<look type="34" corpse="5973" />
 	<targetchange interval="4000" chance="10" />
@@ -26,7 +26,7 @@
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
 	</attacks>
-	<defenses armor="30" defense="30">
+	<defenses armor="25" defense="25">
 		<defense name="healing" interval="2000" chance="15" min="40" max="70">
 			<attribute key="areaEffect" value="blueshimmer" />
 		</defense>
@@ -46,27 +46,26 @@
 		<voice sentence="FCHHHHH" yell="1" />
 	</voices>
 	<loot>
-		<item name="small diamond" chance="380" />
-		<item name="gold coin" countmax="70" chance="47500" />
-		<item name="gold coin" countmax="45" chance="37500" />
-		<item name="life crystal" chance="120" />
-		<item name="wand of inferno" chance="1005" />
-		<item name="double axe" chance="960" />
-		<item name="longsword" chance="4000" />
-		<item name="serpent sword" chance="420" />
-		<item name="broadsword" chance="1950" />
-		<item name="dragon hammer" chance="560" />
-		<item name="crossbow" chance="10000" />
-		<item name="steel helmet" chance="3000" />
-		<item name="steel shield" chance="15000" />
-		<item name="dragon shield" chance="320" />
-		<item name="burst arrow" countmax="10" chance="8060" />
-		<item name="plate legs" chance="2000" />
+		<item name="gold coin" countmax="105" chance="90000" />
 		<item name="dragon ham" countmax="3" chance="65500" />
-		<item name="green dragon leather" chance="1005" />
-		<item name="green dragon scale" chance="1000" />
-		<item name="dragonbone staff" chance="110" />
-		<item name="strong health potion" chance="1000" />
+		<item name="steel shield" chance="15000" />
+		<item name="crossbow" chance="10000" />
 		<item name="dragon's tail" chance="9740" />
+		<item name="burst arrow" countmax="10" chance="8060" />
+		<item name="longsword" chance="4000" />
+		<item name="steel helmet" chance="3000" />
+		<item name="broadsword" chance="1950" />
+		<item name="plate legs" chance="1900" />
+		<item name="wand of inferno" chance="1005" />
+		<item name="strong health potion" chance="1000" />
+		<item name="green dragon scale" chance="1000" />
+		<item name="green dragon leather" chance="1000" />
+		<item name="double axe" chance="1000" />
+		<item name="dragon hammer" chance="560" />
+		<item name="serpent sword" chance="510" />
+		<item name="small diamond" chance="380" />
+		<item name="dragon shield" chance="320" />
+		<item name="life crystal" chance="120" />
+		<item name="dragonbone staff" chance="110" />
 	</loot>
 </monster>

--- a/data/monster/Dragons/dragon_lord.xml
+++ b/data/monster/Dragons/dragon_lord.xml
@@ -49,27 +49,25 @@
 		<voice sentence="YOU WILL BURN!" yell="1" />
 	</voices>
 	<loot>
-		<item name="gemmed book" chance="9000" />
-		<item name="golden mug" chance="3190" />
-		<item name="small sapphire" chance="5300" />
-		<item name="gold coin" countmax="100" chance="33750" />
-		<item name="gold coin" countmax="100" chance="33750" />
-		<item name="gold coin" countmax="45" chance="33750" />
-		<item name="energy ring" chance="5250" />
-		<item name="life crystal" chance="680" />
-		<item name="fire sword" chance="290" />
-		<item name="strange helmet" chance="360" />
-		<item name="dragon scale mail" chance="170" />
-		<item name="royal helmet" chance="280" />
-		<item name="tower shield" chance="250" />
-		<item name="power bolt" countmax="7" chance="6700" />
+		<item name="gold coin" countmax="245" chance="95000" />
 		<item name="dragon ham" countmax="5" chance="80000" />
 		<item name="green mushroom" chance="12000" />
+		<item name="royal spear" countmax="3" chance="9000" />
+		<item id="1976" chance="9000" /><!-- book (gemmed) -->
+		<item name="power bolt" countmax="7" chance="6700" />
+		<item name="energy ring" chance="5250" />
+		<item name="small sapphire" chance="5300" />
+		<item name="golden mug" chance="3190" />
 		<item name="red dragon scale" chance="1920" />
 		<item name="red dragon leather" chance="1040" />
-		<item name="royal spear" countmax="3" chance="8800" />
-		<item name="dragon lord trophy" chance="80" />
-		<item name="dragon slayer" chance="100" />
 		<item name="strong health potion" chance="970" />
+		<item name="life crystal" chance="680" />
+		<item name="strange helmet" chance="360" />
+		<item name="fire sword" chance="290" />
+		<item name="tower shield" chance="250" />
+		<item name="royal helmet" chance="280" />
+		<item name="dragon scale mail" chance="170" />
+		<item name="dragon slayer" chance="110" />
+		<item name="dragon lord trophy" chance="90" />
 	</loot>
 </monster>

--- a/data/monster/Dragons/frost_dragon.xml
+++ b/data/monster/Dragons/frost_dragon.xml
@@ -68,7 +68,7 @@
 		<voice sentence="Chill out!." />
 	</voices>
 	<loot>
-		<item name="gemmed book" chance="8500" />
+		<item id="1976" chance="8500" /><!-- book (gemmed) -->
 		<item name="golden mug" chance="3000" />
 		<item name="small sapphire" chance="5200" />
 		<item name="gold coin" countmax="100" chance="33000" />

--- a/data/monster/Dreamhaunters/minion_of_gaz'haragoth.xml
+++ b/data/monster/Dreamhaunters/minion_of_gaz'haragoth.xml
@@ -42,8 +42,8 @@
 		<voice sentence="Knorrrr!" />
 	</voices>
 	<loot>
-		<item name="white pearl" countmax="1" chance="866" />
-		<item name="black pearl" countmax="1" chance="866" />
+		<item name="white pearl" chance="866" />
+		<item name="black pearl" chance="866" />
 		<item name="gold coin" countmax="100" chance="30000" />
 		<item name="platinum coin" countmax="10" chance="33333" />
 		<item name="giant sword" chance="422" />

--- a/data/monster/Dreamhaunters/nightmare_of_gaz'haragoth.xml
+++ b/data/monster/Dreamhaunters/nightmare_of_gaz'haragoth.xml
@@ -42,8 +42,8 @@
 		<voice sentence="Knorrrr!" />
 	</voices>
 	<loot>
-		<item name="white pearl" countmax="1" chance="866" />
-		<item name="black pearl" countmax="1" chance="866" />
+		<item name="white pearl" chance="866" />
+		<item name="black pearl" chance="866" />
 		<item name="gold coin" countmax="100" chance="30000" />
 		<item name="platinum coin" countmax="10" chance="33333" />
 		<item name="giant sword" chance="422" />

--- a/data/monster/Dreamhaunters/shiversleep.xml
+++ b/data/monster/Dreamhaunters/shiversleep.xml
@@ -44,8 +44,8 @@
 		<voice sentence="Knorrrr!" />
 	</voices>
 	<loot>
-		<item name="white pearl" countmax="1" chance="866" />
-		<item name="black pearl" countmax="1" chance="866" />
+		<item name="white pearl" chance="866" />
+		<item name="black pearl" chance="866" />
 		<item name="gold coin" countmax="100" chance="30000" />
 		<item name="platinum coin" countmax="10" chance="33333" />
 		<item name="giant sword" chance="422" />

--- a/data/monster/Dwarves/dwarf.xml
+++ b/data/monster/Dwarves/dwarf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Dwarf" nameDescription="a dwarf" race="blood" experience="45" speed="180" manacost="320">
+<monster name="Dwarf" nameDescription="a dwarf" race="blood" experience="45" speed="170" manacost="320">
 	<health now="90" max="90" />
 	<look type="69" corpse="6007" />
 	<targetchange interval="4000" chance="0" />
@@ -22,7 +22,7 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />
 	</attacks>
-	<defenses armor="10" defense="10" />
+	<defenses armor="8" defense="8" />
 	<elements>
 		<element earthPercent="10" />
 		<element firePercent="-5" />
@@ -32,16 +32,16 @@
 		<voice sentence="Hail Durin!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="8" chance="35000" />
-		<item name="dwarven ring" chance="100" />
-		<item name="axe" chance="15000" />
-		<item name="hatchet" chance="25000" />
-		<item name="studded armor" chance="8000" />
-		<item name="copper shield" chance="10000" />
-		<item name="pick" chance="10000" />
-		<item name="letter" chance="8000" />
-		<item name="leather legs" chance="10000" />
 		<item name="white mushroom" chance="50000" />
-		<item name="iron ore" chance="700" />
+		<item name="gold coin" countmax="8" chance="35000" />
+		<item name="hatchet" chance="25000" />
+		<item name="axe" chance="15000" />
+		<item name="pick" chance="10000" />
+		<item name="copper shield" chance="10000" />
+		<item name="leather legs" chance="10000" />
+		<item name="studded armor" chance="8000" />
+		<item name="letter" chance="8000" />
+		<item name="dwarven ring" chance="100" />
+		<item name="iron ore" chance="100" />
 	</loot>
 </monster>

--- a/data/monster/Felines/midnight_panther.xml
+++ b/data/monster/Felines/midnight_panther.xml
@@ -17,7 +17,7 @@
 		<flag runonhealth="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="1500" min="0" max="-90" />
+		<attack name="melee" interval="2000" min="0" max="-90" />
 		<attack name="energy" interval="2000" chance="15" range="7" min="-75" max="-215">
 			<attribute key="shootEffect" value="energy" />
 			<attribute key="areaEffect" value="energyarea" />

--- a/data/monster/Giants/cyclops.xml
+++ b/data/monster/Giants/cyclops.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Cyclops" nameDescription="a cyclops" race="blood" experience="150" speed="200" manacost="490">
+<monster name="Cyclops" nameDescription="a cyclops" race="blood" experience="150" speed="190" manacost="490">
 	<health now="260" max="260" />
 	<look type="22" corpse="5962" />
 	<targetchange interval="4000" chance="10" />
@@ -22,7 +22,7 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-105" />
 	</attacks>
-	<defenses armor="20" defense="20" />
+	<defenses armor="17" defense="17" />
 	<elements>
 		<element energyPercent="25" />
 		<element holyPercent="20" />
@@ -37,17 +37,17 @@
 		<voice sentence="Let da mashing begin!" />
 	</voices>
 	<loot>
-		<item name="wolf tooth chain" chance="190" />
 		<item name="gold coin" countmax="47" chance="82000" />
-		<item name="club ring" chance="90" />
-		<item name="halberd" chance="1003" />
+		<item name="meat" chance="30070" />
 		<item name="short sword" chance="8000" />
-		<item name="dark helmet" chance="220" />
+		<item name="cyclops toe" chance="4930" />
 		<item name="plate shield" chance="2500" />
 		<item name="battle shield" chance="1400" />
-		<item name="meat" chance="30070" />
-		<item id="7398" chance="80" /><!-- cyclops trophy -->
-		<item name="health potion" chance="210" />
-		<item name="cyclops toe" chance="4930" />
+		<item name="halberd" chance="730" />
+		<item name="wolf tooth chain" chance="360" />
+		<item name="dark helmet" chance="230" />
+		<item id="7398" chance="180" /><!-- cyclops trophy -->
+		<item name="club ring" chance="140" />
+		<item name="health potion" chance="50" />
 	</loot>
 </monster>

--- a/data/monster/Glires/rat.xml
+++ b/data/monster/Glires/rat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Rat" nameDescription="a rat" race="blood" experience="5" speed="135" manacost="200">
+<monster name="Rat" nameDescription="a rat" race="blood" experience="5" speed="134" manacost="200">
 	<health now="20" max="20" />
 	<look type="21" corpse="5964" />
 	<targetchange interval="4000" chance="0" />
@@ -20,11 +20,11 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="2000" min="0" max="-10" />
+		<attack name="melee" interval="2000" min="0" max="-8" />
 	</attacks>
-	<defenses armor="5" defense="5" />
+	<defenses armor="1" defense="1" />
 	<elements>
-		<element earthPercent="25" />
+		<element earthPercent="20" />
 		<element holyPercent="20" />
 		<element icePercent="-10" />
 		<element deathPercent="-10" />

--- a/data/monster/Insects/bug.xml
+++ b/data/monster/Insects/bug.xml
@@ -22,12 +22,12 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-23" />
 	</attacks>
-	<defenses armor="5" defense="5" />
+	<defenses armor="2" defense="2" />
 	<elements>
 		<element firePercent="-10" />
 	</elements>
 	<loot>
-		<item name="gold coin" countmax="6" chance="51170" />
-		<item name="cherry" countmax="3" chance="2590" />
+		<item name="gold coin" countmax="6" chance="50000" />
+		<item name="cherry" countmax="3" chance="3000" />
 	</loot>
 </monster>

--- a/data/monster/Insects/wasp.xml
+++ b/data/monster/Insects/wasp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Wasp" nameDescription="a wasp" race="venom" experience="24" speed="260" manacost="280">
+<monster name="Wasp" nameDescription="a wasp" race="venom" experience="24" speed="320" manacost="280">
 	<health now="35" max="35" />
 	<look type="44" corpse="5989" />
 	<targetchange interval="4000" chance="10" />
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<attacks>
-		<attack name="melee" interval="1500" min="0" max="-20" poison="20" />
+		<attack name="melee" interval="2000" min="0" max="-20" poison="20" />
 	</attacks>
 	<defenses armor="10" defense="10" />
 	<elements>

--- a/data/monster/Minotaurs/minotaur.xml
+++ b/data/monster/Minotaurs/minotaur.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Minotaur" nameDescription="a minotaur" race="blood" experience="50" speed="170" manacost="330">
+<monster name="Minotaur" nameDescription="a minotaur" race="blood" experience="50" speed="168" manacost="330">
 	<health now="100" max="100" />
 	<look type="25" corpse="5969" />
 	<targetchange interval="4000" chance="0" />
@@ -22,30 +22,29 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />
 	</attacks>
-	<defenses armor="15" defense="15" />
+	<defenses armor="11" defense="11" />
 	<elements>
 		<element firePercent="20" />
 		<element holyPercent="10" />
 		<element icePercent="-10" />
-		<element deathPercent="-5" />
-		<element energyPercent="-15" />
+		<element deathPercent="-10" />
 	</elements>
 	<voices interval="5000" chance="10">
 		<voice sentence="Kaplar!" />
-		<voice sentence="Hurr!" />
+		<voice sentence="Hurr" />
 	</voices>
 	<loot>
 		<item name="gold coin" countmax="25" chance="67500" />
-		<item name="bronze amulet" chance="110" />
-		<item id="2376" chance="5000" /><!-- sword -->
-		<item name="axe" chance="4000" />
-		<item name="mace" chance="12840" />
-		<item name="brass helmet" chance="7700" />
-		<item name="chain armor" chance="10000" />
 		<item name="plate shield" chance="20020" />
-		<item id="2554" chance="310" /><!-- shovel -->
+		<item name="mace" chance="12840" />
+		<item name="chain armor" chance="10000" />
+		<item name="brass helmet" chance="7700" />
+		<item id="2376" chance="5000" /><!-- sword -->
 		<item name="meat" chance="5000" />
-		<item name="minotaur leather" chance="990" />
+		<item name="axe" chance="4000" />
 		<item name="minotaur horn" countmax="2" chance="2090" />
+		<item name="minotaur leather" chance="990" />
+		<item id="2554" chance="310" /><!-- shovel -->
+		<item name="bronze amulet" chance="110" />
 	</loot>
 </monster>

--- a/data/monster/Outlaws/hunter.xml
+++ b/data/monster/Outlaws/hunter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Hunter" nameDescription="a hunter" race="blood" experience="150" speed="195" manacost="530">
+<monster name="Hunter" nameDescription="a hunter" race="blood" experience="150" speed="210" manacost="530">
 	<health now="150" max="150" />
 	<look type="129" head="95" body="116" legs="121" feet="115" corpse="20419" />
 	<targetchange interval="4000" chance="10" />
@@ -25,10 +25,10 @@
 			<attribute key="shootEffect" value="arrow" />
 		</attack>
 	</attacks>
-	<defenses armor="15" defense="15" />
+	<defenses armor="8" defense="8" />
 	<elements>
 		<element holyPercent="20" />
-		<element physicalPercent="-10" />
+		<element physicalPercent="-5" />
 	</elements>
 	<voices interval="5000" chance="10">
 		<voice sentence="Guess who we're hunting, haha!" />
@@ -37,22 +37,22 @@
 		<voice sentence="You'll make a nice trophy!" />
 	</voices>
 	<loot>
-		<item id="2050" chance="3300" /><!-- torch -->
-		<item name="small ruby" chance="150" />
-		<item name="dragon necklace" chance="3000" />
-		<item name="bow" chance="5770" />
-		<item name="brass helmet" chance="5050" />
-		<item name="brass armor" chance="5070" />
 		<item name="arrow" countmax="22" chance="82000" />
-		<item name="poison arrow" countmax="4" chance="4500" />
-		<item name="burst arrow" countmax="3" chance="5360" />
 		<item name="orange" countmax="2" chance="20300" />
 		<item name="roll" countmax="2" chance="11370" />
-		<item name="sniper gloves" chance="610" />
-		<item name="slingshot" chance="120" />
-		<item id="7394" chance="190" /><!-- wolf trophy -->
-		<item id="7397" chance="520" /><!-- deer trophy -->
-		<item id="7400" chance="70" /><!-- lion trophy -->
 		<item name="hunter's quiver" chance="10240" />
+		<item name="bow" chance="5770" />
+		<item name="burst arrow" countmax="3" chance="5360" />
+		<item name="brass armor" chance="5070" />
+		<item name="brass helmet" chance="5050" />
+		<item name="poison arrow" countmax="4" chance="4500" />
+		<item name="dragon necklace" chance="3000" />
+		<item id="2050" chance="3300" /><!-- torch -->
+		<item name="sniper gloves" chance="610" />
+		<item id="7397" chance="520" /><!-- deer trophy -->
+		<item name="small ruby" chance="170" />
+		<item id="7400" chance="140" /><!-- lion trophy -->
+		<item id="7394" chance="130" /><!-- wolf trophy -->
+		<item name="slingshot" chance="120" />
 	</loot>
 </monster>

--- a/data/monster/Outlaws/wild_warrior.xml
+++ b/data/monster/Outlaws/wild_warrior.xml
@@ -22,7 +22,7 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-70" />
 	</attacks>
-	<defenses armor="20" defense="20">
+	<defenses armor="8" defense="8">
 		<defense name="speed" interval="2000" chance="15" speedchange="200" duration="5000">
 			<attribute key="areaEffect" value="redshimmer" />
 		</defense>
@@ -37,17 +37,15 @@
 		<voice sentence="Gimme your money!" />
 	</voices>
 	<loot>
-		<item id="2110" chance="520" /><!-- doll -->
-		<item name="gold coin" countmax="30" chance="49070" />
-		<item name="axe" chance="30710" />
-		<item name="war hammer" chance="100" />
-		<item name="mace" chance="9800" />
-		<item name="chain helmet" chance="5250" />
-		<item name="iron helmet" chance="580" />
-		<item name="brass armor" chance="2540" />
-		<item name="steel shield" chance="910" />
+		<item name="gold coin" countmax="30" chance="64000" />
+		<item name="axe" chance="21000" />
 		<item name="brass shield" chance="17000" />
-		<item name="leather legs" chance="27500" />
-		<item id="2695" countmax="2" chance="9730" /><!-- eggs -->
+		<item name="mace" chance="13000" />
+		<item id="2695" countmax="2" chance="12000" /><!-- egg -->
+		<item name="chain helmet" chance="5250" />
+		<item name="brass armor" chance="2800" />
+		<item name="steel shield" chance="1330" />
+		<item name="iron helmet" chance="1000" />
+		<item id="2110" chance="520" /><!-- doll -->
 	</loot>
 </monster>

--- a/data/monster/Pyro-Elementals/fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/fire_elemental.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Fire Elemental" nameDescription="a fire elemental" race="fire" experience="220" speed="200" manacost="690">
+<monster name="Fire Elemental" nameDescription="a fire elemental" race="fire" experience="220" speed="190" manacost="690">
 	<health now="280" max="280" />
 	<look type="49" corpse="8964" />
 	<targetchange interval="4000" chance="10" />
@@ -28,7 +28,7 @@
 			<attribute key="shootEffect" value="fire" />
 		</attack>
 	</attacks>
-	<defenses armor="15" defense="15" />
+	<defenses armor="18" defense="18" />
 	<elements>
 		<element icePercent="-25" />
 	</elements>

--- a/data/monster/Pyro-Elementals/magma_crawler.xml
+++ b/data/monster/Pyro-Elementals/magma_crawler.xml
@@ -56,9 +56,8 @@
 	</voices>
 	<loot>
 		<item name="small diamond" countmax="3" chance="8800" />
-		<item name="gold coin" countmax="100" chance="50000" />
-		<item name="gold coin" countmax="99" chance="50000" />
-		<item name="platinum coin" countmax="5" chance="100000" />
+		<item name="gold coin" countmax="200" chance="100000" />
+		<item name="platinum coin" countmax="5" chance="95000" />
 		<item name="yellow gem" chance="1030" />
 		<item name="energy ring" chance="1650" />
 		<item name="fire sword" chance="1680" />
@@ -81,7 +80,6 @@
 		<item name="blue crystal splinter" countmax="2" chance="8500" />
 		<item name="green crystal fragment" chance="7000" />
 		<item name="magma clump" chance="11600" />
-		<item name="blazing bone" countmax="1" chance="11500" />
-		<item name="blazing bone" chance="12220" />
+		<item name="blazing bone" chance="11500" />
 	</loot>
 </monster>

--- a/data/monster/Pyro-Elementals/massive_fire_elemental.xml
+++ b/data/monster/Pyro-Elementals/massive_fire_elemental.xml
@@ -49,7 +49,7 @@
 		<item name="gold coin" countmax="100" chance="50000" />
 		<item name="gold coin" countmax="100" chance="25000" />
 		<item name="gold coin" countmax="12" chance="25000" />
-		<item name="bronze amulet" countmax="1" chance="15000" />
+		<item name="bronze amulet" chance="15000" />
 		<item name="wand of inferno" chance="2240" />
 		<item name="fire sword" chance="530" />
 		<item name="magma amulet" chance="1300" />

--- a/data/monster/Skeletons/demon_skeleton.xml
+++ b/data/monster/Skeletons/demon_skeleton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Demon Skeleton" nameDescription="a demon skeleton" race="undead" experience="240" speed="170" manacost="620">
+<monster name="Demon Skeleton" nameDescription="a demon skeleton" race="undead" experience="240" speed="180" manacost="620">
 	<health now="400" max="400" />
 	<look type="37" corpse="5963" />
 	<targetchange interval="4000" chance="10" />
@@ -23,7 +23,7 @@
 			<attribute key="areaEffect" value="smallclouds" />
 		</attack>
 	</attacks>
-	<defenses armor="30" defense="30" />
+	<defenses armor="25" defense="25" />
 	<elements>
 		<element holyPercent="-25" />
 	</elements>
@@ -37,20 +37,19 @@
 		<immunity drunk="1" />
 	</immunities>
 	<loot>
-		<item id="2050" chance="5270" /><!-- torch -->
-		<item name="black pearl" chance="2900" />
-		<item name="small ruby" chance="1400" />
 		<item name="gold coin" countmax="75" chance="97000" />
-		<item name="mind stone" chance="520" />
-		<item name="mysterious fetish" chance="690" />
+		<item name="demonic skeletal hand" chance="12600" />
 		<item name="throwing star" countmax="3" chance="10000" />
+		<item name="health potion" countmax="2" chance="9700" />
+		<item name="mana potion" chance="5000" />
+		<item name="battle shield" chance="5000" />
+		<item id="2050" chance="4800" /><!-- torch -->
 		<item name="battle hammer" chance="4000" />
 		<item name="iron helmet" chance="3450" />
-		<item name="battle shield" chance="5000" />
-		<item name="guardian shield" chance="100" />
-		<item name="health potion" countmax="2" chance="10120" />
-		<item name="health potion" countmax="2" chance="10000" />
-		<item name="mana potion" chance="5300" />
-		<item name="demonic skeletal hand" chance="12600" />
+		<item name="black pearl" chance="2900" />
+		<item name="small ruby" chance="1500" />
+		<item name="mysterious fetish" chance="530" />
+		<item name="mind stone" chance="470" />
+		<item name="guardian shield" chance="110" />
 	</loot>
 </monster>

--- a/data/monster/Skeletons/honour_guard.xml
+++ b/data/monster/Skeletons/honour_guard.xml
@@ -40,7 +40,7 @@
 	</voices>
 	<loot>
 		<item name="gold coin" countmax="15" chance="50000" />
-		<item name="scarab coin" countmax="1" chance="2600" />
+		<item name="scarab coin" chance="2600" />
 		<item name="mace" chance="3760" />
 		<item id="2419" chance="1640" /><!-- scimitar -->
 		<item name="brown mushroom" countmax="2" chance="6120" />

--- a/data/monster/Sorcerers/warlock.xml
+++ b/data/monster/Sorcerers/warlock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Warlock" nameDescription="a warlock" race="blood" experience="4000" speed="220">
+<monster name="Warlock" nameDescription="a warlock" race="blood" experience="4000" speed="230">
 	<health now="3500" max="3500" />
 	<look type="130" head="19" body="71" legs="128" feet="128" addons="1" corpse="20527" />
 	<targetchange interval="4000" chance="10" />
@@ -47,7 +47,7 @@
 	</defenses>
 	<elements>
 		<element earthPercent="95" />
-		<element holyPercent="-5" />
+		<element holyPercent="-8" />
 		<element physicalPercent="-5" />
 	</elements>
 	<immunities>

--- a/data/monster/Undead_Humanoids/ghoul.xml
+++ b/data/monster/Undead_Humanoids/ghoul.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ghoul" nameDescription="a ghoul" race="blood" experience="85" speed="170" manacost="450">
+<monster name="Ghoul" nameDescription="a ghoul" race="blood" experience="85" speed="144" manacost="450">
 	<health now="100" max="100" />
 	<look type="18" corpse="5976" />
 	<targetchange interval="4000" chance="0" />
@@ -25,7 +25,7 @@
 			<attribute key="areaEffect" value="smallclouds" />
 		</attack>
 	</attacks>
-	<defenses armor="15" defense="15">
+	<defenses armor="8" defense="8">
 		<defense name="healing" interval="2000" chance="5" min="9" max="15">
 			<attribute key="areaEffect" value="blueshimmer" />
 		</defense>
@@ -45,16 +45,16 @@
 		<immunity invisible="1" />
 	</immunities>
 	<loot>
-		<item id="2050" chance="5000" /><!-- torch -->
-		<item name="gold coin" countmax="30" chance="68000" />
-		<item name="life ring" chance="180" />
-		<item id="2229" chance="240" /><!-- skull -->
-		<item name="viking helmet" chance="990" />
-		<item name="scale armor" chance="1000" />
-		<item name="worm" countmax="2" chance="9600" />
-		<item name="brown piece of cloth" chance="1000" />
+		<item name="gold coin" countmax="30" chance="70000" />
 		<item name="rotten piece of cloth" chance="14470" />
+		<item name="worm" countmax="2" chance="10000" />
+		<item id="2050" chance="5000" /><!-- torch -->
 		<item name="ghoul snack" chance="5130" />
+		<item name="viking helmet" chance="1000" />
+		<item name="brown piece of cloth" chance="1000" />
 		<item name="pile of grave earth" chance="950" />
+		<item name="scale armor" chance="940" />
+		<item id="2229" chance="280" /><!-- skull -->
+		<item name="life ring" chance="190" />
 	</loot>
 </monster>

--- a/data/monster/Ungulates/black_sheep.xml
+++ b/data/monster/Ungulates/black_sheep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Black Sheep" namedescription="a black sheep" race="blood" experience="0" speed="130" manacost="250">
+<monster name="Black Sheep" namedescription="a black sheep" race="blood" experience="0" speed="116" manacost="250">
 	<health now="20" max="20" />
 	<look type="13" corpse="5994" />
 	<targetchange interval="4000" chance="20" />
@@ -19,12 +19,15 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
-	<defenses armor="5" defense="5" />
+	<defenses armor="1" defense="1" />
+	<elements>
+		<element firePercent="-5" />
+	</elements>
 	<voices interval="5000" chance="10">
 		<voice sentence="Maeh" />
 	</voices>
 	<loot>
-		<item name="meat" countmax="5" chance="70860" />
-		<item name="black wool" countmax="1" chance="1000" />
+		<item name="meat" countmax="5" chance="55380" />
+		<item name="black wool" chance="620" />
 	</loot>
 </monster>

--- a/data/monster/Ungulates/deer.xml
+++ b/data/monster/Ungulates/deer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Deer" nameDescription="a deer" race="blood" experience="0" speed="150" manacost="260">
+<monster name="Deer" nameDescription="a deer" race="blood" experience="0" speed="196" manacost="260">
 	<health now="25" max="25" />
 	<look type="31" corpse="5970" />
 	<targetchange interval="4000" chance="20" />
@@ -22,10 +22,10 @@
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1" />
 	</attacks>
-	<defenses armor="5" defense="5" />
+	<defenses armor="2" defense="2" />
 	<loot>
 		<item name="meat" countmax="4" chance="80000" />
 		<item name="ham" countmax="2" chance="50000" />
-		<item id="11214" chance="870" /><!-- antlers -->
+		<item id="11214" chance="1150" /><!-- antlers -->
 	</loot>
 </monster>


### PR DESCRIPTION
- Removed countmax="1" because it is useless
- Fixed speed and armor from some pre-6.0 monsters
- Fixed gemmed book name
- Fixed duplicated loot in some monsters
- Fixed attack interval and value from some monsters
- Ordered loot by chance as it is on RL tibia
- Updated general murius look and loot
- updated giant spider (wyda) and spider
- Removed leather legs and war hammer from wild warrior as they don't drop them anymore