### PR TITLE
add missing walkthrough update calls when player level changes

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1643,7 +1643,11 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 
 		g_game.changeSpeed(this, 0);
 		g_game.addCreatureHealth(this);
-		g_game.updateCreatureWalkthrough(this);
+
+		const uint32_t protectionLevel = g_config.getNumber(ConfigManager::PROTECTION_LEVEL);
+		if (prevLevel < protectionLevel && level >= protectionLevel) {
+			g_game.updateCreatureWalkthrough(this);
+		}
 
 		if (party) {
 			party->updateSharedExperience();
@@ -1721,7 +1725,11 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 
 		g_game.changeSpeed(this, 0);
 		g_game.addCreatureHealth(this);
-		g_game.updateCreatureWalkthrough(this);
+		
+		const uint32_t protectionLevel = static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL));
+		if (prevLevel >= protectionLevel && level < protectionLevel) {
+			g_game.updateCreatureWalkthrough(this);
+		}
 
 		if (party) {
 			party->updateSharedExperience();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1643,6 +1643,7 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 
 		g_game.changeSpeed(this, 0);
 		g_game.addCreatureHealth(this);
+		g_game.updateCreatureWalkthrough(this);
 
 		if (party) {
 			party->updateSharedExperience();
@@ -1720,6 +1721,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 
 		g_game.changeSpeed(this, 0);
 		g_game.addCreatureHealth(this);
+		g_game.updateCreatureWalkthrough(this);
 
 		if (party) {
 			party->updateSharedExperience();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1644,7 +1644,7 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		g_game.changeSpeed(this, 0);
 		g_game.addCreatureHealth(this);
 
-		const uint32_t protectionLevel = g_config.getNumber(ConfigManager::PROTECTION_LEVEL);
+		const uint32_t protectionLevel = static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL));
 		if (prevLevel < protectionLevel && level >= protectionLevel) {
 			g_game.updateCreatureWalkthrough(this);
 		}
@@ -1727,7 +1727,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		g_game.addCreatureHealth(this);
 		
 		const uint32_t protectionLevel = static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL));
-		if (prevLevel >= protectionLevel && level < protectionLevel) {
+		if (oldLevel >= protectionLevel && level < protectionLevel) {
 			g_game.updateCreatureWalkthrough(this);
 		}
 


### PR DESCRIPTION
this change will prevent the client from experiencing rubberbanding / snapback when trying to walk into a player who's level changed beyond the pvp level while being within your client's viewport