### PR TITLE
Mwall/WGrowth NoPvp destroy onStepIn

### DIFF
--- a/data/movements/movements.xml
+++ b/data/movements/movements.xml
@@ -279,6 +279,10 @@
 	<movevent event="StepIn" itemid="7359" function="onStepInField" />
 	<movevent event="AddItem" itemid="7360" function="onAddField" />
 
+	<!-- Magic Wall NoPvp / Wild Growth NoPvp -->
+	<movevent event="StepIn" itemid="20669" function="onStepInField" />
+	<movevent event="StepIn" itemid="20670" function="onStepInField" />
+
 	<!-- Swimming -->
 	<movevent event="StepIn" fromid="4620" toid="4625" script="swimming.lua" />
 	<movevent event="StepOut" fromid="4620" toid="4625" script="swimming.lua" />

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -531,6 +531,10 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 						itemId = ITEM_POISONFIELD_NOPVP;
 					} else if (itemId == ITEM_ENERGYFIELD_PVP) {
 						itemId = ITEM_ENERGYFIELD_NOPVP;
+					} else if (itemId == ITEM_MAGICWALL) {
+						itemId = ITEM_MAGICWALL_NOPVP;
+					} else if (itemId == ITEM_WILDGROWTH) {
+						itemId = ITEM_WILDGROWTH_NOPVP;
 					}
 				} else if (itemId == ITEM_FIREFIELD_PVP_FULL || itemId == ITEM_POISONFIELD_PVP || itemId == ITEM_ENERGYFIELD_PVP) {
 					casterPlayer->addInFightTicks();

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1462,6 +1462,14 @@ void MagicField::onStepInField(Creature* creature)
 		return;
 	}
 
+	//remove magic walls/wild growth ( only nopvp tiles/world )
+	if (id == ITEM_MAGICWALL_NOPVP || id == ITEM_WILDGROWTH_NOPVP) {
+		if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
+			g_game.internalRemoveItem(this, 1);
+		}
+		return;
+	}
+
 	const ItemType& it = items[getID()];
 	if (it.conditionDamage) {
 		Condition* conditionCopy = it.conditionDamage->clone();


### PR DESCRIPTION
This change was inspired by the PR #3148
> - [x] ITEM_WILDGROWTH_NOPVP and ITEM_MAGICWALL_NOPVP should be destroyed on stepIn by any player (only on NOPVP world types or NOPVP tiles)