### PR TITLE
cmake: git_watcher may put unquoted commit messages

### DIFF
--- a/cmake/gitmetadata.h.in
+++ b/cmake/gitmetadata.h.in
@@ -18,6 +18,3 @@
 
 // When HEAD was committed.
 #define GIT_COMMIT_DATE_ISO8601 "@GIT_COMMIT_DATE_ISO8601@"
-
-// The subject line for the HEAD commit.
-#define GIT_COMMIT_SUBJECT "@GIT_COMMIT_SUBJECT@"

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -113,7 +113,6 @@ void mainLoader(int, char*[], ServiceManager* services)
 #if defined(GIT_RETRIEVED_STATE) && GIT_RETRIEVED_STATE
 	std::cout << STATUS_SERVER_NAME << " - Version " << GIT_DESCRIBE << std::endl;
 	std::cout << "Git SHA1 " << GIT_SHORT_SHA1  << " dated " << GIT_COMMIT_DATE_ISO8601 << std::endl;
-	std::cout << "Git message: " << GIT_COMMIT_SUBJECT << std::endl;
 	#if GIT_IS_DIRTY
 	std::cout << "*** DIRTY - NOT OFFICIAL RELEASE ***" << std::endl;
 	#endif


### PR DESCRIPTION
Remove GIT_COMMIT_SUBJECT.
They cause malformed definition and break build.