### PR TITLE
Adding github action to build on linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # DEBUG
+  debug_build:
+    # The type of runner that the job will run on
+    runs-on: [ubuntu-18.04]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: sudo apt install cmake build-essential liblua5.2-dev libgmp3-dev libmysqlclient-dev libboost-system-dev libboost-iostreams-dev libboost-filesystem-dev libpugixml-dev libcrypto++-dev
+
+    # Runs a set of commands using the runners shell
+    - name: Prepare build Environment
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+    
+    # Building
+    - name: Build
+      run: |
+        cd build
+        make -j `nproc`
+  
+  # RELEASE
+  release_build:
+    # The type of runner that the job will run on
+    runs-on: [ubuntu-18.04]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: sudo apt install cmake build-essential liblua5.2-dev libgmp3-dev libmysqlclient-dev libboost-system-dev libboost-iostreams-dev libboost-filesystem-dev libpugixml-dev libcrypto++-dev
+
+    # Runs a set of commands using the runners shell
+    - name: Prepare build Environment
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+    
+    # Building
+    - name: Build
+      run: |
+        cd build
+        make -j `nproc`
+		

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,13 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Debug ..
-    
+
     # Building
     - name: Build
       run: |
         cd build
         make -j `nproc`
-  
+
   # RELEASE
   release_build:
     # The type of runner that the job will run on
@@ -55,10 +55,9 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release ..
-    
+
     # Building
     - name: Build
       run: |
         cd build
         make -j `nproc`
-		


### PR DESCRIPTION
This includes a check like travis, but inside the github.
Now it is no longer necessary to use tools outside of github, my opinion is that we should no longer use travis for checking, but this new tool is available. Of course, this should be better discussed.
 
Co-Authored-By: Leonardo Pereira <jlcvp@users.noreply.github.com>