### PR TITLE
lua52> 'unpack' error fix #3194

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1330,3 +1330,6 @@ function doSetCreatureLight(cid, lightLevel, lightColor, time)
 	creature:addCondition(condition)
 	return true
 end
+
+-- this is a fix for lua52 or higher which has the function renamed to table.unpack, while luajit still uses unpack
+if unpack == nil then unpack = table.unpack end

--- a/data/scripts/lib/event_callbacks.lua
+++ b/data/scripts/lib/event_callbacks.lua
@@ -108,7 +108,7 @@ setmetatable(EventCallback,
         repeat
             result = {event(...)}
             key, event = next(EventCallbackData[callbackType], key)
-        until event == nil or (result ~= nil and (result == false or table.contains({EVENT_CALLBACK_ONAREACOMBAT, EVENT_CALLBACK_ONTARGETCOMBAT}, callbackType) and result ~= RETURNVALUE_NOERROR))
+        until event == nil or (result[1] ~= nil and (result[1] == false or table.contains({EVENT_CALLBACK_ONAREACOMBAT, EVENT_CALLBACK_ONTARGETCOMBAT}, callbackType) and result[1] ~= RETURNVALUE_NOERROR))
         return unpack(result)
     end
 })


### PR DESCRIPTION
lua52 has the function 'unpack' renamed to 'table.unpack' this solves the issue and further problems which we could have with that function.

This also includes a little parameter check correction on EventCallbacks.
Solves #3194