### PR TITLE
ItemType constructor should return nil if nothing is passed to it.

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -11299,8 +11299,11 @@ int LuaScriptInterface::luaItemTypeCreate(lua_State* L)
 	uint32_t id;
 	if (isNumber(L, 2)) {
 		id = getNumber<uint32_t>(L, 2);
-	} else {
+	} else if (isString(L, 2)) {
 		id = Item::items.getItemIdByName(getString(L, 2));
+	} else {
+		lua_pushnil(L);
+		return 1;
 	}
 
 	const ItemType& itemType = Item::items[id];


### PR DESCRIPTION
Also strict type checking for string as the `name` argument, rather than simply interpreting the argument as a string regardless.

Fixes #2742 