### PR TITLE
Add missing parameter in onDisappear callback

### DIFF
--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -486,7 +486,7 @@ if NpcHandler == nil then
 	-- Handles onThink events. If you wish to handle this yourself, please use the CALLBACK_ONTHINK callback.
 	function NpcHandler:onThink()
 		local callback = self:getCallback(CALLBACK_ONTHINK)
-		if callback == nil or callback() then
+		if callback == nil or callback(cid) then
 			if NPCHANDLER_TALKDELAY == TALKDELAY_ONTHINK then
 				for cid, talkDelay in pairs(self.talkDelay) do
 					if talkDelay.time and talkDelay.message and os.time() >= talkDelay.time then
@@ -531,7 +531,7 @@ if NpcHandler == nil then
 	function NpcHandler:onWalkAway(cid)
 		if self:isFocused(cid) then
 			local callback = self:getCallback(CALLBACK_CREATURE_DISAPPEAR)
-			if callback == nil or callback() then
+			if callback == nil or callback(cid) then
 				if self:processModuleCallback(CALLBACK_CREATURE_DISAPPEAR, cid) then
 					local msg = self:getMessage(MESSAGE_WALKAWAY)
 

--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -486,7 +486,7 @@ if NpcHandler == nil then
 	-- Handles onThink events. If you wish to handle this yourself, please use the CALLBACK_ONTHINK callback.
 	function NpcHandler:onThink()
 		local callback = self:getCallback(CALLBACK_ONTHINK)
-		if callback == nil or callback(cid) then
+		if callback == nil or callback() then
 			if NPCHANDLER_TALKDELAY == TALKDELAY_ONTHINK then
 				for cid, talkDelay in pairs(self.talkDelay) do
 					if talkDelay.time and talkDelay.message and os.time() >= talkDelay.time then


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
I discovered that there were still 2 event `onThink/onDisappear` missing that also lacked the `cid` parameter, so here I added them so that we can then handle these events with our own custom callback 🤗
***However:***
It is worth mentioning that the onThink event does not require the parameter cid, because this is not a direct interaction with some creature, it is only when npc thinks, therefore it is the only event that should not have parameters, in fact, a parameter like cid doesn't even make sense in this callback :D, I don't know how I came up with this idea in the first place ajajjaa

Thanks you @EPuncker 

**Issues addressed:** Nothing!