### PR TITLE
Replace boost::lexical_cast<std::string> with std::to_string

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -28,7 +28,6 @@
 #include <typeinfo>
 
 #include <boost/variant.hpp>
-#include <boost/lexical_cast.hpp>
 #include <deque>
 
 class Creature;
@@ -437,12 +436,12 @@ class ItemAttributes
 
 		template<typename R>
 		void setCustomAttribute(int64_t key, R value) {
-			std::string tmp = boost::lexical_cast<std::string>(key);
+			auto tmp = std::to_string(key);
 			setCustomAttribute(tmp, value);
 		}
 
 		void setCustomAttribute(int64_t key, CustomAttribute& value) {
-			std::string tmp = boost::lexical_cast<std::string>(key);
+			auto tmp = std::to_string(key);
 			setCustomAttribute(tmp, value);
 		}
 
@@ -468,7 +467,7 @@ class ItemAttributes
 		}
 
 		const CustomAttribute* getCustomAttribute(int64_t key) {
-			std::string tmp = boost::lexical_cast<std::string>(key);
+			auto tmp = std::to_string(key);
 			return getCustomAttribute(tmp);
 		}
 
@@ -483,7 +482,7 @@ class ItemAttributes
 		}
 
 		bool removeCustomAttribute(int64_t key) {
-			std::string tmp = boost::lexical_cast<std::string>(key);
+			auto tmp = std::to_string(key);
 			return removeCustomAttribute(tmp);
 		}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -6474,7 +6474,7 @@ int LuaScriptInterface::luaItemSetCustomAttribute(lua_State* L) {
 
 	std::string key;
 	if (isNumber(L, 2)) {
-		key = boost::lexical_cast<std::string>(getNumber<int64_t>(L, 2));
+		key = std::to_string(getNumber<int64_t>(L, 2));
 	} else if (isString(L, 2)) {
 		key = getString(L, 2);
 	} else {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -35,7 +35,6 @@
 #include "database.h"
 #include "enums.h"
 #include "position.h"
-#include <boost/lexical_cast.hpp>
 #include "outfit.h"
 
 class Thing;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Just no need to use boost when the conversion is available in STL

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
