### PR TITLE
Monster loot fixes

### DIFF
--- a/data/monster/Apes/kongra.xml
+++ b/data/monster/Apes/kongra.xml
@@ -40,7 +40,7 @@
 		<voice sentence="Huaauaauaauaa!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="61" chance="87000" />
+		<item name="gold coin" countmax="55" chance="90000" />
 		<item name="banana" countmax="13" chance="30000" />
 		<item name="kongra's shoulderpad" chance="9500" />
 		<item name="protection amulet" chance="1000" />

--- a/data/monster/Misc/Misc Reptiles/hydra.xml
+++ b/data/monster/Misc/Misc Reptiles/hydra.xml
@@ -50,11 +50,13 @@
 		<immunity invisible="1" />
 	</immunities>
 	<voices interval="5000" chance="10">
-		<voice sentence="FCHHHHH" />
-		<voice sentence="HISSSS" />
+		<voice sentence="FCHHHHH" yell="1" />
+		<voice sentence="HISSSS" yell="1" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="246" chance="87000" />
+		<item name="gold coin" countmax="100" chance="34000" />
+		<item name="gold coin" countmax="100" chance="34000" />	
+		<item name="gold coin" countmax="46" chance="20000" />
 		<item name="ham" countmax="4" chance="60000" />
 		<item name="platinum coin" countmax="3" chance="49000" />
 		<item name="hydra head" chance="10120" />

--- a/data/monster/Serpents/serpent_spawn.xml
+++ b/data/monster/Serpents/serpent_spawn.xml
@@ -62,7 +62,9 @@
 		<voice sentence="I bring your deathhh, mortalssss" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="239" chance="98000" />
+		<item name="gold coin" countmax="100" chance="32300" />	
+		<item name="gold coin" countmax="100" chance="32300" />	
+		<item name="gold coin" countmax="39" chance="32300" />
 		<item name="green mushroom" chance="18200" />
 		<item name="snake skin" chance="14800" />
 		<item name="small sapphire" chance="12000" />


### PR DESCRIPTION
- Fixed gold coin drop amount of kongra based on leaked file
- Reverted countmax from hydra and serpent spawn

follow up to https://github.com/otland/forgottenserver/commit/6e3e7ce36f3936a8103b277f21b3122189ff0c08