### PR TITLE
Simplifying the registering of IDs in revscript

### DIFF
--- a/data/scripts/actions/others/costume_bag.lua
+++ b/data/scripts/actions/others/costume_bag.lua
@@ -17,5 +17,7 @@ function costumeBag.onUse(player, item, fromPosition, target, toPosition, isHotk
 	return true
 end
 
-costumeBag:id(7737, 7739, 9076)
+for k,v in pairs(config) do
+	costumeBag:id(k)
+end
 costumeBag:register()

--- a/data/scripts/actions/others/dolls.lua
+++ b/data/scripts/actions/others/dolls.lua
@@ -153,5 +153,7 @@ function dolls.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	return true
 end
 
-dolls:id(5080, 5669, 6566, 6388, 6512, 8974, 8977, 8981, 8982, 23806, 24331, 20624, 16107, 13030, 13559, 10063, 24776, 24316)
+for k,v in pairs(dollsTable) do
+	dolls:id(k)
+end
 dolls:register()


### PR DESCRIPTION
So you need to change IDs only once instead of twice