### PR TITLE
Additional checks for unsigned integers to avoid underflow and overflow

### DIFF
--- a/src/luascript.h
+++ b/src/luascript.h
@@ -280,12 +280,37 @@ class LuaScriptInterface
 		{
 			return static_cast<T>(static_cast<int64_t>(lua_tonumber(L, arg)));
 		}
+
 		template<typename T>
-		static typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value, T>::type
+		static typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type
 			getNumber(lua_State* L, int32_t arg)
 		{
-			return static_cast<T>(lua_tonumber(L, arg));
+			LUA_NUMBER luaNum = lua_tonumber(L, arg);
+			if (luaNum < 0 || luaNum > std::numeric_limits<T>::max()) {
+				std::ostringstream ss;
+				ss << "Passed argument " << arg << " has invalid value" << std::endl;
+				reportErrorFunc(ss.str());
+				return 0;
+			}
+
+			return static_cast<T>(luaNum);
 		}
+
+		template<typename T>
+		static typename std::enable_if<(std::is_integral<T>::value && std::is_signed<T>::value) || std::is_floating_point<T>::value, T>::type
+			getNumber(lua_State* L, int32_t arg)
+		{
+			LUA_NUMBER luaNum = lua_tonumber(L, arg);
+			if (luaNum > std::numeric_limits<T>::max()) {
+				std::ostringstream ss;
+				ss << "Passed argument " << arg << " has invalid value" << std::endl;
+				reportErrorFunc(ss.str());
+				return 0;
+			}
+
+			return static_cast<T>(luaNum);
+		}		
+
 		template<typename T>
 		static T getNumber(lua_State *L, int32_t arg, T defaultValue)
 		{

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -290,7 +290,6 @@ class LuaScriptInterface
 				std::ostringstream ss;
 				ss << "Passed argument " << arg << " has invalid value" << std::endl;
 				reportErrorFunc(ss.str());
-				return 0;
 			}
 
 			return static_cast<T>(luaNum);
@@ -305,7 +304,6 @@ class LuaScriptInterface
 				std::ostringstream ss;
 				ss << "Passed argument " << arg << " has invalid value" << std::endl;
 				reportErrorFunc(ss.str());
-				return 0;
 			}
 
 			return static_cast<T>(luaNum);


### PR DESCRIPTION
Additional checks in getNumber<T>(L, arg)

Prints a handy warning if unsigned integer is negative or exceeds the max number for defined type.

![image](https://user-images.githubusercontent.com/14142246/97061500-62658f00-1597-11eb-9289-28e93e2a81cd.png)
