### PR TITLE
Fix vcpkg workflow's cmake args

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -109,8 +109,8 @@ jobs:
         with:
           useVcpkgToolchainFile: true
           buildDirectory: ${{ runner.workspace }}/build
-          cmakeBuildType: ${{ matrix.buildtype }}
-          cmakeAppendedArgs: -DUSE_LUAJIT=${{ matrix.luajit }}
+          cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+          cmakeAppendedArgs: '-G Ninja -DCMAKE_BUILD_TYPE="${{ matrix.buildtype }}" -DUSE_LUAJIT="${{ matrix.luajit }}"'
 
       - name: dir
         run: find $RUNNER_WORKSPACE


### PR DESCRIPTION
Vcpkg cmake configuration was wrong, therfore the server was always compiled with LuaJIT as it was available and preferred. This PR fixes the use of `USE_LUAJIT `.

Windows fails with LuaJIT off. Fixing this is not in scope of this PR, IMHO.

https://github.com/otland/forgottenserver/actions/runs/689487844