### PR TITLE
Fix Container::queryMaxCount() bug

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2256,7 +2256,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 	if (childIsOwner) {
 		//a child container is querying the player, just check if enough capacity
 		bool skipLimit = hasBitSet(FLAG_NOLIMIT, flags);
-		if (skipLimit || hasCapacity(item, count)) {
+		if (skipLimit || hasCapacity(item, item->getItemCount())) {
 			return RETURNVALUE_NOERROR;
 		}
 		return RETURNVALUE_NOTENOUGHCAPACITY;
@@ -2444,7 +2444,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 	}
 
 	//check if enough capacity
-	if (!hasCapacity(item, count)) {
+	if (!hasCapacity(item, item->getItemCount())) {
 		return RETURNVALUE_NOTENOUGHCAPACITY;
 	}
 


### PR DESCRIPTION
Fix #1561 

Explanation: current code is trying to query remainder which is for example 90 thus it calculates cap for 90x of that item not the real count that we add to backpack.