### PR TITLE
Ignore dll and txt files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ build/
 *.log
 *.scc
 *.dll
-*.txt
+*.exe
 
 # Visual C++ cache files
 ipch/

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ build/
 *.pidb
 *.log
 *.scc
+*.dll
+*.txt
 
 # Visual C++ cache files
 ipch/


### PR DESCRIPTION
In my opinion we are missing these. Dlls should also be ignore, because we don't even push them to repository, same with txt files.