### PR TITLE
Fix for bad value for ReqMana for 0 magic level

### DIFF
--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -187,6 +187,8 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
-	if (magLevel == 0) return 0;
+	if (magLevel == 0) {
+		return 0;
+	}
 	return 1600 * std::pow(manaMultiplier, static_cast<int32_t>(magLevel - 1));
 }

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -187,5 +187,6 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 
 uint64_t Vocation::getReqMana(uint32_t magLevel)
 {
+	if (magLevel == 0) return 0;
 	return 1600 * std::pow(manaMultiplier, static_cast<int32_t>(magLevel - 1));
 }


### PR DESCRIPTION
### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

** That update fixes disability to train magic level. In player.cpp there is if which check if actual required mana isnt higher or equal to next level required mana. If You invoke Vocation::getReqMana it returns extremly high value because it tried to invoke std::pow(manaMultiplier, static_cast<int32_t>(-1)).


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
