### PR TITLE
Change github code viewer tab size from 8 to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,14 +8,14 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{cpp,h,lua,xml}]
+indent_style = tab
+indent_size = 4
+
 [**.{.cpp,.h}]
 # Options not ubiquitous, but useful
 indent_brace_style = K&R
 spaces_around_brackets = none
-
-[*.{.cpp,.h,.lua}]
-indent_style = tab
-indent_size = 4
 
 [.travis.yml]
 indent_style = spaces

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,8 @@ trim_trailing_whitespace = true
 # Options not ubiquitous, but useful
 indent_brace_style = K&R
 spaces_around_brackets = none
+indent_style = tab
+indent_size = 4
 
 [.travis.yml]
 indent_style = spaces

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,8 @@ trim_trailing_whitespace = true
 # Options not ubiquitous, but useful
 indent_brace_style = K&R
 spaces_around_brackets = none
+
+[*.{.cpp,.h,.lua}]
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
8 is simply... overkill (And the default on github). Most people work with a tab size of 4, so when viewing code in github, some things like tab aligned elements can look very bad. 

This normalizes tab size for what we use. And makes the viewing experience on github better during etc code reviewing. 