### PR TITLE
Show Online/Offline in character list

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -75,6 +75,7 @@ emoteSpells = false
 classicEquipmentSlots = false
 classicAttackSpeed = false
 showScriptsLogInConsole = true
+showOnlineStatusInCharlist = false
 
 -- Server Save
 -- NOTE: serverSaveNotifyDuration in minutes

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -144,6 +144,7 @@ bool ConfigManager::load()
 	boolean[SERVER_SAVE_CLEAN_MAP] = getGlobalBoolean(L, "serverSaveCleanMap", false);
 	boolean[SERVER_SAVE_CLOSE] = getGlobalBoolean(L, "serverSaveClose", false);
 	boolean[SERVER_SAVE_SHUTDOWN] = getGlobalBoolean(L, "serverSaveShutdown", true);
+	boolean[ONLINE_OFFLINE_CHARLIST] = getGlobalBoolean(L, "showOnlineStatusInCharlist", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -46,6 +46,7 @@ class ConfigManager
 			SERVER_SAVE_CLEAN_MAP,
 			SERVER_SAVE_CLOSE,
 			SERVER_SAVE_SHUTDOWN,
+			ONLINE_OFFLINE_CHARLIST,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1901,6 +1901,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_CLEAN_MAP)
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_CLOSE)
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_SHUTDOWN)
+	registerEnumIn("configKeys", ConfigManager::ONLINE_OFFLINE_CHARLIST)
 
 	registerEnumIn("configKeys", ConfigManager::MAP_NAME)
 	registerEnumIn("configKeys", ConfigManager::HOUSE_RENT_PERIOD)

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -86,15 +86,19 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	//Add char list
 	output->addByte(0x64);
 
-	output->addByte(1); // number of worlds
-
-	output->addByte(0); // world id
-	output->addString(g_config.getString(ConfigManager::SERVER_NAME));
-	output->addString(g_config.getString(ConfigManager::IP));
-	output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
-	output->addByte(0);
-
 	uint8_t size = std::min<size_t>(std::numeric_limits<uint8_t>::max(), account.characters.size());
+
+	output->addByte(size); // number of worlds
+
+	for (uint8_t i = 0; i < size; i++) {
+		const std::string& character = account.characters[i];
+		output->addByte(0); // world id
+		output->addString((g_game.getCreatureByName(character) ? "Online" : "Offline"));
+		output->addString(g_config.getString(ConfigManager::IP));
+		output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
+		output->addByte(0);
+	}
+
 	output->addByte(size);
 	for (uint8_t i = 0; i < size; i++) {
 		output->addByte(0);

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -89,18 +89,17 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	uint8_t size = std::min<size_t>(std::numeric_limits<uint8_t>::max(), account.characters.size());
 
 	if (g_config.getBoolean(ConfigManager::ONLINE_OFFLINE_CHARLIST)) {
-		output->addByte(size); // number of worlds
+		output->addByte(2); // number of worlds
 
-		for (uint8_t i = 0; i < size; i++) {
-			const std::string& character = account.characters[i];
+		for (uint8_t i = 0; i < 2; i++) {
 			output->addByte(i); // world id
-			output->addString((g_game.getPlayerByName(character) ? "Online" : "Offline"));
+			output->addString(i == 0 ? "Offline" : "Online");
 			output->addString(g_config.getString(ConfigManager::IP));
 			output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
 			output->addByte(0);
 		}
 	} else {
-		output->addByte(1);
+		output->addByte(1); // number of worlds
 		output->addByte(0); // world id
 		output->addString(g_config.getString(ConfigManager::SERVER_NAME));
 		output->addString(g_config.getString(ConfigManager::IP));
@@ -110,8 +109,13 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 
 	output->addByte(size);
 	for (uint8_t i = 0; i < size; i++) {
-		output->addByte(g_config.getBoolean(ConfigManager::ONLINE_OFFLINE_CHARLIST) ? i : 0);
-		output->addString(account.characters[i]);
+		const std::string& character = account.characters[i];
+		if (g_config.getBoolean(ConfigManager::ONLINE_OFFLINE_CHARLIST)) {
+			output->addByte(g_game.getPlayerByName(character) ? 1 : 0);
+		} else {
+			output->addByte(0);
+		}
+		output->addString(character);
 	}
 
 	//Add premium days

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -88,12 +88,21 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 
 	uint8_t size = std::min<size_t>(std::numeric_limits<uint8_t>::max(), account.characters.size());
 
-	output->addByte(size); // number of worlds
+	if (g_config.getBoolean(ConfigManager::ONLINE_OFFLINE_CHARLIST)) {
+		output->addByte(size); // number of worlds
 
-	for (uint8_t i = 0; i < size; i++) {
-		const std::string& character = account.characters[i];
+		for (uint8_t i = 0; i < size; i++) {
+			const std::string& character = account.characters[i];
+			output->addByte(i); // world id
+			output->addString((g_game.getPlayerByName(character) ? "Online" : "Offline"));
+			output->addString(g_config.getString(ConfigManager::IP));
+			output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
+			output->addByte(0);
+		}
+	} else {
+		output->addByte(1);
 		output->addByte(0); // world id
-		output->addString((g_game.getCreatureByName(character) ? "Online" : "Offline"));
+		output->addString(g_config.getString(ConfigManager::SERVER_NAME));
 		output->addString(g_config.getString(ConfigManager::IP));
 		output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
 		output->addByte(0);
@@ -101,7 +110,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 
 	output->addByte(size);
 	for (uint8_t i = 0; i < size; i++) {
-		output->addByte(0);
+		output->addByte(i);
 		output->addString(account.characters[i]);
 	}
 

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -110,7 +110,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 
 	output->addByte(size);
 	for (uint8_t i = 0; i < size; i++) {
-		output->addByte(i);
+		output->addByte(g_config.getBoolean(ConfigManager::ONLINE_OFFLINE_CHARLIST) ? i : 0);
 		output->addString(account.characters[i]);
 	}
 


### PR DESCRIPTION
Includes new config key: showOnlineStatusInCharlist; defaulted to false
Will replace world name with Online or Offline depending on the online status of each character, ex: Player (Forgotten) -> Player (Online).