### PR TITLE
Prevent infinity loop teleports (anti fools)

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -21,7 +21,6 @@
 
 #include "teleport.h"
 #include "game.h"
-#include <boost/format.hpp>
 
 extern Game g_game;
 
@@ -78,7 +77,7 @@ bool Teleport::checkInfinityLoop(Tile* destTile)
 	}
 
 	if (Teleport* teleport = destTile->getTeleportItem()) {
-		Position nextDestPos = teleport->getDestPos();
+		const Position& nextDestPos = teleport->getDestPos();
 		if (getPosition() == nextDestPos) {
 			return true;
 		}
@@ -96,8 +95,8 @@ void Teleport::addThing(int32_t, Thing* thing)
 
 	// Prevent infinity loop (anti fools)
 	if (checkInfinityLoop(destTile)) {
-		const Position pos = getPosition();
-		std::cout << boost::format("Warning: infinity loop teleport. (x:%1%, y:%2%, z:%3%)\n") % pos.getX() % pos.getY() % pos.getZ();
+		const Position& pos = getPosition();
+		std::cout << "Warning: infinity loop teleport. " << pos << std::endl;
 		return;
 	}
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -93,7 +93,7 @@ void Teleport::addThing(int32_t, Thing* thing)
 		return;
 	}
 
-	// Prevent infinity loop (anti fools)
+	// Prevent infinity loop
 	if (checkInfinityLoop(destTile)) {
 		const Position& pos = getPosition();
 		std::cout << "Warning: infinity loop teleport. " << pos << std::endl;

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -45,6 +45,8 @@ class Teleport final : public Item, public Cylinder
 			destPos = std::move(pos);
 		}
 
+		bool checkInfinityLoop(Tile* destTile);
+
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;


### PR DESCRIPTION
With this there will be no way to cause a server crash using teleports loops.
It sounds very silly but what difference does it make?
I like the idea that every time the server avoids more ways of being blocked by any human stupidity.

This was mentioned in the closed Pull Request: #2993