### PR TITLE
Fix crash when calling addEvent

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3684,7 +3684,7 @@ int LuaScriptInterface::luaAddEvent(lua_State* L)
 
 	LuaTimerEventDesc eventDesc;
 	eventDesc.parameters.reserve(parameters - 2); // safe to use -2 since we garanteed that there is at least two parameters
-	for (int i = 0; i < parameters - 2; ++i) { // safe to use -2 since we garanteed that there is at least two parameters
+	for (int i = 0; i < parameters - 2; ++i) {
 		eventDesc.parameters.push_back(luaL_ref(globalState, LUA_REGISTRYINDEX));
 	}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3589,8 +3589,21 @@ int LuaScriptInterface::luaAddEvent(lua_State* L)
 	}
 
 	int parameters = lua_gettop(globalState);
-	if (!isFunction(globalState, -parameters)) { //-parameters means the first parameter from left to right
+
+	if (parameters < 2) {
+		reportErrorFunc(fmt::format("Not enough parameters: {:d}.", parameters));
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	if (!isFunction(globalState, 1)) {
 		reportErrorFunc("callback parameter should be a function.");
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	if (!isNumber(globalState, 2)) {
+		reportErrorFunc("delay parameter should be a number.");
 		pushBoolean(L, false);
 		return 1;
 	}
@@ -3670,7 +3683,8 @@ int LuaScriptInterface::luaAddEvent(lua_State* L)
 	}
 
 	LuaTimerEventDesc eventDesc;
-	for (int i = 0; i < parameters - 2; ++i) { //-2 because addEvent needs at least two parameters
+	eventDesc.parameters.reserve(parameters - 2); // safe to use -2 since we garanteed that there is at least two parameters
+	for (int i = 0; i < parameters - 2; ++i) { // safe to use -2 since we garanteed that there is at least two parameters
 		eventDesc.parameters.push_back(luaL_ref(globalState, LUA_REGISTRYINDEX));
 	}
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -85,7 +85,7 @@ struct LuaVariant {
 struct LuaTimerEventDesc {
 	int32_t scriptId = -1;
 	int32_t function = -1;
-	std::list<int32_t> parameters;
+	std::vector<int32_t> parameters;
 	uint32_t eventId = 0;
 
 	LuaTimerEventDesc() = default;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
`addEvent(function() end)`
This is enough to crash TFS. Why? luajit api is sensible(which mean it will crash if misused) so the call to  
`lua_pop(globalState, 1);` here  https://github.com/otland/forgottenserver/blob/master/src/luascript.cpp#L3678 will cause a crash since the code expects there is at least two parameters(callback and delay). You must pass a valid function as the first parameter thanks to the check here https://github.com/otland/forgottenserver/blob/master/src/luascript.cpp#L3592.
I fixed that with two extra checks: Check if there is at least two parameters and if the second parameter is a lua number.
As a small optimization, we are not using std::list anymore because there was 0 reasons to use it instead of a std::vector.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
