### PR TITLE
Add backwards compatibility for pre 1.x loot containers

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -1362,6 +1362,8 @@ bool Monsters::loadLootItem(const pugi::xml_node& node, LootBlock& lootBlock)
 
 void Monsters::loadLootContainer(const pugi::xml_node& node, LootBlock& lBlock)
 {
+	// NOTE: <inside> attribute was left for backwards compatibility with pre 1.x TFS versions.
+	// Please don't use it, if you don't have to.
 	for (auto subNode : node.child("inside") ? node.child("inside").children() : node.children()) {
 		LootBlock lootBlock;
 		if (loadLootItem(subNode, lootBlock)) {

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -1362,7 +1362,7 @@ bool Monsters::loadLootItem(const pugi::xml_node& node, LootBlock& lootBlock)
 
 void Monsters::loadLootContainer(const pugi::xml_node& node, LootBlock& lBlock)
 {
-	for (auto subNode : node.children()) {
+	for (auto subNode : node.child("inside") ? node.child("inside").children() : node.children()) {
 		LootBlock lootBlock;
 		if (loadLootItem(subNode, lootBlock)) {
 			lBlock.childLoot.emplace_back(std::move(lootBlock));


### PR DESCRIPTION
In old versions you used to write loot containers like:
``` 
<item id="1987" chance="100000"> 
        <inside>
            <item id="2597" chance="8300" />
            <item id="2553" chance="10750" /> 
            <item id="2530" chance="10750" />
            <item id="2213" chance="150" /> 
        </inside>
    </item>
```
now you use it like:
```
  <item id="1987" chance="100000"> 
            <item id="2597" chance="8300" />
            <item id="2553" chance="10750" /> 
            <item id="2530" chance="10750" />
            <item id="2213" chance="150" /> 
    </item>
```

This pr brings back the optional "inside" tag, so it does parse both and is backwards compatible in result.