### PR TITLE
Fix disabled browsefield bypass

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2274,6 +2274,10 @@ void Game::playerMoveUpContainer(uint32_t playerId, uint8_t cid)
 			return;
 		}
 
+		if (!g_events->eventPlayerOnBrowseField(player, tile->getPosition())) {
+			return;
+		}
+		
 		auto it = browseFields.find(tile);
 		if (it == browseFields.end()) {
 			parentContainer = new Container(tile);


### PR DESCRIPTION
The player event onBrowseField could be bypassed after disabling it

To disable, set it to enabled="1" in events.xml and return false in the function
To bypass, you would open a container on the tile and press the up arrow

This fix just makes sure we execute the event and check the return value when pressing the up arrow