### PR TITLE
Minor formatting fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,5 @@ indent_brace_style = K&R
 spaces_around_brackets = none
 
 [.travis.yml]
-indent_style = spaces
+indent_style = space
 indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM alpine:edge
 RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
   boost-iostreams \
   boost-system \
-	boost-filesystem \
+  boost-filesystem \
   crypto++ \
   gmp \
   luajit \


### PR DESCRIPTION
`.editorconfig`'s indent_style does not use plural `spaces`