### PR TITLE
fix inconsistency in the Item class change int32_t to int64_t

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -597,16 +597,16 @@ class Item : virtual public Thing
 			getAttributes()->setStrAttr(type, value);
 		}
 
-		int32_t getIntAttr(itemAttrTypes type) const {
+		int64_t getIntAttr(itemAttrTypes type) const {
 			if (!attributes) {
 				return 0;
 			}
 			return attributes->getIntAttr(type);
 		}
-		void setIntAttr(itemAttrTypes type, int32_t value) {
+		void setIntAttr(itemAttrTypes type, int64_t value) {
 			getAttributes()->setIntAttr(type, value);
 		}
-		void increaseIntAttr(itemAttrTypes type, int32_t value) {
+		void increaseIntAttr(itemAttrTypes type, int64_t value) {
 			getAttributes()->increaseIntAttr(type, value);
 		}
 


### PR DESCRIPTION
Attributes::getIntAttr/setIntAttr/increaseIntAttr uses int64_t but Item::getIntAttr/setIntAttr/IncreaseIntAttr uses int32_t
I think Dalkon forgot to fix it in this commit: https://github.com/otland/forgottenserver/commit/951115fae6a482ec8f72953ff57327afec48ed78#diff-708342412a7a3b1182b63622489c9f97