### PR TITLE
Drop skill caches & fix skill tries precision

### DIFF
--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -179,7 +179,7 @@ uint16_t Vocations::getPromotedVocation(uint16_t vocationId) const
 	return VOCATION_NONE;
 }
 
-static uint32_t skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
+static const uint32_t skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
 
 uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 {

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -186,13 +186,10 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 	if (skill > SKILL_LAST) {
 		return 0;
 	}
-
-	uint64_t tries = static_cast<uint64_t>(skillBase[skill] * std::pow<double>(skillMultipliers[skill], level - 11));
-	return tries;
+	return static_cast<uint64_t>(skillBase[skill] * std::pow<double>(skillMultipliers[skill], level - 11));
 }
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
-	uint64_t reqMana = std::floor<uint64_t>(1600 * std::pow<double>(manaMultiplier, static_cast<int32_t>(magLevel) - 1));
-	return reqMana;
+	return std::floor<uint64_t>(1600 * std::pow<double>(manaMultiplier, static_cast<int32_t>(magLevel) - 1));
 }

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -116,7 +116,7 @@ bool Vocations::loadFromXml()
 				if (skillIdAttribute) {
 					uint16_t skill_id = pugi::cast<uint16_t>(skillIdAttribute.value());
 					if (skill_id <= SKILL_LAST) {
-						voc.skillMultipliers[skill_id] = pugi::cast<float>(childNode.attribute("multiplier").value());
+						voc.skillMultipliers[skill_id] = pugi::cast<double>(childNode.attribute("multiplier").value());
 					} else {
 						std::cout << "[Notice - Vocations::loadFromXml] No valid skill id: " << skill_id << " for vocation: " << voc.id << std::endl;
 					}
@@ -186,10 +186,10 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 	if (skill > SKILL_LAST) {
 		return 0;
 	}
-	return static_cast<uint64_t>(skillBase[skill] * std::pow<double>(skillMultipliers[skill], level - 11));
+	return skillBase[skill] * std::pow(skillMultipliers[skill], level - 11);
 }
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
-	return std::floor<uint64_t>(1600 * std::pow<double>(manaMultiplier, static_cast<int32_t>(magLevel) - 1));
+	return 1600 * std::pow(manaMultiplier, magLevel - 1);
 }

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -179,7 +179,7 @@ uint16_t Vocations::getPromotedVocation(uint16_t vocationId) const
 	return VOCATION_NONE;
 }
 
-uint32_t Vocation::skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
+static uint32_t skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
 
 uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 {
@@ -187,24 +187,12 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 		return 0;
 	}
 
-	auto it = cacheSkill[skill].find(level);
-	if (it != cacheSkill[skill].end()) {
-		return it->second;
-	}
-
-	uint64_t tries = static_cast<uint64_t>(skillBase[skill] * std::pow(static_cast<double>(skillMultipliers[skill]), level - 11));
-	cacheSkill[skill][level] = tries;
+	uint64_t tries = static_cast<uint64_t>(skillBase[skill] * std::pow<double>(skillMultipliers[skill], level - 11));
 	return tries;
 }
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
-	auto it = cacheMana.find(magLevel);
-	if (it != cacheMana.end()) {
-		return it->second;
-	}
-
 	uint64_t reqMana = std::floor<uint64_t>(1600 * std::pow<double>(manaMultiplier, static_cast<int32_t>(magLevel) - 1));
-	cacheMana[magLevel] = reqMana;
 	return reqMana;
 }

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -94,9 +94,6 @@ class Vocation
 	private:
 		friend class Vocations;
 
-		std::map<uint32_t, uint64_t> cacheMana;
-		std::map<uint32_t, uint32_t> cacheSkill[SKILL_LAST + 1];
-
 		std::string name = "none";
 		std::string description;
 
@@ -119,8 +116,6 @@ class Vocation
 
 		uint8_t soulMax = 100;
 		uint8_t clientId = 0;
-
-		static uint32_t skillBase[SKILL_LAST + 1];
 };
 
 class Vocations

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -97,7 +97,7 @@ class Vocation
 		std::string name = "none";
 		std::string description;
 
-		float skillMultipliers[SKILL_LAST + 1] = {1.5f, 2.0f, 2.0f, 2.0f, 2.0f, 1.5f, 1.1f};
+		double skillMultipliers[SKILL_LAST + 1] = {1.5, 2.0, 2.0, 2.0, 2.0, 1.5, 1.1};
 		float manaMultiplier = 4.0f;
 
 		uint32_t gainHealthTicks = 6;


### PR DESCRIPTION
Essentially what I proposed in #3227, just drop the caches since calculating the values is not slow enough to be worth it to cache & add code complexity.

[More details on the speed of std::pow](https://baptiste-wicht.com/posts/2017/09/cpp11-performance-tip-when-to-use-std-pow.html).

Also, moved `skillBase` to the cpp file as it does not need to be declared in the header.

Closes #3217