### PR TITLE
Small fixes following up PR #2800

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -143,7 +143,8 @@
 	<action itemid="5543" script="other/teleport.lua" />
 	<action fromid="2376" toid="2404" script="other/destroy.lua" />
 	<action fromid="2406" toid="2419" script="other/destroy.lua" />
-	<action fromid="2421" toid="2453" script="other/destroy.lua" />
+	<action fromid="2421" toid="2441" script="other/destroy.lua"/>
+	<action fromid="2443" toid="2453" script="other/destroy.lua"/>
 	<action fromid="2005" toid="2009" script="other/fluids.lua" />
 	<action fromid="2011" toid="2015" script="other/fluids.lua" />
 	<action itemid="2023" script="other/fluids.lua" />

--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -143,8 +143,8 @@
 	<action itemid="5543" script="other/teleport.lua" />
 	<action fromid="2376" toid="2404" script="other/destroy.lua" />
 	<action fromid="2406" toid="2419" script="other/destroy.lua" />
-	<action fromid="2421" toid="2441" script="other/destroy.lua"/>
-	<action fromid="2443" toid="2453" script="other/destroy.lua"/>
+	<action fromid="2421" toid="2441" script="other/destroy.lua" />
+	<action fromid="2443" toid="2453" script="other/destroy.lua" />
 	<action fromid="2005" toid="2009" script="other/fluids.lua" />
 	<action fromid="2011" toid="2015" script="other/fluids.lua" />
 	<action itemid="2023" script="other/fluids.lua" />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -31841,6 +31841,12 @@
 		<attribute key="slotType" value="backpack" />
 		<attribute key="weight" value="1800" />
 	</item>
+	<item id="23704" name="belongings of a deceased" editorsuffix=" (The Ravager)">
+		<attribute key="weight" value="5300" />
+	</item>
+	<item id="23705" name="belongings of a deceased" editorsuffix=" (Death Priest Shargon)">
+		<attribute key="weight" value="11000" />
+	</item>
 	<item id="23719" article="the" name="scorcher">
 		<attribute key="description" value="It's warm to the touch." />
 		<attribute key="weight" value="1500" />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -22716,7 +22716,7 @@
 	</item>
 	<item id="13867" name="big stone pile" />
 	<item id="13868" name="greasy stone" />
-	<item id="13868" name="hole" />
+	<item id="13869" name="hole" />
 	<item id="13870" name="eye of a deepling">
 		<attribute key="description" value="Did it just twitch...? No, must have been an optical illusion." />
 		<attribute key="weight" value="240" />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -30993,6 +30993,22 @@
 	<item id="22670" article="a" name="ramp">
 		<attribute key="floorchange" value="south" />
 	</item>
+	<item id="22678" article="an" name="arcane staff">
+		<attribute key="weight" value="4000" />
+	</item>
+	<item id="22690" article="a" name="light rapier">
+		<attribute key="weight" value="1500" />
+		<attribute key="defense" value="8" />
+		<attribute key="attack" value="10" />
+		<attribute key="weaponType" value="sword" />
+		<attribute key="extradef" value="1" />
+		<attribute key="description" value="It has been used a lot, judging by its jagged blade." />
+	</item>
+	<item id="22691" article="a" name="jade amulet">
+		<attribute key="description" value="Golden lines are embedded in the amulet and show mysterious symbols. It was awarded by the gods." />
+		<attribute key="weight" value="400" />
+		<attribute key="slotType" value="necklace" />
+	</item>
 	<item id="22696" article="a" name="cake backpack">
 		<attribute key="weight" value="1800" />
 		<attribute key="containerSize" value="20" />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -20910,7 +20910,7 @@
 		<attribute key="weight" value="950" />
 	</item>
 	<item id="12544" article="a" name="sweet mangonaise elixir">
-		<attribute key="description" value="It's said to have incredible effects if you drink it while wearing a magical ring with time limit." />
+		<attribute key="description" value="It's said to have incredible effects if you drink it while wearing a volatile magical ring with time limit." />
 		<attribute key="weight" value="300" />
 	</item>
 	<item id="12545" article="the" name="dead Glitterscale">

--- a/data/monster/Outlaws/crazed_beggar.xml
+++ b/data/monster/Outlaws/crazed_beggar.xml
@@ -46,7 +46,7 @@
 		<item name="dirty cape" chance="55000" />
 		<item name="wooden hammer" chance="6500" />
 		<item name="wooden spoon" chance="9750" />
-		<item name="rolling pin" chance="5650" />
+		<item id="2570" chance="5650" /><!-- rolling pin -->
 		<item name="meat" chance="9500" />
 		<item name="roll" chance="22500" />
 		<item name="red rose" chance="4700" />

--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -76,7 +76,7 @@ if Modules == nil then
 		local player = Player(cid)
 		if player:isPremium() or not parameters.premium then
 			local promotion = player:getVocation():getPromotion()
-			if player:getStorageValue(STORAGEVALUE_PROMOTION) == 1 then
+			if player:getStorageValue(PlayerStorageKeys.promotion) == 1 then
 				npcHandler:say("You are already promoted!", cid)
 			elseif player:getLevel() < parameters.level then
 				npcHandler:say("I am sorry, but I can only promote you once you have reached level " .. parameters.level .. ".", cid)


### PR DESCRIPTION
- removed duplicate registered heavy machete from actions.xml
- fixed a duplicated item ID
- updated crazed beggar loot to use ID, because now we have two items with same name


a big thanks to @BahamutxD for noticing them