### PR TITLE
Make monster loot count accept count higher than 100

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -18,30 +18,47 @@ function Container.createLootItem(self, item)
 	end
 
 	if itemCount > 0 then
-		local tmpItem = self:addItem(item.itemId, math.min(itemCount, 100))
-		if not tmpItem then
+		local tmpItem = {}
+		while itemCount > 100 do
+			local itm = self:addItem(item.itemId, 100)
+			if itm then
+				tmpItem[#tmpItem + 1] = itm
+			end
+			itemCount = itemCount - 100
+		end
+
+		if itemCount > 0 then
+			local itm = self:addItem(item.itemId, itemCount)
+			if itm then
+				tmpItem[#tmpItem + 1] = itm
+			end
+		end
+		
+		if #tmpItem == 0 then
 			return false
 		end
 
-		if tmpItem:isContainer() then
-			for i = 1, #item.childLoot do
-				if not tmpItem:createLootItem(item.childLoot[i]) then
-					tmpItem:remove()
-					return false
+		for index, tmp in pairs(tmpItem) do
+			if tmp:isContainer() then
+				for i = 1, #item.childLoot do
+					if not tmp:createLootItem(item.childLoot[i]) then
+						tmp:remove()
+						return false
+					end
 				end
 			end
-		end
 
-		if item.subType ~= -1 then
-			tmpItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
-		end
+			if item.subType ~= -1 then
+				tmp:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
+			end
 
-		if item.actionId ~= -1 then
-			tmpItem:setActionId(item.actionId)
-		end
+			if item.actionId ~= -1 then
+				tmp:setActionId(item.actionId)
+			end
 
-		if item.text and item.text ~= "" then
-			tmpItem:setText(item.text)
+			if item.text and item.text ~= "" then
+				tmp:setText(item.text)
+			end
 		end
 	end
 	return true


### PR DESCRIPTION
As I've explained in #2859 , @MillhioreBT provided the code, I tested it, and it retains backward compatibility so, why not do it? :+1: 

test with:
`<item name="gold coin" countmax="700" chance="52500" />`

![2020-03-27 18_31_28-Groove Música](https://user-images.githubusercontent.com/4684880/77802463-ad4b1280-7059-11ea-9e18-8ec431fbb738.png)


fixes #2875 
Co-Authored-By: Sarah Wesker <millhiorebt@users.noreply.github.com>