### PR TITLE
Drop sudo instructions from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: bionic
 language: cpp
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: bionic
 language: cpp
 compiler:
@@ -8,7 +9,7 @@ env:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "jg/5nV1Xe6ePlplxIyRmyTaSEDmKhOxF/Z3cMMU6xOnEyhMTnKgcvi88YB0JA/Y7y3SBFyHdvzSfADgTPYsE+TDp2BTlhPpaS/x987nXfB+0jWB3WyEdxtUuscis9m3vAfdO9OraOfrthQDKQgt1mEoJcdVfLabnZ2hs+wzuFGA="
-  matrix:
+  jobs:
     - LUAJIT=OFF
     - LUAJIT=ON
 cache: apt


### PR DESCRIPTION
* Build config validation
* deprecated key sudo (The key `sudo` has no effect anymore.)

REF: https://config.travis-ci.com/ref/sudo

and anothers warnings...