### PR TITLE
Fix memory leak when reloading global

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1281,15 +1281,19 @@ function createFunctions(class)
 	local exclude = {[2] = {"is"}, [3] = {"get", "set", "add", "can"}, [4] = {"need"}}
 	local temp = {}
 	for name, func in pairs(class) do
+		local add = true
 		for strLen, strTable in pairs(exclude) do
-			if not table.contains(strTable, name:sub(1,strLen)) then
-				local str = name:sub(1,1):upper()..name:sub(2)
-				local getFunc = function(self) return func(self) end
-				local setFunc = function(self, ...) return func(self, ...) end
-				local get = "get".. str
-				local set = "set".. str
-				table.insert(temp, {set, setFunc, get, getFunc})
+			if table.contains(strTable, name:sub(1,strLen)) then
+				add = false
 			end
+		end
+		if add then
+			local str = name:sub(1,1):upper()..name:sub(2)
+			local getFunc = function(self) return func(self) end
+			local setFunc = function(self, ...) return func(self, ...) end
+			local get = "get".. str
+			local set = "set".. str
+			table.insert(temp, {set, setFunc, get, getFunc})
 		end
 	end
 	for _,func in ipairs(temp) do

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1283,20 +1283,22 @@ function createFunctions(class)
 	for name, func in pairs(class) do
 		local add = true
 		for strLen, strTable in pairs(exclude) do
-			if table.contains(strTable, name:sub(1,strLen)) then
+			if table.contains(strTable, name:sub(1, strLen)) then
 				add = false
 			end
 		end
 		if add then
-			local str = name:sub(1,1):upper()..name:sub(2)
+			local str = name:sub(1, 1):upper() .. name:sub(2)
 			local getFunc = function(self) return func(self) end
 			local setFunc = function(self, ...) return func(self, ...) end
-			local get = "get".. str
-			local set = "set".. str
-			table.insert(temp, {set, setFunc, get, getFunc})
+			local get = "get" .. str
+			local set = "set" .. str
+			if not (rawget(class, get) and rawget(class, set)) then
+				table.insert(temp, {set, setFunc, get, getFunc})
+			end
 		end
 	end
-	for _,func in ipairs(temp) do
+	for _, func in ipairs(temp) do
 		rawset(class, func[1], func[2])
 		rawset(class, func[3], func[4])
 	end


### PR DESCRIPTION
Now checks for each method prefix before allowing it to be added. Previously, it would re-create every single method with another prefix added on (such as getGetGetGetGetGetName() for Item class)