### PR TITLE
Fixed data type mismatch from itemtype

### DIFF
--- a/data/migrations/28.lua
+++ b/data/migrations/28.lua
@@ -1,3 +1,10 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 28 (data type mismatch 2)")
+	db.query("ALTER TABLE `market_history` CHANGE `itemtype` `itemtype` smallint unsigned NOT NULL");
+	db.query("ALTER TABLE `market_offers` CHANGE `itemtype` `itemtype` smallint unsigned NOT NULL");
+	db.query("ALTER TABLE `player_depotitems` CHANGE `itemtype` `itemtype` smallint unsigned NOT NULL");
+	db.query("ALTER TABLE `player_inboxitems` CHANGE `itemtype` `itemtype` smallint unsigned NOT NULL");
+	db.query("ALTER TABLE `player_storeinboxitems` CHANGE `itemtype` `itemtype` smallint unsigned NOT NULL");
+	db.query("ALTER TABLE `player_items` CHANGE `itemtype` `itemtype` smallint unsigned NOT NULL");
+	return true
 end

--- a/data/migrations/29.lua
+++ b/data/migrations/29.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -223,7 +223,7 @@ CREATE TABLE IF NOT EXISTS `market_history` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `player_id` int NOT NULL,
   `sale` tinyint NOT NULL DEFAULT '0',
-  `itemtype` int unsigned NOT NULL,
+  `itemtype` smallint unsigned NOT NULL,
   `amount` smallint unsigned NOT NULL,
   `price` int unsigned NOT NULL DEFAULT '0',
   `expires_at` bigint unsigned NOT NULL,
@@ -238,7 +238,7 @@ CREATE TABLE IF NOT EXISTS `market_offers` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `player_id` int NOT NULL,
   `sale` tinyint NOT NULL DEFAULT '0',
-  `itemtype` int unsigned NOT NULL,
+  `itemtype` smallint unsigned NOT NULL,
   `amount` smallint unsigned NOT NULL,
   `created` bigint unsigned NOT NULL,
   `anonymous` tinyint NOT NULL DEFAULT '0',
@@ -273,7 +273,7 @@ CREATE TABLE IF NOT EXISTS `player_depotitems` (
   `player_id` int NOT NULL,
   `sid` int NOT NULL COMMENT 'any given range eg 0-100 will be reserved for depot lockers and all > 100 will be then normal items inside depots',
   `pid` int NOT NULL DEFAULT '0',
-  `itemtype` smallint NOT NULL,
+  `itemtype` smallint unsigned NOT NULL,
   `count` smallint NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
   UNIQUE KEY `player_id_2` (`player_id`, `sid`),
@@ -284,7 +284,7 @@ CREATE TABLE IF NOT EXISTS `player_inboxitems` (
   `player_id` int NOT NULL,
   `sid` int NOT NULL,
   `pid` int NOT NULL DEFAULT '0',
-  `itemtype` smallint NOT NULL,
+  `itemtype` smallint unsigned NOT NULL,
   `count` smallint NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
   UNIQUE KEY `player_id_2` (`player_id`, `sid`),
@@ -295,7 +295,7 @@ CREATE TABLE IF NOT EXISTS `player_storeinboxitems` (
   `player_id` int NOT NULL,
   `sid` int NOT NULL,
   `pid` int NOT NULL DEFAULT '0',
-  `itemtype` smallint NOT NULL,
+  `itemtype` smallint unsigned NOT NULL,
   `count` smallint NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
   UNIQUE KEY `player_id_2` (`player_id`, `sid`),
@@ -306,7 +306,7 @@ CREATE TABLE IF NOT EXISTS `player_items` (
   `player_id` int NOT NULL DEFAULT '0',
   `pid` int NOT NULL DEFAULT '0',
   `sid` int NOT NULL DEFAULT '0',
-  `itemtype` smallint NOT NULL DEFAULT '0',
+  `itemtype` smallint unsigned NOT NULL DEFAULT '0',
   `count` smallint NOT NULL DEFAULT '0',
   `attributes` blob NOT NULL,
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE,
@@ -349,7 +349,7 @@ CREATE TABLE IF NOT EXISTS `towns` (
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '27'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '28'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 DROP TRIGGER IF EXISTS `ondelete_players`;
 DROP TRIGGER IF EXISTS `oncreate_guilds`;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Users using higher item IDs were being affected because of the data type mismatch. Also change itemtype from market_* tables from int to smallint for consistence
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://otland.net/threads/items-transform-into-another-item-after-relog.263781/
https://otland.net/threads/item-transform-to-a-randomid-after-relog.274770/

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
