### PR TITLE
Disappearing item trade fix

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2731,10 +2731,17 @@ void Game::playerAcceptTrade(uint32_t playerId)
 			if (tradePartnerRet == RETURNVALUE_NOERROR && playerRet == RETURNVALUE_NOERROR) {
 				tradePartnerRet = internalMoveItem(playerTradeItem->getParent(), tradePartner, INDEX_WHEREEVER, playerTradeItem, playerTradeItem->getItemCount(), nullptr, FLAG_IGNOREAUTOSTACK, nullptr, partnerTradeItem);
 				if (tradePartnerRet == RETURNVALUE_NOERROR) {
-					internalMoveItem(partnerTradeItem->getParent(), player, INDEX_WHEREEVER, partnerTradeItem, partnerTradeItem->getItemCount(), nullptr, FLAG_IGNOREAUTOSTACK);
-					playerTradeItem->onTradeEvent(ON_TRADE_TRANSFER, tradePartner);
-					partnerTradeItem->onTradeEvent(ON_TRADE_TRANSFER, player);
-					isSuccess = true;
+					// check again if we can move this item to player
+					playerRet = internalAddItem(player, partnerTradeItem, INDEX_WHEREEVER, 0, true);
+					if (playerRet != RETURNVALUE_NOERROR) {
+						// we cant, so container was probably moved (or any item that removed the free spot/spots), so revert the first move
+						internalMoveItem(playerTradeItem->getParent(), player, INDEX_WHEREEVER, playerTradeItem, playerTradeItem->getItemCount(), nullptr, FLAG_IGNOREAUTOSTACK, nullptr, partnerTradeItem);
+					} else {
+						internalMoveItem(partnerTradeItem->getParent(), player, INDEX_WHEREEVER, partnerTradeItem, partnerTradeItem->getItemCount(), nullptr, FLAG_IGNOREAUTOSTACK);
+						playerTradeItem->onTradeEvent(ON_TRADE_TRANSFER, tradePartner);
+						partnerTradeItem->onTradeEvent(ON_TRADE_TRANSFER, player);
+						isSuccess = true;
+					}
 				}
 			}
 		}

--- a/src/player.h
+++ b/src/player.h
@@ -1305,6 +1305,7 @@ class Player final : public Creature, public Cylinder
 		bool isConnecting = false;
 		bool addAttackSkillPoint = false;
 		bool inventoryAbilities[CONST_SLOT_LAST + 1] = {};
+		bool tradeOwner = false;
 
 		static uint32_t playerAutoID;
 


### PR DESCRIPTION
This is alternative version of fix provided by @mackerel225 in #2966
also now player and partner variable are guaranteed to be the real trade requester and trade partner, does not matter who accepted the trade last.