### PR TITLE
MonsterType Inconsistencies and compatibility

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -117,8 +117,11 @@ registerMonsterType.flags = function(mtype, mask)
 end
 registerMonsterType.light = function(mtype, mask)
 	if mask.light then
-		if mask.light.color and mask.light.level then
-			mtype:light(mask.light.color, mask.light.level)
+		if mask.light.color then
+			local color = mask.light.color
+		end
+		if mask.light.level then
+			mtype:light(color, mask.light.level)
 		end
 	end
 end
@@ -151,7 +154,7 @@ end
 registerMonsterType.summons = function(mtype, mask)
 	if type(mask.summons) == "table" then
 		for k, v in pairs(mask.summons) do
-			mtype:addSummon(v.name, v.interval, v.chance, v.max or mtype:maxSummons())
+			mtype:addSummon(v.name, v.interval, v.chance)
 		end
 	end
 end
@@ -244,12 +247,8 @@ registerMonsterType.attacks = function(mtype, mask)
 			if attack.name then
 				if attack.name == "melee" then
 					spell:setType("melee")
-					if attack.attack and attack.skill then						
-						if attack.attack ~= 0 and attack.skill ~= 0 then
-							spell:setAttackValue(attack.attack, attack.skill)
-						elseif attack.minDamage and attack.maxDamage then
-							spell:setCombatValue(attack.minDamage, attack.maxDamage)
-						end
+					if attack.attack and attack.skill then
+						spell:setAttackValue(attack.attack, attack.skill)
 					end
 					if attack.interval then
 						spell:setInterval(attack.interval)

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -117,11 +117,8 @@ registerMonsterType.flags = function(mtype, mask)
 end
 registerMonsterType.light = function(mtype, mask)
 	if mask.light then
-		if mask.light.color then
-			local color = mask.light.color
-		end
-		if mask.light.level then
-			mtype:light(color, mask.light.level)
+		if mask.light.color and mask.light.level then
+			mtype:light(mask.light.color, mask.light.level)
 		end
 	end
 end
@@ -154,7 +151,7 @@ end
 registerMonsterType.summons = function(mtype, mask)
 	if type(mask.summons) == "table" then
 		for k, v in pairs(mask.summons) do
-			mtype:addSummon(v.name, v.interval, v.chance)
+			mtype:addSummon(v.name, v.interval, v.chance, v.max or mtype:maxSummons())
 		end
 	end
 end
@@ -247,8 +244,12 @@ registerMonsterType.attacks = function(mtype, mask)
 			if attack.name then
 				if attack.name == "melee" then
 					spell:setType("melee")
-					if attack.attack and attack.skill then
-						spell:setAttackValue(attack.attack, attack.skill)
+					if attack.attack and attack.skill then						
+						if attack.attack ~= 0 and attack.skill ~= 0 then
+							spell:setAttackValue(attack.attack, attack.skill)
+						elseif attack.minDamage and attack.maxDamage then
+							spell:setCombatValue(attack.minDamage, attack.maxDamage)
+						end
 					end
 					if attack.interval then
 						spell:setInterval(attack.interval)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12974,13 +12974,14 @@ int LuaScriptInterface::luaMonsterTypeGetSummonList(lua_State* L)
 
 int LuaScriptInterface::luaMonsterTypeAddSummon(lua_State* L)
 {
-	// monsterType:addSummon(name, interval, chance)
+	// monsterType:addSummon(name, interval, chance, max)
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		summonBlock_t summon;
 		summon.name = getString(L, 2);
 		summon.chance = getNumber<int32_t>(L, 3);
 		summon.speed = getNumber<int32_t>(L, 4);
+		summon.max = getNumber<int32_t>(L, 5);
 		monsterType->info.summons.push_back(summon);
 		pushBoolean(L, true);
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12974,14 +12974,13 @@ int LuaScriptInterface::luaMonsterTypeGetSummonList(lua_State* L)
 
 int LuaScriptInterface::luaMonsterTypeAddSummon(lua_State* L)
 {
-	// monsterType:addSummon(name, interval, chance, max)
+	// monsterType:addSummon(name, interval, chance)
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		summonBlock_t summon;
 		summon.name = getString(L, 2);
 		summon.chance = getNumber<int32_t>(L, 3);
 		summon.speed = getNumber<int32_t>(L, 4);
-		summon.max = getNumber<int32_t>(L, 5);
 		monsterType->info.summons.push_back(summon);
 		pushBoolean(L, true);
 	} else {


### PR DESCRIPTION
Currently, when creating monsters with "revscripts" there was a problem with invocations, because nowhere was the maximum of them specified, so by default the value was zero and therefore invocations were never generated, now with these changes if they can spawn invocations, as long as a specified maximum amount of the invocation or a global maximum amount of the monster as such is specified.

Change fixed a crazy thing that was in the function that gives lighting to the creature type: D

Also fixed a backward compatibility issue when setting the melee attack type, currently if you don't specify a skill level and attack damage constant then the monster just doesn't deal damage, no matter if you specify an absolute and constant damage, just like it is done in XML files