### PR TITLE
Docker compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 cmake-build-debug
 vc14
+db

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-cmake-build-debug
 vc14
 db

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+cmake-build-debug
+vc14

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ pip-log.txt
 config.lua
 cmake-build-debug
 .idea
+db

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,5 @@ pip-log.txt
 ## TFS / OT
 #############
 config.lua
-cmake-build-debug
 .idea
 db

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ pip-log.txt
 ## TFS / OT
 #############
 config.lua
+cmake-build-debug
+.idea

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default it:
  
 ##### Preparation:
 
-Update your `configu.lua.dist` with these values, so that server properly connects to the database:
+1. Update your `configu.lua.dist` with these values, so that server properly connects to the database:
 
 ```lua
 -- MySQL
@@ -37,6 +37,13 @@ mysqlDatabase = "forgottenserver"
 mysqlPort = 3306
 mysqlSock = ""
 ```
+
+2. Change your database user password by replacing 
+`<your_db_password>` with your password of choice. 
+**Remember** to also update it in `docker-compose.yml`.
+
+3. Change your database root password by replacing 
+`<your_root_password>` in `docker-compose.yml`.
 
 ##### Start:
 
@@ -59,7 +66,7 @@ docker-compose up -d --build
 
 1. The Forgotten Server - `localhost:7171`, `localhost:7172`.
 2. Database - direct connection hidden to the outside world.
-3. Database explorer - `localhost:8080`. It allows viewing what's inside the database.
+3. Database explorer - `localhost:8080`. Allows viewing what's inside the database.
 
 #### Docker-compose issues:
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,16 @@ docker-compose down
 docker-compose up -d --build
 ```
 
-Additionally, it also creates a database explorer available at `localhost:8080`.
+#### Created services:
 
-##### Issues on startup
+1. The Forgotten Server - `localhost:7171`, `localhost:7172`.
+2. Database - direct connection hidden to the outside world.
+3. Database explorer - `localhost:8080`. It allows viewing what's inside the database.
 
-During startup the server container is created after database, however, the database might not be initially available.
+#### Docker-compose issues:
+
+1. During startup the server container is created after database, however, the database might not be initially available.
 This is why the server will restart a couple of times before it successfully establishes the connection.
+
+2. If you are using Docker Toolbox for Windows and it uses VirtualBox,
+ then the server and database explorer address host name will be `192.168.99.100` insead of `localhost`.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ docker-compose down
 ```
 
 Additionally, it also creates a database explorer available at `localhost:8080`.
+
+##### Issues on startup
+
+During startup the server container is created after database, however, the database might not be initially available.
+This is why the server will restart a couple of times before it successfully establishes the connection.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you need help, please visit the [support forum on OTLand](https://otland.net/
 
 We use the [issue tracker on GitHub](https://github.com/otland/forgottenserver/issues). Keep in mind that everyone who is watching the repository gets notified by e-mail when there is activity, so be thoughtful and avoid writing comments that aren't meaningful for an issue (e.g. "+1"). If you'd like for an issue to be fixed faster, you should either fix it yourself and submit a pull request, or place a bounty on the issue.
 
-### Docker Compose
+## Docker Compose
 
 There is also a way of running the server + database at once using `docker-compose`.
 By default it:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Forgotten Server is a free and open-source MMORPG server emulator written in
 
 * [Compiling](https://github.com/otland/forgottenserver/wiki/Compiling), alternatively download [AppVeyor builds for Windows](https://ci.appveyor.com/project/otland/forgottenserver)
 * [Scripting Reference](https://github.com/otland/forgottenserver/wiki/Script-Interface)
+* [Docker Compose](https://github.com/otland/forgottenserver/wiki/Docker-Compose)
 
 ### Support
 
@@ -15,63 +16,3 @@ If you need help, please visit the [support forum on OTLand](https://otland.net/
 ### Issues
 
 We use the [issue tracker on GitHub](https://github.com/otland/forgottenserver/issues). Keep in mind that everyone who is watching the repository gets notified by e-mail when there is activity, so be thoughtful and avoid writing comments that aren't meaningful for an issue (e.g. "+1"). If you'd like for an issue to be fixed faster, you should either fix it yourself and submit a pull request, or place a bounty on the issue.
-
-## Docker Compose
-
-There is also a way of running the server + database at once using `docker-compose`.
-By default it:
- * Creates a database named `forgottenserver`.
- * Executes `schema.sql` file, so that you don't have to manually import it.
- * Saves all the database files inside a `./db` local directory.
- 
-##### Preparation:
-
-1. Update your `configu.lua.dist` with these values, so that server properly connects to the database:
-
-```lua
--- MySQL
-mysqlHost = "db"
-mysqlUser = "forgottenserver"
-mysqlPass = "<your_db_password>"
-mysqlDatabase = "forgottenserver"
-mysqlPort = 3306
-mysqlSock = ""
-```
-
-2. Change your database user password by replacing 
-`<your_db_password>` with your password of choice. 
-**Remember** to also update it in `docker-compose.yml`.
-
-3. Change your database root password by replacing 
-`<your_root_password>` in `docker-compose.yml`.
-
-##### Start:
-
-```bash
-docker-compose up -d
-```
-
-##### Stop:
-```bash
-docker-compose down
-```
-
-##### Rebuild container after source code changes:
-
-```bash
-docker-compose up -d --build
-```
-
-#### Created services:
-
-1. The Forgotten Server - `localhost:7171`, `localhost:7172`.
-2. Database - direct connection hidden to the outside world.
-3. Database explorer - `localhost:8080`. Allows viewing what's inside the database.
-
-#### Docker-compose issues:
-
-1. During startup the server container is created after database, however, the database might not be initially available.
-This is why the server will restart a couple of times before it successfully establishes the connection.
-
-2. If you are using Docker Toolbox for Windows and it uses VirtualBox,
- then the server and database explorer address host name will be `192.168.99.100` insead of `localhost`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ To stop:
 docker-compose down
 ```
 
+To rebuild container after source code changes:
+
+```bash
+docker-compose up -d --build
+```
+
 Additionally, it also creates a database explorer available at `localhost:8080`.
 
 ##### Issues on startup

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There is also a way of running the server + database at once using `docker-compo
 By default it:
  * Creates a database named `forgotten-server-db`.
  * Executes `schema.sql` file, so that you don't have to manually import it.
- * Saves all the database files in `./db` directory.
+ * Saves all the database files in `./db` local directory.
  
 
 To start:

--- a/README.md
+++ b/README.md
@@ -20,23 +20,36 @@ We use the [issue tracker on GitHub](https://github.com/otland/forgottenserver/i
 
 There is also a way of running the server + database at once using `docker-compose`.
 By default it:
- * Creates a database named `forgotten-server-db`.
+ * Creates a database named `forgottenserver`.
  * Executes `schema.sql` file, so that you don't have to manually import it.
- * Saves all the database files in `./db` local directory.
+ * Saves all the database files inside a `./db` local directory.
  
+##### Preparation:
 
-To start:
+Update your `configu.lua.dist` with these values, so that server properly connects to the database:
+
+```lua
+-- MySQL
+mysqlHost = "db"
+mysqlUser = "forgottenserver"
+mysqlPass = "<your_db_password>"
+mysqlDatabase = "forgottenserver"
+mysqlPort = 3306
+mysqlSock = ""
+```
+
+##### Start:
 
 ```bash
 docker-compose up -d
 ```
 
-To stop:
+##### Stop:
 ```bash
 docker-compose down
 ```
 
-To rebuild container after source code changes:
+##### Rebuild container after source code changes:
 
 ```bash
 docker-compose up -d --build

--- a/README.md
+++ b/README.md
@@ -15,3 +15,25 @@ If you need help, please visit the [support forum on OTLand](https://otland.net/
 ### Issues
 
 We use the [issue tracker on GitHub](https://github.com/otland/forgottenserver/issues). Keep in mind that everyone who is watching the repository gets notified by e-mail when there is activity, so be thoughtful and avoid writing comments that aren't meaningful for an issue (e.g. "+1"). If you'd like for an issue to be fixed faster, you should either fix it yourself and submit a pull request, or place a bounty on the issue.
+
+### Docker Compose
+
+There is also a way of running the server + database at once using `docker-compose`.
+By default it:
+ * Creates a database named `forgotten-server-db`.
+ * Executes `schema.sql` file, so that you don't have to manually import it.
+ * Saves all the database files in `./db` directory.
+ 
+
+To start:
+
+```bash
+docker-compose up -d
+```
+
+To stop:
+```bash
+docker-compose down
+```
+
+Additionally, it also creates a database explorer available at `localhost:8080`.

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -59,7 +59,7 @@ maxMarketOffersAtATimePerPlayer = 100
 mysqlHost = "db"
 mysqlUser = "root"
 mysqlPass = "<your_db_password>"
-mysqlDatabase = "forgottenserver"
+mysqlDatabase = "forgotten-server-db"
 mysqlPort = 3306
 mysqlSock = ""
 

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -15,7 +15,7 @@ expFromPlayersLevelRange = 75
 
 -- Connection Config
 -- NOTE: maxPlayers set to 0 means no limit
-ip = "0.0.0.0"
+ip = "127.0.0.1"
 bindOnlyGlobalAddress = false
 loginProtocolPort = 7171
 gameProtocolPort = 7172
@@ -56,10 +56,10 @@ checkExpiredMarketOffersEachMinutes = 60
 maxMarketOffersAtATimePerPlayer = 100
 
 -- MySQL
-mysqlHost = "db"
-mysqlUser = "root"
-mysqlPass = "<your_db_password>"
-mysqlDatabase = "forgotten-server-db"
+mysqlHost = "127.0.0.1"
+mysqlUser = "forgottenserver"
+mysqlPass = ""
+mysqlDatabase = "forgottenserver"
 mysqlPort = 3306
 mysqlSock = ""
 

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -15,7 +15,7 @@ expFromPlayersLevelRange = 75
 
 -- Connection Config
 -- NOTE: maxPlayers set to 0 means no limit
-ip = "127.0.0.1"
+ip = "0.0.0.0"
 bindOnlyGlobalAddress = false
 loginProtocolPort = 7171
 gameProtocolPort = 7172
@@ -56,9 +56,9 @@ checkExpiredMarketOffersEachMinutes = 60
 maxMarketOffersAtATimePerPlayer = 100
 
 -- MySQL
-mysqlHost = "127.0.0.1"
-mysqlUser = "forgottenserver"
-mysqlPass = ""
+mysqlHost = "db"
+mysqlUser = "root"
+mysqlPass = "<your_db_password>"
 mysqlDatabase = "forgottenserver"
 mysqlPort = 3306
 mysqlSock = ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: <your_db_password>
       # Automatically creates a database
-      MYSQL_DATABASE: forgottenserver
+      MYSQL_DATABASE: forgotten-server-db
     volumes:
       # Saves all the data in ./db directory
       - ./db:/var/lib/mysql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,10 @@ services:
     image: mysql
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: <your_db_password>
+      MYSQL_USER: forgottenserver
+      MYSQL_PASSWORD: <your_db_password>
       # Automatically creates a database
-      MYSQL_DATABASE: forgotten-server-db
+      MYSQL_DATABASE: forgottenserver
     volumes:
       # Saves all the data in ./db directory
       - ./db:/var/lib/mysql
@@ -31,7 +32,7 @@ services:
     image: adminer
     restart: always
     ports:
-      - 8080:8080
+      - 8081:8080
     networks:
       - db-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       # Automatically creates a database
       MYSQL_DATABASE: forgottenserver
     volumes:
+      # Saves all the data in ./db directory
       - ./db:/var/lib/mysql
       # Automatically executes schema.sql on startup
       - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "3.0"
+
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - "7171:7171"
+      - "7172:7172"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,36 @@ services:
   server:
     build:
       context: .
+    restart: always
     ports:
       - "7171:7171"
       - "7172:7172"
+    depends_on:
+      - db
+    networks:
+      - db-network
+  db:
+    image: mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: <your_db_password>
+      # Automatically creates a database
+      MYSQL_DATABASE: forgottenserver
+    volumes:
+      - ./db:/var/lib/mysql
+      # Automatically executes schema.sql on startup
+      - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    networks:
+      - db-network
+
+  db-adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+    networks:
+      - db-network
+
+networks:
+  db-network:
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
     image: mysql
     restart: always
     environment:
+      MYSQL_ROOT_PASSWORD: ECpkF11U6ofV9sD3FJFqVS9Myv4GpdN6Fgr6u0sPkdE8bVPn2d4UzRjIJ
       MYSQL_USER: forgottenserver
       MYSQL_PASSWORD: <your_db_password>
       # Automatically creates a database

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
     image: adminer
     restart: always
     ports:
-      - 8081:8080
+      - 8080:8080
     networks:
       - db-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     image: mysql
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: ECpkF11U6ofV9sD3FJFqVS9Myv4GpdN6Fgr6u0sPkdE8bVPn2d4UzRjIJ
+      MYSQL_ROOT_PASSWORD: <your_root_password>
       MYSQL_USER: forgottenserver
       MYSQL_PASSWORD: <your_db_password>
       # Automatically creates a database


### PR DESCRIPTION
## Docker Compose

There is also a way of running the server + database at once using `docker-compose`.
By default it:
 * Creates a database named `forgottenserver`.
 * Executes `schema.sql` file, so that you don't have to manually import it.
 * Saves all the database files inside a `./db` local directory.

##### Preparation:

1. Update your `configu.lua.dist` with these values, so that server properly connects to the database:

```lua
-- MySQL
mysqlHost = "db"
mysqlUser = "forgottenserver"
mysqlPass = "<your_db_password>"
mysqlDatabase = "forgottenserver"
mysqlPort = 3306
mysqlSock = ""
```

2. Change your database user password by replacing
`<your_db_password>` with your password of choice.
**Remember** to also update it in `docker-compose.yml`.

3. Change your database root password by replacing
`<your_root_password>` in `docker-compose.yml`.

##### Start:

```bash
docker-compose up -d
```

##### Stop:
```bash
docker-compose down
```

##### Rebuild container after source code changes:

```bash
docker-compose up -d --build
```

#### Created services:

1. The Forgotten Server - `localhost:7171`, `localhost:7172`.
2. Database - direct connection hidden to the outside world.
3. Database explorer - `localhost:8080`. Allows viewing what's inside the database.

#### Docker-compose issues:

1. During startup the server container is created after database, however, the database might not be initially available.
This is why the server will restart a couple of times before it successfully establishes the connection.

2. If you are using Docker Toolbox for Windows and it uses VirtualBox,
 then the server and database explorer address host name will be `192.168.99.100` insead of `localhost`.