### PR TITLE
Cleaner and faster XTEA implementation

### DIFF
--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -1,6 +1,6 @@
 /**
  * The Forgotten Server - a free and open-source MMORPG server emulator
- * Copyright (C) 2019  Mark Samman <mark.samman@gmail.com>
+ * Copyright (C) 2020  Mark Samman <mark.samman@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,111 +30,46 @@ namespace {
 
 constexpr uint32_t delta = 0x9E3779B9;
 
-template<size_t BLOCK_SIZE>
-void XTEA_encrypt(uint8_t data[BLOCK_SIZE * 8], const key& k)
+template<typename Round>
+void apply_rounds(uint8_t* data, size_t length, Round round)
 {
-    alignas(16) uint32_t left[BLOCK_SIZE], right[BLOCK_SIZE];
-    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
-        left[i] = data[j] | data[j+1] << 8u | data[j+2] << 16u | data[j+3] << 24u;
-        right[i] = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
-    }
+    for (auto j = 0u; j < length; j += 8) {
+        uint32_t left = data[j+0] | data[j+1] << 8u | data[j+2] << 16u | data[j+3] << 24u,
+                right = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
 
-    uint32_t sum = 0u;
-    for (auto i = 0u; i < 32; ++i) {
-        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
-            left[j] += (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum + k[sum & 3]);
-        }
-        sum += delta;
-        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
-            right[j] += (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum + k[(sum >> 11) & 3]);
-        }
-    }
+        round(left, right);
 
-    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
-        data[j] = static_cast<uint8_t>(left[i]);
-        data[j+1] = static_cast<uint8_t>(left[i] >> 8u);
-        data[j+2] = static_cast<uint8_t>(left[i] >> 16u);
-        data[j+3] = static_cast<uint8_t>(left[i] >> 24u);
-        data[j+4] = static_cast<uint8_t>(right[i]);
-        data[j+5] = static_cast<uint8_t>(right[i] >> 8u);
-        data[j+6] = static_cast<uint8_t>(right[i] >> 16u);
-        data[j+7] = static_cast<uint8_t>(right[i] >> 24u);
+        data[j] = static_cast<uint8_t>(left);
+        data[j+1] = static_cast<uint8_t>(left >> 8u);
+        data[j+2] = static_cast<uint8_t>(left >> 16u);
+        data[j+3] = static_cast<uint8_t>(left >> 24u);
+        data[j+4] = static_cast<uint8_t>(right);
+        data[j+5] = static_cast<uint8_t>(right >> 8u);
+        data[j+6] = static_cast<uint8_t>(right >> 16u);
+        data[j+7] = static_cast<uint8_t>(right >> 24u);
     }
 }
 
-template<size_t BLOCK_SIZE>
-void XTEA_decrypt(uint8_t data[BLOCK_SIZE * 8], const key& k)
-{
-    alignas(16) uint32_t left[BLOCK_SIZE], right[BLOCK_SIZE];
-    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
-        left[i] = data[j] | data[j+1] << 8u | data[j+2] << 16u | data[j+3] << 24u;
-        right[i] = data[j+4] | data[j+5] << 8u | data[j+6] << 16u | data[j+7] << 24u;
-    }
-
-    uint32_t sum = delta << 5;
-    for (auto i = 0u; i < 32; ++i) {
-        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
-            right[j] -= (((left[j] << 4) ^ (left[j] >> 5)) + left[j]) ^ (sum + k[(sum >> 11) & 3]);
-        }
-        sum -= delta;
-        for (auto j = 0u; j < BLOCK_SIZE; ++j) {
-            left[j] -= (((right[j] << 4) ^ (right[j] >> 5)) + right[j]) ^ (sum + k[(sum) & 3]);
-        }
-    }
-
-    for (auto i = 0u, j = 0u; i < BLOCK_SIZE; i += 1u, j += 8u) {
-        data[j] = static_cast<uint8_t>(left[i]);
-        data[j+1] = static_cast<uint8_t>(left[i] >> 8u);
-        data[j+2] = static_cast<uint8_t>(left[i] >> 16u);
-        data[j+3] = static_cast<uint8_t>(left[i] >> 24u);
-        data[j+4] = static_cast<uint8_t>(right[i]);
-        data[j+5] = static_cast<uint8_t>(right[i] >> 8u);
-        data[j+6] = static_cast<uint8_t>(right[i] >> 16u);
-        data[j+7] = static_cast<uint8_t>(right[i] >> 24u);
-    }
 }
 
-constexpr auto InitialBlockSize =
-#if defined(__AVX512F__)
-      128u;
-#elif defined(__AVX__)
-      32u;
-#elif defined(__SSE__) || defined(__ARM_FEATURE_SIMD32)
-      8u;
-#elif defined(__x86_64__)
-      2u;
-#else
-      1u;
-#endif
+void encrypt(uint8_t* data, size_t length, const key& k)
+{
+    for (auto i = 0u, sum = 0u, next_sum = sum + delta; i < 32u; ++i, sum = next_sum, next_sum += delta) {
+        apply_rounds(data, length, [&](uint32_t& left, uint32_t& right) {
+            left += ((right << 4 ^ right >> 5) + right) ^ (sum + k[sum & 3]);
+            right += ((left << 4 ^ left >> 5) + left) ^ (next_sum + k[(next_sum >> 11) & 3]);
+        });
+    };
+}
 
-template<bool Encrypt, size_t BlockSize>
-struct XTEA {
-    static constexpr auto step = BlockSize * 8u;
-
-    void operator()(uint8_t* input, size_t length, const key& k) const {
-        const auto blocks = (length & ~(step - 1));
-        for (auto i = 0u; i < blocks; i += step) {
-            if (Encrypt) {
-                XTEA_encrypt<BlockSize>(input + i, k);
-            } else {
-                XTEA_decrypt<BlockSize>(input + i, k);
-            }
-        }
-        input += blocks;
-        length -= blocks;
-
-        if (BlockSize != 1) {
-            XTEA<Encrypt, (BlockSize + 1u) / 2u>()(input, length, k);
-        }
-    }
-};
-
-constexpr auto encrypt_v = XTEA<true, InitialBlockSize>();
-constexpr auto decrypt_v = XTEA<false, InitialBlockSize>();
-
-} // anonymous namespace
-
-void encrypt(uint8_t* data, size_t length, const key& k) { encrypt_v(data, length, k); }
-void decrypt(uint8_t* data, size_t length, const key& k) { decrypt_v(data, length, k); }
+void decrypt(uint8_t* data, size_t length, const key& k)
+{
+    for (auto i = 0u, sum = delta * 32, next_sum = sum - delta; i < 32u; ++i, sum = next_sum, next_sum -= delta) {
+        apply_rounds(data, length, [&](uint32_t& left, uint32_t& right) {
+            right -= ((left << 4 ^ left >> 5) + left) ^ (sum + k[(sum >> 11) & 3]);
+            left -= ((right << 4 ^ right >> 5) + right) ^ (next_sum + k[next_sum & 3]);
+        });
+    };
+}
 
 } // namespace xtea

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -54,7 +54,7 @@ void apply_rounds(uint8_t* data, size_t length, Round round)
 
 void encrypt(uint8_t* data, size_t length, const key& k)
 {
-    for (auto i = 0u, sum = 0u, next_sum = sum + delta; i < 32u; ++i, sum = next_sum, next_sum += delta) {
+    for (uint32_t i = 0, sum = 0, next_sum = sum + delta; i < 32; ++i, sum = next_sum, next_sum += delta) {
         apply_rounds(data, length, [&](uint32_t& left, uint32_t& right) {
             left += ((right << 4 ^ right >> 5) + right) ^ (sum + k[sum & 3]);
             right += ((left << 4 ^ left >> 5) + left) ^ (next_sum + k[(next_sum >> 11) & 3]);
@@ -64,7 +64,7 @@ void encrypt(uint8_t* data, size_t length, const key& k)
 
 void decrypt(uint8_t* data, size_t length, const key& k)
 {
-    for (auto i = 0u, sum = delta * 32, next_sum = sum - delta; i < 32u; ++i, sum = next_sum, next_sum -= delta) {
+    for (uint32_t i = 0, sum = delta << 5, next_sum = sum - delta; i < 32; ++i, sum = next_sum, next_sum -= delta) {
         apply_rounds(data, length, [&](uint32_t& left, uint32_t& right) {
             right -= ((left << 4 ^ left >> 5) + left) ^ (sum + k[(sum >> 11) & 3]);
             left -= ((right << 4 ^ right >> 5) + right) ^ (next_sum + k[next_sum & 3]);


### PR DESCRIPTION
Out with all that optimal block size width, let the compiler figure it out. Reduces the amount of code by half and increases performance by ~20%.

Shameless plug: [I wrote about the optimization of this algorithm](https://dev.to/rsa/making-an-algorithm-15x-faster-without-parallelism-38k5), please read it :stuck_out_tongue: 