### PR TITLE
Fix removeTileCreature client debug when spectator can't see the pos

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2439,8 +2439,21 @@ void ProtocolGame::sendRemoveTileThing(const Position& pos, uint32_t stackpos)
 
 void ProtocolGame::sendRemoveTileCreature(const Creature* creature, const Position& pos, uint32_t stackpos)
 {
+	if (stackpos < 10) {
+		if (!canSee(pos)) {
+			return;
+		}
+
+		NetworkMessage msg;
+		RemoveTileThing(msg, pos, stackpos);
+		writeToOutputBuffer(msg);
+		return;
+	}
+
 	NetworkMessage msg;
-	RemoveTileCreature(msg, creature, pos, stackpos);
+	msg.addByte(0x6C);
+	msg.add<uint16_t>(0xFFFF);
+	msg.add<uint32_t>(creature->getID());
 	writeToOutputBuffer(msg);
 }
 


### PR DESCRIPTION
Fix #3381 