### PR TITLE
[revscriptsys] MoveEvent slot enhancement

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14928,6 +14928,11 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 	// moveevent:register()
 	MoveEvent* moveevent = getUserdata<MoveEvent>(L, 1);
 	if (moveevent) {
+		if ((moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP) && moveevent->getSlot() == SLOTP_WHEREEVER) {
+			uint32_t id = moveevent->getItemIdRange().at(0);
+			ItemType& it = Item::items.getItemType(id);
+			moveevent->setSlot(it.slotPosition);
+		}
 		if (!moveevent->isScripted()) {
 			pushBoolean(L, g_moveEvents->registerLuaFunction(moveevent));
 			return 1;


### PR DESCRIPTION
This will return the default slotType from the first item returned from the array and uses the slot of that item from items.xml, if there was no :slot() method set.
Suggested in #2900