### PR TITLE
Fixed summoning creature crash in debug mode

### DIFF
--- a/data/lib/core/position.lua
+++ b/data/lib/core/position.lua
@@ -74,7 +74,7 @@ end
 function Position:notifySummonAppear(summon)
 	local spectators = Game.getSpectators(self)
 	for _, spectator in ipairs(spectators) do
-		if spectator:isMonster() then
+		if spectator:isMonster() and spectator ~= summon then
 			spectator:addTarget(summon)
 		end
 	end


### PR DESCRIPTION
As reported [here](https://otland.net/threads/forgotten-server-crashes-after-summoning-creature.270378/) and fix by @SaiyansKing

follow up of this commit https://github.com/otland/forgottenserver/commit/c614a3c61bac954fdf6325e9b831e65cbc1a8fc2