### PR TITLE
Add .vs/ directory to ignored directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.sln.docstates
 .idea/
 .vscode/
+.vs/
 
 # Build results
 


### PR DESCRIPTION
This directory is some random trashcan from visual studio, we don't need to consider it.