### PR TITLE
Fishing water elemental corpse fix

### DIFF
--- a/data/actions/scripts/tools/fishing.lua
+++ b/data/actions/scripts/tools/fishing.lua
@@ -19,7 +19,8 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		end
 
 		toPosition:sendMagicEffect(CONST_ME_WATERSPLASH)
-		target:remove()
+		target:transform(targetId + 1)
+		target:decay()
 
 		local rareChance = math.random(1, 100)
 		if rareChance == 1 then


### PR DESCRIPTION
It shouldn't disappear when fished, but instead be transformed to its next decay stage