### PR TITLE
Set default channel type to avoid client crash

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7709,7 +7709,7 @@ int LuaScriptInterface::luaCreatureTeleportTo(lua_State* L)
 
 int LuaScriptInterface::luaCreatureSay(lua_State* L)
 {
-	// creature:say(text[, type[, ghost = false[, target = nullptr[, position]]]])
+	// creature:say(text[, type = TALKTYPE_MONSTER_SAY[, ghost = false[, target = nullptr[, position]]]])
 	int parameters = lua_gettop(L);
 
 	Position position;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7729,7 +7729,7 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 
 	bool ghost = getBoolean(L, 4, false);
 
-	SpeakClasses type = getNumber<SpeakClasses>(L, 3);
+	SpeakClasses type = getNumber<SpeakClasses>(L, 3, TALKTYPE_MONSTER_SAY);
 	const std::string& text = getString(L, 2);
 	Creature* creature = getUserdata<Creature>(L, 1);
 	if (!creature) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7709,7 +7709,7 @@ int LuaScriptInterface::luaCreatureTeleportTo(lua_State* L)
 
 int LuaScriptInterface::luaCreatureSay(lua_State* L)
 {
-	// creature:say(text, type[, ghost = false[, target = nullptr[, position]]])
+	// creature:say(text[, type[, ghost = false[, target = nullptr[, position]]]])
 	int parameters = lua_gettop(L);
 
 	Position position;


### PR DESCRIPTION
Should only need to use this on creature:say, type param is at the end of the positional param list, other methods which use type param have more positional params after type.