### PR TITLE
Added a config to enable/disable dice usage on depot

### DIFF
--- a/data/actions/scripts/other/die.lua
+++ b/data/actions/scripts/other/die.lua
@@ -1,7 +1,17 @@
+local depotTiles = {11062, 11063}
+local diceEnabledOnDepot = true
+
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local position = item:getPosition()
 	local value = math.random(1, 6)
 	local isInGhostMode = player:isInGhostMode()
+	local tile = Tile(player:getPosition())
+	if not tile then
+		return false
+	end
+	if table.contains(depotTiles, tile:getGround():getId()) and not diceEnabledOnDepot then
+		return false
+	end
 
 	position:sendMagicEffect(CONST_ME_CRAPS, isInGhostMode and player)
 


### PR DESCRIPTION
It is not possible any longer to use Dies on Depot Lockers and the Counter between the them. [10.36 update]