### PR TITLE
new method itemType:getDecayTime()

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2614,6 +2614,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("ItemType", "getTransformDeEquipId", LuaScriptInterface::luaItemTypeGetTransformDeEquipId);
 	registerMethod("ItemType", "getDestroyId", LuaScriptInterface::luaItemTypeGetDestroyId);
 	registerMethod("ItemType", "getDecayId", LuaScriptInterface::luaItemTypeGetDecayId);
+	registerMethod("ItemType", "getDecayTime", LuaScriptInterface::luaItemTypeGetDecayTime);
 	registerMethod("ItemType", "getRequiredLevel", LuaScriptInterface::luaItemTypeGetRequiredLevel);
 	registerMethod("ItemType", "getAmmoType", LuaScriptInterface::luaItemTypeGetAmmoType);
 	registerMethod("ItemType", "getCorpseType", LuaScriptInterface::luaItemTypeGetCorpseType);
@@ -11648,6 +11649,24 @@ int LuaScriptInterface::luaItemTypeGetDecayId(lua_State* L)
 	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushnumber(L, itemType->decayTo);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaItemTypeGetDecayTime(lua_State* L)
+{
+	// itemType:getDecayTime()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		uint32_t decayTime = itemType->decayTime;
+		if (decayTime == 0 && itemType->showDuration) {
+			const ItemType& equipItemType = Item::items[itemType->transformEquipTo];
+			decayTime = equipItemType.decayTime;
+		}
+
+		lua_pushnumber(L, decayTime);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1166,6 +1166,7 @@ class LuaScriptInterface
 		static int luaItemTypeGetTransformDeEquipId(lua_State* L);
 		static int luaItemTypeGetDestroyId(lua_State* L);
 		static int luaItemTypeGetDecayId(lua_State* L);
+		static int luaItemTypeGetDecayTime(lua_State* L);
 		static int luaItemTypeGetRequiredLevel(lua_State* L);
 		static int luaItemTypeGetAmmoType(lua_State* L);
 		static int luaItemTypeGetCorpseType(lua_State* L);


### PR DESCRIPTION
fixed version of #1229 (added missing & symbol)
closes #1212 

test results:
```
15:29 > print(ItemType("dead rat"):getDecayTime())	-> 300 /dead rat
15:29 > print(ItemType(2168):getDecayTime())		-> 1200 /life ring
15:29 > print(ItemType(2169):getDecayTime())		-> 600 /time ring
15:29 > print(ItemType(407):getDecayTime())		-> 0 /black tile floor
15:30 > print(ItemType(2640):getDecayTime())		-> 14400 /active soft boots
15:42 > print(ItemType.getDecayTime())			-> nil /empty value
15:42 > print(ItemType.getDecayTime({}))		-> nil /table as argument
```

didn't had a single crash