### PR TITLE
Perfect blockHit and correct value result

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1846,9 +1846,10 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 			continue;
 		}
 
+		int32_t unmodifiedDamage = damage;
 		const int16_t& absorbPercent = it.abilities->absorbPercent[combatTypeToIndex(combatType)];
 		if (absorbPercent != 0) {
-			damage -= std::round(damage * (absorbPercent / 100.));
+			damage -= std::round(unmodifiedDamage * (absorbPercent / 100.));
 
 			uint16_t charges = item->getCharges();
 			if (charges != 0) {
@@ -1859,7 +1860,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 		if (field) {
 			const int16_t& fieldAbsorbPercent = it.abilities->fieldAbsorbPercent[combatTypeToIndex(combatType)];
 			if (fieldAbsorbPercent != 0) {
-				damage -= std::round(damage * (fieldAbsorbPercent / 100.));
+				damage -= std::round(unmodifiedDamage * (fieldAbsorbPercent / 100.));
 
 				uint16_t charges = item->getCharges();
 				if (charges != 0) {


### PR DESCRIPTION
This small problem was present for a long time and apparently nobody cares, since no one else plans to fix it, I have done it for you to support this engine to be more perfect every time.
With this change there will no longer be a difference between an object that protects 50% or two objects that protect 25% + 25%
If you test the sources prior to this change, you will notice that the results are different and mathematically wrong.

TEST VISUAL
![TestVisual](https://image.prntscr.com/image/KlRygeOgQ6aLqgWBR4HOew.png)

Lua Example:
local damage50 = 1000
damage50 = damage50 - (damage50 / 100 * 50)
print(damage50)

local damage2525 = 1000
damage2525 = damage2525 - (damage2525 / 100 * 25)
damage2525 = damage2525 - (damage2525 / 100 * 25)
print(damage2525)

-- Print 500 <-- 50%
-- Print 562.5 <--- 25% + 25%
