### PR TITLE
Fix a bug with unnamed containers (normal client)

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -85,6 +85,11 @@ Container* Container::getParentContainer()
 	return thing->getContainer();
 }
 
+std::string Container::getName() const {
+	const ItemType& it = items[id];
+	return getNameDescription(it, this, -1, false);
+}
+
 bool Container::hasParent() const
 {
 	return getID() != ITEM_BROWSEFIELD && dynamic_cast<const Player*>(getParent()) == nullptr;

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -85,9 +85,9 @@ Container* Container::getParentContainer()
 	return thing->getContainer();
 }
 
-std::string Container::getName() const {
+std::string Container::getName(bool addArticle /* = false*/) const {
 	const ItemType& it = items[id];
-	return getNameDescription(it, this, -1, false);
+	return getNameDescription(it, this, -1, addArticle);
 }
 
 bool Container::hasParent() const

--- a/src/container.h
+++ b/src/container.h
@@ -101,7 +101,7 @@ class Container : public Item, public Cylinder
 			return itemlist.rend();
 		}
 
-		std::string getName() const;
+		std::string getName(bool addArticle = false) const;
 
 		bool hasParent() const;
 		void addItem(Item* item);

--- a/src/container.h
+++ b/src/container.h
@@ -101,6 +101,8 @@ class Container : public Item, public Cylinder
 			return itemlist.rend();
 		}
 
+		std::string getName() const;
+
 		bool hasParent() const;
 		void addItem(Item* item);
 		Item* getItemByIndex(size_t index) const;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1510,7 +1510,10 @@ std::string Item::getNameDescription(const ItemType& it, const Item* item /*= nu
 			s << name;
 		}
 	} else {
-		s << "an item of type " << it.id;
+		if (addArticle) {
+			s << "an ";
+		}
+		s << "item of type " << it.id;
 	}
 	return s.str();
 }

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1485,14 +1485,8 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	} else {
 		msg.addItem(container);
 
-		std::string containerName = container->getName();
-		if (containerName.empty()) {
-			std::ostringstream ss;
-			ss << "item of type " << container->getID();
-			containerName = ss.str();
-		}
-
-		msg.addString(containerName);
+		const std::string& containerName = container->getName();
+		msg.addString(containerName.empty() ? "item of type " + std::to_string(container->getID()) : containerName);
 	}
 
 	msg.addByte(container->capacity());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1484,9 +1484,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 		msg.addString("Browse Field");
 	} else {
 		msg.addItem(container);
-
-		const std::string& containerName = container->getName();
-		msg.addString(containerName.empty() ? "item of type " + std::to_string(container->getID()) : containerName);
+		msg.addString(container->getName());
 	}
 
 	msg.addByte(container->capacity());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1484,7 +1484,15 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 		msg.addString("Browse Field");
 	} else {
 		msg.addItem(container);
-		msg.addString(container->getName());
+
+		std::string containerName = container->getName();
+		if (containerName.empty()) {
+			std::ostringstream ss;
+			ss << "item of type " << container->getID();
+			containerName = ss.str();
+		}
+
+		msg.addString(containerName);
 	}
 
 	msg.addByte(container->capacity());


### PR DESCRIPTION
**steps to reproduce:**
1. remove item that is a container from items.xml
2. log in and open that container

**expected result:** it opens without label like it does on otclient
**observed result:** client crash with log pointing to container without name

reproduction rate: 100%

**what this fix does:**
it labels unnamed containers as item of type xxxx (number)