### PR TITLE
Made NPCs doesn't ignore height by default

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -103,7 +103,7 @@ void Npc::reset()
 	pushable = true;
 	floorChange = false;
 	attackable = false;
-	ignoreHeight = true;
+	ignoreHeight = false;
 	focusCreature = 0;
 	speechBubble = SPEECHBUBBLE_NONE;
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Its pretty confusing to have it on since in most of the cases, npcs should not be able to walk over objects otherwise they may go out of the players range
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
