### PR TITLE
Fixes to mad sheep summoning

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -4,6 +4,7 @@ PlayerStorageKeys = {
 	delayLargeSeaShell = 30019,
 	firstRod = 30020,
 	delayWallMirror = 30021,
+	madSheepSummon = 30023,
 }
 
 GlobalStorageKeys = {

--- a/data/monster/Ungulates/mad_sheep.xml
+++ b/data/monster/Ungulates/mad_sheep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Mad Sheep" nameDescription="a mad sheep" race="blood" experience="0" speed="116">
+<monster name="Mad Sheep" nameDescription="a mad sheep" race="blood" experience="0" speed="272">
 	<health now="22" max="22" />
 	<look type="14" corpse="5991" />
 	<targetchange interval="4000" chance="0" />
@@ -23,10 +23,10 @@
 		<attack name="melee" interval="2000" min="0" max="-1" />
 	</attacks>
 	<defenses armor="1" defense="1">
-		<defense name="healing" interval="2000" chance="30" min="5" max="10">
+		<defense name="healing" interval="2000" chance="50" min="5" max="10">
 			<attribute key="areaEffect" value="hearts" />
 		</defense>
-		<defense name="speed" interval="2000" chance="15" speedchange="136" duration="5000" />
+		<defense name="speed" interval="2000" chance="15" speedchange="292" duration="5000" />
 	</defenses>
 	<elements>
 		<element firePercent="-1" />

--- a/data/scripts/actions/others/spellwand.lua
+++ b/data/scripts/actions/others/spellwand.lua
@@ -14,8 +14,9 @@ function spellwand.onUse(player, item, fromPosition, target, toPosition, isHotke
 	if math.random(100) <= 33 then
 		item:remove()
 		player:say("The spellwand broke.", TALKTYPE_MONSTER_SAY)
-		if math.random(100) <= 75 then
+		if math.random(100) <= 75 and player:getStorageValue(PlayerStorageKeys.madSheepSummon) <= os.time() then
 			Game.createMonster("Mad Sheep", fromPosition)
+			player:setStorageValue(PlayerStorageKeys.madSheepSummon, os.time() + 43200)
 		end
 	else
 		target:setMonsterOutfit(monsters[math.random(#monsters)], 60 * 1000)
@@ -26,5 +27,4 @@ function spellwand.onUse(player, item, fromPosition, target, toPosition, isHotke
 end
 
 spellwand:id(7735)
-spellwand:allowFarUse(true)
 spellwand:register()

--- a/data/scripts/actions/others/spellwand.lua
+++ b/data/scripts/actions/others/spellwand.lua
@@ -16,7 +16,7 @@ function spellwand.onUse(player, item, fromPosition, target, toPosition, isHotke
 		player:say("The spellwand broke.", TALKTYPE_MONSTER_SAY)
 		if math.random(100) <= 75 and player:getStorageValue(PlayerStorageKeys.madSheepSummon) <= os.time() then
 			Game.createMonster("Mad Sheep", fromPosition)
-			player:setStorageValue(PlayerStorageKeys.madSheepSummon, os.time() + 43200)
+			player:setStorageValue(PlayerStorageKeys.madSheepSummon, os.time() + 12 * 60 * 60)
 		end
 	else
 		target:setMonsterOutfit(monsters[math.random(#monsters)], 60 * 1000)


### PR DESCRIPTION
- Added cooldown so you can only summon one every 12 hours
- Removed allowFarUse from spellwand, it can only be used in close range
- Increased mad sheep speed, she is pretty fast