### PR TITLE
add methods for revscriptsys talkactions

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2941,6 +2941,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("TalkAction", "onSay", LuaScriptInterface::luaTalkactionOnSay);
 	registerMethod("TalkAction", "register", LuaScriptInterface::luaTalkactionRegister);
 	registerMethod("TalkAction", "separator", LuaScriptInterface::luaTalkactionSeparator);
+	registerMethod("TalkAction", "permission", LuaScriptInterface::luaTalkactionPermission);
 
 	// CreatureEvent
 	registerClass("CreatureEvent", "", LuaScriptInterface::luaCreateCreatureEvent);
@@ -15342,6 +15343,28 @@ int LuaScriptInterface::luaTalkactionSeparator(lua_State* L)
 	TalkAction* talk = getUserdata<TalkAction>(L, 1);
 	if (talk) {
 		talk->setSeparator(getString(L, 2).c_str());
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaTalkactionPermission(lua_State* L)
+{
+	// talkAction:permission(needAccess = false[, AccountType_t = ACCOUNT_TYPE_NORMAL])
+	TalkAction* talk = getUserdata<TalkAction>(L, 1);
+	if (talk) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, true);
+			return 1;
+		}
+
+		if (lua_gettop(L) == 3) {
+			talk->setRequiredAccountType(getNumber<AccountType_t>(L, 3));
+		}
+
+		talk->setNeedAccess(getBoolean(L, 2));
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2941,7 +2941,8 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("TalkAction", "onSay", LuaScriptInterface::luaTalkactionOnSay);
 	registerMethod("TalkAction", "register", LuaScriptInterface::luaTalkactionRegister);
 	registerMethod("TalkAction", "separator", LuaScriptInterface::luaTalkactionSeparator);
-	registerMethod("TalkAction", "permission", LuaScriptInterface::luaTalkactionPermission);
+	registerMethod("TalkAction", "access", LuaScriptInterface::luaTalkactionAccess);
+	registerMethod("TalkAction", "accountType", LuaScriptInterface::luaTalkactionAccountType);
 
 	// CreatureEvent
 	registerClass("CreatureEvent", "", LuaScriptInterface::luaCreateCreatureEvent);
@@ -15350,21 +15351,25 @@ int LuaScriptInterface::luaTalkactionSeparator(lua_State* L)
 	return 1;
 }
 
-int LuaScriptInterface::luaTalkactionPermission(lua_State* L)
+int LuaScriptInterface::luaTalkactionAccess(lua_State* L)
 {
-	// talkAction:permission(needAccess = false[, AccountType_t = ACCOUNT_TYPE_NORMAL])
+	// talkAction:permission(needAccess = false)
 	TalkAction* talk = getUserdata<TalkAction>(L, 1);
 	if (talk) {
-		if (lua_gettop(L) == 1) {
-			pushBoolean(L, true);
-			return 1;
-		}
-
-		if (lua_gettop(L) == 3) {
-			talk->setRequiredAccountType(getNumber<AccountType_t>(L, 3));
-		}
-
 		talk->setNeedAccess(getBoolean(L, 2));
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaTalkactionAccountType(lua_State* L)
+{
+	// talkAction:accountType(AccountType_t = ACCOUNT_TYPE_NORMAL)
+	TalkAction* talk = getUserdata<TalkAction>(L, 1);
+	if (talk) {
+		talk->setRequiredAccountType(getNumber<AccountType_t>(L, 2));
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15353,7 +15353,7 @@ int LuaScriptInterface::luaTalkactionSeparator(lua_State* L)
 
 int LuaScriptInterface::luaTalkactionAccess(lua_State* L)
 {
-	// talkAction:permission(needAccess = false)
+	// talkAction:access(needAccess = false)
 	TalkAction* talk = getUserdata<TalkAction>(L, 1);
 	if (talk) {
 		talk->setNeedAccess(getBoolean(L, 2));

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1429,7 +1429,8 @@ class LuaScriptInterface
 		static int luaTalkactionOnSay(lua_State* L);
 		static int luaTalkactionRegister(lua_State* L);
 		static int luaTalkactionSeparator(lua_State* L);
-		static int luaTalkactionPermission(lua_State* L);
+		static int luaTalkactionAccess(lua_State* L);
+		static int luaTalkactionAccountType(lua_State* L);
 
 		// CreatureEvents
 		static int luaCreateCreatureEvent(lua_State* L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1429,6 +1429,7 @@ class LuaScriptInterface
 		static int luaTalkactionOnSay(lua_State* L);
 		static int luaTalkactionRegister(lua_State* L);
 		static int luaTalkactionSeparator(lua_State* L);
+		static int luaTalkactionPermission(lua_State* L);
 
 		// CreatureEvents
 		static int luaCreateCreatureEvent(lua_State* L);

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -130,6 +130,16 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 			}
 		}
 
+		if (it->second.fromLua) {
+			if (it->second.getNeedAccess() && !player->getGroup()->access) {
+				return TALKACTION_CONTINUE;
+			}
+
+			if (player->getAccountType() < it->second.getRequiredAccountType()) {
+				return TALKACTION_BREAK;
+			}
+		}
+
 		if (it->second.executeSay(player, words, param, type)) {
 			return TALKACTION_CONTINUE;
 		} else {

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -59,7 +59,22 @@ class TalkAction : public Event
 
 		//scripting
 		bool executeSay(Player* player, const std::string& words, const std::string& param, SpeakClasses type) const;
-		//
+
+		AccountType_t getRequiredAccountType() const {
+			return requiredAccountType;
+		}
+
+		void setRequiredAccountType(AccountType_t reqAccType) {
+			requiredAccountType = reqAccType;
+		}
+
+		bool getNeedAccess() const {
+			return needAccess;
+		}
+
+		void setNeedAccess(bool b) {
+			needAccess = b;
+		}
 
 	private:
 		std::string getScriptEventName() const override;
@@ -67,6 +82,10 @@ class TalkAction : public Event
 		std::string words;
 		std::vector<std::string> wordsMap;
 		std::string separator = "\"";
+
+		bool needAccess = false;
+
+		AccountType_t requiredAccountType = ACCOUNT_TYPE_NORMAL;
 };
 
 class TalkActions final : public BaseEvents

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -82,9 +82,7 @@ class TalkAction : public Event
 		std::string words;
 		std::vector<std::string> wordsMap;
 		std::string separator = "\"";
-
 		bool needAccess = false;
-
 		AccountType_t requiredAccountType = ACCOUNT_TYPE_NORMAL;
 };
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR is an attempt to allow setting command permission (access & account type) from revscriptsys in order to avoid the following lines in most script files:
```lua
if not player:getGroup():getAccess() then
	return true
end

if player:getAccountType() < ACCOUNT_TYPE_GOD then
	return false
end
```

The above code can be done in the following way:
```lua
-- talkaction:permission(needAccess = false, AccountType_t = ACCOUNT_TYPE_NORMAL)
talkaction:permission(true, ACCOUNT_TYPE_GOD)
```

Example:
```lua
local talk = TalkAction("/abc")

function talk.onSay(player, words, param)
	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, 'Henlo! get bonked')
	return false
end

talk:permission(true, ACCOUNT_TYPE_GOD)
talk:separator(" ")
talk:register()
```

**Issues addressed:** none


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
