### PR TITLE
Fix pagination in sendAddContainerItem

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -927,9 +927,12 @@ void Player::sendAddContainerItem(const Container* container, const Item* item)
 				slot = containerSize;
 			}
 		} else if (openContainer.index >= container->capacity()) {
-			item = container->getItemByIndex(openContainer.index - 1);
+			item = container->getItemByIndex(openContainer.index);
 		}
-		client->sendAddContainerItem(it.first, slot, item);
+
+		if (item) {
+			client->sendAddContainerItem(it.first, slot, item);
+		}
 	}
 }
 


### PR DESCRIPTION
This should fix an issue with pagination upon adding items.

It was vaguely reported [here](https://otland.net/threads/the-reason-why-tfs-is-delayed-we-let-the-great-programmers-goes-away.274114/page-3#post-2645334) "first".