### PR TITLE
Fixed non-unique loot item

### DIFF
--- a/data/monster/lua/#example.lua
+++ b/data/monster/lua/#example.lua
@@ -43,7 +43,7 @@ monster.voices = {
 
 monster.loot = {
 	{id = "gold coin", chance = 60000, maxCount = 100},
-	{id = "bag", chance = 60000,
+	{id = 1987, chance = 60000, -- bag
 		child = {
 			{id = "platinum coin", chance = 60000, maxCount = 100},
 			{id = "crystal coin", chance = 60000, maxCount = 100}


### PR DESCRIPTION
we have two bags called bag, so it errored the example monster

> [Warning - Loot:setId] Non-unique loot item "bag".
> [Warning - end] Monster: "example" loot could not correctly be load.