### PR TITLE
Fix trade stacking items

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1067,7 +1067,6 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 
 	while ((subCylinder = toCylinder->queryDestination(index, *item, &toItem, flags)) != toCylinder) {
 		toCylinder = subCylinder;
-		flags = 0;
 
 		//to prevent infinite loop
 		if (++floorN >= MAP_MAX_LAYERS) {


### PR DESCRIPTION
I'm not entirely sure why this code is there, but this breaks passing FLAG_IGNOREAUTOSTACK (and probably other flags too) for trading and any other internalMoveItem that is not moved in single queryDestination execute.
I think it's probably, because Tile::queryDestination can add "FLAG_NOLIMIT" to flags

Here is the explanation behind this "flags = 0;" code
In trade item is moved to player, so it queries two cylinders, first one is player, second one is his backpack to which item is moved, querying player deletes flag "flags = 0", so second query stacks the item, because flags is 0 at this point and it merges two same stackable items in trade which results in whole stack on one side.
