### PR TITLE
Remove unnecessary metatable for a table simple

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14826,7 +14826,6 @@ int LuaScriptInterface::luaSpellVocation(lua_State* L)
 			pushString(L, name);
 			lua_rawseti(L, -2, ++i);
 		}
-		setMetatable(L, -1, "Spell");
 	} else {
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		for (int i = 0; i < parameters; ++i) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
We are providing to a table simple that only contains vocations names with the Spell metatable, this is incorrect and surely it was a detail that they forgot to remove when they copy paste in revscript implementation

**Issues addressed:** Nothing!