### PR TITLE
Outfit lua metatable

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -786,6 +786,16 @@ Outfit_t LuaScriptInterface::getOutfit(lua_State* L, int32_t arg)
 	return outfit;
 }
 
+Outfit LuaScriptInterface::getOutfitClass(lua_State* L, int32_t arg)
+{
+	uint16_t lookType = getField<uint16_t>(L, arg, "lookType");
+	const std::string& name = getFieldString(L, arg, "name");
+	bool premium = getField<uint8_t>(L, arg, "premium") == 1 ? true : false;
+	bool unlocked = getField<uint8_t>(L, arg, "unlocked") == 1 ? true : false;
+	lua_pop(L, 4);
+	return Outfit(name, lookType, premium, unlocked);
+}
+
 LuaVariant LuaScriptInterface::getVariant(lua_State* L, int32_t arg)
 {
 	LuaVariant var;
@@ -948,6 +958,16 @@ void LuaScriptInterface::pushOutfit(lua_State* L, const Outfit_t& outfit)
 	setField(L, "lookFeet", outfit.lookFeet);
 	setField(L, "lookAddons", outfit.lookAddons);
 	setField(L, "lookMount", outfit.lookMount);
+}
+
+void LuaScriptInterface::pushOutfit(lua_State* L, const Outfit* outfit)
+{
+	lua_createtable(L, 0, 4);
+	setField(L, "lookType", outfit->lookType);
+	setField(L, "name", outfit->name);
+	setField(L, "premium", outfit->premium);
+	setField(L, "unlocked", outfit->unlocked);
+	setMetatable(L, -1, "Outfit");
 }
 
 void LuaScriptInterface::pushLoot(lua_State* L, const std::vector<LootBlock>& lootList)
@@ -2657,6 +2677,10 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Condition", "setOutfit", LuaScriptInterface::luaConditionSetOutfit);
 
 	registerMethod("Condition", "addDamage", LuaScriptInterface::luaConditionAddDamage);
+
+	// Outfit
+	registerClass("Outfit", "", LuaScriptInterface::luaOutfitCreate);
+	registerMetaMethod("Outfit", "__eq", LuaScriptInterface::luaOutfitCompare);
 
 	// MonsterType
 	registerClass("MonsterType", "", LuaScriptInterface::luaMonsterTypeCreate);
@@ -12102,6 +12126,29 @@ int LuaScriptInterface::luaConditionAddDamage(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+// Outfit
+int LuaScriptInterface::luaOutfitCreate(lua_State* L)
+{
+	// Outfit(looktype)
+	const Outfit* outfit = Outfits::getInstance().getOutfitByLookType(getNumber<uint16_t>(L, 2));
+	if (outfit) {
+		pushOutfit(L, outfit);
+	}
+	else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaOutfitCompare(lua_State* L)
+{
+	// outfit == outfitEx
+	Outfit outfitEx = getOutfitClass(L, 2);
+	Outfit outfit = getOutfitClass(L, 1);
+	pushBoolean(L, outfit == outfitEx);
 	return 1;
 }
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12136,8 +12136,7 @@ int LuaScriptInterface::luaOutfitCreate(lua_State* L)
 	const Outfit* outfit = Outfits::getInstance().getOutfitByLookType(getNumber<uint16_t>(L, 2));
 	if (outfit) {
 		pushOutfit(L, outfit);
-	}
-	else {
+	} else {
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -36,6 +36,7 @@
 #include "enums.h"
 #include "position.h"
 #include <boost/lexical_cast.hpp>
+#include "outfit.h"
 
 class Thing;
 class Creature;
@@ -327,6 +328,7 @@ class LuaScriptInterface
 		static Position getPosition(lua_State* L, int32_t arg, int32_t& stackpos);
 		static Position getPosition(lua_State* L, int32_t arg);
 		static Outfit_t getOutfit(lua_State* L, int32_t arg);
+		static Outfit getOutfitClass(lua_State* L, int32_t arg);
 		static LuaVariant getVariant(lua_State* L, int32_t arg);
 		static InstantSpell* getInstantSpell(lua_State* L, int32_t arg);
 
@@ -377,6 +379,7 @@ class LuaScriptInterface
 		static void pushInstantSpell(lua_State* L, const InstantSpell& spell);
 		static void pushPosition(lua_State* L, const Position& position, int32_t stackpos = 0);
 		static void pushOutfit(lua_State* L, const Outfit_t& outfit);
+		static void pushOutfit(lua_State* L, const Outfit* outfit);
 		static void pushLoot(lua_State* L, const std::vector<LootBlock>& lootList);
 
 		//
@@ -1202,6 +1205,10 @@ class LuaScriptInterface
 		static int luaConditionSetOutfit(lua_State* L);
 
 		static int luaConditionAddDamage(lua_State* L);
+
+		// Outfit
+		static int luaOutfitCreate(lua_State* L);
+		static int luaOutfitCompare(lua_State* L);
 
 		// MonsterType
 		static int luaMonsterTypeCreate(lua_State* L);

--- a/src/outfit.cpp
+++ b/src/outfit.cpp
@@ -75,3 +75,15 @@ const Outfit* Outfits::getOutfitByLookType(PlayerSex_t sex, uint16_t lookType) c
 	}
 	return nullptr;
 }
+
+const Outfit* Outfits::getOutfitByLookType(uint16_t lookType) const
+{
+	for (uint8_t sex = 0; sex <= 1; sex++) {
+		for (const Outfit& outfit : outfits[sex]) {
+			if (outfit.lookType == lookType) {
+				return &outfit;
+			}
+		}
+	}
+	return nullptr;
+}

--- a/src/outfit.h
+++ b/src/outfit.h
@@ -26,6 +26,11 @@ struct Outfit {
 	Outfit(std::string name, uint16_t lookType, bool premium, bool unlocked) :
 		name(std::move(name)), lookType(lookType), premium(premium), unlocked(unlocked) {}
 
+	bool operator==(const Outfit& otherOutfit) const
+	{
+		return (name == otherOutfit.name) && (lookType == otherOutfit.lookType) && (premium == otherOutfit.premium) && (unlocked == otherOutfit.unlocked);
+	}
+
 	std::string name;
 	uint16_t lookType;
 	bool premium;
@@ -52,6 +57,7 @@ class Outfits
 		bool loadFromXml();
 
 		const Outfit* getOutfitByLookType(PlayerSex_t sex, uint16_t lookType) const;
+		const Outfit* getOutfitByLookType(uint16_t lookType) const;
 		const std::vector<Outfit>& getOutfits(PlayerSex_t sex) const {
 			return outfits[sex];
 		}


### PR DESCRIPTION
This pr adds Outfit() metatable to use in lua. Helpful in cases when you for example need to get name of outfit from looktype.

Outfit(looktype)
and outfit compare method