### PR TITLE
Correct loadMonsterType from Xml

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -77,12 +77,7 @@ bool Monsters::loadFromXml(bool reloading /*= false*/)
 	bool forceLoad = g_config.getBoolean(ConfigManager::FORCE_MONSTERTYPE_LOAD);
 
 	for (auto it : unloadedMonsters) {
-		if (forceLoad) {
-			loadMonster(it.second, it.first, reloading);
-			continue;
-		}
-
-		if (reloading && monsters.find(it.first) != monsters.end()) {
+		if (forceLoad || reloading && monsters.find(it.first) != monsters.end()) {
 			loadMonster(it.second, it.first, reloading);
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
We must save in advance a physical reference of the xml file of the monsters, and then in another loop iterate over all the references to load each monster file, in this way we make sure that if a monsterType has not yet been loaded we can load the monsterType with its reference already saved previously

I'm not 100% sure this is the right way to do it, so if you have any suggestions, just give me your suggestions.

**Issues addressed:** #3397
This case only occurs when we want to know information about a type of monster that has not loaded yet.
In the example of the green frog, it was obvious that the `Dark Apprentice` could not know anything about `Green Frog` because it had not loaded yet, and since we are forcing the direct loading of the monsters then we evaded the saving of the reference of the xml file