### PR TITLE
Prevent rsa decryption from crashing server

### DIFF
--- a/src/rsa.cpp
+++ b/src/rsa.cpp
@@ -31,9 +31,13 @@ static CryptoPP::AutoSeededRandomPool prng;
 
 void RSA::decrypt(char* msg) const
 {
-	CryptoPP::Integer m{reinterpret_cast<uint8_t*>(msg), 128};
-	auto c = pk.CalculateInverse(prng, m);
-	c.Encode(reinterpret_cast<uint8_t*>(msg), 128);
+	try {
+		CryptoPP::Integer m{reinterpret_cast<uint8_t*>(msg), 128};
+		auto c = pk.CalculateInverse(prng, m);
+		c.Encode(reinterpret_cast<uint8_t*>(msg), 128);
+	} catch (const CryptoPP::Exception& e) {
+		std::cout << e.what() << '\n';
+	}
 }
 
 static const std::string header = "-----BEGIN RSA PRIVATE KEY-----";


### PR DESCRIPTION
CalculateInverse has the abiility to throw exception, which is unhandled and will crash the server, we should use try catch there.
Source: https://www.cryptopp.com/docs/ref/rsa_8cpp_source.html#l00235