### PR TITLE
Fixed (Clear Weapons RevScripts) by reload weapons

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15374,6 +15374,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponMelee>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);
 			}
@@ -15386,6 +15387,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponDistance>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);
 			}
@@ -15397,6 +15399,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponWand>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);
 			}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15374,6 +15374,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponMelee>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				// Fixed #3123, this comment is only for to activate builds AppVeyor/TravisCI
 				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15374,7 +15374,6 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponMelee>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
-				// Fixed #3123, this comment is only for to activate builds AppVeyor/TravisCI
 				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);


### PR DESCRIPTION
When reloading the weapons module, the weapons created from the module (RevScripts) were deleted, this fixes it!