### PR TITLE
Removing useless thread variable

### DIFF
--- a/src/tasks.h
+++ b/src/tasks.h
@@ -77,7 +77,6 @@ class Dispatcher : public ThreadHolder<Dispatcher> {
 		void threadMain();
 
 	private:
-		std::thread thread;
 		std::mutex taskLock;
 		std::condition_variable taskSignal;
 


### PR DESCRIPTION
ThreadHolder already have a thread member, i think this variable is useless.