### PR TITLE
Use fmt to format messages

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
         run: >
           sudo apt-get install git cmake build-essential libluajit-5.1-dev libmysqlclient-dev
           libboost-date-time-dev libboost-system-dev libboost-iostreams-dev libboost-filesystem-dev
-          libpugixml-dev libcrypto++-dev
+          libpugixml-dev libcrypto++-dev libfmt-dev
 
       - name: Build with cmake
         uses: ashutoshvarma/action-cmake-build@master

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -39,7 +39,7 @@ jobs:
             triplet: x64-windows
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
-              lua luajit libmariadb pugixml cryptopp
+              lua luajit libmariadb pugixml cryptopp fmt
           - name: ubuntu-gcc
             os: ubuntu
             cxx: g++
@@ -47,7 +47,7 @@ jobs:
             triplet: x64-linux
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
-              lua libmariadb pugixml cryptopp
+              lua libmariadb pugixml cryptopp fmt
           - name: ubuntu-clang
             os: ubuntu
             cxx: clang++
@@ -55,7 +55,7 @@ jobs:
             triplet: x64-linux
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
-              lua libmariadb pugixml cryptopp
+              lua libmariadb pugixml cryptopp fmt
           - name: macos-clang
             os: macos
             cxx: clang++
@@ -63,7 +63,7 @@ jobs:
             triplet: x64-osx
             packages: >
               boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
-              lua libmariadb pugixml cryptopp
+              lua libmariadb pugixml cryptopp fmt
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -20,7 +20,7 @@ jobs:
         run: >
           sudo apt-get install git cmake build-essential libluajit-5.1-dev libgmp3-dev libmysqlclient-dev
           libboost-date-time-dev libboost-system-dev libboost-iostreams-dev libboost-filesystem-dev
-          libpugixml-dev libcrypto++-dev
+          libpugixml-dev libcrypto++-dev libfmt-dev
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - libboost-filesystem-dev
       - libboost-iostreams-dev
       - libcrypto++-dev
+      - libfmt-dev
       - liblua5.2-dev
       - libluajit-5.1-dev
       - libmysqlclient-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if (CryptoPP_FOUND)  # vcpkg-provided cmake package called CryptoPP
 else()
     find_package(Crypto++ REQUIRED)
 endif ()
+find_package(fmt REQUIRED)
 find_package(MySQL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(PugiXML REQUIRED)
@@ -68,6 +69,7 @@ target_link_libraries(tfs PRIVATE
         Boost::system
         Boost::filesystem
         Boost::iostreams
+        fmt::fmt
         ${CMAKE_THREAD_LIBS_INIT}
         ${Crypto++_LIBRARIES}
         ${LUA_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(tfs PRIVATE
         Boost::system
         Boost::filesystem
         Boost::iostreams
-	fmt::fmt
+        fmt::fmt
         ${CMAKE_THREAD_LIBS_INIT}
         ${Crypto++_LIBRARIES}
         ${LUA_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(tfs PRIVATE
         Boost::system
         Boost::filesystem
         Boost::iostreams
-        fmt::fmt
+	fmt::fmt
         ${CMAKE_THREAD_LIBS_INIT}
         ${Crypto++_LIBRARIES}
         ${LUA_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if (CryptoPP_FOUND)  # vcpkg-provided cmake package called CryptoPP
 else()
     find_package(Crypto++ REQUIRED)
 endif ()
-find_package(fmt REQUIRED)
+find_package(fmt 6.1.2 REQUIRED)
 find_package(MySQL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(PugiXML REQUIRED)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/test
   clang \
   cmake \
   crypto++-dev \
+  fmt \
   gcc \
   gmp-dev \
   luajit-dev \
@@ -27,6 +28,7 @@ RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/test
   boost-system \
   boost-filesystem \
   crypto++ \
+  fmt \
   gmp \
   luajit \
   mariadb-connector-c \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ install:
   - cmd : vcpkg install boost-variant:x64-windows
   - cmd : vcpkg install boost-lockfree:x64-windows
   - cmd : vcpkg install cryptopp:x64-windows
+  - cmd : vcpkg install fmt:x64-windows
   - cmd : vcpkg install luajit:x64-windows
   - cmd : vcpkg install --recurse libmariadb:x64-windows
   - cmd : vcpkg install pugixml:x64-windows

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4023,22 +4023,23 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 				} else if (tmpPlayer == targetPlayer) {
 					message.type = MESSAGE_HEALED;
 					if (!attacker) {
-						message.text = fmt::format("You were healed for {:d}.", damageString);
+						message.text = fmt::format("You were healed for {:s}.", damageString);
 					} else if (targetPlayer == attackerPlayer) {
-						message.text = fmt::format("You healed yourself for {:d}.", damageString);
+						message.text = fmt::format("You healed yourself for {:s}.", damageString);
 					} else {
-						message.text = fmt::format("You were healed by {:d} for {:s}.", attacker->getNameDescription(), damageString);
+						message.text = fmt::format("You were healed by {:s} for {:s}.", attacker->getNameDescription(), damageString);
 					}
 				} else if (!attacker) {
 					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = fmt::format("{:s} was healed for {:s}.", ucfirst(target->getNameDescription()), damageString);
+					message.text = fmt::format("{:s} was healed for {:s}.", target->getNameDescription(), damageString);
 				} else if (attacker == target) {
 					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = fmt::format("{:s} healed {:s}self for {:s}.", ucfirst(attacker->getNameDescription()), targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "him") : "it", damageString);
+					message.text = fmt::format("{:s} healed {:s}self for {:s}.", attacker->getNameDescription(), targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "him") : "it", damageString);
 				} else {
 					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = fmt::format("{:s} healed {:s} for {:s}.", ucfirst(attacker->getNameDescription()), target->getNameDescription(), damageString);
+					message.text = fmt::format("{:s} healed {:s} for {:s}.", attacker->getNameDescription(), target->getNameDescription(), damageString);
 				}
+				message.text[0] = std::toupper(message.text[0]);
 				tmpPlayer->sendTextMessage(message);
 			}
 		}
@@ -4106,7 +4107,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 					if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 						message.type = MESSAGE_DAMAGE_DEALT;
-						message.text = fmt::format("{:s} loses {:d} mana due to your attack.", ucfirst(target->getNameDescription()), manaDamage);
+						message.text = fmt::format("{:s} loses {:d} mana due to your attack.", target->getNameDescription(), manaDamage);
 					} else if (tmpPlayer == targetPlayer) {
 						message.type = MESSAGE_DAMAGE_RECEIVED;
 						if (!attacker) {
@@ -4118,14 +4119,15 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 						}
 					} else if (!attacker) {
 						message.type = MESSAGE_DAMAGE_OTHERS;
-						message.text = fmt::format("{:s} loses {:d} mana.", ucfirst(target->getNameDescription()), manaDamage);
+						message.text = fmt::format("{:s} loses {:d} mana.", target->getNameDescription(), manaDamage);
 					} else if (attacker == target) {
 						message.type = MESSAGE_DAMAGE_OTHERS;
-						message.text = fmt::format("{:s} loses {:d} mana due to {:s} own attack.", ucfirst(target->getNameDescription()), manaDamage, targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his");
+						message.text = fmt::format("{:s} loses {:d} mana due to {:s} own attack.", target->getNameDescription(), manaDamage, targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his");
 					} else {
 						message.type = MESSAGE_DAMAGE_OTHERS;
-						message.text = fmt::format("{:s} loses {:d} mana due to an attack by {:s}.", ucfirst(target->getNameDescription()), manaDamage, attacker->getNameDescription());
+						message.text = fmt::format("{:s} loses {:d} mana due to an attack by {:s}.", target->getNameDescription(), manaDamage, attacker->getNameDescription());
 					}
+					message.text[0] = std::toupper(message.text[0]);
 					tmpPlayer->sendTextMessage(message);
 				}
 
@@ -4199,7 +4201,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 				if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 					message.type = MESSAGE_DAMAGE_DEALT;
-					message.text = fmt::format("{:s} loses {:s} due to your attack.", ucfirst(target->getNameDescription()), damageString);
+					message.text = fmt::format("{:s} loses {:s} due to your attack.", target->getNameDescription(), damageString);
 				} else if (tmpPlayer == targetPlayer) {
 					message.type = MESSAGE_DAMAGE_RECEIVED;
 					if (!attacker) {
@@ -4211,14 +4213,15 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 					}
 				} else if (!attacker) {
 					message.type = MESSAGE_DAMAGE_OTHERS;
-					message.text = fmt::format("{:s} loses {:s}.", ucfirst(target->getNameDescription()), damageString);
+					message.text = fmt::format("{:s} loses {:s}.", target->getNameDescription(), damageString);
 				} else if (attacker == target) {
 					message.type = MESSAGE_DAMAGE_OTHERS;
-					message.text = fmt::format("{:s} loses {:s} due to {:s} own attack.", ucfirst(target->getNameDescription()), damageString, targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his") : "its");
+					message.text = fmt::format("{:s} loses {:s} due to {:s} own attack.", target->getNameDescription(), damageString, targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his") : "its");
 				} else {
 					message.type = MESSAGE_DAMAGE_OTHERS;
-					message.text = fmt::format("{:s} loses {:s} due to an attack by {:s}.", ucfirst(target->getNameDescription()), damageString, attacker->getNameDescription());
+					message.text = fmt::format("{:s} loses {:s} due to an attack by {:s}.", target->getNameDescription(), damageString, attacker->getNameDescription());
 				}
+				message.text[0] = std::toupper(message.text[0]);
 				tmpPlayer->sendTextMessage(message);
 			}
 		}
@@ -4331,7 +4334,7 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, CombatDamage& 
 			Player* tmpPlayer = spectator->getPlayer();
 			if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 				message.type = MESSAGE_DAMAGE_DEALT;
-				message.text = fmt::format("{:s} loses {:d} mana due to your attack.", ucfirst(target->getNameDescription()), manaLoss);
+				message.text = fmt::format("{:s} loses {:d} mana due to your attack.", target->getNameDescription(), manaLoss);
 			} else if (tmpPlayer == targetPlayer) {
 				message.type = MESSAGE_DAMAGE_RECEIVED;
 				if (!attacker) {
@@ -4343,14 +4346,15 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, CombatDamage& 
 				}
 			} else if (!attacker) {
 				message.type = MESSAGE_DAMAGE_OTHERS;
-				message.text = fmt::format("{:s} loses {:d} mana.", ucfirst(target->getNameDescription()), manaLoss);
+				message.text = fmt::format("{:s} loses {:d} mana.", target->getNameDescription(), manaLoss);
 			} else if (attacker == target) {
 				message.type = MESSAGE_DAMAGE_OTHERS;
-				message.text = fmt::format("{:s} loses {:d} mana due to {:s} own attack.", ucfirst(target->getNameDescription()), manaLoss, targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his");
+				message.text = fmt::format("{:s} loses {:d} mana due to {:s} own attack.", target->getNameDescription(), manaLoss, targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his");
 			} else {
 				message.type = MESSAGE_DAMAGE_OTHERS;
-				message.text = fmt::format("{:s} loses {:d} mana due to an attack by {:s}.", ucfirst(target->getNameDescription()), manaLoss, attacker->getNameDescription());
+				message.text = fmt::format("{:s} loses {:d} mana due to an attack by {:s}.", target->getNameDescription(), manaLoss, attacker->getNameDescription());
 			}
+			message.text[0] = std::toupper(message.text[0]);
 			tmpPlayer->sendTextMessage(message);
 		}
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4034,16 +4034,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 					message.text = fmt::format("{:s} was healed for {:s}", ucfirst(target->getNameDescription()), damageString);
 				} else if (attacker == target) {
 					message.type = MESSAGE_HEALED_OTHERS;
-					const auto pronoun = [=]() {
-						if (targetPlayer) {
-							switch (targetPlayer->getSex()) {
-								case PLAYERSEX_FEMALE: return "herself";
-								case PLAYERSEX_MALE: return "himself";
-							};
-						}
-						return "itself";
-					}();
-					message.text = fmt::format("{:s} healed {:s} for {:s}", ucfirst(attacker->getNameDescription()), pronoun, damageString);
+					message.text = fmt::format("{:s} healed {:s}self for {:s}", ucfirst(attacker->getNameDescription()), targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "him") : "it", damageString);
 				} else {
 					message.type = MESSAGE_HEALED_OTHERS;
 					message.text = fmt::format("{:s} healed {:s} for {:s}", ucfirst(attacker->getNameDescription()), target->getNameDescription(), damageString);
@@ -4223,16 +4214,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 					message.text = fmt::format("{:s} loses {:s}.", ucfirst(target->getNameDescription()), damageString);
 				} else if (attacker == target) {
 					message.type = MESSAGE_DAMAGE_OTHERS;
-					const auto pronoun = [=]() {
-						if (targetPlayer) {
-							switch (targetPlayer->getSex()) {
-								case PLAYERSEX_FEMALE: return "her";
-								case PLAYERSEX_MALE: return "his";
-							};
-						}
-						return "its";
-					}();
-					message.text = fmt::format("{:s} loses {:s} due to {:s} own attack.", ucfirst(target->getNameDescription()), damageString, pronoun);
+					message.text = fmt::format("{:s} loses {:s} due to {:s} own attack.", ucfirst(target->getNameDescription()), damageString, targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "his") : "its");
 				} else {
 					message.type = MESSAGE_DAMAGE_OTHERS;
 					message.text = fmt::format("{:s} loses {:s} due to an attack by {:s}.", ucfirst(target->getNameDescription()), damageString, attacker->getNameDescription());

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4006,7 +4006,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		realHealthChange = target->getHealth() - realHealthChange;
 
 		if (realHealthChange > 0 && !target->isInGhostMode()) {
-			auto damageString = fmt::format("{:d} hitpoint{:s}.", realHealthChange, realHealthChange != 1 ? "s" : "");
+			auto damageString = fmt::format("{:d} hitpoint{:s}", realHealthChange, realHealthChange != 1 ? "s" : "");
 
 			TextMessage message;
 			message.position = targetPos;
@@ -4019,25 +4019,25 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 				Player* tmpPlayer = spectator->getPlayer();
 				if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 					message.type = MESSAGE_HEALED;
-					message.text = fmt::format("You heal {:s} for {:s}", target->getNameDescription(), damageString);
+					message.text = fmt::format("You heal {:s} for {:s}.", target->getNameDescription(), damageString);
 				} else if (tmpPlayer == targetPlayer) {
 					message.type = MESSAGE_HEALED;
 					if (!attacker) {
-						message.text = fmt::format("You were healed for {:d}", damageString);
+						message.text = fmt::format("You were healed for {:d}.", damageString);
 					} else if (targetPlayer == attackerPlayer) {
-						message.text = fmt::format("You healed yourself for {:d}", damageString);
+						message.text = fmt::format("You healed yourself for {:d}.", damageString);
 					} else {
-						message.text = fmt::format("You were healed by {:d} for {:s}", attacker->getNameDescription(), damageString);
+						message.text = fmt::format("You were healed by {:d} for {:s}.", attacker->getNameDescription(), damageString);
 					}
 				} else if (!attacker) {
 					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = fmt::format("{:s} was healed for {:s}", ucfirst(target->getNameDescription()), damageString);
+					message.text = fmt::format("{:s} was healed for {:s}.", ucfirst(target->getNameDescription()), damageString);
 				} else if (attacker == target) {
 					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = fmt::format("{:s} healed {:s}self for {:s}", ucfirst(attacker->getNameDescription()), targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "him") : "it", damageString);
+					message.text = fmt::format("{:s} healed {:s}self for {:s}.", ucfirst(attacker->getNameDescription()), targetPlayer ? (targetPlayer->getSex() == PLAYERSEX_FEMALE ? "her" : "him") : "it", damageString);
 				} else {
 					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = fmt::format("{:s} healed {:s} for {:s}", ucfirst(attacker->getNameDescription()), target->getNameDescription(), damageString);
+					message.text = fmt::format("{:s} healed {:s} for {:s}.", ucfirst(attacker->getNameDescription()), target->getNameDescription(), damageString);
 				}
 				tmpPlayer->sendTextMessage(message);
 			}
@@ -4189,7 +4189,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		}
 
 		if (message.primary.color != TEXTCOLOR_NONE || message.secondary.color != TEXTCOLOR_NONE) {
-			auto damageString = fmt::format("{:d} hitpoint{:s}.", realDamage, realDamage != 1 ? "s" : "");
+			auto damageString = fmt::format("{:d} hitpoint{:s}", realDamage, realDamage != 1 ? "s" : "");
 
 			for (Creature* spectator : spectators) {
 				Player* tmpPlayer = spectator->getPlayer();

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -20,6 +20,7 @@
 #include "otpch.h"
 
 #include <boost/range/adaptor/reversed.hpp>
+#include <fmt/format.h>
 
 #include "luascript.h"
 #include "chat.h"
@@ -9018,9 +9019,7 @@ int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 	uint32_t key = getNumber<uint32_t>(L, 2);
 	Player* player = getUserdata<Player>(L, 1);
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
-		std::ostringstream ss;
-		ss << "Accessing reserved range: " << key;
-		reportErrorFunc(ss.str());
+		reportErrorFunc(fmt::format("Accessing reserved range: {:d}", key));
 		pushBoolean(L, false);
 		return 1;
 	}

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -36,6 +36,7 @@
 #include "databasetasks.h"
 #include "script.h"
 #include <fstream>
+#include <fmt/format.h>
 #if __has_include("gitmetadata.h")
 	#include "gitmetadata.h"
 #endif
@@ -278,10 +279,7 @@ void mainLoader(int, char*[], ServiceManager* services)
 		g_game.setWorldType(WORLD_TYPE_PVP_ENFORCED);
 	} else {
 		std::cout << std::endl;
-
-		std::ostringstream ss;
-		ss << "> ERROR: Unknown world type: " << g_config.getString(ConfigManager::WORLD_TYPE) << ", valid world types are: pvp, no-pvp and pvp-enforced.";
-		startupErrorMessage(ss.str());
+		startupErrorMessage(fmt::format("Unknown world type: {:s}, valid world types are: pvp, no-pvp and pvp-enforced.", g_config.getString(ConfigManager::WORLD_TYPE)));
 		return;
 	}
 	std::cout << asUpperCaseString(worldType) << std::endl;

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -29,6 +29,8 @@
 #include "ban.h"
 #include "game.h"
 
+#include <fmt/format.h>
+
 extern ConfigManager g_config;
 extern Game g_game;
 
@@ -70,10 +72,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	if (!motd.empty()) {
 		//Add MOTD
 		output->addByte(0x14);
-
-		std::ostringstream ss;
-		ss << g_game.getMotdNum() << "\n" << motd;
-		output->addString(ss.str());
+		output->addString(fmt::format("{:d}\n{:s}", g_game.getMotdNum(), motd));
 	}
 
 	//Add session key
@@ -153,9 +152,7 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	 */
 
 	if (version <= 760) {
-		std::ostringstream ss;
-		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
-		disconnectClient(ss.str(), version);
+		disconnectClient(fmt::format("Only clients with protocol {:s} allowed!", CLIENT_VERSION_STR), version);
 		return;
 	}
 
@@ -173,9 +170,7 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	setXTEAKey(std::move(key));
 
 	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {
-		std::ostringstream ss;
-		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
-		disconnectClient(ss.str(), version);
+		disconnectClient(fmt::format("Only clients with protocol {:s} allowed!", CLIENT_VERSION_STR), version);
 		return;
 	}
 
@@ -200,9 +195,7 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 			banInfo.reason = "(none)";
 		}
 
-		std::ostringstream ss;
-		ss << "Your IP has been banned until " << formatDateShort(banInfo.expiresAt) << " by " << banInfo.bannedBy << ".\n\nReason specified:\n" << banInfo.reason;
-		disconnectClient(ss.str(), version);
+		disconnectClient(fmt::format("Your IP has been banned until {:s} by {:s}.\n\nReason specified:\n{:s}", formatDateShort(banInfo.expiresAt), banInfo.bannedBy, banInfo.reason), version);
 		return;
 	}
 

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -24,6 +24,8 @@
 
 #include "game.h"
 
+#include <fmt/format.h>
+
 extern Game g_game;
 
 void ProtocolOld::disconnectClient(const std::string& message)
@@ -48,9 +50,7 @@ void ProtocolOld::onRecvFirstMessage(NetworkMessage& msg)
 	msg.skipBytes(12);
 
 	if (version <= 760) {
-		std::ostringstream ss;
-		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
-		disconnectClient(ss.str());
+		disconnectClient(fmt::format("Only clients with protocol {:s} allowed!", CLIENT_VERSION_STR));
 		return;
 	}
 
@@ -71,7 +71,5 @@ void ProtocolOld::onRecvFirstMessage(NetworkMessage& msg)
 		disableChecksum();
 	}
 
-	std::ostringstream ss;
-	ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
-	disconnectClient(ss.str());
+	disconnectClient(fmt::format("Only clients with protocol {:s} allowed!", CLIENT_VERSION_STR));
 }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

[fmt](https://fmt.dev) is a library that provides fast and safe string formatting, with a syntax similar to `printf` (or `str.format` for my fellow Pythonists).

This pull request adds it as a dependency, and also changes some usages of stringstreams for formatting where `fmt::format` would suit objectively better. There are many more places there `fmt::format` would fit (just grep for `std::ostringstream` to find), but I can't do that much alone 😛 

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
