### PR TITLE
MonsterType skull method & flags fix

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -75,28 +75,28 @@ registerMonsterType.corpse = function(mtype, mask)
 end
 registerMonsterType.flags = function(mtype, mask)
 	if mask.flags then
-		if mask.flags.attackable then
+		if mask.flags.attackable ~= nil then
 			mtype:isAttackable(mask.flags.attackable)
 		end
-		if mask.flags.healthHidden then
+		if mask.flags.healthHidden ~= nil then
 			mtype:isHealthHidden(mask.flags.healthHidden)
 		end
-		if mask.flags.convinceable then
+		if mask.flags.convinceable ~= nil then
 			mtype:isConvinceable(mask.flags.convinceable)
 		end
-		if mask.flags.illusionable then
+		if mask.flags.illusionable ~= nil then
 			mtype:isIllusionable(mask.flags.illusionable)
 		end
-		if mask.flags.hostile then
+		if mask.flags.hostile ~= nil then
 			mtype:isHostile(mask.flags.hostile)
 		end
-		if mask.flags.pushable then
+		if mask.flags.pushable ~= nil then
 			mtype:isPushable(mask.flags.pushable)
 		end
-		if mask.flags.canPushItems then
+		if mask.flags.canPushItems ~= nil then
 			mtype:canPushItems(mask.flags.canPushItems)
 		end
-		if mask.flags.canPushCreatures then
+		if mask.flags.canPushCreatures ~= nil then
 			mtype:canPushCreatures(mask.flags.canPushCreatures)
 		end
 		if mask.flags.targetDistance then

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -23,6 +23,11 @@ registerMonsterType.experience = function(mtype, mask)
 		mtype:experience(mask.experience)
 	end
 end
+registerMonsterType.skull = function(mtype, mask)
+	if mask.skull then
+		mtype:skull(mask.skull)
+	end
+end
 registerMonsterType.outfit = function(mtype, mask)
 	if mask.outfit then
 		mtype:outfit(mask.outfit)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12548,10 +12548,10 @@ int LuaScriptInterface::luaMonsterTypeSkull(lua_State* L)
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.skull);
 		} else {
-			if (isString(L, 2)) {
-				monsterType->info.skull = getSkullType(getString(L, 2));
-			} else {
+			if (isNumber(L, 2)) {
 				monsterType->info.skull = getNumber<Skulls_t>(L, 2);
+			} else {
+				monsterType->info.skull = getSkullType(getString(L, 2));
 			}
 			pushBoolean(L, true);
 		}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12542,13 +12542,17 @@ int LuaScriptInterface::luaMonsterTypeExperience(lua_State* L)
 
 int LuaScriptInterface::luaMonsterTypeSkull(lua_State* L)
 {
-	// get: monsterType:skull() set: monsterType:skull(str)
+	// get: monsterType:skull() set: monsterType:skull(str/constant)
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.skull);
 		} else {
-			monsterType->info.skull = getSkullType(getString(L, 2));
+			if (isString(L, 2)) {
+				monsterType->info.skull = getSkullType(getString(L, 2));
+			} else {
+				monsterType->info.skull = getNumber<Skulls_t>(L, 2);
+			}
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2691,6 +2691,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("MonsterType", "maxHealth", LuaScriptInterface::luaMonsterTypeMaxHealth);
 	registerMethod("MonsterType", "runHealth", LuaScriptInterface::luaMonsterTypeRunHealth);
 	registerMethod("MonsterType", "experience", LuaScriptInterface::luaMonsterTypeExperience);
+	registerMethod("MonsterType", "skull", LuaScriptInterface::luaMonsterTypeSkull);
 
 	registerMethod("MonsterType", "combatImmunities", LuaScriptInterface::luaMonsterTypeCombatImmunities);
 	registerMethod("MonsterType", "conditionImmunities", LuaScriptInterface::luaMonsterTypeConditionImmunities);
@@ -12531,6 +12532,23 @@ int LuaScriptInterface::luaMonsterTypeExperience(lua_State* L)
 			lua_pushnumber(L, monsterType->info.experience);
 		} else {
 			monsterType->info.experience = getNumber<uint64_t>(L, 2);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterTypeSkull(lua_State* L)
+{
+	// get: monsterType:skull() set: monsterType:skull(str)
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		if (lua_gettop(L) == 1) {
+			lua_pushnumber(L, monsterType->info.skull);
+		} else {
+			monsterType->info.skull = getSkullType(getString(L, 2));
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1237,6 +1237,7 @@ class LuaScriptInterface
 		static int luaMonsterTypeMaxHealth(lua_State* L);
 		static int luaMonsterTypeRunHealth(lua_State* L);
 		static int luaMonsterTypeExperience(lua_State* L);
+		static int luaMonsterTypeSkull(lua_State* L);
 
 		static int luaMonsterTypeCombatImmunities(lua_State* L);
 		static int luaMonsterTypeConditionImmunities(lua_State* L);


### PR DESCRIPTION
MonsterType now supports ex: get :skull() and set :skull("red") : skull(SKULL_RED)
It supports strings and constants.
This also solves that the MonsterType flags where not correctly set if you set them to "false"
solves #2764