### PR TITLE
Fix combat adding conditions

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -773,7 +773,7 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 	}
 
 	if (success) {
-		if (params.origin != ORIGIN_MELEE && damage.primary.value != 0 && damage.secondary.value != 0) {
+		if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
 			for (const auto& condition : params.conditionList) {
 				if (caster == target || !target->isImmune(condition->getType())) {
 					Condition* conditionCopy = condition->clone();
@@ -899,7 +899,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 					}
 
 					if (success) {
-						if (params.origin != ORIGIN_MELEE && damageCopy.primary.value != 0 && damageCopy.secondary.value != 0) {
+						if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
 							for (const auto& condition : params.conditionList) {
 								if (caster == creature || !creature->isImmune(condition->getType())) {
 									Condition* conditionCopy = condition->clone();

--- a/src/enums.h
+++ b/src/enums.h
@@ -606,10 +606,12 @@ struct CombatDamage
 	} primary, secondary;
 
 	CombatOrigin origin;
+	BlockType_t blockType;
 	bool critical;
 	CombatDamage()
 	{
 		origin = ORIGIN_NONE;
+		blockType = BLOCK_NONE;
 		primary.type = secondary.type = COMBAT_NONE;
 		primary.value = secondary.value = 0;
 		critical = false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3804,6 +3804,9 @@ bool Game::combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* ta
 	} else {
 		secondaryBlockType = BLOCK_NONE;
 	}
+
+	damage.blockType = primaryBlockType;
+
 	return (primaryBlockType != BLOCK_NONE) && (secondaryBlockType != BLOCK_NONE);
 }
 


### PR DESCRIPTION
Rewrite of combat.cpp stopped conditions from being added. For example, if you currently test having a scorpion attack and bleed you, it will not give poison condition.

I also addressed an issue that has been in the repository for a while, which is how conditions will not be added if block type is BLOCK_ARMOR. In real tibia, if you block with armor and get yellow hit marker, you should still receive conditions.

Lastly, I rethought the logic of when you should add conditions, and the previous way did not seem right:
`params.origin != ORIGIN_MELEE && damage.primary.value != 0 && damage.secondary.value != 0`

I cannot see a reason why we should check for ORIGIN_MELEE and also it shouldn't matter if damage was 0 because as explained above BLOCK_ARMOR should still give condition. So instead I have changed it to only check for BLOCK_ARMOR or BLOCK_NONE because BLOCK_DEFENSE and BLOCK_IMMUNITY should not give conditions at all.