### PR TITLE
further onHear improvements (more in description)

### DIFF
--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -10,5 +10,12 @@ function Creature:onTargetCombat(target)
 	return RETURNVALUE_NOERROR
 end
 
-function Creature:onHear(speaker, words, type)
+function Creature:onHear(speaker, words, type)	
+	if words:find("fuck") then
+		local filtered = string.gsub(words, "(fuck)", "****")
+		speaker:say(filtered, type, false, self)
+		return false
+	end
+	
+	return true
 end

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -279,16 +279,16 @@ ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* ta
 	return returnValue;
 }
 
-void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type)
+bool Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type)
 {
 	// Creature:onHear(speaker, words, type)
 	if (info.creatureOnHear == -1) {
-		return;
+		return true;
 	}
 
 	if (!scriptInterface.reserveScriptEnv()) {
 		std::cout << "[Error - Events::eventCreatureOnHear] Call stack overflow" << std::endl;
-		return;
+		return true;
 	}
 
 	ScriptEnvironment* env = scriptInterface.getScriptEnv();
@@ -306,7 +306,7 @@ void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const st
 	LuaScriptInterface::pushString(L, words);
 	lua_pushnumber(L, type);
 
-	scriptInterface.callVoidFunction(4);
+	return scriptInterface.callFunction(4);
 }
 
 // Party

--- a/src/events.h
+++ b/src/events.h
@@ -76,7 +76,7 @@ class Events
 		bool eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& outfit);
 		ReturnValue eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bool aggressive);
 		ReturnValue eventCreatureOnTargetCombat(Creature* creature, Creature* target);
-		void eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
+		bool eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
 
 		// Party
 		bool eventPartyOnJoin(Party* party, Player* player);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3528,15 +3528,22 @@ bool Game::playerSpeakTo(Player* player, SpeakClasses type, const std::string& r
 		type = TALKTYPE_PRIVATE_FROM;
 	}
 
-	toPlayer->sendPrivateMessage(player, type, text);
+	bool messageSent = false;
+	if (g_events->eventCreatureOnHear(toPlayer, player, text, type)) {
+		toPlayer->sendPrivateMessage(player, type, text);
+		messageSent = true;
+	}
+
 	toPlayer->onCreatureSay(player, type, text);
 
-	if (toPlayer->isInGhostMode() && !player->isAccessPlayer()) {
-		player->sendTextMessage(MESSAGE_STATUS_SMALL, "A player with this name is not online.");
-	} else {
-		std::ostringstream ss;
-		ss << "Message sent to " << toPlayer->getName() << '.';
-		player->sendTextMessage(MESSAGE_STATUS_SMALL, ss.str());
+	if (messageSent) {
+		if (toPlayer->isInGhostMode() && !player->isAccessPlayer()) {
+			player->sendTextMessage(MESSAGE_STATUS_SMALL, "A player with this name is not online.");
+		} else {
+			std::ostringstream ss;
+			ss << "Message sent to " << toPlayer->getName() << '.';
+			player->sendTextMessage(MESSAGE_STATUS_SMALL, ss.str());
+		}
 	}
 	return true;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3474,10 +3474,8 @@ void Game::playerWhisper(Player* player, const std::string& text)
 				}
 			}
 		}
-	}
 
-	//event method
-	for (Creature* spectator : spectators) {
+		//event method
 		spectator->onCreatureSay(player, TALKTYPE_WHISPER, text);
 	}
 }
@@ -3614,17 +3612,16 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 
 	//send to client
 	for (Creature* spectator : spectators) {
-		spectator->onCreatureSay(creature, type, text);
-
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (!ghostMode || tmpPlayer->canSeeCreature(creature)) {
-
-				//event method
 				if (g_events->eventCreatureOnHear(spectator, creature, text, type)) {
 					tmpPlayer->sendCreatureSay(creature, type, text, pos);
 				}
 			}
 		}
+
+		//event method
+		spectator->onCreatureSay(creature, type, text);
 	}
 	return true;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3466,10 +3466,13 @@ void Game::playerWhisper(Player* player, const std::string& text)
 	//send to client
 	for (Creature* spectator : spectators) {
 		if (Player* spectatorPlayer = spectator->getPlayer()) {
-			if (!Position::areInRange<1, 1>(player->getPosition(), spectatorPlayer->getPosition())) {
-				spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, "pspsps");
-			} else {
-				spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, text);
+			if (g_events->eventCreatureOnHear(spectatorPlayer, player, text, TALKTYPE_WHISPER)) {
+				if (!Position::areInRange<1, 1>(player->getPosition(), spectatorPlayer->getPosition())) {
+					spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, "pspsps");
+				}
+				else {
+					spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, text);
+				}
 			}
 		}
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3469,8 +3469,7 @@ void Game::playerWhisper(Player* player, const std::string& text)
 			if (g_events->eventCreatureOnHear(spectatorPlayer, player, text, TALKTYPE_WHISPER)) {
 				if (!Position::areInRange<1, 1>(player->getPosition(), spectatorPlayer->getPosition())) {
 					spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, "pspsps");
-				}
-				else {
+				} else {
 					spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, text);
 				}
 			}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3614,6 +3614,8 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 
 	//send to client
 	for (Creature* spectator : spectators) {
+		spectator->onCreatureSay(creature, type, text);
+
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (!ghostMode || tmpPlayer->canSeeCreature(creature)) {
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3612,16 +3612,12 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			if (!ghostMode || tmpPlayer->canSeeCreature(creature)) {
-				tmpPlayer->sendCreatureSay(creature, type, text, pos);
-			}
-		}
-	}
 
-	//event method
-	for (Creature* spectator : spectators) {
-		spectator->onCreatureSay(creature, type, text);
-		if (creature != spectator) {
-			g_events->eventCreatureOnHear(spectator, creature, text, type);
+				//event method
+				if (g_events->eventCreatureOnHear(spectator, creature, text, type)) {
+					tmpPlayer->sendCreatureSay(creature, type, text, pos);
+				}
+			}
 		}
 	}
 	return true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1815,7 +1815,9 @@ bool Game::playerBroadcastMessage(Player* player, const std::string& text) const
 	std::cout << "> " << player->getName() << " broadcasted: \"" << text << "\"." << std::endl;
 
 	for (const auto& it : players) {
-		it.second->sendPrivateMessage(player, TALKTYPE_BROADCAST, text);
+		if (g_events->eventCreatureOnHear(it.second, player, text, TALKTYPE_BROADCAST)) {
+			it.second->sendPrivateMessage(player, TALKTYPE_BROADCAST, text);
+		}
 	}
 
 	return true;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9076,11 +9076,18 @@ int LuaScriptInterface::luaPlayerSendPrivateMessage(lua_State* L)
 		return 1;
 	}
 
-	const Player* speaker = getUserdata<const Player>(L, 2);
+	Player* speaker = getUserdata<Player>(L, 2);
 	const std::string& text = getString(L, 3);
 	SpeakClasses type = getNumber<SpeakClasses>(L, 4, TALKTYPE_PRIVATE_FROM);
-	player->sendPrivateMessage(speaker, type, text);
-	pushBoolean(L, true);
+
+	if (g_events->eventCreatureOnHear(player, speaker, text, type)) {
+		player->sendPrivateMessage(speaker, type, text);
+		pushBoolean(L, true);
+	} else {
+		pushBoolean(L, false);
+	}
+
+	
 	return 1;
 }
 


### PR DESCRIPTION
see #3001 for details

now interacts with
- received private message
- received broadcast
- received yell and whisper

test logs:

(notes: normal message on default)
```
speaker: Administrator, listener: Administrator, message: hi, type: say
speaker: Administrator, listener: Player, message: hi, type: say
```

(notes: original message instead of "pspsps" when out of range gets passed as param for the purpose of catching what the player actually said, distance can be checked through lua anyway)
```
speaker: Administrator, listener: Administrator, message: hi, type: whisper
speaker: Administrator, listener: Player, message: hi, type: whisper
```

(notes: yell function)
```
speaker: Player, listener: Administrator, message: I'M YELLING, type: yell
speaker: Player, listener: Player, message: I'M YELLING, type: yell
```

(notes: can't change the message on sender's end because displaying it is client-sided)
```
speaker: Player, listener: Administrator, message: hey it's player speaking to administor, type: priv from
```

(notes: returning false lets the spell cast, the text just doesn't get displayed)
```
speaker: Administrator, listener: Administrator, message: utevo lux, type: say
speaker: Administrator, listener: Player, message: utevo lux, type: say
```

(notes: speaker is correct, the message was sent from player character with god account type)
```
speaker: Player, listener: Administrator, message: red private test ("@username@
message"), type: private red from
```

(notes: \#b message in client)
```
> Administrator broadcasted: "broadcasting through hasttag b".
speaker: Administrator, listener: Player, message: broadcasting through hasttag
b, type: broadcast
speaker: Administrator, listener: Administrator, message: broadcasting through h
asttag b, type: broadcast
```

(notes: /b message)
```
> Administrator broadcasted: "broadcasting through talkaction".
speaker: Administrator, listener: Player, message: broadcasting through talkacti
on, type: broadcast
speaker: Administrator, listener: Administrator, message: broadcasting through t
alkaction, type: broadcast
```

(notes: npc response to hi)
```
speaker: The Oracle, listener: Administrator, message: CHILD! COME BACK WHEN YOU
 HAVE GROWN UP!, type: npc from
```

script used for testing:
```lua

local types = {
	[TALKTYPE_SAY] = "say",
	[TALKTYPE_WHISPER] = "whisper",
	[TALKTYPE_YELL] = "yell",
	[TALKTYPE_PRIVATE_FROM] = "priv from",
	[TALKTYPE_PRIVATE_TO] = "priv to",
	[TALKTYPE_CHANNEL_Y] = "channel yellow",
	[TALKTYPE_CHANNEL_O] = "channel orange",
	[TALKTYPE_PRIVATE_NP] = "npc from",
	[TALKTYPE_PRIVATE_PN] = "npc to",
	[TALKTYPE_BROADCAST] = "broadcast",
	[TALKTYPE_CHANNEL_R1] = "channel red",
	[TALKTYPE_PRIVATE_RED_FROM] = "private red from",
	[TALKTYPE_PRIVATE_RED_TO] = "private red to",
	[TALKTYPE_MONSTER_SAY] = "monster say",
	[TALKTYPE_MONSTER_YELL] = "monster yell",
	[TALKTYPE_CHANNEL_R2] = "red 2",

}

function Creature:onHear(speaker, words, type)
	print("speaker: "..speaker:getName()..", listener: "..self:getName()..", message: "..words..", type: "..types[type])
	
	return true
end

```