### PR TITLE
Fixed NoGain SkillTries When SkillLvl is exactly 10 or less

### DIFF
--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -182,10 +182,10 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 	if (skill > SKILL_LAST) {
 		return 0;
 	}
-	return skillBase[skill] * std::pow(skillMultipliers[skill], level - 11);
+	return skillBase[skill] * std::pow(skillMultipliers[skill], static_cast<int32_t>(level - 11));
 }
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
-	return 1600 * std::pow(manaMultiplier, magLevel - 1);
+	return 1600 * std::pow(manaMultiplier, static_cast<int32_t>(magLevel - 1));
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The title is quite specific and there is not much to say.

**Issues addressed:** Nothing.

Here is an example of why these changes are necessary.
```c++
uint32_t level = 10;
std::cout << level - 11;
// result: 4294967295
```