### PR TITLE
Implement scheduler timers using asio deadline timers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: bionic
+dist: focal
 language: cpp
 compiler:
   - clang

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -30,12 +30,7 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 {
 	// check if the event has a valid id
 	if (task->getEventId() == 0) {
-		uint32_t tmpEventId = ++lastEventId;
-		// if not generate one
-		if (tmpEventId == 0) {
-			tmpEventId = ++lastEventId;
-		}
-		task->setEventId(tmpEventId);
+		task->setEventId(++lastEventId);
 	}
 
 	// insert the event id in the list of active events

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -20,6 +20,7 @@
 #include "otpch.h"
 
 #include "scheduler.h"
+#include <memory>
 
 void Scheduler::threadMain()
 {
@@ -35,8 +36,7 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 
 	// insert the event id in the list of active events
 	io_service.post([this, task]() {
-		boost::asio::deadline_timer* timer;
-		timer = new boost::asio::deadline_timer(io_service);
+		auto timer = std::make_shared<boost::asio::deadline_timer>(io_service);
 		eventIdTimerMap[task->getEventId()] = timer;
 
 		timer->expires_from_now(boost::posix_time::milliseconds(task->getDelay()));

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -23,11 +23,6 @@
 #include <boost/asio/post.hpp>
 #include <memory>
 
-void Scheduler::threadMain()
-{
-	io_context.run();
-}
-
 uint32_t Scheduler::addEvent(SchedulerTask* task)
 {
 	// check if the event has a valid id

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -65,10 +65,9 @@ void Scheduler::stopEvent(uint32_t eventId)
 	io_service.post([this, eventId]() {
 		// search the event id..
 		auto it = eventIdTimerMap.find(eventId);
-		if (it == eventIdTimerMap.end()) {
-			return;
+		if (it != eventIdTimerMap.end()) {
+			it->second->cancel();
 		}
-		it->second->cancel();
 	});
 }
 

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -36,11 +36,11 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 
 	// insert the event id in the list of active events
 	io_service.post([this, task]() {
-		auto timer = std::make_shared<boost::asio::deadline_timer>(io_service);
-		eventIdTimerMap[task->getEventId()] = timer;
+		auto& timer = eventIdTimerMap[task->getEventId()];
+		timer.reset(new boost::asio::deadline_timer(io_service));
 
 		timer->expires_from_now(boost::posix_time::milliseconds(task->getDelay()));
-		timer->async_wait([this, task, timer](const boost::system::error_code& error) {
+		timer->async_wait([this, task](const boost::system::error_code& error) {
 			eventIdTimerMap.erase(task->getEventId());
 
 			if (error == boost::asio::error::operation_aborted || getState() == THREAD_STATE_TERMINATED) {

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -21,8 +21,8 @@
 #define FS_SCHEDULER_H_2905B3D5EAB34B4BA8830167262D2DC1
 
 #include "tasks.h"
-#include <unordered_set>
-#include <queue>
+#include <unordered_map>
+#include <atomic>
 
 #include "thread_holder_base.h"
 
@@ -38,44 +38,36 @@ class SchedulerTask : public Task
 			return eventId;
 		}
 
-		std::chrono::system_clock::time_point getCycle() const {
-			return expiration;
+		uint32_t getDelay() const {
+			return delay;
 		}
-
 	private:
-		SchedulerTask(uint32_t delay, std::function<void (void)>&& f) : Task(delay, std::move(f)) {}
+		SchedulerTask(uint32_t delay, std::function<void (void)>&& f) : Task(std::move(f)), delay(delay) {}
 
 		uint32_t eventId = 0;
+		uint32_t delay = 0;
 
 		friend SchedulerTask* createSchedulerTask(uint32_t, std::function<void (void)>);
 };
 
 SchedulerTask* createSchedulerTask(uint32_t delay, std::function<void (void)> f);
 
-struct TaskComparator {
-	bool operator()(const SchedulerTask* lhs, const SchedulerTask* rhs) const {
-		return lhs->getCycle() > rhs->getCycle();
-	}
-};
-
 class Scheduler : public ThreadHolder<Scheduler>
 {
 	public:
 		uint32_t addEvent(SchedulerTask* task);
-		bool stopEvent(uint32_t eventId);
+		void stopEvent(uint32_t eventId);
 
 		void shutdown();
 
 		void threadMain();
-
 	private:
 		std::thread thread;
-		std::mutex eventLock;
-		std::condition_variable eventSignal;
-
-		uint32_t lastEventId {0};
-		std::priority_queue<SchedulerTask*, std::deque<SchedulerTask*>, TaskComparator> eventList;
-		std::unordered_set<uint32_t> eventIds;
+		std::atomic<uint32_t> lastEventId {0};
+		std::unordered_map<uint32_t, boost::asio::deadline_timer*> eventIdTimerMap;
+		std::vector<boost::asio::deadline_timer*> timerCacheVec;
+		boost::asio::io_service io_service;
+		boost::asio::io_service::work work {io_service};
 };
 
 extern Scheduler g_scheduler;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -63,7 +63,7 @@ class Scheduler : public ThreadHolder<Scheduler>
 		void threadMain();
 	private:
 		std::atomic<uint32_t> lastEventId{0};
-		std::unordered_map<uint32_t, std::unique_ptr<boost::asio::deadline_timer>> eventIdTimerMap;
+		std::unordered_map<uint32_t, boost::asio::deadline_timer> eventIdTimerMap;
 		boost::asio::io_context io_context;
 		boost::asio::io_context::work work{io_context};
 };

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -60,7 +60,7 @@ class Scheduler : public ThreadHolder<Scheduler>
 
 		void shutdown();
 
-		void threadMain();
+		void threadMain() { io_context.run(); }
 	private:
 		std::atomic<uint32_t> lastEventId{0};
 		std::unordered_map<uint32_t, boost::asio::deadline_timer> eventIdTimerMap;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -65,7 +65,6 @@ class Scheduler : public ThreadHolder<Scheduler>
 		std::thread thread;
 		std::atomic<uint32_t> lastEventId {0};
 		std::unordered_map<uint32_t, boost::asio::deadline_timer*> eventIdTimerMap;
-		std::vector<boost::asio::deadline_timer*> timerCacheVec;
 		boost::asio::io_service io_service;
 		boost::asio::io_service::work work {io_service};
 };

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -22,7 +22,6 @@
 
 #include "tasks.h"
 #include <unordered_map>
-#include <atomic>
 
 #include "thread_holder_base.h"
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -63,10 +63,10 @@ class Scheduler : public ThreadHolder<Scheduler>
 		void threadMain();
 	private:
 		std::thread thread;
-		std::atomic<uint32_t> lastEventId {0};
+		std::atomic<uint32_t> lastEventId{0};
 		std::unordered_map<uint32_t, std::unique_ptr<boost::asio::deadline_timer>> eventIdTimerMap;
-		boost::asio::io_service io_service;
-		boost::asio::io_service::work work {io_service};
+		boost::asio::io_context io_context;
+		boost::asio::io_context::work work{io_context};
 };
 
 extern Scheduler g_scheduler;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -64,7 +64,7 @@ class Scheduler : public ThreadHolder<Scheduler>
 	private:
 		std::thread thread;
 		std::atomic<uint32_t> lastEventId {0};
-		std::unordered_map<uint32_t, boost::asio::deadline_timer*> eventIdTimerMap;
+		std::unordered_map<uint32_t, std::shared_ptr<boost::asio::deadline_timer>> eventIdTimerMap;
 		boost::asio::io_service io_service;
 		boost::asio::io_service::work work {io_service};
 };

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -62,7 +62,6 @@ class Scheduler : public ThreadHolder<Scheduler>
 
 		void threadMain();
 	private:
-		std::thread thread;
 		std::atomic<uint32_t> lastEventId{0};
 		std::unordered_map<uint32_t, std::unique_ptr<boost::asio::deadline_timer>> eventIdTimerMap;
 		boost::asio::io_context io_context;

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -64,7 +64,7 @@ class Scheduler : public ThreadHolder<Scheduler>
 	private:
 		std::thread thread;
 		std::atomic<uint32_t> lastEventId {0};
-		std::unordered_map<uint32_t, std::shared_ptr<boost::asio::deadline_timer>> eventIdTimerMap;
+		std::unordered_map<uint32_t, std::unique_ptr<boost::asio::deadline_timer>> eventIdTimerMap;
 		boost::asio::io_service io_service;
 		boost::asio::io_service::work work {io_service};
 };


### PR DESCRIPTION
As it's been a while that #3056 was last updated, and there is usage of deprecated facilities. This is a bit cleaner using smart pointers to avoid manual deletion and skip the cache as constructing a timer seems very lightweight.

Closes #2218
Closes #3056