### PR TITLE
Update Container.createLootItem ( item.maxCount increase )

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -23,7 +23,7 @@ function Container.createLootItem(self, item)
 			end
 			if stacks > 1 then
 				randvalue = getLootRandom()
-				if randvalue < item.chance then
+				if randvalue >= item.chance then
 					i = i + 1
 				end
 			end

--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -2,9 +2,9 @@ function Container.isContainer(self)
 	return true
 end
 
-function Container:createLootItem(item, player, bonus)
+function Container.createLootItem(self, item)
 	if self:getEmptySlots() == 0 then
-        return true
+		return true
 	end
 
 	local itemCount = 0
@@ -43,7 +43,7 @@ function Container:createLootItem(item, player, bonus)
 			if item.actionId ~= -1 then
 				itm:setActionId(item.actionId)
 			end
-			
+
 			if item.text and item.text ~= "" then
 				itm:setAttribute(ITEM_ATTRIBUTE_TEXT, item.text)
 			end

--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -2,71 +2,53 @@ function Container.isContainer(self)
 	return true
 end
 
-function Container.createLootItem(self, item)
+function Container:createLootItem(item, player, bonus)
 	if self:getEmptySlots() == 0 then
-		return true
+        return true
 	end
 
 	local itemCount = 0
-	local randvalue = getLootRandom()
-	if randvalue < item.chance then
-		local maxCount = math.min(item.maxCount, 100)
-		local isStackable = ItemType(item.itemId):isStackable()
+	local maxCount = math.min(item.maxCount, 100)
+	if ItemType(item.itemId):isStackable() then
 		local stacks = math.ceil(item.maxCount / 100)
 		for i = 1, stacks do
-			if isStackable then
+			local randvalue = getLootRandom()
+			if randvalue < item.chance then
 				itemCount = itemCount + (randvalue % maxCount + 1)
 				item.maxCount = item.maxCount - maxCount
 				maxCount = math.min(item.maxCount, 100)
-			else
-				itemCount = itemCount + 1
-			end
-			if stacks > 1 then
-				randvalue = getLootRandom()
-				if randvalue >= item.chance then
-					i = i + 1
-				end
 			end
 		end
+	elseif getLootRandom(player, bonus) < item.chance then
+		itemCount = 1
 	end
 
-	if itemCount > 0 then
-		local tmpItem = {}
-		repeat
-			local addCount = math.min(itemCount, 100)
-			local itm = self:addItem(item.itemId, addCount)
-			if itm then
-				tmpItem[#tmpItem + 1] = itm
-			end
-			itemCount = itemCount - addCount
-		until itemCount < 1
-		
-		if #tmpItem == 0 then
-			return false
-		end
-
-		for index, tmp in pairs(tmpItem) do
-			if tmp:isContainer() then
+	repeat
+		local addCount = math.min(itemCount, 100)
+		local itm = self:addItem(item.itemId, addCount)
+		if itm then
+			if itm:isContainer() then
 				for i = 1, #item.childLoot do
-					if not tmp:createLootItem(item.childLoot[i]) then
-						tmp:remove()
+					if not itm:createLootItem(item.childLoot[i]) then
+						itm:remove()
 						return false
 					end
 				end
 			end
 
 			if item.subType ~= -1 then
-				tmp:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
+				itm:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
 			end
 
 			if item.actionId ~= -1 then
-				tmp:setActionId(item.actionId)
+				itm:setActionId(item.actionId)
 			end
-
+			
 			if item.text and item.text ~= "" then
-				tmp:setText(item.text)
+				itm:setAttribute(ITEM_ATTRIBUTE_TEXT, item.text)
 			end
 		end
-	end
+		itemCount = itemCount - addCount
+	until itemCount < 1
 	return true
 end

--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -10,38 +10,55 @@ function Container.createLootItem(self, item)
 	local itemCount = 0
 	local randvalue = getLootRandom()
 	if randvalue < item.chance then
-		if ItemType(item.itemId):isStackable() then
-			itemCount = randvalue % item.maxCount + 1
-		else
-			itemCount = 1
+		local maxCount = math.min(item.maxCount, 100)
+		local isStackable = ItemType(item.itemId):isStackable()
+		for i = 1, math.ceil(item.maxCount / 100) do
+			if isStackable then
+				itemCount = itemCount + (randvalue % maxCount + 1)
+				item.maxCount = item.maxCount - maxCount
+				maxCount = math.min(item.maxCount, 100)
+			else
+				itemCount = itemCount + 1
+			end
 		end
 	end
 
 	if itemCount > 0 then
-		local tmpItem = self:addItem(item.itemId, math.min(itemCount, 100))
-		if not tmpItem then
+		local tmpItem = {}
+		repeat
+			local addCount = math.min(itemCount, 100)
+			local itm = self:addItem(item.itemId, addCount)
+			if itm then
+				tmpItem[#tmpItem + 1] = itm
+			end
+			itemCount = itemCount - addCount
+		until itemCount < 1
+		
+		if #tmpItem == 0 then
 			return false
 		end
 
-		if tmpItem:isContainer() then
-			for i = 1, #item.childLoot do
-				if not tmpItem:createLootItem(item.childLoot[i]) then
-					tmpItem:remove()
-					return false
+		for index, tmp in pairs(tmpItem) do
+			if tmp:isContainer() then
+				for i = 1, #item.childLoot do
+					if not tmp:createLootItem(item.childLoot[i]) then
+						tmp:remove()
+						return false
+					end
 				end
 			end
-		end
 
-		if item.subType ~= -1 then
-			tmpItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
-		end
+			if item.subType ~= -1 then
+				tmp:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
+			end
 
-		if item.actionId ~= -1 then
-			tmpItem:setActionId(item.actionId)
-		end
+			if item.actionId ~= -1 then
+				tmp:setActionId(item.actionId)
+			end
 
-		if item.text and item.text ~= "" then
-			tmpItem:setText(item.text)
+			if item.text and item.text ~= "" then
+				tmp:setText(item.text)
+			end
 		end
 	end
 	return true

--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -12,13 +12,20 @@ function Container.createLootItem(self, item)
 	if randvalue < item.chance then
 		local maxCount = math.min(item.maxCount, 100)
 		local isStackable = ItemType(item.itemId):isStackable()
-		for i = 1, math.ceil(item.maxCount / 100) do
+		local stacks = math.ceil(item.maxCount / 100)
+		for i = 1, stacks do
 			if isStackable then
 				itemCount = itemCount + (randvalue % maxCount + 1)
 				item.maxCount = item.maxCount - maxCount
 				maxCount = math.min(item.maxCount, 100)
 			else
 				itemCount = itemCount + 1
+			end
+			if stacks > 1 then
+				randvalue = getLootRandom()
+				if randvalue < item.chance then
+					i = i + 1
+				end
 			end
 		end
 	end


### PR DESCRIPTION
With these changes you can increase the maximum number of stackable objects, for example:
![image](https://user-images.githubusercontent.com/28090948/78634448-f9742f00-7871-11ea-9c09-60acf8dfd603.png)

Other info: If the maximum number is greater than 100, take measures so that this does not affect the standard behavior, if for example the number was 200, the calculation is divided into two, so that it is treated as two items of 100 and 100, the same for the other major cases.

This is a request from the PR: https://github.com/otland/forgottenserver/pull/2875