### PR TITLE
Optimize IOLoginData::saveItems by reducing number of allocations

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -591,7 +591,8 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 	std::ostringstream ss;
 
 	using ContainerBlock = std::pair<Container*, int32_t>;
-	std::list<ContainerBlock> queue;
+	std::vector<ContainerBlock> containers;
+	containers.reserve(150);
 
 	int32_t runningId = 100;
 
@@ -613,22 +614,21 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 		}
 
 		if (Container* container = item->getContainer()) {
-			queue.emplace_back(container, runningId);
+			containers.emplace_back(container, runningId);
 		}
 	}
 
-	while (!queue.empty()) {
-		const ContainerBlock& cb = queue.front();
+	for (size_t i = 0; i < containers.size(); i++) {
+		const ContainerBlock& cb = containers[i];
 		Container* container = cb.first;
 		int32_t parentId = cb.second;
-		queue.pop_front();
 
 		for (Item* item : container->getItemList()) {
 			++runningId;
 
 			Container* subContainer = item->getContainer();
 			if (subContainer) {
-				queue.emplace_back(subContainer, runningId);
+				containers.emplace_back(subContainer, runningId);
 			}
 
 			propWriteStream.clear();

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -592,7 +592,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 
 	using ContainerBlock = std::pair<Container*, int32_t>;
 	std::vector<ContainerBlock> containers;
-	containers.reserve(150);
+	containers.reserve(32);
 
 	int32_t runningId = 100;
 


### PR DESCRIPTION
Note that this is untested, just an idea I got by quickly looking at the function. std::list would allocate for each push, std::vector tends to have a growth strategy where it only allocates when it reaches capacity