### PR TITLE
Improved loading of the storage library.

### DIFF
--- a/data/lib/core/core.lua
+++ b/data/lib/core/core.lua
@@ -1,3 +1,6 @@
+-- Note: The library of storages must be loaded previously to the other libraries.
+dofile('data/lib/core/storages.lua')
+
 dofile('data/lib/core/combat.lua')
 dofile('data/lib/core/constants.lua')
 dofile('data/lib/core/container.lua')
@@ -8,7 +11,6 @@ dofile('data/lib/core/itemtype.lua')
 dofile('data/lib/core/party.lua')
 dofile('data/lib/core/player.lua')
 dofile('data/lib/core/position.lua')
-dofile('data/lib/core/storages.lua')
 dofile('data/lib/core/teleport.lua')
 dofile('data/lib/core/tile.lua')
 dofile('data/lib/core/vocation.lua')


### PR DESCRIPTION
For some reason when the file exceeds a certain number of storages it stops loading and the server scripts will not be able to read at startup.
Making the library load first, the problem no longer happens.

This is the way in which I managed to correct the problem, I did not get to go deeper to get a better solution.