### PR TITLE
Include git-based version at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,3 +86,13 @@ else ()
     message(STATUS "IPO / LTO not supported: <${error}>")
 endif ()
 ### END INTERPROCEDURAL_OPTIMIZATION ###
+
+### Git Version ###
+# Define the two required variables before including
+# the source code for watching a git repository.
+set(PRE_CONFIGURE_FILE "cmake/gitmetadata.h.in")
+set(POST_CONFIGURE_FILE "${CMAKE_CURRENT_BINARY_DIR}/gitmetadata.h")
+include(git_watcher)
+add_dependencies(tfs check_git)
+target_include_directories(tfs PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+### END  Git Version ###

--- a/cmake/git_watcher.cmake
+++ b/cmake/git_watcher.cmake
@@ -1,0 +1,292 @@
+# git_watcher.cmake
+# https://raw.githubusercontent.com/andrew-hardin/cmake-git-version-tracking/master/git_watcher.cmake
+#
+# Released under the MIT License.
+# https://raw.githubusercontent.com/andrew-hardin/cmake-git-version-tracking/master/LICENSE
+
+
+# This file defines a target that monitors the state of a git repo.
+# If the state changes (e.g. a commit is made), then a file gets reconfigured.
+# Here are the primary variables that control script behavior:
+#
+#   PRE_CONFIGURE_FILE (REQUIRED)
+#   -- The path to the file that'll be configured.
+#
+#   POST_CONFIGURE_FILE (REQUIRED)
+#   -- The path to the configured PRE_CONFIGURE_FILE.
+#
+#   GIT_STATE_FILE (OPTIONAL)
+#   -- The path to the file used to store the previous build's git state.
+#      Defaults to the current binary directory.
+#
+#   GIT_WORKING_DIR (OPTIONAL)
+#   -- The directory from which git commands will be run.
+#      Defaults to the directory with the top level CMakeLists.txt.
+#
+#   GIT_EXECUTABLE (OPTIONAL)
+#   -- The path to the git executable. It'll automatically be set if the
+#      user doesn't supply a path.
+#
+# DESIGN
+#   - This script was designed similar to a Python application
+#     with a Main() function. I wanted to keep it compact to
+#     simplify "copy + paste" usage.
+#
+#   - This script is invoked under two CMake contexts:
+#       1. Configure time (when build files are created).
+#       2. Build time (called via CMake -P).
+#     The first invocation is what registers the script to
+#     be executed at build time.
+#
+# MODIFICATIONS
+#   You may wish to track other git properties like when the last
+#   commit was made. There are two sections you need to modify,
+#   and they're tagged with a ">>>" header.
+
+# Short hand for converting paths to absolute.
+macro(PATH_TO_ABSOLUTE var_name)
+    get_filename_component(${var_name} "${${var_name}}" ABSOLUTE)
+endmacro()
+
+# Check that a required variable is set.
+macro(CHECK_REQUIRED_VARIABLE var_name)
+    if(NOT DEFINED ${var_name})
+        message(FATAL_ERROR "The \"${var_name}\" variable must be defined.")
+    endif()
+    PATH_TO_ABSOLUTE(${var_name})
+endmacro()
+
+# Check that an optional variable is set, or, set it to a default value.
+macro(CHECK_OPTIONAL_VARIABLE var_name default_value)
+    if(NOT DEFINED ${var_name})
+        set(${var_name} ${default_value})
+    endif()
+    PATH_TO_ABSOLUTE(${var_name})
+endmacro()
+
+CHECK_REQUIRED_VARIABLE(PRE_CONFIGURE_FILE)
+CHECK_REQUIRED_VARIABLE(POST_CONFIGURE_FILE)
+CHECK_OPTIONAL_VARIABLE(GIT_STATE_FILE "${CMAKE_BINARY_DIR}/git-state-hash")
+CHECK_OPTIONAL_VARIABLE(GIT_WORKING_DIR "${CMAKE_SOURCE_DIR}")
+
+# Check the optional git variable.
+# If it's not set, we'll try to find it using the CMake packaging system.
+if(NOT DEFINED GIT_EXECUTABLE)
+    find_package(Git QUIET REQUIRED)
+endif()
+CHECK_REQUIRED_VARIABLE(GIT_EXECUTABLE)
+
+
+set(_state_variable_names
+        GIT_RETRIEVED_STATE
+        GIT_HEAD_SHA1
+        GIT_IS_DIRTY
+        GIT_AUTHOR_NAME
+        GIT_AUTHOR_EMAIL
+        GIT_COMMIT_DATE_ISO8601
+        GIT_COMMIT_SUBJECT
+        GIT_COMMIT_BODY
+        GIT_DESCRIBE
+        GIT_SHORT_SHA1
+        # >>>
+        # 1. Add the name of the additional git variable you're interested in monitoring
+        #    to this list.
+        )
+
+
+
+# Macro: RunGitCommand
+# Description: short-hand macro for calling a git function. Outputs are the
+#              "exit_code" and "output" variables.
+macro(RunGitCommand)
+    execute_process(COMMAND
+            "${GIT_EXECUTABLE}" ${ARGV}
+            WORKING_DIRECTORY "${_working_dir}"
+            RESULT_VARIABLE exit_code
+            OUTPUT_VARIABLE output
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT exit_code EQUAL 0)
+        set(ENV{GIT_RETRIEVED_STATE} "false")
+    endif()
+endmacro()
+
+
+
+# Function: GetGitState
+# Description: gets the current state of the git repo.
+# Args:
+#   _working_dir (in)  string; the directory from which git commands will be executed.
+function(GetGitState _working_dir)
+
+    # This is an error code that'll be set to FALSE if the
+    # RunGitCommand ever returns a non-zero exit code.
+    set(ENV{GIT_RETRIEVED_STATE} "true")
+
+    # Get whether or not the working tree is dirty.
+    RunGitCommand(status --porcelain)
+    if(NOT exit_code EQUAL 0)
+        set(ENV{GIT_IS_DIRTY} "false")
+    else()
+        if(NOT "${output}" STREQUAL "")
+            set(ENV{GIT_IS_DIRTY} "true")
+        else()
+            set(ENV{GIT_IS_DIRTY} "false")
+        endif()
+    endif()
+
+    # There's a long list of attributes grabbed from git show.
+    set(object HEAD)
+    RunGitCommand(show -s "--format=%H" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_HEAD_SHA1} ${output})
+    endif()
+
+    RunGitCommand(show -s "--format=%an" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_AUTHOR_NAME} "${output}")
+    endif()
+
+    RunGitCommand(show -s "--format=%ae" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_AUTHOR_EMAIL} "${output}")
+    endif()
+
+    RunGitCommand(show -s "--format=%cI" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_COMMIT_DATE_ISO8601} "${output}")
+    endif()
+
+    RunGitCommand(show -s "--format=%s" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_COMMIT_SUBJECT} "${output}")
+    endif()
+
+    RunGitCommand(show -s "--format=%b" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_COMMIT_BODY} "${output}")
+    endif()
+
+    RunGitCommand(describe --tags "--match=v*" ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_DESCRIBE} "${output}")
+    endif()
+
+    RunGitCommand(rev-parse --short ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_SHORT_SHA1} ${output})
+    endif()
+
+    # >>>
+    # 2. Additional git properties can be added here via the
+    #    "execute_process()" command. Be sure to set them in
+    #    the environment using the same variable name you added
+    #    to the "_state_variable_names" list.
+
+endfunction()
+
+
+
+# Function: GitStateChangedAction
+# Description: this function is executed when the state of the git
+#              repository changes (e.g. a commit is made).
+function(GitStateChangedAction)
+    foreach(var_name ${_state_variable_names})
+        set(${var_name} $ENV{${var_name}})
+    endforeach()
+    configure_file("${PRE_CONFIGURE_FILE}" "${POST_CONFIGURE_FILE}" @ONLY)
+endfunction()
+
+
+
+# Function: HashGitState
+# Description: loop through the git state variables and compute a unique hash.
+# Args:
+#   _state (out)  string; a hash computed from the current git state.
+function(HashGitState _state)
+    set(ans "")
+    foreach(var_name ${_state_variable_names})
+        string(SHA256 ans "${ans}$ENV{${var_name}}")
+    endforeach()
+    set(${_state} ${ans} PARENT_SCOPE)
+endfunction()
+
+
+
+# Function: CheckGit
+# Description: check if the git repo has changed. If so, update the state file.
+# Args:
+#   _working_dir    (in)  string; the directory from which git commands will be ran.
+#   _state_changed (out)    bool; whether or no the state of the repo has changed.
+function(CheckGit _working_dir _state_changed)
+
+    # Get the current state of the repo.
+    GetGitState("${_working_dir}")
+
+    # Convert that state into a hash that we can compare against
+    # the hash stored on-disk.
+    HashGitState(state)
+
+    # Check if the state has changed compared to the backup on disk.
+    if(EXISTS "${GIT_STATE_FILE}")
+        file(READ "${GIT_STATE_FILE}" OLD_HEAD_CONTENTS)
+        if(OLD_HEAD_CONTENTS STREQUAL "${state}")
+            # State didn't change.
+            set(${_state_changed} "false" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+    # The state has changed.
+    # We need to update the state file on disk.
+    # Future builds will compare their state to this file.
+    file(WRITE "${GIT_STATE_FILE}" "${state}")
+    set(${_state_changed} "true" PARENT_SCOPE)
+endfunction()
+
+
+
+# Function: SetupGitMonitoring
+# Description: this function sets up custom commands that make the build system
+#              check the state of git before every build. If the state has
+#              changed, then a file is configured.
+function(SetupGitMonitoring)
+    add_custom_target(check_git
+            ALL
+            DEPENDS ${PRE_CONFIGURE_FILE}
+            BYPRODUCTS
+            ${POST_CONFIGURE_FILE}
+            ${GIT_STATE_FILE}
+            COMMENT "Checking the git repository for changes..."
+            COMMAND
+            ${CMAKE_COMMAND}
+            -D_BUILD_TIME_CHECK_GIT=TRUE
+            -DGIT_WORKING_DIR=${GIT_WORKING_DIR}
+            -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+            -DGIT_STATE_FILE=${GIT_STATE_FILE}
+            -DPRE_CONFIGURE_FILE=${PRE_CONFIGURE_FILE}
+            -DPOST_CONFIGURE_FILE=${POST_CONFIGURE_FILE}
+            -P "${CMAKE_CURRENT_LIST_FILE}")
+endfunction()
+
+
+
+# Function: Main
+# Description: primary entry-point to the script. Functions are selected based
+#              on whether it's configure or build time.
+function(Main)
+    if(_BUILD_TIME_CHECK_GIT)
+        # Check if the repo has changed.
+        # If so, run the change action.
+        CheckGit("${GIT_WORKING_DIR}" changed)
+        if(changed OR NOT EXISTS "${POST_CONFIGURE_FILE}")
+            GitStateChangedAction()
+        endif()
+    else()
+        # >> Executes at configure time.
+        SetupGitMonitoring()
+    endif()
+endfunction()
+
+# And off we go...
+Main()

--- a/cmake/gitmetadata.h.in
+++ b/cmake/gitmetadata.h.in
@@ -1,0 +1,23 @@
+// This file was create automatically by CMake.
+#pragma once
+
+// Whether or not we retrieved the state of the repo.
+#define GIT_RETRIEVED_STATE @GIT_RETRIEVED_STATE@
+
+// git describe --tags --match 'v*'
+#define GIT_DESCRIBE "@GIT_DESCRIBE@"
+
+// The SHA1 for the HEAD of the repo.
+#define GIT_HEAD_SHA1 "@GIT_HEAD_SHA1@"
+
+// git rev-parse --short HEAD
+#define GIT_SHORT_SHA1 "@GIT_SHORT_SHA1@"
+
+// Whether or not there were uncommited changes present.
+#define GIT_IS_DIRTY @GIT_IS_DIRTY@
+
+// When HEAD was committed.
+#define GIT_COMMIT_DATE_ISO8601 "@GIT_COMMIT_DATE_ISO8601@"
+
+// The subject line for the HEAD commit.
+#define GIT_COMMIT_SUBJECT "@GIT_COMMIT_SUBJECT@"

--- a/cmake/gitmetadata.h.in
+++ b/cmake/gitmetadata.h.in
@@ -1,4 +1,4 @@
-// This file was create automatically by CMake.
+// This file was created automatically by CMake.
 #pragma once
 
 // Whether or not we retrieved the state of the repo.

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -36,6 +36,9 @@
 #include "databasetasks.h"
 #include "script.h"
 #include <fstream>
+#if __has_include("gitmetadata.h")
+	#include "gitmetadata.h"
+#endif
 
 DatabaseTasks g_databaseTasks;
 Dispatcher g_dispatcher;
@@ -107,10 +110,20 @@ void mainLoader(int, char*[], ServiceManager* services)
 #ifdef _WIN32
 	SetConsoleTitle(STATUS_SERVER_NAME);
 #endif
+#if defined(GIT_RETRIEVED_STATE) && GIT_RETRIEVED_STATE
+	std::cout << STATUS_SERVER_NAME << " - Version " << GIT_DESCRIBE << std::endl;
+	std::cout << "Git SHA1 " << GIT_SHORT_SHA1  << " dated " << GIT_COMMIT_DATE_ISO8601 << std::endl;
+	std::cout << "Git message: " << GIT_COMMIT_SUBJECT << std::endl;
+	#if GIT_IS_DIRTY
+	std::cout << "*** DIRTY - NOT OFFICIAL RELEASE ***" << std::endl;
+	#endif
+#else
 	std::cout << STATUS_SERVER_NAME << " - Version " << STATUS_SERVER_VERSION << std::endl;
+#endif
+	std::cout << std::endl;
+
 	std::cout << "Compiled with " << BOOST_COMPILER << std::endl;
 	std::cout << "Compiled on " << __DATE__ << ' ' << __TIME__ << " for platform ";
-
 #if defined(__amd64__) || defined(_M_X64)
 	std::cout << "x64" << std::endl;
 #elif defined(__i386__) || defined(_M_IX86) || defined(_X86_)
@@ -119,6 +132,11 @@ void mainLoader(int, char*[], ServiceManager* services)
 	std::cout << "ARM" << std::endl;
 #else
 	std::cout << "unknown" << std::endl;
+#endif
+#if defined(LUAJIT_VERSION)
+	std::cout << "Linked with " << LUAJIT_VERSION << " for Lua support" << std::endl;
+#else
+	std::cout << "Linked with " << LUA_RELEASE << " for Lua support"  << std::endl;
 #endif
 	std::cout << std::endl;
 


### PR DESCRIPTION
Builds are now stamped like this:
```
The Forgotten Server - Version v1.2-566-ga00b0bbf
Git SHA1 a00b0bbf dated 2020-05-03T04:23:32-04:00
Git message: Stamp builds with git-based version
*** DIRTY - NOT OFFICIAL RELEASE ***

Compiled with Microsoft Visual C++ version 14.2
Compiled on May  3 2020 04:23:59 for platform x64
Linked with LuaJIT 2.0.5 for Lua support

A server developed by Mark Samman
Visit our forum for updates, support, and resources: https://otland.net/.
```