### PR TITLE
Update FindLuaJIT.cmake

### DIFF
--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -10,7 +10,7 @@
 find_path(LUA_INCLUDE_DIR luajit.h
   HINTS
     ENV LUA_DIR
-  PATH_SUFFIXES include/luajit-2.0 include/luajit-2.1 include luajit
+  PATH_SUFFIXES include/luajit-2.0 include/luajit-2.1 include include/luajit
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
addressing error:

-- Could NOT find LuaJIT (missing: LUA_INCLUDE_DIR)
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find Lua (missing: LUA_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindLua.cmake:113 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:43 (find_package)