### PR TITLE
Fix isPersistent condition check

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -266,7 +266,7 @@ bool Condition::isPersistent() const
 		return true;
 	}
 
-	if (id == CONDITIONID_DEFAULT || id == CONDITIONID_COMBAT) {
+	if (id == CONDITIONID_DEFAULT || id == CONDITIONID_COMBAT || conditionType == CONDITION_MUTED) {
 		return true;
 	}
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -263,14 +263,14 @@ bool Condition::startCondition(Creature*)
 bool Condition::isPersistent() const
 {
 	if (ticks == -1) {
-		return false;
+		return true;
 	}
 
-	if (!(id == CONDITIONID_DEFAULT || id == CONDITIONID_COMBAT || conditionType == CONDITION_MUTED)) {
-		return false;
+	if (id == CONDITIONID_DEFAULT || id == CONDITIONID_COMBAT) {
+		return true;
 	}
 
-	return true;
+	return false;
 }
 
 uint32_t Condition::getIcons() const

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2030,7 +2030,7 @@ void Player::death(Creature* lastHitCreature)
 		auto it = conditions.begin(), end = conditions.end();
 		while (it != end) {
 			Condition* condition = *it;
-			if (condition->isPersistent()) {
+			if (!condition->isPersistent()) {
 				it = conditions.erase(it);
 
 				condition->endCondition(this);
@@ -2046,7 +2046,7 @@ void Player::death(Creature* lastHitCreature)
 		auto it = conditions.begin(), end = conditions.end();
 		while (it != end) {
 			Condition* condition = *it;
-			if (condition->isPersistent()) {
+			if (!condition->isPersistent()) {
 				it = conditions.erase(it);
 
 				condition->endCondition(this);


### PR DESCRIPTION
Fixed - When a player dies, the condition muted is removed.
Fixed - When a player received conditions such as outfit, drunk, etc. All will be removed if he relogged.

It doesn't make sense for the function name to be isPersistent which to me means "persists" and after dead/logout the condition to be removed.