### PR TITLE
Vocation.getVocationId Use lowercase names too

### DIFF
--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -161,8 +161,10 @@ Vocation* Vocations::getVocation(uint16_t id)
 
 int32_t Vocations::getVocationId(const std::string& name) const
 {
-	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [&name](decltype(vocationsMap)::value_type it) {
-		return strcasecmp(it.second.name.c_str(), name.c_str()) == 0;
+	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [&name](auto it) {
+		return name.size() == it.second.name.size() && std::equal(name.begin(), name.end(), it.second.name.begin(), [](char a, char b) {
+			return std::tolower(a) == std::tolower(b);
+			});
 	});
 	return it != vocationsMap.end() ? it->first : -1;
 }

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -164,7 +164,7 @@ int32_t Vocations::getVocationId(const std::string& name) const
 	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [&name](auto it) {
 		return name.size() == it.second.name.size() && std::equal(name.begin(), name.end(), it.second.name.begin(), [](char a, char b) {
 			return std::tolower(a) == std::tolower(b);
-			});
+		});
 	});
 	return it != vocationsMap.end() ? it->first : -1;
 }

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -162,7 +162,7 @@ Vocation* Vocations::getVocation(uint16_t id)
 int32_t Vocations::getVocationId(const std::string& name) const
 {
 	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [&name](decltype(vocationsMap)::value_type it) {
-		return it.second.name == name;
+		return strcasecmp(it.second.name.c_str(), name.c_str()) == 0;
 	});
 	return it != vocationsMap.end() ? it->first : -1;
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
In previous versions you could write the names of the vocations in lowercase, at this time the name must exactly match the name, which is not very comfortable.

### Example
`spell:vocation("sorcerer")` -- Error
`spell:vocation("Sorcerer)` -- Correct because in the xml file it is written that way

Now with these changes the two options are valid

it is worth mentioning that previously this already worked, but with the changes of PR #3285 it is now no longer possible

**Issues addressed:** Nothing!