### PR TITLE
New configurable 'Yell' options

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -76,6 +76,8 @@ classicEquipmentSlots = false
 classicAttackSpeed = false
 showScriptsLogInConsole = true
 showOnlineStatusInCharlist = false
+yellMinimumLevel = 2
+yellAlwaysAllowPremium = false
 
 -- Server Save
 -- NOTE: serverSaveNotifyDuration in minutes

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -145,6 +145,7 @@ bool ConfigManager::load()
 	boolean[SERVER_SAVE_CLOSE] = getGlobalBoolean(L, "serverSaveClose", false);
 	boolean[SERVER_SAVE_SHUTDOWN] = getGlobalBoolean(L, "serverSaveShutdown", true);
 	boolean[ONLINE_OFFLINE_CHARLIST] = getGlobalBoolean(L, "showOnlineStatusInCharlist", false);
+	boolean[YELL_ALLOW_PREMIUM] = getGlobalBoolean(L, "yellAlwaysAllowPremium", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");
@@ -182,6 +183,7 @@ bool ConfigManager::load()
 	integer[MAX_MARKET_OFFERS_AT_A_TIME_PER_PLAYER] = getGlobalNumber(L, "maxMarketOffersAtATimePerPlayer", 100);
 	integer[MAX_PACKETS_PER_SECOND] = getGlobalNumber(L, "maxPacketsPerSecond", 25);
 	integer[SERVER_SAVE_NOTIFY_DURATION] = getGlobalNumber(L, "serverSaveNotifyDuration", 5);
+	integer[YELL_MINIMUM_LEVEL] = getGlobalNumber(L, "yellMinimumLevel", 2);
 
 	loaded = true;
 	lua_close(L);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -47,6 +47,7 @@ class ConfigManager
 			SERVER_SAVE_CLOSE,
 			SERVER_SAVE_SHUTDOWN,
 			ONLINE_OFFLINE_CHARLIST,
+			YELL_ALLOW_PREMIUM,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};
@@ -106,6 +107,7 @@ class ConfigManager
 			EXP_FROM_PLAYERS_LEVEL_RANGE,
 			MAX_PACKETS_PER_SECOND,
 			SERVER_SAVE_NOTIFY_DURATION,
+			YELL_MINIMUM_LEVEL,
 
 			LAST_INTEGER_CONFIG /* this must be the last one */
 		};

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3430,16 +3430,13 @@ bool Game::playerYell(Player* player, const std::string& text)
 
 	uint32_t minimumLevel = g_config.getNumber(ConfigManager::YELL_MINIMUM_LEVEL);
 	if (player->getLevel() < minimumLevel) {
-
 		std::ostringstream ss;
 		ss << "You may not yell unless you have reached level " << minimumLevel;
-
 		if (g_config.getBoolean(ConfigManager::YELL_ALLOW_PREMIUM)) {
 			if (player->isPremium()) {
 				internalCreatureSay(player, TALKTYPE_YELL, asUpperCaseString(text), false);
 				return true;
-			}
-			else {
+			} else {
 				ss << " or have a premium account";
 			}
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3423,13 +3423,28 @@ void Game::playerWhisper(Player* player, const std::string& text)
 
 bool Game::playerYell(Player* player, const std::string& text)
 {
-	if (player->getLevel() == 1) {
-		player->sendTextMessage(MESSAGE_STATUS_SMALL, "You may not yell as long as you are on level 1.");
+	if (player->hasCondition(CONDITION_YELLTICKS)) {
+		player->sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
 		return false;
 	}
 
-	if (player->hasCondition(CONDITION_YELLTICKS)) {
-		player->sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
+	uint32_t minimumLevel = g_config.getNumber(ConfigManager::YELL_MINIMUM_LEVEL);
+	if (player->getLevel() < minimumLevel) {
+
+		std::ostringstream ss;
+		ss << "You may not yell unless you have reached level " << minimumLevel;
+
+		if (g_config.getBoolean(ConfigManager::YELL_ALLOW_PREMIUM)) {
+			if (player->isPremium()) {
+				internalCreatureSay(player, TALKTYPE_YELL, asUpperCaseString(text), false);
+				return true;
+			}
+			else {
+				ss << " or have a premium account";
+			}
+		}
+		ss << ".";
+		player->sendTextMessage(MESSAGE_STATUS_SMALL, ss.str());
 		return false;
 	}
 


### PR DESCRIPTION
This is for: https://github.com/otland/forgottenserver/issues/2771

`yellAlwaysAllowPremium`
if `true` players less than `yellMinimumLevel` need to be premium in order to yell.
if `false` players less than `yellMinimumLevel` may not yell.

Tested in all all four instances and works exactly as expected.