### PR TITLE
Revert "Multiple words to talkaction RevScript (#3132)"

### DIFF
--- a/data/scripts/talkactions/position.lua
+++ b/data/scripts/talkactions/position.lua
@@ -1,4 +1,4 @@
-local talk = TalkAction("/pos", "/position", "!pos", "!position")
+local talk = TalkAction("/pos")
 
 function talk.onSay(player, words, param)
 	if player:getGroup():getAccess() and param ~= "" then

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -926,7 +926,7 @@ void LuaScriptInterface::pushInstantSpell(lua_State* L, const InstantSpell& spel
 	lua_createtable(L, 0, 6);
 
 	setField(L, "name", spell.getName());
-	setField(L, "words", spell.getWords().front());
+	setField(L, "words", spell.getWords());
 	setField(L, "level", spell.getLevel());
 	setField(L, "mlevel", spell.getMagicLevel());
 	setField(L, "mana", spell.getMana());
@@ -14438,7 +14438,7 @@ int LuaScriptInterface::luaSpellWords(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			pushString(L, spell->getWords().front());
+			pushString(L, spell->getWords());
 			pushString(L, spell->getSeparator());
 			return 2;
 		} else {
@@ -14862,9 +14862,7 @@ int LuaScriptInterface::luaCreateTalkaction(lua_State* L)
 
 	TalkAction* talk = new TalkAction(getScriptEnv()->getScriptInterface());
 	if (talk) {
-		for (int i = 2; i <= lua_gettop(L); i++) {
-			talk->setWords(getString(L, i));
-		}
+		talk->setWords(getString(L, 2));
 		talk->fromLua = true;
 		pushUserdata<TalkAction>(L, talk);
 		setMetatable(L, -1, "TalkAction");

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -57,9 +57,8 @@ TalkActionResult_t Spells::playerSaySpell(Player* player, std::string& words)
 
 	std::string param;
 
-	const std::string& spellWords = instantSpell->getWords().front();
 	if (instantSpell->getHasParam()) {
-		size_t spellLen = spellWords.length();
+		size_t spellLen = instantSpell->getWords().length();
 		size_t paramLen = str_words.length() - spellLen;
 		std::string paramText = str_words.substr(spellLen, paramLen);
 		if (!paramText.empty() && paramText.front() == ' ') {
@@ -86,7 +85,7 @@ TalkActionResult_t Spells::playerSaySpell(Player* player, std::string& words)
 	}
 
 	if (instantSpell->playerCastInstant(player, param)) {
-		words = spellWords;
+		words = instantSpell->getWords();
 
 		if (instantSpell->getHasParam() && !param.empty()) {
 			words += " \"" + param + "\"";
@@ -148,10 +147,9 @@ bool Spells::registerEvent(Event_ptr event, const pugi::xml_node&)
 {
 	InstantSpell* instant = dynamic_cast<InstantSpell*>(event.get());
 	if (instant) {
-		std::string words = instant->getWords().front();
-		auto result = instants.emplace(words, std::move(*instant));
+		auto result = instants.emplace(instant->getWords(), std::move(*instant));
 		if (!result.second) {
-			std::cout << "[Warning - Spells::registerEvent] Duplicate registered instant spell with words: " << words << std::endl;
+			std::cout << "[Warning - Spells::registerEvent] Duplicate registered instant spell with words: " << instant->getWords() << std::endl;
 		}
 		return result.second;
 	}
@@ -172,8 +170,8 @@ bool Spells::registerInstantLuaEvent(InstantSpell* event)
 {
 	InstantSpell_ptr instant { event };
 	if (instant) {
-		std::string words = instant->getWords().front();
-		auto result = instants.emplace(words, std::move(*instant));
+		std::string words = instant->getWords();
+		auto result = instants.emplace(instant->getWords(), std::move(*instant));
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerInstantLuaEvent] Duplicate registered instant spell with words: " << words << std::endl;
 		}
@@ -236,9 +234,10 @@ InstantSpell* Spells::getInstantSpell(const std::string& words)
 	InstantSpell* result = nullptr;
 
 	for (auto& it : instants) {
-		size_t spellLen = it.second.getWords().front().length();
-		if (strncasecmp(it.second.getWords().front().c_str(), words.c_str(), spellLen) == 0) {
-			if (!result || spellLen > result->getWords().front().length()) {
+		const std::string& instantSpellWords = it.second.getWords();
+		size_t spellLen = instantSpellWords.length();
+		if (strncasecmp(instantSpellWords.c_str(), words.c_str(), spellLen) == 0) {
+			if (!result || spellLen > result->getWords().length()) {
 				result = &it.second;
 				if (words.length() == spellLen) {
 					break;
@@ -248,12 +247,13 @@ InstantSpell* Spells::getInstantSpell(const std::string& words)
 	}
 
 	if (result) {
-		if (words.length() > result->getWords().front().length()) {
+		const std::string& resultWords = result->getWords();
+		if (words.length() > resultWords.length()) {
 			if (!result->getHasParam()) {
 				return nullptr;
 			}
 
-			size_t spellLen = result->getWords().front().length();
+			size_t spellLen = resultWords.length();
 			size_t paramLen = words.length() - spellLen;
 			if (paramLen < 2 || words[spellLen] != ' ') {
 				return nullptr;

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -68,14 +68,14 @@ Event_ptr TalkActions::getEvent(const std::string& nodeName)
 bool TalkActions::registerEvent(Event_ptr event, const pugi::xml_node&)
 {
 	TalkAction_ptr talkAction{static_cast<TalkAction*>(event.release())}; // event is guaranteed to be a TalkAction
-	talkActions.emplace(talkAction->getWords().front(), std::move(*talkAction));
+	talkActions.emplace(talkAction->getWords(), std::move(*talkAction));
 	return true;
 }
 
 bool TalkActions::registerLuaEvent(TalkAction* event)
 {
 	TalkAction_ptr talkAction{ event };
-	talkActions.emplace(talkAction->getWords().front(), std::move(*talkAction));
+	talkActions.emplace(talkAction->getWords(), std::move(*talkAction));
 	return true;
 }
 
@@ -83,39 +83,40 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 {
 	size_t wordsLength = words.length();
 	for (auto it = talkActions.begin(); it != talkActions.end(); ) {
-		for (auto& talkactionWords : it->second.getWords()) {
-			size_t talkactionLength = talkactionWords.length();
-			if (wordsLength < talkactionLength || strncasecmp(words.c_str(), talkactionWords.c_str(), talkactionLength) != 0) {
+		const std::string& talkactionWords = it->first;
+		size_t talkactionLength = talkactionWords.length();
+		if (wordsLength < talkactionLength || strncasecmp(words.c_str(), talkactionWords.c_str(), talkactionLength) != 0) {
+			++it;
+			continue;
+		}
+
+		std::string param;
+		if (wordsLength != talkactionLength) {
+			param = words.substr(talkactionLength);
+			if (param.front() != ' ') {
+				++it;
 				continue;
 			}
+			trim_left(param, ' ');
 
-			std::string param;
-			if (wordsLength != talkactionLength) {
-				param = words.substr(talkactionLength);
-				if (param.front() != ' ') {
-					continue;
-				}
-				trim_left(param, ' ');
-
-				std::string separator = it->second.getSeparator();
-				if (separator != " ") {
-					if (!param.empty()) {
-						if (param != separator) {
-							continue;
-						} else {
-							param.erase(param.begin());
-						}
+			std::string separator = it->second.getSeparator();
+			if (separator != " ") {
+				if (!param.empty()) {
+					if (param != separator) {
+						++it;
+						continue;
+					} else {
+						param.erase(param.begin());
 					}
 				}
 			}
-
-			if (it->second.executeSay(player, talkactionWords, param, type)) {
-				return TALKACTION_CONTINUE;
-			} else {
-				return TALKACTION_BREAK;
-			}
 		}
-		++it;
+
+		if (it->second.executeSay(player, param, type)) {
+			return TALKACTION_CONTINUE;
+		} else {
+			return TALKACTION_BREAK;
+		}
 	}
 	return TALKACTION_CONTINUE;
 }
@@ -133,9 +134,7 @@ bool TalkAction::configureEvent(const pugi::xml_node& node)
 		separator = pugi::cast<char>(separatorAttribute.value());
 	}
 
-	for (auto w : explodeString(wordsAttribute.as_string(), ";")) {
-		setWords(w);
-	}
+	words = wordsAttribute.as_string();
 	return true;
 }
 
@@ -144,7 +143,7 @@ std::string TalkAction::getScriptEventName() const
 	return "onSay";
 }
 
-bool TalkAction::executeSay(Player* player, const std::string& word, const std::string& param, SpeakClasses type) const
+bool TalkAction::executeSay(Player* player, const std::string& param, SpeakClasses type) const
 {
 	//onSay(player, words, param, type)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -162,7 +161,7 @@ bool TalkAction::executeSay(Player* player, const std::string& word, const std::
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushString(L, word);
+	LuaScriptInterface::pushString(L, words);
 	LuaScriptInterface::pushString(L, param);
 	lua_pushnumber(L, type);
 

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -40,11 +40,11 @@ class TalkAction : public Event
 
 		bool configureEvent(const pugi::xml_node& node) override;
 
-		std::vector<std::string> getWords() const {
+		const std::string& getWords() const {
 			return words;
 		}
 		void setWords(std::string word) {
-			words.push_back(word);
+			words = word;
 		}
 		std::string getSeparator() const {
 			return separator;
@@ -54,13 +54,13 @@ class TalkAction : public Event
 		}
 
 		//scripting
-		bool executeSay(Player* player, const std::string& word, const std::string& param, SpeakClasses type) const;
+		bool executeSay(Player* player, const std::string& param, SpeakClasses type) const;
 		//
 
 	private:
 		std::string getScriptEventName() const override;
 
-		std::vector<std::string> words;
+		std::string words;
 		std::string separator = "\"";
 };
 


### PR DESCRIPTION
This reverts commit 5a29332cd2a0de8acb29348e15438fd35cb0e16f.

https://github.com/otland/forgottenserver/pull/3132 

This PR causes a crash and/or memory allocation failure when casting spells in-game.

Tested in Ubuntu 18.04 and 20.04