### PR TITLE
Fix data race on addEvent

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -30,7 +30,7 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 		task->setEventId(++lastEventId);
 	}
 
-	io_context.post([this, task]() {
+	boost::asio::post(io_context, [this, task]() {
 		// insert the event id in the list of active events
 		auto it = eventIdTimerMap.emplace(task->getEventId(), boost::asio::steady_timer{io_context});
 		auto& timer = it.first->second;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -30,21 +30,23 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 		task->setEventId(++lastEventId);
 	}
 
-	// insert the event id in the list of active events
-	auto it = eventIdTimerMap.emplace(task->getEventId(), boost::asio::steady_timer{io_context});
-	auto& timer = it.first->second;
+	io_context.post([this, task]() {
+		// insert the event id in the list of active events
+		auto it = eventIdTimerMap.emplace(task->getEventId(), boost::asio::steady_timer{io_context});
+		auto& timer = it.first->second;
 
-	timer.expires_from_now(std::chrono::milliseconds(task->getDelay()));
-	timer.async_wait([this, task](const boost::system::error_code& error) {
-		eventIdTimerMap.erase(task->getEventId());
+		timer.expires_from_now(std::chrono::milliseconds(task->getDelay()));
+		timer.async_wait([this, task](const boost::system::error_code& error) {
+			eventIdTimerMap.erase(task->getEventId());
 
-		if (error == boost::asio::error::operation_aborted || getState() == THREAD_STATE_TERMINATED) {
-			// the timer has been manually cancelled(timer->cancel()) or Scheduler::shutdown has been called
-			delete task;
-			return;
-		}
+			if (error == boost::asio::error::operation_aborted || getState() == THREAD_STATE_TERMINATED) {
+				// the timer has been manually cancelled(timer->cancel()) or Scheduler::shutdown has been called
+				delete task;
+				return;
+			}
 
-		g_dispatcher.addTask(task, true);
+			g_dispatcher.addTask(task, true);
+		});
 	});
 
 	return task->getEventId();


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
[As pointed out by](https://github.com/otland/forgottenserver/pull/3278#issuecomment-779525741) @yamaken93, there is a data race when manipulating the event timer map. I didn't notice that `addEvent` could be added by several threads at once, so this wraps in a scheduler post, so the map manipulation can only happen inside the scheduler thread now.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3278 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
