### PR TITLE
On Linux, build with gcc and clang

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -119,21 +119,21 @@ jobs:
       - name: Upload artifact binary
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ runner.workspace }}/build/tfs
         if: "! contains( matrix.os, 'windows')"
 
       - name: Upload artifact binary (exe)
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ runner.workspace }}/build/tfs.exe
         if: contains( matrix.os, 'windows')
 
       - name: Upload artifact binary (dlls)
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ runner.workspace }}/build/*.dll
         if: contains( matrix.os, 'windows')
 
@@ -144,5 +144,5 @@ jobs:
       - name: Upload datapack contents
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ github.workspace }}

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -6,13 +6,13 @@ on:
       - master
       - v*
 
-    tags:
-      - v*
+#    tags:
+#      - v*
 
-    paths:
-      - cmake/**
-      - src/**
-      - CMakeLists.txt
+#    paths:
+#      - cmake/**
+#      - src/**
+#      - CMakeLists.txt
 
   pull_request:
     paths:
@@ -22,27 +22,44 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
+    name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       max-parallel: 8
       matrix:
-        os: [ubuntu, windows, macos]
+        name: [ubuntu-gcc, ubuntu-clang, macos-clang, windows-msvc]
         buildtype: [Debug, Release]
         luajit: [on, off]
         include:
-          - os: windows
+          - name: windows-msvc
+            os: windows
+            cxx: cl.exe
+            cc: cl.exe
             triplet: x64-windows
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
               lua luajit libmariadb pugixml cryptopp
-          - os: ubuntu
+          - name: ubuntu-gcc
+            os: ubuntu
+            cxx: g++
+            cc: gcc
             triplet: x64-linux
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
               lua libmariadb pugixml cryptopp
-          - os: macos
+          - name: ubuntu-clang
+            os: ubuntu
+            cxx: clang++
+            cc: clang
+            triplet: x64-linux
+            packages: >
+              boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
+              lua libmariadb pugixml cryptopp
+          - name: macos-clang
+            os: macos
+            cxx: clang++
+            cc: clang
             triplet: x64-osx
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
@@ -74,13 +91,19 @@ jobs:
         run: rm -r -fo C:/mysql-5.7.21-winx64
         if: contains( matrix.os, 'windows')
 
+      - uses: lukka/set-shell-env@v1
+        with:
+          CXX: ${{ matrix.cxx }}
+          CC: ${{ matrix.cc }}
+
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v2
         with:
           vcpkgArguments: ${{ matrix.packages }}
-          vcpkgDirectory: ${{ runner.workspace }}/vcpkg
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
           vcpkgTriplet: ${{ matrix.triplet }}
-          vcpkgGitCommitId: c444db5f5a954bd53c8dad004cee39c4064d844e
+          vcpkgGitCommitId: d3e83b0964db500eb8eda5c0e92590a17d652ae4
+          vcpkgGitURL: https://github.com/strega-nil/vcpkg
 
       - name: Build with CMake
         uses: lukka/run-cmake@v2

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -6,13 +6,13 @@ on:
       - master
       - v*
 
-#    tags:
-#      - v*
+    tags:
+      - v*
 
-#    paths:
-#      - cmake/**
-#      - src/**
-#      - CMakeLists.txt
+    paths:
+      - cmake/**
+      - src/**
+      - CMakeLists.txt
 
   pull_request:
     paths:
@@ -102,8 +102,7 @@ jobs:
           vcpkgArguments: ${{ matrix.packages }}
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
           vcpkgTriplet: ${{ matrix.triplet }}
-          vcpkgGitCommitId: d3e83b0964db500eb8eda5c0e92590a17d652ae4
-          vcpkgGitURL: https://github.com/strega-nil/vcpkg
+          vcpkgGitCommitId: 7db401cb1ef1fc559ec9f9ce814d064c328fd767
 
       - name: Build with CMake
         uses: lukka/run-cmake@v2


### PR DESCRIPTION
I just seen you would like to build with `clang `and `gcc `as well on most of the platforms, and the switch to GitHub workflows lost the possibility to run on `clang `on all platforms.

In this PR i show how to build on `clang` with Linux, besides `gcc`. It may be helpful to augment the CI coverage.
On macOS it would be possible to do the same for `gcc `(i.e. install `gcc `with `homebrew `and then build).
On Windows not sure you want to build with clang, or if building with `msvc `is just enough. 

There are some changes in this PR that should be reverted, i.e.: 
1. workflow filters;
2. remote vcpkg URL, that is the one that contains a fix which would otherwise fail vcpkg's build on Ubuntu+gcc7.