### PR TITLE
Make combat for "no vocation" configurable

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -3,7 +3,7 @@
 	<!-- Creature methods -->
 	<event class="Creature" method="onChangeOutfit" enabled="0" />
 	<event class="Creature" method="onAreaCombat" enabled="0" />
-	<event class="Creature" method="onTargetCombat" enabled="0" />
+	<event class="Creature" method="onTargetCombat" enabled="1" />
 	<event class="Creature" method="onHear" enabled="0" />
 
 	<!-- Party methods -->

--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -7,6 +7,20 @@ function Creature:onAreaCombat(tile, isAggressive)
 end
 
 function Creature:onTargetCombat(target)
+	-- No Vocation Combat Config --
+	disableNoVocationCombat = true
+	-- No Vocation Combat Config --
+	
+	if disableNoVocationCombat then
+		if self:isPlayer() and target:isPlayer() then
+			if self:getVocation():getId() == VOCATION_NONE or target:getVocation():getId() == VOCATION_NONE then
+				if not self:getGroup():getAccess() then
+					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER
+				end
+			end
+		end
+	end
+	
 	return RETURNVALUE_NOERROR
 end
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -273,10 +273,6 @@ bool Combat::isProtected(const Player* attacker, const Player* target)
 		return true;
 	}
 
-	if (attacker->getVocationId() == VOCATION_NONE || target->getVocationId() == VOCATION_NONE) {
-		return true;
-	}
-
 	if (attacker->getSkull() == SKULL_BLACK && attacker->getSkullClient(target) == SKULL_NONE) {
 		return true;
 	}


### PR DESCRIPTION
Removed outdated check that disables combat with no vocation characters.

There are enough better ways to deal with it today like using non-PVP tiles on map or even using protectionLevel option on config.lua.