### PR TITLE
Don't update monster idle status if it cannot see the creature

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -369,9 +369,7 @@ void Monster::updateTargetList()
 	g_game.map.getSpectators(spectators, position, true);
 	spectators.erase(this);
 	for (Creature* spectator : spectators) {
-		if (canSee(spectator->getPosition())) {
-			onCreatureFound(spectator);
-		}
+		onCreatureFound(spectator);
 	}
 }
 
@@ -393,6 +391,14 @@ void Monster::clearFriendList()
 
 void Monster::onCreatureFound(Creature* creature, bool pushFront/* = false*/)
 {
+	if (!creature) {
+		return;
+	}
+	
+	if (!canSee(creature->getPosition())) {
+		return;
+	}
+	
 	if (isFriend(creature)) {
 		addFriend(creature);
 	}


### PR DESCRIPTION
onCreatureFound is called for every single creature around, even if monster cannot see the creature, later it will call canSee on targets to delete them from target list.
This pr adds check to onCreatureFound, so it will check canSee before checking if its friend or opponent..