### PR TITLE
Change int to uint16_t in house class for consistency

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -426,7 +426,7 @@ void AccessList::parseList(const std::string& list)
 	std::istringstream listStream(list);
 	std::string line;
 
-	int lineNo = 1;
+	uint16_t lineNo = 1;
 	while (getline(listStream, line)) {
 		if (++lineNo > 100) {
 			break;


### PR DESCRIPTION
As we use precise data types in all parts of the sources. I think we should replace this int with corresponding u16 or even u8 too for consistency.