### PR TITLE
Fix crash when reloading invalid CreatureEvents

### DIFF
--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -47,6 +47,10 @@ class Event
 		bool scripted = false;
 		bool fromLua = false;
 
+		int32_t getScriptId() {
+			return scriptId;
+		}
+
 	protected:
 		virtual std::string getScriptEventName() const = 0;
 

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -40,6 +40,15 @@ void CreatureEvents::clear(bool fromLua)
 	reInitState(fromLua);
 }
 
+void CreatureEvents::removeInvalidEvents()
+{
+	for (auto it = creatureEvents.begin(); it != creatureEvents.end(); ++it) {
+		if (it->second.getScriptId() == 0) {
+			creatureEvents.erase(it->second.getName());
+		}
+	}
+}
+
 LuaScriptInterface& CreatureEvents::getScriptInterface()
 {
 	return scriptInterface;

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -114,6 +114,8 @@ class CreatureEvents final : public BaseEvents
 		bool registerLuaEvent(CreatureEvent* event);
 		void clear(bool fromLua) override final;
 
+		void removeInvalidEvents();
+
 	private:
 		LuaScriptInterface& getScriptInterface() override;
 		std::string getScriptBaseName() const override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5725,7 +5725,11 @@ bool Game::reload(ReloadTypes_t reloadType)
 		case RELOAD_TYPE_ACTIONS: return g_actions->reload();
 		case RELOAD_TYPE_CHAT: return g_chat->load();
 		case RELOAD_TYPE_CONFIG: return g_config.reload();
-		case RELOAD_TYPE_CREATURESCRIPTS: return g_creatureEvents->reload();
+		case RELOAD_TYPE_CREATURESCRIPTS: {
+			g_creatureEvents->reload();
+			g_creatureEvents->removeInvalidEvents();
+			return true;
+		}
 		case RELOAD_TYPE_EVENTS: return g_events->load();
 		case RELOAD_TYPE_GLOBALEVENTS: return g_globalEvents->reload();
 		case RELOAD_TYPE_ITEMS: return Item::items.reload();
@@ -5770,6 +5774,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_weapons->loadDefaults();
 			g_spells->clear(true);
 			g_scripts->loadScripts("scripts", false, true);
+			g_creatureEvents->removeInvalidEvents();
 			/*
 			Npcs::reload();
 			raids.reload() && raids.startup();
@@ -5816,6 +5821,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_globalEvents->clear(true);
 			g_spells->clear(true);
 			g_scripts->loadScripts("scripts", false, true);
+			g_creatureEvents->removeInvalidEvents();
 			return true;
 		}
 	}


### PR DESCRIPTION
The server crashes when you reload the CreatureEvents module, this happens when you create an event, and then delete it, the server still tries to use the copy of this event, but the copy is invalid, because it was cleaned in the reload.

GIF/already fixed test:
![creatureEventFixed](https://user-images.githubusercontent.com/28090948/78511521-46b9a900-776b-11ea-8aee-d49c62de8f18.gif)