### PR TITLE
Dont allocate new attributes when calling getCustomAttribute

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -647,14 +647,14 @@ class Item : virtual public Thing
 
 		bool removeCustomAttribute(int64_t key) {
 			if (!attributes) {
-				return true;
+				return false;
 			}
 			return getAttributes()->removeCustomAttribute(key);
 		}
 
 		bool removeCustomAttribute(const std::string& key) {
 			if (!attributes) {
-				return true;
+				return false;
 			}
 			return getAttributes()->removeCustomAttribute(key);
 		}

--- a/src/item.h
+++ b/src/item.h
@@ -632,10 +632,16 @@ class Item : virtual public Thing
 		}
 
 		const ItemAttributes::CustomAttribute* getCustomAttribute(int64_t key) {
+			if (!attributes) {
+				return nullptr;
+			}
 			return getAttributes()->getCustomAttribute(key);
 		}
 
 		const ItemAttributes::CustomAttribute* getCustomAttribute(const std::string& key) {
+			if (!attributes) {
+				return nullptr;
+			}
 			return getAttributes()->getCustomAttribute(key);
 		}
 

--- a/src/item.h
+++ b/src/item.h
@@ -646,10 +646,16 @@ class Item : virtual public Thing
 		}
 
 		bool removeCustomAttribute(int64_t key) {
+			if (!attributes) {
+				return nullptr;
+			}
 			return getAttributes()->removeCustomAttribute(key);
 		}
 
 		bool removeCustomAttribute(const std::string& key) {
+			if (!attributes) {
+				return nullptr;
+			}
 			return getAttributes()->removeCustomAttribute(key);
 		}
 

--- a/src/item.h
+++ b/src/item.h
@@ -647,14 +647,14 @@ class Item : virtual public Thing
 
 		bool removeCustomAttribute(int64_t key) {
 			if (!attributes) {
-				return nullptr;
+				return true;
 			}
 			return getAttributes()->removeCustomAttribute(key);
 		}
 
 		bool removeCustomAttribute(const std::string& key) {
 			if (!attributes) {
-				return nullptr;
+				return true;
 			}
 			return getAttributes()->removeCustomAttribute(key);
 		}


### PR DESCRIPTION
item:getCustomAttribute method was recreating attributes class each time it was called, which in case when they don't exist shouldn't be created.
This was also breaking stackables after you call item:getCustomAttribute they would stop stacking.

How to reproduce?
call thing:getCustomAttribute("")
in events Player:onLook on one stackable item and try to stack it with other of the same type.