### PR TITLE
Fixes using shovel on sand hole spots

### DIFF
--- a/data/actions/lib/actions.lua
+++ b/data/actions/lib/actions.lua
@@ -170,14 +170,14 @@ function onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
 
 		toPosition.z = toPosition.z + 1
 		tile:relocateTo(toPosition)
-	elseif table.contains(sandIds, groundId) then
+	elseif table.contains(sandIds, groundId) and target.actionid == 100 then
 		local randomValue = math.random(1, 100)
-		if target.actionid == 100 and randomValue <= 20 then
+		if randomValue <= 20 then
 			ground:transform(489)
 			ground:decay()
-		elseif randomValue == 1 then
+		elseif randomValue >= 98 then
 			Game.createItem(2159, 1, toPosition)
-		elseif randomValue > 95 then
+		elseif randomValue >= 93 then
 			Game.createMonster("Scarab", toPosition)
 		end
 		toPosition:sendMagicEffect(CONST_ME_POFF)

--- a/data/actions/lib/actions.lua
+++ b/data/actions/lib/actions.lua
@@ -175,9 +175,9 @@ function onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
 		if randomValue <= 20 then
 			ground:transform(489)
 			ground:decay()
-		elseif randomValue >= 98 then
+		elseif randomValue > 99 then
 			Game.createItem(2159, 1, toPosition)
-		elseif randomValue >= 93 then
+		elseif randomValue >= 95 then
 			Game.createMonster("Scarab", toPosition)
 		end
 		toPosition:sendMagicEffect(CONST_ME_POFF)


### PR DESCRIPTION
When using a shovel on sand with action id 100 it should:
1) 20% of the time open the hole
2) 5% of the time spawn a scarab
3) 1% of the time spawn a scarab coin

This script was able to do 2 and 3 on a sand spots without action id 100.
This script was not able to do 3 on a sand spot with action id 100.

It is now fixed.