### PR TITLE
replace deadline_timer with steady_timer

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -116,7 +116,7 @@ void Connection::accept()
 {
 	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
 	try {
-		readTimer.expires_from_now(boost::posix_time::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()), std::placeholders::_1));
 
 		// Read size of the first packet
@@ -160,7 +160,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 	}
 
 	try {
-		readTimer.expires_from_now(boost::posix_time::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                    std::placeholders::_1));
 
@@ -222,7 +222,7 @@ void Connection::parsePacket(const boost::system::error_code& error)
 	}
 
 	try {
-		readTimer.expires_from_now(boost::posix_time::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                    std::placeholders::_1));
 
@@ -254,7 +254,7 @@ void Connection::internalSend(const OutputMessage_ptr& msg)
 {
 	protocol->onSendMessage(msg);
 	try {
-		writeTimer.expires_from_now(boost::posix_time::seconds(CONNECTION_WRITE_TIMEOUT));
+		writeTimer.expires_from_now(std::chrono::seconds(CONNECTION_WRITE_TIMEOUT));
 		writeTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                     std::placeholders::_1));
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -106,8 +106,8 @@ class Connection : public std::enable_shared_from_this<Connection>
 
 		NetworkMessage msg;
 
-		boost::asio::deadline_timer readTimer;
-		boost::asio::deadline_timer writeTimer;
+		boost::asio::steady_timer readTimer;
+		boost::asio::steady_timer writeTimer;
 
 		std::recursive_mutex connectionLock;
 

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -31,10 +31,10 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 	}
 
 	// insert the event id in the list of active events
-	auto it = eventIdTimerMap.emplace(task->getEventId(), boost::asio::deadline_timer{io_context});
+	auto it = eventIdTimerMap.emplace(task->getEventId(), boost::asio::steady_timer{io_context});
 	auto& timer = it.first->second;
 
-	timer.expires_from_now(boost::posix_time::milliseconds(task->getDelay()));
+	timer.expires_from_now(std::chrono::milliseconds(task->getDelay()));
 	timer.async_wait([this, task](const boost::system::error_code& error) {
 		eventIdTimerMap.erase(task->getEventId());
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -62,7 +62,7 @@ class Scheduler : public ThreadHolder<Scheduler>
 		void threadMain() { io_context.run(); }
 	private:
 		std::atomic<uint32_t> lastEventId{0};
-		std::unordered_map<uint32_t, boost::asio::deadline_timer> eventIdTimerMap;
+		std::unordered_map<uint32_t, boost::asio::steady_timer> eventIdTimerMap;
 		boost::asio::io_context io_context;
 		boost::asio::io_context::work work{io_context};
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -63,7 +63,7 @@ void ServiceManager::stop()
 
 	acceptors.clear();
 
-	death_timer.expires_from_now(boost::posix_time::seconds(3));
+	death_timer.expires_from_now(std::chrono::seconds(3));
 	death_timer.async_wait(std::bind(&ServiceManager::die, this));
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -119,7 +119,7 @@ class ServiceManager
 
 		boost::asio::io_service io_service;
 		Signals signals{io_service};
-		boost::asio::deadline_timer death_timer { io_service };
+		boost::asio::steady_timer death_timer { io_service };
 		bool running = false;
 };
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Replace deadline_timer with steady_timer so we use std::chrono::steady_clock. Its make senses for tfs to use steady_clock since all the intervals are delays from now independently of the system time.
Why not high_resolution_timer? Seens like chrono::high_resolution_clock is not reliable across platforms.


Links:
https://stackoverflow.com/a/16364002/470739
https://www.boost.org/doc/libs/1_75_0/doc/html/boost_asio/reference/steady_timer.html
https://en.cppreference.com/w/cpp/chrono/steady_clock
https://en.cppreference.com/w/cpp/chrono/high_resolution_clock

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
