### PR TITLE
Say without echo in onHear event

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -27,6 +27,10 @@ class Party;
 class ItemType;
 class Tile;
 
+enum class EventInfoId {
+	EVENT_INFO_ONHEAR
+};
+
 class Events
 {
 	struct EventsInfo {
@@ -107,6 +111,16 @@ class Events
 		// Monster
 		void eventMonsterOnDropLoot(Monster* monster, Container* corpse);
 		bool eventMonsterOnSpawn(Monster* monster, const Position& position, bool startup, bool artificial);
+
+		int32_t getScriptId(EventInfoId eventInfoId) {
+			switch (eventInfoId)
+			{
+			case EventInfoId::EVENT_INFO_ONHEAR:
+				return info.creatureOnHear;
+			default:
+				return -1;
+			}
+		};
 
 	private:
 		LuaScriptInterface scriptInterface;

--- a/src/events.h
+++ b/src/events.h
@@ -28,7 +28,7 @@ class ItemType;
 class Tile;
 
 enum class EventInfoId {
-	EVENT_INFO_ONHEAR
+	CREATURE_ONHEAR
 };
 
 class Events
@@ -115,7 +115,7 @@ class Events
 		int32_t getScriptId(EventInfoId eventInfoId) {
 			switch (eventInfoId)
 			{
-			case EventInfoId::EVENT_INFO_ONHEAR:
+			case EventInfoId::CREATURE_ONHEAR:
 				return info.creatureOnHear;
 			default:
 				return -1;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3580,7 +3580,7 @@ bool Game::internalCreatureTurn(Creature* creature, Direction dir)
 }
 
 bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std::string& text,
-                               bool ghostMode, SpectatorVec* spectatorsPtr/* = nullptr*/, const Position* pos/* = nullptr*/)
+                               bool ghostMode, SpectatorVec* spectatorsPtr/* = nullptr*/, const Position* pos/* = nullptr*/, bool echo/* = false*/)
 {
 	if (text.empty()) {
 		return false;
@@ -3618,10 +3618,12 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 	}
 
 	//event method
-	for (Creature* spectator : spectators) {
-		spectator->onCreatureSay(creature, type, text);
-		if (creature != spectator) {
-			g_events->eventCreatureOnHear(spectator, creature, text, type);
+	if (!echo) {
+		for (Creature* spectator : spectators) {
+			spectator->onCreatureSay(creature, type, text);
+			if (creature != spectator) {
+				g_events->eventCreatureOnHear(spectator, creature, text, type);
+			}
 		}
 	}
 	return true;

--- a/src/game.h
+++ b/src/game.h
@@ -307,7 +307,7 @@ class Game
 		  * \param text The text to say
 		  */
 		bool internalCreatureSay(Creature* creature, SpeakClasses type, const std::string& text,
-		                         bool ghostMode, SpectatorVec* spectatorsPtr = nullptr, const Position* pos = nullptr);
+		                         bool ghostMode, SpectatorVec* spectatorsPtr = nullptr, const Position* pos = nullptr, bool echo = false);
 
 		void loadPlayersRecord();
 		void checkPlayersRecord();

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7584,10 +7584,13 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 		spectators.emplace_back(target);
 	}
 
+	// Prevent infinity echo on event onHear
+	bool echo = getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::EVENT_INFO_ONHEAR);
+
 	if (position.x != 0) {
-		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators, &position));
+		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators, &position, echo));
 	} else {
-		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators));
+		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators, nullptr, echo));
 	}
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7585,7 +7585,7 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 	}
 
 	// Prevent infinity echo on event onHear
-	bool echo = getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::EVENT_INFO_ONHEAR);
+	bool echo = getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::CREATURE_ONHEAR);
 
 	if (position.x != 0) {
 		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators, &position, echo));


### PR DESCRIPTION
With this modification you will be able to speak within the listening event without overflow problems when starting an infinite listening loop

This was mentioned in the following PR: #3001 and #3004
I decided to make my own version, it is quite simple and fix the problem perfectly, if this can be improved please tell me.