### PR TITLE
items.xml now warns about duplicated items

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -21550,7 +21550,9 @@
 	</item>
 	<item id="12672" article="a" name="telescope" />
 	<item id="12673" article="a" name="red chair" />
-	<item id="12673" article="a" name="rocking horse" />
+	<item id="12674" article="a" name="large amphora" />
+	<item id="12675" article="a" name="globe" />
+	<item id="12676" article="a" name="rocking horse" />
 	<item fromid="12678" toid="12679" article="a" name="timber wall" />
 	<item id="12680" article="a" name="dead rabbit" />
 	<item id="12681" name="wooden planks" />
@@ -22285,7 +22287,6 @@
 	<item id="13506" article="a" name="medicine pouch">
 		<attribute key="weight" value="1200" />
 	</item>
-	<item id="13495" article="a" name="faint glow" />
 	<item id="13507" article="a" name="faint glow" />
 	<item id="13508" article="a" name="slug drug">
 		<attribute key="description" value="A hermit near Carlin might be able to tell you more about it." />
@@ -23241,8 +23242,6 @@
 	<item id="13983" name="fan doll of Queen Eloise">
 		<attribute key="weight" value="1560" />
 	</item>
-	<item id="13929" article="an" name="orc dummy" />
-	<item id="13931" article="an" name="orc warlord dummy" />
 	<item id="14320" article="a" name="special flask">
 		<attribute key="description" value="It contains the smell of a freshly slain slime." />
 		<attribute key="weight" value="180" />
@@ -29274,7 +29273,6 @@
 		<attribute key="allowpickupable" value="1" />
 		<attribute key="fluidSource" value="blood" />
 	</item>
-	<item id="20937" name="blood" />
 	<item fromid="20938" toid="20942" article="a" name="sandy rock pile" />
 	<item id="20946" article="a" name="sandy rock pile" />
 	<item fromid="20947" toid="20958" article="a" name="sandstone mountain" />
@@ -30148,8 +30146,8 @@
 	</item>
 	<item id="21442" name="red effect" />
 	<item id="21443" name="green effect" />
-	<item id="21443" name="blue effect" />
-	<item id="21443" name="yellow effect" />
+	<item id="21444" name="blue effect" />
+	<item id="21445" name="yellow effect" />
 	<item id="21446" name="shadow ashes">
 		<attribute key="weight" value="5" />
 		<attribute key="description" value="The ashes are warm and greasy to the touch. They emit a faint, dark glow." />
@@ -30238,10 +30236,6 @@
 	<item id="21482" name="Omrabas' bone key">
 		<attribute key="description" value="It is delicately carved out of the bone of some animal and bears strange inscriptions." />
 		<attribute key="weight" value="100" />
-	</item>
-	<item id="21585" name="smoking coal">
-		<attribute key="description" value="This coal is smoking and emmits quite a stench." />
-		<attribute key="weight" value="1000" />
 	</item>
 	<item id="21489" name="Omrabas' copper key">
 		<attribute key="weight" value="100" />
@@ -34174,7 +34168,6 @@
 	</item>
 	<item id="24817" article="a" name="lit strange statue" />
 	<item id="24818" article="a" name="coffin" />
-	<item id="24819" article="a" name="grave" />
 	<item id="24819" article="a" name="strange statue" />
 	<item fromid="24820" toid="24821" article="a" name="dark stone wall" />
 	<item fromid="24822" toid="24825" article="a" name="blood fountain" />

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -556,6 +556,11 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 		return;
 	}
 
+	if (!it.name.empty()) {
+		std::cout << "[Warning - Items::parseItemNode] Duplicate item with id: " << id << std::endl;
+		return;
+	}
+
 	it.name = itemNode.attribute("name").as_string();
 
 	nameToItems.insert({ asLowerCaseString(it.name), id });


### PR DESCRIPTION
- edited Items::parseItemNode to add the check and warning message
- fixed current warnings

closes #3094 

Co-Authored-By: Sarah Wesker <sarahelizabetwesker@gmail.com>