### PR TITLE
Creature:onHear(speaker, words, type) improvements

### DIFF
--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -10,5 +10,12 @@ function Creature:onTargetCombat(target)
 	return RETURNVALUE_NOERROR
 end
 
-function Creature:onHear(speaker, words, type)
+function Creature:onHear(speaker, words, type)	
+	if words:find("fuck") then
+		local filtered = string.gsub(words, "(fuck)", "****")
+		speaker:say(filtered, type, false, self)
+		return false
+	end
+	
+	return true
 end

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -279,16 +279,16 @@ ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* ta
 	return returnValue;
 }
 
-void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type)
+bool Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type)
 {
 	// Creature:onHear(speaker, words, type)
 	if (info.creatureOnHear == -1) {
-		return;
+		return true;
 	}
 
 	if (!scriptInterface.reserveScriptEnv()) {
 		std::cout << "[Error - Events::eventCreatureOnHear] Call stack overflow" << std::endl;
-		return;
+		return true;
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
@@ -306,7 +306,7 @@ void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const st
 	LuaScriptInterface::pushString(L, words);
 	lua_pushnumber(L, type);
 
-	scriptInterface.callVoidFunction(4);
+	return scriptInterface.callFunction(4);
 }
 
 // Party

--- a/src/events.h
+++ b/src/events.h
@@ -76,7 +76,7 @@ class Events
 		bool eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& outfit);
 		ReturnValue eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bool aggressive);
 		ReturnValue eventCreatureOnTargetCombat(Creature* creature, Creature* target);
-		void eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
+		bool eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
 
 		// Party
 		bool eventPartyOnJoin(Party* party, Player* player);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3610,6 +3610,8 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 
 	//send to client
 	for (Creature* spectator : spectators) {
+		spectator->onCreatureSay(creature, type, text);
+
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (!ghostMode || tmpPlayer->canSeeCreature(creature)) {
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3612,16 +3612,12 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (!ghostMode || tmpPlayer->canSeeCreature(creature)) {
-				tmpPlayer->sendCreatureSay(creature, type, text, pos);
-			}
-		}
-	}
 
-	//event method
-	for (Creature* spectator : spectators) {
-		spectator->onCreatureSay(creature, type, text);
-		if (creature != spectator) {
-			g_events->eventCreatureOnHear(spectator, creature, text, type);
+				//event method
+				if (g_events->eventCreatureOnHear(spectator, creature, text, type)) {
+					tmpPlayer->sendCreatureSay(creature, type, text, pos);
+				}
+			}
 		}
 	}
 	return true;


### PR DESCRIPTION
closes #2998 without unnecessary code to implement another feature (the goal can be fully reproduced in onHear now)

unified sendCreatureSay so speaker == spectator check is not necessary anymore

onCreatureHear is now a boolean

same convention as in talkactions:
- return true - the character line is displayed for the spectator
- return false - it doesn't - creature:say(...) can now be used instead, to send a different message (return false has to be used after onSay events within onHear to prevent overflow)