### PR TITLE
Paralyze fixes

### DIFF
--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -487,7 +487,7 @@
 	<rune group="attack" spellid="116" name="Stone Shower Rune" id="2288" allowfaruse="1" charges="4" level="28" magiclevel="4" cooldown="2000" groupcooldown="2000" script="attack/stone_shower_rune.lua" />
 	<rune group="attack" spellid="21" name="Sudden Death Rune" id="2268" allowfaruse="1" charges="3" level="45" magiclevel="15" cooldown="2000" groupcooldown="2000" needtarget="1" blocktype="solid" script="attack/sudden_death_rune.lua" />
 	<rune group="attack" spellid="117" name="Thunderstorm Rune" id="2315" allowfaruse="1" charges="4" level="28" magiclevel="4" cooldown="2000" groupcooldown="2000" script="attack/thunderstorm_rune.lua" />
-	<rune group="attack" spellid="54" name="Paralyze Rune" id="2278" allowfaruse="1" charges="1" level="54" magiclevel="18" aggressive="1" cooldown="2000" groupcooldown="2000" mana="1400" needtarget="1" blocktype="solid" script="attack/paralyze_rune.lua">
+	<rune group="attack" spellid="54" name="Paralyze Rune" id="2278" allowfaruse="1" charges="1" level="54" magiclevel="18" pzlock="1" cooldown="2000" groupcooldown="2000" mana="1400" needtarget="1" blocktype="solid" script="attack/paralyze_rune.lua">
 		<vocation name="Druid" />
 		<vocation name="Elder Druid" showInDescription="0" />
 	</rune>

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -1238,8 +1238,7 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 
 	target = g_game.getCreatureByID(var.number);
 	if (getPzLock() && target) {
-		// NOTICE: we are passing false there, because player will get inFightTicks from Spell:postCastSpell
-		player->onAttackedCreature(target->getCreature(), false);
+		player->onAttackedCreature(target->getCreature());
 	}
 
 	if (hasCharges && item && g_config.getBoolean(ConfigManager::REMOVE_RUNE_CHARGES)) {

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -1238,7 +1238,8 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 
 	target = g_game.getCreatureByID(var.number);
 	if (getPzLock() && target) {
-		player->onAttackedCreature(target->getCreature());
+		// NOTICE: we are passing false there, because player will get inFightTicks from Spell:postCastSpell
+		player->onAttackedCreature(target->getCreature(), false);
 	}
 
 	if (hasCharges && item && g_config.getBoolean(ConfigManager::REMOVE_RUNE_CHARGES)) {

--- a/src/spells.h
+++ b/src/spells.h
@@ -288,6 +288,12 @@ class Spell : public BaseSpell
 		void setAggressive(bool a) {
 			aggressive = a;
 		}
+		bool getPzLock() const {
+			return pzLock;
+		}
+		void setPzLock(bool pzLock) {
+			this->pzLock = pzLock;
+		}
 
 		SpellType_t spellType = SPELL_UNDEFINED;
 
@@ -323,6 +329,7 @@ class Spell : public BaseSpell
 		bool blockingSolid = false;
 		bool blockingCreature = false;
 		bool aggressive = true;
+		bool pzLock = true;
 		bool learnable = false;
 		bool enabled = true;
 		bool premium = false;

--- a/src/spells.h
+++ b/src/spells.h
@@ -329,7 +329,7 @@ class Spell : public BaseSpell
 		bool blockingSolid = false;
 		bool blockingCreature = false;
 		bool aggressive = true;
-		bool pzLock = true;
+		bool pzLock = false;
 		bool learnable = false;
 		bool enabled = true;
 		bool premium = false;


### PR DESCRIPTION
#2840 introduced some inconsistency.
This PR correctly handles targeted runes which inflicts pz lock. Aggressive is true by default which means recent PR changes weren't correctly applied.