### PR TITLE
fixed EventCallback, gain/lose_exp and skilltries

### DIFF
--- a/data/scripts/lib/event_callbacks.lua
+++ b/data/scripts/lib/event_callbacks.lua
@@ -70,6 +70,12 @@ local callbacks = {
 	["onSpawn"] = EVENT_CALLBACK_ONSPAWN
 }
 
+local feedbackParams = {
+	[EVENT_CALLBACK_ONGAINEXPERIENCE] = {3},
+	[EVENT_CALLBACK_ONLOSEEXPERIENCE] = {2},
+	[EVENT_CALLBACK_ONGAINSKILLTRIES] = {3}
+}
+
 -- can't be overwritten on /reload global/libs now
 if not EventCallbackData then
 	EventCallbackData = {}
@@ -103,10 +109,17 @@ setmetatable(EventCallback,
 
 	__call =
     function(self, callbackType, ...)
-        local result
-        local key, event = next(EventCallbackData[callbackType])
-        repeat
-            result = {event(...)}
+		local params = {...}
+		local result
+		local key, event = next(EventCallbackData[callbackType])
+		repeat
+			result = {event(unpack(params))}
+			local feedbackParam = feedbackParams[callbackType]
+			if feedbackParam then
+				for _, pos in pairs(feedbackParam) do
+					params[pos] = result[1]
+				end
+			end
             key, event = next(EventCallbackData[callbackType], key)
         until event == nil or (result[1] ~= nil and (result[1] == false or table.contains({EVENT_CALLBACK_ONAREACOMBAT, EVENT_CALLBACK_ONTARGETCOMBAT}, callbackType) and result[1] ~= RETURNVALUE_NOERROR))
         return unpack(result)


### PR DESCRIPTION
Some events require that one of their parameters be kept up to date with the previous results to work correctly, here is an example:

Current:
```lua
local ev = EventCallback

function ev.onGainExperience(player, source, exp, rawExp)
	exp = exp + 1000
	return exp
end

function ev.onGainExperience(player, source, exp, rawExp)
	exp = exp + 1000
	return exp
end

-- RESULT: exp + 1000
```

Now with this changes:
```lua
local ev = EventCallback

function ev.onGainExperience(player, source, exp, rawExp)
	exp = exp + 1000
	return exp
end

function ev.onGainExperience(player, source, exp, rawExp)
	exp = exp + 1000
	return exp
end

-- RESULT: exp + 2000
```

@EvilHero90 check pls

The code is a bit generalized with tables that only contain a single value, I did it with that intention in case in the future there are new events that require updating several parameters, I do not know if it is right