### PR TITLE
Several monsters fixes

### DIFF
--- a/data/monster/monsters/ancient_scarab.xml
+++ b/data/monster/monsters/ancient_scarab.xml
@@ -52,7 +52,8 @@
 		<summon name="Larva" interval="2000" chance="10" />
 	</summons>
 	<loot>
-		<item name="gold coin" countmax="187" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="87" chance="50000" />
 		<item id="2162" chance="10300" /><!-- magic lightwand -->
 		<item name="scarab coin" countmax="2" chance="8100" />
 		<item name="scarab pincers" chance="7140" />

--- a/data/monster/monsters/ashmunrah.xml
+++ b/data/monster/monsters/ashmunrah.xml
@@ -75,7 +75,10 @@
 		<voice sentence="You will be history soon." />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="304" chance="100000" />
+		<item name="gold coin" countmax="100" chance="33000" />
+		<item name="gold coin" countmax="100" chance="33000" />
+		<item name="gold coin" countmax="100" chance="33000" />
+		<item name="gold coin" countmax="4" chance="50000" />
 		<item name="great mana potion" chance="12500" />
 		<item name="might ring" chance="4600" />
 		<item name="silver brooch" chance="4000" />

--- a/data/monster/monsters/behemoth.xml
+++ b/data/monster/monsters/behemoth.xml
@@ -69,7 +69,7 @@
 		<item name="steel boots" chance="440" />
 		<item name="crowbar" chance="130" />
 		<item id="7396" chance="170" /><!-- behemoth trophy -->
-		<item name="amphora" chance="90" />
+		<item id="2023" chance="90" /><!-- amphora -->
 		<item name="titan axe" chance="70" />
 		<item name="war axe" chance="60" />
 	</loot>

--- a/data/monster/monsters/black_knight.xml
+++ b/data/monster/monsters/black_knight.xml
@@ -44,7 +44,8 @@
 		<voice sentence="You're no match for me!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="136" chance="48000" />
+		<item name="gold coin" countmax="100" chance="24000" />
+		<item name="gold coin" countmax="36" chance="24000" />
 		<item name="spear" countmax="3" chance="30800" />
 		<item name="brown bread" countmax="2" chance="21600" />
 		<item id="2120" chance="14020" /><!-- rope -->

--- a/data/monster/monsters/blightwalker.xml
+++ b/data/monster/monsters/blightwalker.xml
@@ -53,7 +53,8 @@
 		<voice sentence="Your lifeforce is waning!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="197" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="97" chance="50000" />
 		<item name="platinum coin" countmax="5" chance="100000" />
 		<item name="amulet of loss" chance="120" />
 		<item name="gold ring" chance="1870" />

--- a/data/monster/monsters/blood_hand.xml
+++ b/data/monster/monsters/blood_hand.xml
@@ -55,7 +55,8 @@
 		<voice sentence="Die, filth!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="130" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="30" chance="50000" />
 		<item name="necrotic rod" chance="3000" />
 		<item name="boots of haste" chance="210" />
 		<item name="skull staff" chance="130" />

--- a/data/monster/monsters/blue_djinn.xml
+++ b/data/monster/monsters/blue_djinn.xml
@@ -57,7 +57,8 @@
 		<voice sentence="Wishes can come true." />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="115" chance="86000" />
+		<item name="gold coin" countmax="100" chance="43000" />
+		<item name="gold coin" countmax="15" chance="43000" />
 		<item id="2684" chance="23480" /><!-- carrot -->
 		<item name="royal spear" countmax="2" chance="4500" />
 		<item name="small sapphire" countmax="4" chance="2560" />

--- a/data/monster/monsters/corym_vanguard.xml
+++ b/data/monster/monsters/corym_vanguard.xml
@@ -44,7 +44,8 @@
 		<voice sentence="Gimme! Gimme!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="120" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="20" chance="50000" />
 		<item id="2696" chance="20000" /><!-- cheese -->
 		<item name="bola" chance="10000" />
 		<item name="spike shield" chance="4761" />

--- a/data/monster/monsters/crazed_beggar.xml
+++ b/data/monster/monsters/crazed_beggar.xml
@@ -43,7 +43,7 @@
 		<item id="2072" chance="360" /><!-- lute -->
 		<item name="gold coin" countmax="9" chance="99000" />
 		<item name="dwarven ring" chance="120" />
-		<item name="dirty cape" chance="55000" />
+		<item id="2237" chance="55000" /><!-- dirty cape -->
 		<item name="wooden hammer" chance="6500" />
 		<item name="wooden spoon" chance="9750" />
 		<item id="2570" chance="5650" /><!-- rolling pin -->

--- a/data/monster/monsters/death_priest.xml
+++ b/data/monster/monsters/death_priest.xml
@@ -39,7 +39,8 @@
 	</immunities>
 	<loot>
 		<item name="white pearl" chance="3000" />
-		<item name="gold coin" countmax="144" chance="70000" />
+		<item name="gold coin" countmax="100" chance="35000" />
+		<item name="gold coin" countmax="44" chance="35000" />
 		<item name="scarab coin" countmax="3" chance="10000" />
 		<item id="2175" chance="6800" /><!-- spellbook -->
 		<item name="ring of healing" chance="1000" />

--- a/data/monster/monsters/dipthrah.xml
+++ b/data/monster/monsters/dipthrah.xml
@@ -62,7 +62,9 @@
 	</voices>
 	<loot>
 		<item name="ornamented ankh" chance="100000" />
-		<item name="gold coin" countmax="226" chance="90000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="26" chance="30000" />
 		<item name="small sapphire" countmax="3" chance="9800" />
 		<item name="great mana potion" chance="8900" />
 		<item name="energy ring" chance="4800" />

--- a/data/monster/monsters/dragon.xml
+++ b/data/monster/monsters/dragon.xml
@@ -46,7 +46,8 @@
 		<voice sentence="FCHHHHH" yell="1" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="105" chance="90000" />
+		<item name="gold coin" countmax="100" chance="45000" />
+		<item name="gold coin" countmax="5" chance="45000" />
 		<item name="dragon ham" countmax="3" chance="65500" />
 		<item name="steel shield" chance="15000" />
 		<item name="crossbow" chance="10000" />

--- a/data/monster/monsters/dragon_lord.xml
+++ b/data/monster/monsters/dragon_lord.xml
@@ -49,7 +49,9 @@
 		<voice sentence="YOU WILL BURN!" yell="1" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="245" chance="95000" />
+		<item name="gold coin" countmax="100" chance="32000" />
+		<item name="gold coin" countmax="100" chance="32000" />
+		<item name="gold coin" countmax="45" chance="32000" />
 		<item name="dragon ham" countmax="5" chance="80000" />
 		<item name="green mushroom" chance="12000" />
 		<item name="royal spear" countmax="3" chance="9000" />

--- a/data/monster/monsters/elder_mummy.xml
+++ b/data/monster/monsters/elder_mummy.xml
@@ -42,7 +42,8 @@
 		<item id="2124" chance="1650" /><!-- crystal ring -->
 		<item name="silver brooch" chance="4000" />
 		<item name="black pearl" chance="1340" />
-		<item name="gold coin" countmax="160" chance="87000" />
+		<item name="gold coin" countmax="100" chance="43000" />
+		<item name="gold coin" countmax="60" chance="43000" />
 		<item name="scarab coin" countmax="3" chance="10000" />
 		<item name="strange talisman" chance="4500" />
 		<item id="2162" chance="6000" /><!-- magic lightwand -->

--- a/data/monster/monsters/elder_wyrm.xml
+++ b/data/monster/monsters/elder_wyrm.xml
@@ -51,7 +51,8 @@
 	</voices>
 	<loot>
 		<item name="small diamond" countmax="5" chance="4000" />
-		<item name="gold coin" countmax="174" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="74" chance="50000" />
 		<item name="platinum coin" countmax="3" chance="25150" />
 		<item name="crossbow" chance="9690" />
 		<item name="dragon ham" countmax="2" chance="32420" />

--- a/data/monster/monsters/elf_arcanist.xml
+++ b/data/monster/monsters/elf_arcanist.xml
@@ -72,7 +72,7 @@
 		<item name="holy orchid" chance="2000" />
 		<item name="wand of cosmic energy" chance="1160" />
 		<item name="life crystal" chance="970" />
-		<item name="inkwell" chance="1000" />
+		<item id="2600" chance="1000" /><!-- inkwell -->
 		<item name="sandals" chance="950" />
 		<item name="grave flower" chance="880" />
 		<item name="yellow gem" chance="50" />

--- a/data/monster/monsters/frazzlemaw.xml
+++ b/data/monster/monsters/frazzlemaw.xml
@@ -84,7 +84,7 @@
 		<item name="violet crystal shard" chance="3000" />
 		<item name="brown crystal splinter" chance="16000" />
 		<item name="red crystal fragment" chance="7600" />
-		<item name="crystal rubbish" chance="10000" />
+		<item id="18554" chance="10000" /><!-- crystal rubbish -->
 		<item name="cluster of solace" chance="450" />
 		<item name="frazzle tongue" chance="18760" />
 		<item name="frazzle skin" chance="16000" />

--- a/data/monster/monsters/furious_troll.xml
+++ b/data/monster/monsters/furious_troll.xml
@@ -31,7 +31,8 @@
 		<voice sentence="DIE!!!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="146" chance="93000" />
+		<item name="gold coin" countmax="100" chance="47000" />
+		<item name="gold coin" countmax="46" chance="47000" />
 		<item name="platinum coin" chance="6000" />
 		<item name="war hammer" chance="750" />
 		<item name="bunch of troll hair" chance="4400" />

--- a/data/monster/monsters/giant_spider.xml
+++ b/data/monster/monsters/giant_spider.xml
@@ -43,10 +43,11 @@
 		<immunity earth="1" />
 	</immunities>
 	<summons maxSummons="2">
-		<summon name="Poison Spider" interval="2000" chance="10" max="2" />
+		<summon name="Poison Spider" interval="2000" chance="10" />
 	</summons>
 	<loot>
-		<item name="gold coin" countmax="195" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="95" chance="50000" />
 		<item name="poison arrow" countmax="12" chance="12500" />
 		<item name="plate armor" chance="10000" />
 		<item name="plate legs" chance="8000" />

--- a/data/monster/monsters/gravedigger.xml
+++ b/data/monster/monsters/gravedigger.xml
@@ -59,7 +59,8 @@
 		<voice sentence="Put it there!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="137" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="37" chance="50000" />
 		<item name="platinum coin" chance="24470" />
 		<item name="yellow gem" chance="800" />
 		<item name="wand of inferno" chance="5590" />

--- a/data/monster/monsters/green_djinn.xml
+++ b/data/monster/monsters/green_djinn.xml
@@ -58,7 +58,8 @@
 		<voice sentence="Good wishes are for fairytales" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="115" chance="88000" />
+		<item name="gold coin" countmax="100" chance="44000" />
+		<item name="gold coin" countmax="15" chance="44000" />
 		<item id="2696" chance="24500" /><!-- cheese -->
 		<item name="royal spear" countmax="2" chance="4870" />
 		<item name="small emerald" countmax="4" chance="2960" />

--- a/data/monster/monsters/grim_reaper.xml
+++ b/data/monster/monsters/grim_reaper.xml
@@ -61,7 +61,9 @@
 		<voice sentence="The end is near!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="263" chance="99000" />
+		<item name="gold coin" countmax="100" chance="33000" />
+		<item name="gold coin" countmax="100" chance="33000" />
+		<item name="gold coin" countmax="63" chance="33000" />
 		<item name="platinum coin" countmax="4" chance="5200" />
 		<item id="2162" chance="4850" /><!-- magic lightwand -->
 		<item name="dark shield" chance="3000" />

--- a/data/monster/monsters/guzzlemaw.xml
+++ b/data/monster/monsters/guzzlemaw.xml
@@ -83,7 +83,7 @@
 		<item name="violet crystal shard" chance="3000" />
 		<item name="brown crystal splinter" countmax="2" chance="12000" />
 		<item name="red crystal fragment" chance="7600" />
-		<item name="crystal rubbish" chance="12000" />
+		<item id="18554" chance="12000" /><!-- crystal rubbish -->
 		<item name="cluster of solace" chance="920" />
 		<item name="frazzle tongue" chance="15000" />
 		<item name="frazzle skin" chance="14000" />

--- a/data/monster/monsters/horestis.xml
+++ b/data/monster/monsters/horestis.xml
@@ -56,7 +56,9 @@
 	</voices>
 	<loot>
 		<item name="silver brooch" chance="12500" />
-		<item name="gold coin" countmax="243" chance="50000" />
+		<item name="gold coin" countmax="100" chance="17000" />
+		<item name="gold coin" countmax="100" chance="17000" />
+		<item name="gold coin" countmax="43" chance="17000" />
 		<item name="platinum coin" countmax="5" chance="33333" />
 		<item name="scarab coin" countmax="5" chance="14285" />
 		<item name="pharaoh sword" chance="5000" />

--- a/data/monster/monsters/infected_weeper.xml
+++ b/data/monster/monsters/infected_weeper.xml
@@ -45,14 +45,15 @@
 		<immunity paralyze="1" />
 		<immunity invisible="1" />
 	</immunities>
-	<summons maxSummons="6">
+	<summons maxSummons="1">
 		<summon name="Parasite" interval="2000" chance="10" />
 	</summons>
 	<voices interval="5000" chance="10">
 		<voice sentence="Moooaaan!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="198" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="98" chance="50000" />
 		<item name="platinum coin" countmax="7" chance="100000" />
 		<item id="8748" chance="1460" /><!-- coal -->
 	</loot>

--- a/data/monster/monsters/ironblight.xml
+++ b/data/monster/monsters/ironblight.xml
@@ -56,7 +56,8 @@
 		<voice sentence="Yowl!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="199" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="99" chance="50000" />
 		<item name="small emerald" countmax="3" chance="10890" />
 		<item name="small amethyst" countmax="3" chance="15020" />
 		<item name="platinum coin" countmax="8" chance="100000" />

--- a/data/monster/monsters/juggernaut.xml
+++ b/data/monster/monsters/juggernaut.xml
@@ -68,7 +68,7 @@
 		<item name="golden legs" chance="500" />
 		<item name="knight armor" chance="4990" />
 		<item name="mastermind shield" chance="800" />
-		<item name="closed trap" chance="280" />
+		<item id="2578" chance="280" /><!-- closed trap -->
 		<item name="ham" countmax="8" chance="60000" />
 		<item name="soul orb" chance="33333" />
 		<item name="demonic essence" chance="45333" />

--- a/data/monster/monsters/koshei_the_deathless.xml
+++ b/data/monster/monsters/koshei_the_deathless.xml
@@ -50,7 +50,7 @@
 		<immunity invisible="1" />
 	</immunities>
 	<summons maxSummons="1">
-		<summon name="bonebeast" interval="1000" chance="16" max="1" />
+		<summon name="bonebeast" interval="1000" chance="16" />
 	</summons>
 	<voices interval="5000" chance="10">
 		<voice sentence="Your pain will be beyond imagination!" />
@@ -67,7 +67,7 @@
 		<item name="platinum amulet" chance="1666" />
 		<item id="2175" chance="10000" /><!-- spellbook -->
 		<item name="gold ring" chance="900" />
-		<item name="dirty cape" chance="10000" />
+		<item id="2237" chance="10000" /><!-- dirty cape -->
 		<item id="2401" chance="10000" /><!-- staff -->
 		<item name="castle shield" chance="588" />
 		<item name="blue robe" chance="709" />

--- a/data/monster/monsters/lava_golem.xml
+++ b/data/monster/monsters/lava_golem.xml
@@ -53,7 +53,8 @@
 		<voice sentence="Grrrrunt" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="199" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="99" chance="50000" />
 		<item name="platinum coin" countmax="11" chance="100000" />
 		<item name="yellow gem" chance="6480" />
 		<item name="red gem" chance="1180" />

--- a/data/monster/monsters/lich.xml
+++ b/data/monster/monsters/lich.xml
@@ -64,7 +64,8 @@
 		<voice sentence="Come to me my children!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="139" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="39" chance="50000" />
 		<item name="platinum coin" chance="19720" />
 		<item id="2175" chance="10000" /><!-- spellbook -->
 		<item name="strong mana potion" chance="7700" />

--- a/data/monster/monsters/magma_crawler.xml
+++ b/data/monster/monsters/magma_crawler.xml
@@ -56,7 +56,8 @@
 	</voices>
 	<loot>
 		<item name="small diamond" countmax="3" chance="8800" />
-		<item name="gold coin" countmax="200" chance="100000" />
+		<item name="gold coin" countmax="100" chance="50000" />
+		<item name="gold coin" countmax="100" chance="50000" />
 		<item name="platinum coin" countmax="5" chance="95000" />
 		<item name="yellow gem" chance="1030" />
 		<item name="energy ring" chance="1650" />

--- a/data/monster/monsters/mahrdis.xml
+++ b/data/monster/monsters/mahrdis.xml
@@ -69,7 +69,9 @@
 	</voices>
 	<loot>
 		<item name="burning heart" chance="100000" />
-		<item name="gold coin" countmax="230" chance="88000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="30" chance="30000" />
 		<item name="small ruby" countmax="3" chance="12000" />
 		<item name="great health potion" chance="10500" />
 		<item name="life ring" chance="6700" />

--- a/data/monster/monsters/marid.xml
+++ b/data/monster/monsters/marid.xml
@@ -69,7 +69,8 @@
 		<voice sentence="Be careful what you wish." />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="129" chance="98000" />
+		<item name="gold coin" countmax="100" chance="49000" />
+		<item name="gold coin" countmax="29" chance="49000" />
 		<item name="blueberry" countmax="25" chance="25000" />
 		<item name="royal spear" countmax="3" chance="15500" />
 		<item name="strong mana potion" chance="9800" />

--- a/data/monster/monsters/mazoran.xml
+++ b/data/monster/monsters/mazoran.xml
@@ -64,7 +64,8 @@
 		<item id="18421" countmax="5" chance="23000" /><!-- green crystal fragment -->
 		<item id="2143" countmax="8" chance="12000" /><!-- white pearl -->
 		<item id="2146" countmax="9" chance="12000" /><!-- small sapphire -->
-		<item id="2148" countmax="200" chance="98000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="49000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="49000" /><!-- gold coin -->
 		<item id="2150" countmax="5" chance="10000" /><!-- small amethyst -->
 		<item id="2152" countmax="58" chance="8000" /><!-- platinum coin -->
 		<item id="2155" chance="1000" /><!-- green gem -->

--- a/data/monster/monsters/morguthis.xml
+++ b/data/monster/monsters/morguthis.xml
@@ -69,7 +69,9 @@
 	</voices>
 	<loot>
 		<item name="sword hilt" chance="100000" />
-		<item name="gold coin" countmax="221" chance="91000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="21" chance="30000" />
 		<item name="black pearl" chance="10000" />
 		<item name="assassin star" countmax="3" chance="9700" />
 		<item name="great health potion" chance="9500" />

--- a/data/monster/monsters/omruc.xml
+++ b/data/monster/monsters/omruc.xml
@@ -68,7 +68,8 @@
 	</voices>
 	<loot>
 		<item name="crystal arrow" chance="100000" />
-		<item name="gold coin" countmax="160" chance="85000" />
+		<item name="gold coin" countmax="100" chance="43000" />
+		<item name="gold coin" countmax="60" chance="43000" />
 		<item name="red apple" countmax="2" chance="76000" />
 		<item name="poison arrow" countmax="20" chance="56000" />
 		<item name="burst arrow" countmax="15" chance="47000" />

--- a/data/monster/monsters/plagirath.xml
+++ b/data/monster/monsters/plagirath.xml
@@ -71,7 +71,8 @@
 		<item id="18421" countmax="6" chance="23000" /><!-- green crystal fragment -->
 		<item id="2143" countmax="8" chance="12000" /><!-- white pearl -->
 		<item id="2146" countmax="9" chance="12000" /><!-- small sapphire -->
-		<item id="2148" countmax="200" chance="98000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="49000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="49000" /><!-- gold coin -->
 		<item id="2150" countmax="5" chance="10000" /><!-- small amethyst -->
 		<item id="2152" countmax="58" chance="8000" /><!-- platinum coin -->
 		<item id="25383" chance="800" /><!-- rift lance -->

--- a/data/monster/monsters/plaguesmith.xml
+++ b/data/monster/monsters/plaguesmith.xml
@@ -67,7 +67,7 @@
 		<item name="club ring" chance="4761" />
 		<item name="piece of iron" chance="20000" />
 		<item name="mouldy cheese" chance="50000" />
-		<item name="dirty cape" chance="60000" />
+		<item id="2237" chance="60000" /><!-- dirty cape -->
 		<item name="two handed sword" chance="20000" />
 		<item name="war hammer" chance="2127" />
 		<item name="morning star" chance="29000" />

--- a/data/monster/monsters/poacher.xml
+++ b/data/monster/monsters/poacher.xml
@@ -37,7 +37,7 @@
 		<item name="leather helmet" chance="30600" />
 		<item name="arrow" countmax="17" chance="49500" />
 		<item name="poison arrow" countmax="3" chance="2930" />
-		<item name="closed trap" chance="710" />
+		<item id="2578" chance="710" /><!-- closed trap -->
 		<item name="leather legs" chance="26740" />
 		<item name="roll" countmax="2" chance="11110" />
 	</loot>

--- a/data/monster/monsters/rahemos.xml
+++ b/data/monster/monsters/rahemos.xml
@@ -72,7 +72,9 @@
 	</voices>
 	<loot>
 		<item name="ancient rune" chance="100000" />
-		<item name="gold coin" countmax="242" chance="90000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="42" chance="30000" />
 		<item name="great mana potion" chance="9000" />
 		<item name="small amethyst" countmax="3" chance="8000" />
 		<item name="ring of healing" chance="4000" />

--- a/data/monster/monsters/sandstone_scorpion.xml
+++ b/data/monster/monsters/sandstone_scorpion.xml
@@ -41,7 +41,8 @@
 		<voice sentence="*tak tak tak*" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="128" chance="90000" />
+		<item name="gold coin" countmax="100" chance="45000" />
+		<item name="gold coin" countmax="28" chance="45000" />
 		<item name="small emerald" countmax="2" chance="9900" />
 		<item name="platinum coin" countmax="2" chance="11111" />
 		<item name="daramian mace" chance="6250" />

--- a/data/monster/monsters/stampor.xml
+++ b/data/monster/monsters/stampor.xml
@@ -49,7 +49,9 @@
 		<voice sentence="KRRRRRNG" yell="1" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="242" chance="30000" />
+		<item name="gold coin" countmax="100" chance="10000" />
+		<item name="gold coin" countmax="100" chance="10000" />
+		<item name="gold coin" countmax="42" chance="10000" />
 		<item name="platinum coin" countmax="2" chance="9920" />
 		<item name="war hammer" chance="1010" />
 		<item name="knight armor" chance="870" />

--- a/data/monster/monsters/thalas.xml
+++ b/data/monster/monsters/thalas.xml
@@ -62,7 +62,9 @@
 	</voices>
 	<loot>
 		<item name="cobrafang dagger" chance="100000" />
-		<item name="gold coin" countmax="238" chance="91000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="100" chance="30000" />
+		<item name="gold coin" countmax="38" chance="30000" />
 		<item name="poison dagger" chance="21000" />
 		<item name="small emerald" countmax="3" chance="9000" />
 		<item name="great health potion" chance="8200" />

--- a/data/monster/monsters/tomb_servant.xml
+++ b/data/monster/monsters/tomb_servant.xml
@@ -35,7 +35,8 @@
 		<voice sentence="Ngl..Nglll...Gll" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="108" chance="82350" />
+		<item name="gold coin" countmax="100" chance="41000" />
+		<item name="gold coin" countmax="8" chance="41000" />
 		<item name="scarab coin" chance="8210" />
 		<item name="rotten meat" chance="2000" />
 		<item id="2230" chance="49000" /><!-- bone -->

--- a/data/monster/monsters/troll_legionnaire.xml
+++ b/data/monster/monsters/troll_legionnaire.xml
@@ -38,7 +38,8 @@
 		<voice sentence="Graaaaar!" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="155" chance="92000" />
+		<item name="gold coin" countmax="100" chance="46000" />
+		<item name="gold coin" countmax="55" chance="46000" />
 		<item name="stealth ring" chance="560" />
 		<item name="throwing star" countmax="10" chance="28000" />
 		<item name="frosty ear of a troll" chance="5120" />

--- a/data/monster/monsters/vampire_bride.xml
+++ b/data/monster/monsters/vampire_bride.xml
@@ -63,7 +63,8 @@
 	<loot>
 		<item name="emerald bangle" chance="1100" />
 		<item name="small diamond" countmax="2" chance="1020" />
-		<item name="gold coin" countmax="149" chance="90000" />
+		<item name="gold coin" countmax="100" chance="45000" />
+		<item name="gold coin" countmax="49" chance="45000" />
 		<item name="platinum coin" chance="9910" />
 		<item name="moonlight rod" chance="5500" />
 		<item name="boots of haste" chance="220" />

--- a/data/monster/monsters/vashresamun.xml
+++ b/data/monster/monsters/vashresamun.xml
@@ -57,7 +57,9 @@
 	</voices>
 	<loot>
 		<item name="blue note" chance="100000" />
-		<item name="gold coin" countmax="250" chance="91000" />
+		<item name="gold coin" countmax="100" chance="31000" />
+		<item name="gold coin" countmax="100" chance="31000" />
+		<item name="gold coin" countmax="50" chance="31000" />
 		<item name="white pearl" chance="10000" />
 		<item id="2072" chance="9200" /><!-- lute -->
 		<item name="great mana potion" chance="8000" />

--- a/data/monster/monsters/warlock.xml
+++ b/data/monster/monsters/warlock.xml
@@ -82,7 +82,7 @@
 		<item name="small sapphire" chance="1200" />
 		<item name="talon" chance="1150" />
 		<item name="lightning robe" chance="1000" />
-		<item name="inkwell" chance="1000" />
+		<item id="2600" chance="1000" /><!-- inkwell -->
 		<item id="2124" chance="730" /><!-- crystal ring -->
 		<item name="luminous orb" chance="450" />
 		<item name="ring of the sky" chance="380" />


### PR DESCRIPTION
- Mostly fixed gold coin **countmax** to work as intended with values higher than 100 (monsters were dropping only 100)
- Infected Weeper summons only 1 parasite now instead of 6
- Changed a few loot to use ID instead of name to prevent duplicate name conflict in the future (amphora, inkwell, closed trap, dirty cape and crystal rubbish)
- Removed two redundant max summon