### PR TITLE
Removed spike sword description

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -3176,7 +3176,6 @@
 		<attribute key="weaponType" value="club" />
 	</item>
 	<item id="2383" article="a" name="spike sword">
-		<attribute key="description" value="It can be enchanted with an element." />
 		<attribute key="weight" value="5000" />
 		<attribute key="defense" value="21" />
 		<attribute key="attack" value="24" />


### PR DESCRIPTION
It is no longer enchantable and doesn't have its description anymore