### PR TITLE
Vocation cache optimization

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -96,4 +96,16 @@ int64_t OTSYS_TIME();
 
 SpellGroup_t stringToSpellGroup(const std::string& value);
 
+constexpr double fast_pow(double base, uint32_t exp) {
+	double result = 1.0;
+	while (exp) {
+		if (exp & 1) {
+			result *= base;
+		}
+		exp >>= 1;
+		base *= base;
+	}
+	return result;
+}
+
 #endif

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -183,7 +183,7 @@ uint32_t Vocation::skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
 
 uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 {
-	if (skill > SKILL_LAST) {
+	if (skill > SKILL_LAST || level <= 10) {
 		return 0;
 	}
 
@@ -199,6 +199,10 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
+	if (magLevel == 0) {
+		return 0;
+	}
+
 	auto it = cacheMana.find(magLevel);
 	if (it != cacheMana.end()) {
 		return it->second;

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -1,4 +1,4 @@
-/**
+getReqSkillTries/**
  * The Forgotten Server - a free and open-source MMORPG server emulator
  * Copyright (C) 2019  Mark Samman <mark.samman@gmail.com>
  *
@@ -34,7 +34,7 @@ class Vocation
 		const std::string& getVocDescription() const {
 			return description;
 		}
-		uint64_t getReqSkillTries(uint8_t skill, uint16_t level);
+		uint64_t getReqSkillTries(uint8_t skill, uint32_t level);
 		uint64_t getReqMana(uint32_t magLevel);
 
 		uint16_t getId() const {
@@ -94,14 +94,14 @@ class Vocation
 	private:
 		friend class Vocations;
 
-		std::map<uint32_t, uint64_t> cacheMana;
-		std::map<uint32_t, uint32_t> cacheSkill[SKILL_LAST + 1];
+		std::vector<uint64_t> cacheMana;
+		std::vector<uint64_t> cacheSkill[SKILL_LAST + 1];
 
 		std::string name = "none";
 		std::string description;
 
-		float skillMultipliers[SKILL_LAST + 1] = {1.5f, 2.0f, 2.0f, 2.0f, 2.0f, 1.5f, 1.1f};
-		float manaMultiplier = 4.0f;
+		double skillMultipliers[SKILL_LAST + 1] = {1.5, 2.0, 2.0, 2.0, 2.0, 1.5, 1.1};
+		double manaMultiplier = 4.0;
 
 		uint32_t gainHealthTicks = 6;
 		uint32_t gainHealthAmount = 1;

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -1,4 +1,4 @@
-getReqSkillTries/**
+/**
  * The Forgotten Server - a free and open-source MMORPG server emulator
  * Copyright (C) 2019  Mark Samman <mark.samman@gmail.com>
  *


### PR DESCRIPTION
- Change cache complexity from O(log n) to O(1)
- Use faster pow function
- Prevent skill try calculation from underflowing

also fixes #3217

all code by @SaiyansKing and @Erza 