### PR TITLE
Fix stacking unpassable movable item

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -92,7 +92,7 @@ void Teleport::addThing(int32_t, Thing* thing)
 			g_game.addMagicEffect(destTile->getPosition(), effect);
 			g_game.addMagicEffect(item->getPosition(), effect);
 		}
-		g_game.internalMoveItem(getTile(), destTile, INDEX_WHEREEVER, item, item->getItemCount(), nullptr);
+		g_game.internalMoveItem(getTile(), destTile, INDEX_WHEREEVER, item, item->getItemCount(), nullptr, FLAG_NOLIMIT);
 	}
 }
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -680,10 +680,6 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 						continue;
 					}
 
-					if (!item->isPickupable()) {
-						return RETURNVALUE_NOTENOUGHROOM;
-					}
-
 					if (!iiType.hasHeight || iiType.pickupable || iiType.isBed()) {
 						return RETURNVALUE_NOTENOUGHROOM;
 					}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -680,6 +680,10 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 						continue;
 					}
 
+					if (!item->isPickupable()) {
+						return RETURNVALUE_NOTENOUGHROOM;
+					}
+
 					if (!iiType.hasHeight || iiType.pickupable || iiType.isBed()) {
 						return RETURNVALUE_NOTENOUGHROOM;
 					}


### PR DESCRIPTION
Fix #2537 

There is actually no reason to restrict adding not pickupable item to tile with other non blocking items, until I'm not aware of something?