### PR TITLE
Feature/refactor viewports

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -172,6 +172,13 @@ class Creature : virtual public Thing
 			hiddenHealth = b;
 		}
 
+		bool isMoveLocked() const {
+			return moveLocked;
+		}
+		void setMoveLocked(bool locked) {
+			moveLocked = locked;
+		}
+
 		int32_t getThrowRange() const override final {
 			return 1;
 		}
@@ -525,6 +532,7 @@ class Creature : virtual public Thing
 		bool forceUpdateFollowPath = false;
 		bool hiddenHealth = false;
 		bool canUseDefense = true;
+		bool moveLocked = false;
 
 		//creature script events
 		bool hasEventRegistered(CreatureEventType_t event) const {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3602,7 +3602,9 @@ bool Game::internalCreatureSay(Creature* creature, SpeakClasses type, const std:
 			              Map::maxClientViewportX, Map::maxClientViewportX,
 			              Map::maxClientViewportY, Map::maxClientViewportY);
 		} else {
-			map.getSpectators(spectators, *pos, true, false, 18, 18, 14, 14);
+			int32_t width = Map::getWidth();
+			int32_t height = Map::getHeight();
+			map.getSpectators(spectators, *pos, true, false, width, width, height, height);
 		}
 	} else {
 		spectators = (*spectatorsPtr);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2231,6 +2231,9 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "setMaxHealth", LuaScriptInterface::luaCreatureSetMaxHealth);
 	registerMethod("Creature", "setHiddenHealth", LuaScriptInterface::luaCreatureSetHiddenHealth);
 
+	registerMethod("Creature", "isMoveLocked", LuaScriptInterface::luaCreatureIsMoveLocked);
+	registerMethod("Creature", "setMoveLocked", LuaScriptInterface::luaCreatureSetMoveLocked);
+
 	registerMethod("Creature", "getSkull", LuaScriptInterface::luaCreatureGetSkull);
 	registerMethod("Creature", "setSkull", LuaScriptInterface::luaCreatureSetSkull);
 
@@ -7335,6 +7338,31 @@ int LuaScriptInterface::luaCreatureSetHiddenHealth(lua_State* L)
 	if (creature) {
 		creature->setHiddenHealth(getBoolean(L, 2));
 		g_game.addCreatureHealth(creature);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureIsMoveLocked(lua_State* L)
+{
+	// creature:isMoveLocked()
+	const Creature* creature = getUserdata<const Creature>(L, 1);
+	if (creature) {
+		pushBoolean(L, creature->isMoveLocked());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureSetMoveLocked(lua_State* L)
+{
+	// creature:setMoveLocked(moveLocked)
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (creature) {
+		creature->setMoveLocked(getBoolean(L, 2));
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -788,6 +788,9 @@ class LuaScriptInterface
 		static int luaCreatureSetMaxHealth(lua_State* L);
 		static int luaCreatureSetHiddenHealth(lua_State* L);
 
+		static int luaCreatureIsMoveLocked(lua_State* L);
+		static int luaCreatureSetMoveLocked(lua_State* L);
+
 		static int luaCreatureGetSkull(lua_State* L);
 		static int luaCreatureSetSkull(lua_State* L);
 

--- a/src/map.h
+++ b/src/map.h
@@ -178,6 +178,14 @@ class Map
 		static constexpr int32_t maxClientViewportX = 8;
 		static constexpr int32_t maxClientViewportY = 6;
 
+		static int32_t getWidth() {
+			return (maxClientViewportX * 2) + 2;
+		}
+
+		static int32_t getHeight() {
+			return (maxClientViewportY * 2) + 2;
+		}
+
 		uint32_t clean() const;
 
 		/**

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -25,6 +25,7 @@
 #include "creature.h"
 #include "tasks.h"
 
+class Map;
 class NetworkMessage;
 class Player;
 class Game;
@@ -314,6 +315,9 @@ class ProtocolGame final : public Protocol
 		void addGameTaskTimed(uint32_t delay, Callable function, Args&&... args) {
 			g_dispatcher.addTask(createTask(delay, std::bind(function, &g_game, std::forward<Args>(args)...)));
 		}
+
+		int32_t rangex = Map::maxClientViewportX;
+		int32_t rangey = Map::maxClientViewportY;
 
 		std::unordered_set<uint32_t> knownCreatureSet;
 		Player* player = nullptr;

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -487,6 +487,10 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
+		if (creature->isMoveLocked()) {
+			return RETURNVALUE_NOTPOSSIBLE;
+		}
+
 		if (ground == nullptr) {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}


### PR DESCRIPTION
I did this change on my personal project, might be useful for some of you.
Centralizing the viewport usage and removing the hardcode allows you to perform some more complex client/server view operations, like customize the view size with server/client sync (e.g. zooming in the client requests more tiles to the server and updates the viewport).

While those more complex usages demands otc, this simple refactor does not.