### PR TITLE
Fix on combat target callback

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -733,6 +733,14 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 					} else {
 						creature->removeCombatCondition(params.dispelType);
 					}
+
+					if (params.targetCallback) {
+						params.targetCallback->onTargetCombat(caster, creature);
+					}
+
+					if (params.targetCasterOrTopMost) {
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Last combat changes broke some stuff.
Target callback was removed and so any possibility to use spells like exeta res

fix by @joseluis2g 