### PR TITLE
Change storage values size to int64_t

### DIFF
--- a/data/migrations/25.lua
+++ b/data/migrations/25.lua
@@ -1,3 +1,5 @@
 function onUpdateDatabase()
-	return false
+	print('> Updating database to version 26 (Change storage values to 64bit signed integers)')
+	db.query('ALTER TABLE `player_storage` MODIFY COLUMN `value` bigint(20) NOT NULL DEFAULT 0')
+	return true
 end

--- a/data/migrations/26.lua
+++ b/data/migrations/26.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -312,7 +312,7 @@ CREATE TABLE IF NOT EXISTS `player_spells` (
 CREATE TABLE IF NOT EXISTS `player_storage` (
   `player_id` int(11) NOT NULL DEFAULT '0',
   `key` int(10) unsigned NOT NULL DEFAULT '0',
-  `value` int(11) NOT NULL DEFAULT '0',
+  `value` bigint(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`player_id`,`key`),
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -546,7 +546,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	query << "SELECT `key`, `value` FROM `player_storage` WHERE `player_id` = " << player->getGUID();
 	if ((result = db.storeQuery(query.str()))) {
 		do {
-			player->addStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int32_t>("value"), true);
+			player->addStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int64_t>("value"), true);
 		} while (result->next());
 	}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8727,7 +8727,7 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 	}
 
 	uint32_t key = getNumber<uint32_t>(L, 2);
-	int32_t value;
+	int64_t value;
 	if (player->getStorageValue(key, value)) {
 		lua_pushnumber(L, value);
 	} else {
@@ -8739,7 +8739,7 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 {
 	// player:setStorageValue(key, value)
-	int32_t value = getNumber<int32_t>(L, 3);
+	int64_t value = getNumber<int64_t>(L, 3);
 	uint32_t key = getNumber<uint32_t>(L, 2);
 	Player* player = getUserdata<Player>(L, 1);
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -156,7 +156,7 @@ class ScriptEnvironment
 
 	private:
 		using VariantVector = std::vector<const LuaVariant*>;
-		using StorageMap = std::map<uint32_t, int32_t>;
+		using StorageMap = std::map<uint32_t, int64_t>;
 		using DBResultMap = std::map<uint32_t, DBResult_ptr>;
 
 		LuaScriptInterface* interface;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -621,7 +621,7 @@ uint16_t Player::getLookCorpse() const
 	}
 }
 
-void Player::addStorageValue(const uint32_t key, const int32_t value, const bool isLogin/* = false*/)
+void Player::addStorageValue(const uint32_t key, const int64_t value, const bool isLogin/* = false*/)
 {
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
 		if (IS_IN_KEYRANGE(key, OUTFITS_RANGE)) {
@@ -639,7 +639,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 	}
 
 	if (value != -1) {
-		int32_t oldValue;
+		int64_t oldValue;
 		getStorageValue(key, oldValue);
 
 		storageMap[key] = value;
@@ -656,7 +656,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 	}
 }
 
-bool Player::getStorageValue(const uint32_t key, int32_t& value) const
+bool Player::getStorageValue(const uint32_t key, int64_t& value) const
 {
 	auto it = storageMap.find(key);
 	if (it == storageMap.end()) {
@@ -4085,7 +4085,7 @@ GuildEmblems_t Player::getGuildEmblem(const Player* player) const
 
 uint8_t Player::getCurrentMount() const
 {
-	int32_t value;
+	int64_t value;
 	if (getStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, value)) {
 		return value;
 	}
@@ -4173,11 +4173,11 @@ bool Player::tameMount(uint8_t mountId)
 	const uint8_t tmpMountId = mountId - 1;
 	const uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
 
-	int32_t value;
+	int64_t value;
 	if (getStorageValue(key, value)) {
-		value |= (1 << (tmpMountId % 31));
+		value |= (1ULL << (tmpMountId % 31));
 	} else {
-		value = (1 << (tmpMountId % 31));
+		value = (1ULL << (tmpMountId % 31));
 	}
 
 	addStorageValue(key, value);
@@ -4193,7 +4193,7 @@ bool Player::untameMount(uint8_t mountId)
 	const uint8_t tmpMountId = mountId - 1;
 	const uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
 
-	int32_t value;
+	int64_t value;
 	if (!getStorageValue(key, value)) {
 		return true;
 	}
@@ -4225,12 +4225,12 @@ bool Player::hasMount(const Mount* mount) const
 
 	const uint8_t tmpMountId = mount->id - 1;
 
-	int32_t value;
+	int64_t value;
 	if (!getStorageValue(PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31), value)) {
 		return false;
 	}
 
-	return ((1 << (tmpMountId % 31)) & value) != 0;
+	return ((1ULL << (tmpMountId % 31)) & value) != 0;
 }
 
 void Player::dismount()

--- a/src/player.h
+++ b/src/player.h
@@ -339,8 +339,8 @@ class Player final : public Creature, public Cylinder
 
 		bool canOpenCorpse(uint32_t ownerId) const;
 
-		void addStorageValue(const uint32_t key, const int32_t value, const bool isLogin = false);
-		bool getStorageValue(const uint32_t key, int32_t& value) const;
+		void addStorageValue(const uint32_t key, const int64_t value, const bool isLogin = false);
+		bool getStorageValue(const uint32_t key, int64_t& value) const;
 		void genReservedStorageRange();
 
 		void setGroup(Group* newGroup) {
@@ -1195,7 +1195,7 @@ class Player final : public Creature, public Cylinder
 		std::map<uint8_t, OpenContainer> openContainers;
 		std::map<uint32_t, DepotLocker*> depotLockerMap;
 		std::map<uint32_t, DepotChest*> depotChests;
-		std::map<uint32_t, int32_t> storageMap;
+		std::map<uint32_t, int64_t> storageMap;
 
 		std::vector<OutfitEntry> outfits;
 		GuildWarVector guildWarVector;

--- a/src/quests.cpp
+++ b/src/quests.cpp
@@ -25,7 +25,7 @@
 
 std::string Mission::getDescription(Player* player) const
 {
-	int32_t value;
+	int64_t value;
 	player->getStorageValue(storageID, value);
 
 	if (!mainDescription.empty()) {
@@ -36,7 +36,7 @@ std::string Mission::getDescription(Player* player) const
 	}
 
 	if (ignoreEndValue) {
-		for (int32_t current = endValue; current >= startValue; current--) {
+		for (int64_t current = endValue; current >= startValue; current--) {
 			if (value >= current) {
 				auto sit = descriptions.find(current);
 				if (sit != descriptions.end()) {
@@ -45,7 +45,7 @@ std::string Mission::getDescription(Player* player) const
 			}
 		}
 	} else {
-		for (int32_t current = endValue; current >= startValue; current--) {
+		for (int64_t current = endValue; current >= startValue; current--) {
 			if (value == current) {
 				auto sit = descriptions.find(current);
 				if (sit != descriptions.end()) {
@@ -63,7 +63,7 @@ bool Mission::isStarted(Player* player) const
 		return false;
 	}
 
-	int32_t value;
+	int64_t value;
 	if (!player->getStorageValue(storageID, value)) {
 		return false;
 	}
@@ -85,7 +85,7 @@ bool Mission::isCompleted(Player* player) const
 		return false;
 	}
 
-	int32_t value;
+	int64_t value;
 	if (!player->getStorageValue(storageID, value)) {
 		return false;
 	}
@@ -132,7 +132,7 @@ bool Quest::isStarted(Player* player) const
 		return false;
 	}
 
-	int32_t value;
+	int64_t value;
 	if (!player->getStorageValue(startStorageID, value) || value < startStorageValue) {
 		return false;
 	}
@@ -161,7 +161,7 @@ bool Quests::loadFromXml()
 			questNode.attribute("name").as_string(),
 			++id,
 			pugi::cast<int32_t>(questNode.attribute("startstorageid").value()),
-			pugi::cast<int32_t>(questNode.attribute("startstoragevalue").value())
+			pugi::cast<int64_t>(questNode.attribute("startstoragevalue").value())
 		);
 		Quest& quest = quests.back();
 
@@ -171,8 +171,8 @@ bool Quests::loadFromXml()
 			quest.missions.emplace_back(
 				missionNode.attribute("name").as_string(),
 				pugi::cast<int32_t>(missionNode.attribute("storageid").value()),
-				pugi::cast<int32_t>(missionNode.attribute("startvalue").value()),
-				pugi::cast<int32_t>(missionNode.attribute("endvalue").value()),
+				pugi::cast<int64_t>(missionNode.attribute("startvalue").value()),
+				pugi::cast<int64_t>(missionNode.attribute("endvalue").value()),
 				missionNode.attribute("ignoreendvalue").as_bool()
 			);
 			Mission& mission = quest.missions.back();
@@ -211,7 +211,7 @@ uint16_t Quests::getQuestsCount(Player* player) const
 	return count;
 }
 
-bool Quests::isQuestStorage(const uint32_t key, const int32_t value, const int32_t oldValue) const
+bool Quests::isQuestStorage(const uint32_t key, const int64_t value, const int64_t oldValue) const
 {
 	for (const Quest& quest : quests) {
 		if (quest.getStartStorageId() == key && quest.getStartStorageValue() == value) {

--- a/src/quests.h
+++ b/src/quests.h
@@ -32,7 +32,7 @@ using QuestsList = std::list<Quest>;
 class Mission
 {
 	public:
-		Mission(std::string name, int32_t storageID, int32_t startValue, int32_t endValue, bool ignoreEndValue) :
+		Mission(std::string name, int32_t storageID, int64_t startValue, int64_t endValue, bool ignoreEndValue) :
 			name(std::move(name)), storageID(storageID), startValue(startValue), endValue(endValue), ignoreEndValue(ignoreEndValue) {}
 
 		bool isCompleted(Player* player) const;
@@ -43,10 +43,10 @@ class Mission
 		uint32_t getStorageId() const {
 			return storageID;
 		}
-		int32_t getStartStorageValue() const {
+		int64_t getStartStorageValue() const {
 			return startValue;
 		}
-		int32_t getEndStorageValue() const {
+		int64_t getEndStorageValue() const {
 			return endValue;
 		}
 
@@ -56,14 +56,14 @@ class Mission
 	private:
 		std::string name;
 		uint32_t storageID;
-		int32_t startValue, endValue;
+		int64_t startValue, endValue;
 		bool ignoreEndValue;
 };
 
 class Quest
 {
 	public:
-		Quest(std::string name, uint16_t id, int32_t startStorageID, int32_t startStorageValue) :
+		Quest(std::string name, uint16_t id, int32_t startStorageID, int64_t startStorageValue) :
 			name(std::move(name)), startStorageID(startStorageID), startStorageValue(startStorageValue), id(id) {}
 
 		bool isCompleted(Player* player) const;
@@ -79,7 +79,7 @@ class Quest
 		uint32_t getStartStorageId() const {
 			return startStorageID;
 		}
-		int32_t getStartStorageValue() const {
+		int64_t getStartStorageValue() const {
 			return startStorageValue;
 		}
 
@@ -91,7 +91,7 @@ class Quest
 		std::string name;
 
 		uint32_t startStorageID;
-		int32_t startStorageValue;
+		int64_t startStorageValue;
 		uint16_t id;
 
 		MissionsList missions;
@@ -108,7 +108,7 @@ class Quests
 
 		bool loadFromXml();
 		Quest* getQuestByID(uint16_t id);
-		bool isQuestStorage(const uint32_t key, const int32_t value, const int32_t oldValue) const;
+		bool isQuestStorage(const uint32_t key, const int64_t value, const int64_t oldValue) const;
 		uint16_t getQuestsCount(Player* player) const;
 		bool reload();
 


### PR DESCRIPTION
Main point of this was to use `os.mtime()` as a storage value for more precision.