### PR TITLE
Rewrite Spell constructor to avoid conflicts & properly return runes

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13896,9 +13896,40 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 		return 1;
 	}
 
-	SpellType_t type = getNumber<SpellType_t>(L, 2);
+	SpellType_t type = SPELL_UNDEFINED;
 
-	if (isString(L, 2)) {
+	if (isNumber(L, 2)) {
+		int32_t id = getNumber<int32_t>(L, 2);
+		RuneSpell* rune = g_spells->getRuneSpell(id);
+
+		if (rune) {
+			pushUserdata<Spell>(L, rune);
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+
+		type = static_cast<SpellType_t>(id);
+	} else if (isString(L, 2)) {
+		std::string arg = getString(L, 2);
+		InstantSpell* instant = g_spells->getInstantSpellByName(arg);
+		if (instant) {
+			pushUserdata<Spell>(L, instant);
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+		instant = g_spells->getInstantSpell(arg);
+		if (instant) {
+			pushUserdata<Spell>(L, instant);
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+		RuneSpell* rune = g_spells->getRuneSpellByName(arg);
+		if (rune) {
+			pushUserdata<Spell>(L, rune);
+			setMetatable(L, -1, "Spell");
+			return 1;
+		}
+
 		std::string tmp = asLowerCaseString(getString(L, 2));
 		if (tmp == "instant") {
 			type = SPELL_INSTANT;
@@ -13923,41 +13954,6 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 		return 1;
 	}
 
-	// isNumber(L, 2) doesn't work here for some reason, maybe a bug?
-	if (getNumber<uint32_t>(L, 2)) {
-		InstantSpell* instant = g_spells->getInstantSpellById(getNumber<uint32_t>(L, 2));
-		if (instant) {
-			pushUserdata<Spell>(L, instant);
-			setMetatable(L, -1, "Spell");
-			return 1;
-		}
-		RuneSpell* rune = g_spells->getRuneSpell(getNumber<uint32_t>(L, 2));
-		if (rune) {
-			pushUserdata<Spell>(L, rune);
-			setMetatable(L, -1, "Spell");
-			return 1;
-		}
-	} else if (isString(L, 2)) {
-		std::string arg = getString(L, 2);
-		InstantSpell* instant = g_spells->getInstantSpellByName(arg);
-		if (instant) {
-			pushUserdata<Spell>(L, instant);
-			setMetatable(L, -1, "Spell");
-			return 1;
-		}
-		instant = g_spells->getInstantSpell(arg);
-		if (instant) {
-			pushUserdata<Spell>(L, instant);
-			setMetatable(L, -1, "Spell");
-			return 1;
-		}
-		RuneSpell* rune = g_spells->getRuneSpellByName(arg);
-		if (rune) {
-			pushUserdata<Spell>(L, rune);
-			setMetatable(L, -1, "Spell");
-			return 1;
-		}
-	}
 	lua_pushnil(L);
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13896,7 +13896,7 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 		return 1;
 	}
 
-	SpellType_t type = SPELL_UNDEFINED;
+	SpellType_t spellType = SPELL_UNDEFINED;
 
 	if (isNumber(L, 2)) {
 		int32_t id = getNumber<int32_t>(L, 2);
@@ -13908,7 +13908,7 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 			return 1;
 		}
 
-		type = static_cast<SpellType_t>(id);
+		spellType = static_cast<SpellType_t>(id);
 	} else if (isString(L, 2)) {
 		std::string arg = getString(L, 2);
 		InstantSpell* instant = g_spells->getInstantSpellByName(arg);
@@ -13930,22 +13930,22 @@ int LuaScriptInterface::luaSpellCreate(lua_State* L)
 			return 1;
 		}
 
-		std::string tmp = asLowerCaseString(getString(L, 2));
+		std::string tmp = asLowerCaseString(arg);
 		if (tmp == "instant") {
-			type = SPELL_INSTANT;
+			spellType = SPELL_INSTANT;
 		} else if (tmp == "rune") {
-			type = SPELL_RUNE;
+			spellType = SPELL_RUNE;
 		}
 	}
 
-	if (type == SPELL_INSTANT) {
+	if (spellType == SPELL_INSTANT) {
 		InstantSpell* spell = new InstantSpell(getScriptEnv()->getScriptInterface());
 		spell->fromLua = true;
 		pushUserdata<Spell>(L, spell);
 		setMetatable(L, -1, "Spell");
 		spell->spellType = SPELL_INSTANT;
 		return 1;
-	} else if (type == SPELL_RUNE) {
+	} else if (spellType == SPELL_RUNE) {
 		RuneSpell* spell = new RuneSpell(getScriptEnv()->getScriptInterface());
 		spell->fromLua = true;
 		pushUserdata<Spell>(L, spell);


### PR DESCRIPTION
* Can now access existing runes through Spell(runeId) calls, previously impossible because of the initial type check where 2nd arg is converted, resulting in an equivalent of a Spell(SPELL_INSTANT) call
* Removed Spell(spellId) calls because they are not unique identifiers and conflict with underlying SpellType_t ids
* Checks for existing spells now  and falls back to constructing a new spell with the determined type, using int32_t number instead of SpellType_t when retrieving 2nd argument to avoid undefined behavior when the underlying `static_cast` occurs to SpellType_t with an out-of-range value