### PR TITLE
Game.getMonsterTypes()

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1971,6 +1971,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Game", "getMonsterCount", LuaScriptInterface::luaGameGetMonsterCount);
 	registerMethod("Game", "getPlayerCount", LuaScriptInterface::luaGameGetPlayerCount);
 	registerMethod("Game", "getNpcCount", LuaScriptInterface::luaGameGetNpcCount);
+	registerMethod("Game", "getMonsterTypes", LuaScriptInterface::luaGameGetMonsterTypes);
 
 	registerMethod("Game", "getTowns", LuaScriptInterface::luaGameGetTowns);
 	registerMethod("Game", "getHouses", LuaScriptInterface::luaGameGetHouses);
@@ -4296,6 +4297,21 @@ int LuaScriptInterface::luaGameGetNpcCount(lua_State* L)
 {
 	// Game.getNpcCount()
 	lua_pushnumber(L, g_game.getNpcsOnline());
+	return 1;
+}
+
+int LuaScriptInterface::luaGameGetMonsterTypes(lua_State* L)
+{
+	// Game.getMonsterTypes()
+	auto& type = g_monsters.monsters;
+	lua_createtable(L, type.size(), 0);
+
+	int index = 0;
+	for (auto& mType : type) {
+		pushUserdata<MonsterType>(L, &mType.second);
+		setMetatable(L, -1, "MonsterType");
+		lua_setfield(L, -2, mType.first.c_str());
+	}
 	return 1;
 }
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4306,7 +4306,6 @@ int LuaScriptInterface::luaGameGetMonsterTypes(lua_State* L)
 	auto& type = g_monsters.monsters;
 	lua_createtable(L, type.size(), 0);
 
-	int index = 0;
 	for (auto& mType : type) {
 		pushUserdata<MonsterType>(L, &mType.second);
 		setMetatable(L, -1, "MonsterType");

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -539,6 +539,7 @@ class LuaScriptInterface
 		static int luaGameGetMonsterCount(lua_State* L);
 		static int luaGameGetPlayerCount(lua_State* L);
 		static int luaGameGetNpcCount(lua_State* L);
+		static int luaGameGetMonsterTypes(lua_State* L);
 
 		static int luaGameGetTowns(lua_State* L);
 		static int luaGameGetHouses(lua_State* L);

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -241,6 +241,7 @@ class Monsters
 		bool deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std::string& description = "");
 
 		std::unique_ptr<LuaScriptInterface> scriptInterface;
+		std::map<std::string, MonsterType> monsters;
 
 	private:
 		ConditionDamage* getDamageCondition(ConditionType_t conditionType,
@@ -252,7 +253,6 @@ class Monsters
 		void loadLootContainer(const pugi::xml_node& node, LootBlock&);
 		bool loadLootItem(const pugi::xml_node& node, LootBlock&);
 
-		std::map<std::string, MonsterType> monsters;
 		std::map<std::string, std::string> unloadedMonsters;
 
 		bool loaded = false;


### PR DESCRIPTION
This will add the function `Game.getMonsterTypes()`
It will return as the key the monster name and as the value the metatable.

This helps a lot if you want to register a certain event to all of your existing MonsterTypes.

Beware! 
This does not trigger unloaded MonsterTypes which are created through xml and not once spawned on map load, it'll only fetch MonsterTypes which are created through revscriptsys (monster/lua) or xml monsters which are load and spawned on startup.