### PR TITLE
New math option config exp formula

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -101,6 +101,10 @@ rateLoot = 2
 rateMagic = 3
 rateSpawn = 1
 
+-- Formulas
+-- NOTE: default experienceForLevel formula = ((50 * lv * lv * lv) - (150 * lv * lv) + (400 * lv)) / 3
+experienceForLevel = {50, 150, 400, 3}
+
 -- Monsters
 deSpawnRange = 2
 deSpawnRadius = 50

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -117,17 +117,25 @@ class ConfigManager
 			LAST_INTEGER_CONFIG /* this must be the last one */
 		};
 
+		enum table_num_config_t {
+			EXPERIENCE_FOR_LEVEL,
+
+			LAST_TABLENUM_CONFIG /* this must be the last one */
+		};
+
 		bool load();
 		bool reload();
 
 		const std::string& getString(string_config_t what) const;
 		int32_t getNumber(integer_config_t what) const;
 		bool getBoolean(boolean_config_t what) const;
+		std::vector<double> getTableNum(table_num_config_t what) const;
 
 	private:
 		std::string string[LAST_STRING_CONFIG] = {};
 		int32_t integer[LAST_INTEGER_CONFIG] = {};
 		bool boolean[LAST_BOOLEAN_CONFIG] = {};
+		std::vector<double> tableNum[LAST_TABLENUM_CONFIG] = {};
 
 		bool loaded = false;
 };

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1048,6 +1048,9 @@ void LuaScriptInterface::registerFunctions()
 	//sendGuildChannelMessage(guildId, type, message)
 	lua_register(luaState, "sendGuildChannelMessage", LuaScriptInterface::luaSendGuildChannelMessage);
 
+	//getExpForLevel(level)
+	lua_register(luaState, "getExpForLevel", LuaScriptInterface::luaGetExpForLevel);
+
 #ifndef LUAJIT_VERSION
 	//bit operations for Lua, based on bitlib project release 24
 	//bit.bnot, bit.band, bit.bor, bit.bxor, bit.lshift, bit.rshift
@@ -3696,6 +3699,14 @@ int LuaScriptInterface::luaSendGuildChannelMessage(lua_State* L)
 	std::string message = getString(L, 3);
 	channel->sendToAll(message, type);
 	pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaGetExpForLevel(lua_State* L)
+{
+	//getExpForLevel(level)
+	int32_t level = getNumber<int32_t>(L, 1);
+	lua_pushnumber(L, Player::getExpForLevel(level));
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -479,6 +479,8 @@ class LuaScriptInterface
 		static int luaSendChannelMessage(lua_State* L);
 		static int luaSendGuildChannelMessage(lua_State* L);
 
+		static int luaGetExpForLevel(lua_State* L);
+
 #ifndef LUAJIT_VERSION
 		static int luaBitNot(lua_State* L);
 		static int luaBitAnd(lua_State* L);

--- a/src/player.h
+++ b/src/player.h
@@ -36,6 +36,7 @@
 #include "groups.h"
 #include "town.h"
 #include "mounts.h"
+#include "configmanager.h"
 
 class House;
 class NetworkMessage;
@@ -107,6 +108,8 @@ using MuteCountMap = std::map<uint32_t, uint32_t>;
 
 static constexpr int32_t PLAYER_MAX_SPEED = 1500;
 static constexpr int32_t PLAYER_MIN_SPEED = 10;
+
+extern ConfigManager g_config;
 
 class Player final : public Creature, public Cylinder
 {
@@ -181,7 +184,8 @@ class Player final : public Creature, public Cylinder
 
 		static uint64_t getExpForLevel(int32_t lv) {
 			lv--;
-			return ((50ULL * lv * lv * lv) - (150ULL * lv * lv) + (400ULL * lv)) / 3ULL;
+			std::vector<double> F = g_config.getTableNum(ConfigManager::EXPERIENCE_FOR_LEVEL);
+			return static_cast<uint64_t>(((F[0] * lv * lv * lv) - (F[1] * lv * lv) + (F[2] * lv)) / F[3]);
 		}
 
 		uint16_t getStaminaMinutes() const {


### PR DESCRIPTION
Open proposal!

With this change you will be able to control the flow of experience through the levels, giving you the opportunity to further modify your server, the function `getExpForLevel` will now be available in the global functions environment of the server

![image](https://user-images.githubusercontent.com/28090948/80744670-055bb580-8aed-11ea-86c2-78359d3b54af.png)
![image](https://user-images.githubusercontent.com/28090948/80744708-15739500-8aed-11ea-9fa3-eb37a041a001.png)
