### PR TITLE
Container overflow fix (freeze on /i)

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2641,15 +2641,16 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 			Container* tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
 				//we need to find first empty container as fast as we can for non-stackable items
-				uint32_t n = tmpContainer->capacity() - tmpContainer->size();
-				while (n) {
-					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
-						index = tmpContainer->capacity() - n;
+				uint32_t c = tmpContainer->capacity();
+				uint32_t n = c - tmpContainer->size();
+				while (n <= c) {
+					if (tmpContainer->queryAdd(c - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
+						index = c - n;
 						*destItem = nullptr;
 						return tmpContainer;
 					}
 
-					n--;
+					--n;
 				}
 
 				for (Item* tmpContainerItem : tmpContainer->getItemList()) {


### PR DESCRIPTION
regarding #3225

credits [SaiyansKing/optimized_forgottenserver@a205b5f](https://github.com/SaiyansKing/optimized_forgottenserver/commit/a205b5f033e88fe217721116dd623b6ef253bb43)

tests performed:

- picking up items
- /i pickupable item
- /i non-pickupable item

in these situations:
- player has no eq
- player has no eq but has a container
- player has eq but no container
- player has both eq and a container
- player has a overloaded container
- player has multiple overloaded containers in his eq

result:
- items cannot be picked up if there is no room in container
- created items get dropped on the floor with no freeze

Items that are beyond container limit are still inside that container. They can be regained through removing other items from the container.