### PR TITLE
Replace hand-rolled algorithms in spectator container

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -419,7 +419,7 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 			if (it != playersSpectatorCache.end()) {
 				if (!spectators.empty()) {
 					const SpectatorVec& cachedSpectators = it->second;
-					spectators.insert(spectators.end(), cachedSpectators.begin(), cachedSpectators.end());
+					spectators.addSpectators(cachedSpectators);
 				} else {
 					spectators = it->second;
 				}
@@ -434,7 +434,7 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 				if (!onlyPlayers) {
 					if (!spectators.empty()) {
 						const SpectatorVec& cachedSpectators = it->second;
-						spectators.insert(spectators.end(), cachedSpectators.begin(), cachedSpectators.end());
+						spectators.addSpectators(cachedSpectators);
 					} else {
 						spectators = it->second;
 					}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -418,8 +418,7 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 			auto it = playersSpectatorCache.find(centerPos);
 			if (it != playersSpectatorCache.end()) {
 				if (!spectators.empty()) {
-					const SpectatorVec& cachedSpectators = it->second;
-					spectators.addSpectators(cachedSpectators);
+					spectators.addSpectators(it->second);
 				} else {
 					spectators = it->second;
 				}

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -35,32 +35,22 @@ public:
 	}
 
 	void addSpectators(const SpectatorVec& spectators) {
-		const size_t size = vec.size();
 		for (Creature* spectator : spectators.vec) {
-			bool duplicate = false;
-			for (size_t i = 0; i < size; ++i) {
-				if (vec[i] == spectator) {
-					duplicate = true;
-					break;
-				}
+			auto it = std::find(begin(), end(), spectator);
+			if (it != end()) {
+				continue;
 			}
-
-			if (!duplicate) {
-				vec.emplace_back(spectator);
-			}
+			vec.emplace_back(spectator);
 		}
 	}
 
 	void erase(Creature* spectator) {
-		for (size_t i = 0, len = vec.size(); i < len; i++) {
-			if (vec[i] == spectator) {
-				Creature* tmp = vec[len - 1];
-				vec[len - 1] = vec[i];
-				vec[i] = tmp;
-				vec.pop_back();
-				break;
-			}
+		auto it = std::find(begin(), end(), spectator);
+		if (it == end()) {
+			return;
 		}
+		std::iter_swap(it, end());
+		vec.pop_back();
 	}
 
 	inline size_t size() const { return vec.size(); }
@@ -71,7 +61,7 @@ public:
 	inline Iterator end() { return vec.end(); }
 	inline ConstIterator end() const { return vec.end(); }
 	inline ConstIterator cend() const { return vec.cend(); }
-	inline void emplace_back(Creature* c) { return vec.emplace_back(c); }
+	inline void emplace_back(Creature* c) { vec.emplace_back(c); }
 
 	template<class InputIterator>
 	inline void insert(Iterator pos, InputIterator first, InputIterator last) { vec.insert(pos, first, last); }

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -36,7 +36,7 @@ public:
 
 	void addSpectators(const SpectatorVec& spectators) {
 		for (Creature* spectator : spectators.vec) {
-			auto it = std::find(begin(), end(), spectator);
+			auto it = std::find(vec.begin(), vec.end(), spectator);
 			if (it != end()) {
 				continue;
 			}
@@ -45,7 +45,7 @@ public:
 	}
 
 	void erase(Creature* spectator) {
-		auto it = std::find(begin(), end(), spectator);
+		auto it = std::find(vec.begin(), vec.end(), spectator);
 		if (it == end()) {
 			return;
 		}
@@ -53,18 +53,13 @@ public:
 		vec.pop_back();
 	}
 
-	inline size_t size() const { return vec.size(); }
-	inline bool empty() const { return vec.empty(); }
-	inline Iterator begin() { return vec.begin(); }
-	inline ConstIterator begin() const { return vec.begin(); }
-	inline ConstIterator cbegin() const { return vec.cbegin(); }
-	inline Iterator end() { return vec.end(); }
-	inline ConstIterator end() const { return vec.end(); }
-	inline ConstIterator cend() const { return vec.cend(); }
-	inline void emplace_back(Creature* c) { vec.emplace_back(c); }
-
-	template<class InputIterator>
-	inline void insert(Iterator pos, InputIterator first, InputIterator last) { vec.insert(pos, first, last); }
+	size_t size() const { return vec.size(); }
+	bool empty() const { return vec.empty(); }
+	Iterator begin() { return vec.begin(); }
+	ConstIterator begin() const { return vec.begin(); }
+	Iterator end() { return vec.end(); }
+	ConstIterator end() const { return vec.end(); }
+	void emplace_back(Creature* c) { vec.emplace_back(c); }
 
 private:
 	Vec vec;

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -49,7 +49,7 @@ public:
 		if (it == end()) {
 			return;
 		}
-		std::iter_swap(it, end());
+		std::iter_swap(it, end() - 1);
 		vec.pop_back();
 	}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Instead of writing algorithms by hand, this replaces with functions already present in the standard library. Additionally, fixes a potential duplication issue when concatenating with the cache.

If there is a specific reason to use `insert` instead of the usual `addSpectators`, then I have a workaround in mind, too.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
