### PR TITLE
Change Beholder to Bonelord in forgotten-spawn.xml

### DIFF
--- a/data/world/forgotten-spawn.xml
+++ b/data/world/forgotten-spawn.xml
@@ -1262,7 +1262,7 @@
 		<monster name="Scorpion" x="2" y="5" z="10" spawntime="60" />
 	</spawn>
 	<spawn centerx="243" centery="590" centerz="10" radius="5">
-		<monster name="Beholder" x="0" y="0" z="10" spawntime="60" />
+		<monster name="Bonelord" x="0" y="0" z="10" spawntime="60" />
 	</spawn>
 	<spawn centerx="220" centery="602" centerz="10" radius="5">
 		<monster name="Scorpion" x="-2" y="-1" z="10" spawntime="60" />


### PR DESCRIPTION
This commit fix the warning below that is shown on console:
[Warning - Spawn::addMonster] Can not find Beholder

Signed-off-by: Lucas Henrique Grizante <lucasgrizante95@gmail.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Change beholder name to bonelord in map spawn, so the console warning is not shown anymore.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
