### PR TITLE
Fix trade bug

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2728,13 +2728,11 @@ void Game::playerAcceptTrade(uint32_t playerId)
 
 		// if player is trying to trade its own backpack
 		if (tradePartner->getInventoryItem(CONST_SLOT_BACKPACK) == partnerTradeItem) {
-			slots_t playerSlotItem = getSlotType(Item::items[playerTradeItem->getID()]);
-			tradePartnerRet = (tradePartner->getInventoryItem(playerSlotItem) ? RETURNVALUE_NOTENOUGHROOM : RETURNVALUE_NOERROR);
+			tradePartnerRet = (tradePartner->getInventoryItem(getSlotType(Item::items[playerTradeItem->getID()])) ? RETURNVALUE_NOTENOUGHROOM : RETURNVALUE_NOERROR);
 		}
 
 		if (player->getInventoryItem(CONST_SLOT_BACKPACK) == playerTradeItem) {
-			slots_t partnerSlotItem = getSlotType(Item::items[partnerTradeItem->getID()]);
-			playerRet = (player->getInventoryItem(partnerSlotItem) ? RETURNVALUE_NOTENOUGHROOM : RETURNVALUE_NOERROR);
+			playerRet = (player->getInventoryItem(getSlotType(Item::items[partnerTradeItem->getID()])) ? RETURNVALUE_NOTENOUGHROOM : RETURNVALUE_NOERROR);
 		}
 
 		if (tradePartnerRet == RETURNVALUE_NOERROR && playerRet == RETURNVALUE_NOERROR) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2723,25 +2723,17 @@ void Game::playerAcceptTrade(uint32_t playerId)
 
 		bool isSuccess = false;
 		
-		// assign item as itemType
-		const ItemType& partnerItemType = Item::items[partnerTradeItem->getID()];
-		const ItemType& playerItemType = Item::items[playerTradeItem->getID()];
-
-		// retrieve slot type for given item
-		slots_t partnerSlotItem = getSlotType(partnerItemType);
-		slots_t playerSlotItem = getSlotType(playerItemType);
-
-		// initialise default variables
 		ReturnValue tradePartnerRet = RETURNVALUE_NOERROR;
 		ReturnValue playerRet = RETURNVALUE_NOERROR;
 
 		// if player is trying to trade its own backpack
 		if (tradePartner->getInventoryItem(CONST_SLOT_BACKPACK) == partnerTradeItem) {
-			// check if player will have free slot available
+			slots_t playerSlotItem = getSlotType(Item::items[playerTradeItem->getID()]);
 			tradePartnerRet = (tradePartner->getInventoryItem(playerSlotItem) ? RETURNVALUE_NOTENOUGHROOM : RETURNVALUE_NOERROR);
 		}
 
 		if (player->getInventoryItem(CONST_SLOT_BACKPACK) == playerTradeItem) {
+			slots_t partnerSlotItem = getSlotType(Item::items[partnerTradeItem->getID()]);
 			playerRet = (player->getInventoryItem(partnerSlotItem) ? RETURNVALUE_NOTENOUGHROOM : RETURNVALUE_NOERROR);
 		}
 


### PR DESCRIPTION
More information about the bug can be found here: https://otland.net/threads/trade-bug.270083/

Feel free to change the code if you feel there is a better approach as it's my first time looking into C++ properly. One of the things I wanted to change is to simply call slotType for traded item, like this: playerTradeItem->getSlotType(). But unfortunately, it does not seem possible as first you have to retrieve its type and then use another function to retrieve its slot type.

Anyway, with these changes, the bug goes away!