### PR TITLE
Fix tool gear when use with jungleGrass

### DIFF
--- a/data/actions/lib/actions.lua
+++ b/data/actions/lib/actions.lua
@@ -116,6 +116,7 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 
 		toPosition.z = toPosition.z + 1
 		tile:relocateTo(toPosition)
+		return true
 	end
 
 	-- Ice fishing hole
@@ -123,9 +124,10 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		ground:transform(7236)
 		ground:decay()
 		toPosition:sendMagicEffect(CONST_ME_HITAREA)
+		return true
 	end
 
-	return true
+	return false
 end
 
 function onUseRope(player, item, fromPosition, target, toPosition, isHotkey)


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These changes fix a small detail with the script: `tool_gear.lua`, when you try to cut the weed it has no effect, and this is because the pick function always returns true

**Issues addressed:** Nothing
