### PR TITLE
Multiple words to talkaction RevScript

### DIFF
--- a/data/scripts/talkactions/position.lua
+++ b/data/scripts/talkactions/position.lua
@@ -1,4 +1,4 @@
-local talk = TalkAction("/pos", "/position", "/mypos")
+local talk = TalkAction("/pos", "/position", "!pos", "!position")
 
 function talk.onSay(player, words, param)
 	if player:getGroup():getAccess() and param ~= "" then

--- a/data/scripts/talkactions/position.lua
+++ b/data/scripts/talkactions/position.lua
@@ -1,4 +1,4 @@
-local talk = TalkAction("/pos")
+local talk = TalkAction("/pos", "/position", "/mypos")
 
 function talk.onSay(player, words, param)
 	if player:getGroup():getAccess() and param ~= "" then

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14751,7 +14751,9 @@ int LuaScriptInterface::luaCreateTalkaction(lua_State* L)
 
 	TalkAction* talk = new TalkAction(getScriptEnv()->getScriptInterface());
 	if (talk) {
-		talk->setWords(getString(L, 2));
+		for (int i = 2; i <= lua_gettop(L); i++) {
+			talk->setWords(getString(L, i));
+		}
 		talk->fromLua = true;
 		pushUserdata<TalkAction>(L, talk);
 		setMetatable(L, -1, "TalkAction");

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -916,7 +916,7 @@ void LuaScriptInterface::pushInstantSpell(lua_State* L, const InstantSpell& spel
 	lua_createtable(L, 0, 6);
 
 	setField(L, "name", spell.getName());
-	setField(L, "words", spell.getWords());
+	setField(L, "words", spell.getWords().front());
 	setField(L, "level", spell.getLevel());
 	setField(L, "mlevel", spell.getMagicLevel());
 	setField(L, "mana", spell.getMana());
@@ -14327,7 +14327,7 @@ int LuaScriptInterface::luaSpellWords(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			pushString(L, spell->getWords());
+			pushString(L, spell->getWords().front());
 			pushString(L, spell->getSeparator());
 			return 2;
 		} else {

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -144,7 +144,7 @@ std::string TalkAction::getScriptEventName() const
 	return "onSay";
 }
 
-bool TalkAction::executeSay(Player* player, const std::string& param, SpeakClasses type) const
+bool TalkAction::executeSay(Player* player, const std::string& word, const std::string& param, SpeakClasses type) const
 {
 	//onSay(player, words, param, type)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -162,7 +162,7 @@ bool TalkAction::executeSay(Player* player, const std::string& param, SpeakClass
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushString(L, words);
+	LuaScriptInterface::pushString(L, word);
 	LuaScriptInterface::pushString(L, param);
 	lua_pushnumber(L, type);
 

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -83,40 +83,39 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 {
 	size_t wordsLength = words.length();
 	for (auto it = talkActions.begin(); it != talkActions.end(); ) {
-		const std::string& talkactionWords = it->first;
-		size_t talkactionLength = talkactionWords.length();
-		if (wordsLength < talkactionLength || strncasecmp(words.c_str(), talkactionWords.c_str(), talkactionLength) != 0) {
-			++it;
-			continue;
-		}
-
-		std::string param;
-		if (wordsLength != talkactionLength) {
-			param = words.substr(talkactionLength);
-			if (param.front() != ' ') {
-				++it;
+		for (auto& talkactionWords : it->second.getWothers()) {
+			size_t talkactionLength = talkactionWords.length();
+			if (wordsLength < talkactionLength || strncasecmp(words.c_str(), talkactionWords.c_str(), talkactionLength) != 0) {
 				continue;
 			}
-			trim_left(param, ' ');
 
-			std::string separator = it->second.getSeparator();
-			if (separator != " ") {
-				if (!param.empty()) {
-					if (param != separator) {
-						++it;
-						continue;
-					} else {
-						param.erase(param.begin());
+			std::string param;
+			if (wordsLength != talkactionLength) {
+				param = words.substr(talkactionLength);
+				if (param.front() != ' ') {
+					continue;
+				}
+				trim_left(param, ' ');
+
+				std::string separator = it->second.getSeparator();
+				if (separator != " ") {
+					if (!param.empty()) {
+						if (param != separator) {
+							continue;
+						} else {
+							param.erase(param.begin());
+						}
 					}
 				}
 			}
-		}
 
-		if (it->second.executeSay(player, param, type)) {
-			return TALKACTION_CONTINUE;
-		} else {
-			return TALKACTION_BREAK;
+			if (it->second.executeSay(player, param, type)) {
+				return TALKACTION_CONTINUE;
+			} else {
+				return TALKACTION_BREAK;
+			}
 		}
+		++it;
 	}
 	return TALKACTION_CONTINUE;
 }
@@ -134,7 +133,7 @@ bool TalkAction::configureEvent(const pugi::xml_node& node)
 		separator = pugi::cast<char>(separatorAttribute.value());
 	}
 
-	words = wordsAttribute.as_string();
+	setWords(wordsAttribute.as_string());
 	return true;
 }
 

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -68,14 +68,14 @@ Event_ptr TalkActions::getEvent(const std::string& nodeName)
 bool TalkActions::registerEvent(Event_ptr event, const pugi::xml_node&)
 {
 	TalkAction_ptr talkAction{static_cast<TalkAction*>(event.release())}; // event is guaranteed to be a TalkAction
-	talkActions.emplace(talkAction->getWords(), std::move(*talkAction));
+	talkActions.emplace(talkAction->getWords().front(), std::move(*talkAction));
 	return true;
 }
 
 bool TalkActions::registerLuaEvent(TalkAction* event)
 {
 	TalkAction_ptr talkAction{ event };
-	talkActions.emplace(talkAction->getWords(), std::move(*talkAction));
+	talkActions.emplace(talkAction->getWords().front(), std::move(*talkAction));
 	return true;
 }
 
@@ -83,7 +83,7 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 {
 	size_t wordsLength = words.length();
 	for (auto it = talkActions.begin(); it != talkActions.end(); ) {
-		for (auto& talkactionWords : it->second.getWothers()) {
+		for (auto& talkactionWords : it->second.getWords()) {
 			size_t talkactionLength = talkactionWords.length();
 			if (wordsLength < talkactionLength || strncasecmp(words.c_str(), talkactionWords.c_str(), talkactionLength) != 0) {
 				continue;

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -109,7 +109,7 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 				}
 			}
 
-			if (it->second.executeSay(player, param, type)) {
+			if (it->second.executeSay(player, talkactionWords, param, type)) {
 				return TALKACTION_CONTINUE;
 			} else {
 				return TALKACTION_BREAK;

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -133,7 +133,9 @@ bool TalkAction::configureEvent(const pugi::xml_node& node)
 		separator = pugi::cast<char>(separatorAttribute.value());
 	}
 
-	setWords(wordsAttribute.as_string());
+	for (auto w : explodeString(wordsAttribute.as_string(), ";")) {
+		setWords(w);
+	}
 	return true;
 }
 

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -26,6 +26,7 @@
 
 class TalkAction;
 using TalkAction_ptr = std::unique_ptr<TalkAction>;
+using TalkAction_words = std::vector<std::string>;
 
 enum TalkActionResult_t {
 	TALKACTION_CONTINUE,
@@ -45,12 +46,16 @@ class TalkAction : public Event
 		}
 		void setWords(std::string word) {
 			words = word;
+			wothers.push_back(word);
 		}
 		std::string getSeparator() const {
 			return separator;
 		}
 		void setSeparator(std::string sep) {
 			separator = sep;
+		}
+		const TalkAction_words getWothers() const {
+			return wothers;
 		}
 
 		//scripting
@@ -62,6 +67,7 @@ class TalkAction : public Event
 
 		std::string words;
 		std::string separator = "\"";
+		TalkAction_words wothers = {};
 };
 
 class TalkActions final : public BaseEvents

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -54,7 +54,7 @@ class TalkAction : public Event
 		}
 
 		//scripting
-		bool executeSay(Player* player, const std::string& param, SpeakClasses type) const;
+		bool executeSay(Player* player, const std::string& word, const std::string& param, SpeakClasses type) const;
 		//
 
 	private:

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -26,7 +26,6 @@
 
 class TalkAction;
 using TalkAction_ptr = std::unique_ptr<TalkAction>;
-using TalkAction_words = std::vector<std::string>;
 
 enum TalkActionResult_t {
 	TALKACTION_CONTINUE,
@@ -41,21 +40,17 @@ class TalkAction : public Event
 
 		bool configureEvent(const pugi::xml_node& node) override;
 
-		const std::string& getWords() const {
+		std::vector<std::string> getWords() const {
 			return words;
 		}
 		void setWords(std::string word) {
-			words = word;
-			wothers.push_back(word);
+			words.push_back(word);
 		}
 		std::string getSeparator() const {
 			return separator;
 		}
 		void setSeparator(std::string sep) {
 			separator = sep;
-		}
-		const TalkAction_words getWothers() const {
-			return wothers;
 		}
 
 		//scripting
@@ -65,9 +60,8 @@ class TalkAction : public Event
 	private:
 		std::string getScriptEventName() const override;
 
-		std::string words;
+		std::vector<std::string> words;
 		std::string separator = "\"";
-		TalkAction_words wothers = {};
 };
 
 class TalkActions final : public BaseEvents


### PR DESCRIPTION
I liked this implementation a lot and I always wondered if someone else would think the same, this was mentioned by @EPuncker in the following Issue (#3126)

Example:
`data/scripts/talkactions/position.lua`
```lua
local talk = TalkAction("/pos", "/position", "/mypos")

function talk.onSay(player, words, param)
	if player:getGroup():getAccess() and param ~= "" then
		local split = param:split(",")
		player:teleportTo(Position(split[1], split[2], split[3]))
	else
		local position = player:getPosition()
		player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Your current position is: " .. position.x .. ", " .. position.y .. ", " .. position.z .. ".")
	end
	return false
end

talk:separator(" ")
talk:register()
```

_For a couple of days now, the compilations have not happened correctly, no matter if the code is ok, this is a github error?_