### PR TITLE
Added NOPVP magic wall and wild growth

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -29219,7 +29219,6 @@
 		<attribute key="type" value="magicfield" />
 		<attribute key="decayTo" value="0" />
 		<attribute key="duration" value="45" />
-		<attribute key="blocking" value="1" />
 	</item>
 	<item fromid="20671" toid="20691" article="a" name="basalt crystal wall" />
 	<item fromid="20692" toid="20700" name="the spike of a crystal drill" />

--- a/data/movements/movements.xml
+++ b/data/movements/movements.xml
@@ -278,6 +278,10 @@
 	<movevent event="AddItem" itemid="1507" function="onAddField" />
 	<movevent event="StepIn" itemid="7359" function="onStepInField" />
 	<movevent event="AddItem" itemid="7360" function="onAddField" />
+	<movevent event="StepIn" itemid="20669" function="onStepInField" />
+	<movevent event="AddItem" itemid="20669" function="onAddField" />
+	<movevent event="StepIn" itemid="20670" function="onStepInField" />
+	<movevent event="AddItem" itemid="20670" function="onAddField" />
 
 	<!-- Swimming -->
 	<movevent event="StepIn" fromid="4620" toid="4625" script="swimming.lua" />

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -531,6 +531,10 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 						itemId = ITEM_POISONFIELD_NOPVP;
 					} else if (itemId == ITEM_ENERGYFIELD_PVP) {
 						itemId = ITEM_ENERGYFIELD_NOPVP;
+					} else if (itemId == ITEM_MAGICWALL) {
+						itemId = ITEM_MAGICWALL_NOPVP;
+					} else if (itemId == ITEM_WILDGROWTH) {
+						itemId = ITEM_WILDGROWTH_NOPVP;
 					}
 				} else if (itemId == ITEM_FIREFIELD_PVP_FULL || itemId == ITEM_POISONFIELD_PVP || itemId == ITEM_ENERGYFIELD_PVP) {
 					casterPlayer->addInFightTicks();


### PR DESCRIPTION
- Added them to the code responsible for changing them to the NOPVP IDs when used on NOPVP world type or NOPVP tiles
- Also, registered them on movements.xml