### PR TITLE
Fixed Fury loot, jalapeno pepper

### DIFF
--- a/data/monster/Insects/ladybug.xml
+++ b/data/monster/Insects/ladybug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<monster name="Ladybug" nameDescription="Ladybug" race="venom" experience="70" speed="200">
+<monster name="Lady Bug" nameDescription="Ladybug" race="venom" experience="70" speed="200">
 	<health now="255" max="255" />
 	<look type="448" corpse="15272" />
 	<targetchange interval="5000" chance="0" />

--- a/data/monster/Sorcerers/fury.xml
+++ b/data/monster/Sorcerers/fury.xml
@@ -89,7 +89,7 @@
 		<item name="assassin dagger" chance="660" />
 		<item name="noble axe" chance="2000" />
 		<item name="great health potion" chance="10500" />
-		<item name="jalapeño pepper" countmax="4" chance="29280" />
+		<item name="jalapeno pepper" countmax="4" chance="29280" />
 		<item id="9813" chance="1920" /><!-- rusty legs -->
 	</loot>
 </monster>

--- a/data/monster/monsters.xml
+++ b/data/monster/monsters.xml
@@ -529,7 +529,7 @@
 	<monster name="Insectoid Scout" file="Insects/insectoid_scout.xml" />
 	<monster name="Insectoid Worker" file="Insects/insectoid_worker.xml" />
 	<monster name="Kollos" file="Insects/kollos.xml" />
-	<monster name="Ladybug" file="Insects/ladybug.xml" />
+	<monster name="Lady Bug" file="Insects/ladybug.xml" />
 	<monster name="Lancer Beetle" file="Insects/lancer_beetle.xml" />
 	<monster name="Larva" file="Insects/larva.xml" />
 	<monster name="Lesser Swarmer" file="Insects/lesser_swarmer.xml" />


### PR DESCRIPTION
Threw an error in console about missing loot because it did not match the spelling in items.xml