### PR TITLE
Precompute xtea round keys

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -28,7 +28,7 @@ extern RSA g_RSA;
 
 namespace {
 
-void XTEA_encrypt(OutputMessage& msg, const xtea::key& key)
+void XTEA_encrypt(OutputMessage& msg, const xtea::round_keys& key)
 {
 	// The message must be a multiple of 8
 	size_t paddingBytes = msg.getLength() % 8u;
@@ -40,7 +40,7 @@ void XTEA_encrypt(OutputMessage& msg, const xtea::key& key)
 	xtea::encrypt(buffer, msg.getLength(), key);
 }
 
-bool XTEA_decrypt(NetworkMessage& msg, const xtea::key& key)
+bool XTEA_decrypt(NetworkMessage& msg, const xtea::round_keys& key)
 {
 	if (((msg.getLength() - 6) & 7) != 0) {
 		return false;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -72,8 +72,8 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		void enableXTEAEncryption() {
 			encryptionEnabled = true;
 		}
-		void setXTEAKey(xtea::key key) {
-			this->key = std::move(key);
+		void setXTEAKey(const xtea::key& key) {
+			this->key = xtea::expand_key(key);
 		}
 		void disableChecksum() {
 			checksumEnabled = false;
@@ -93,7 +93,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		OutputMessage_ptr outputBuffer;
 
 		const ConnectionWeak_ptr connection;
-		xtea::key key;
+		xtea::round_keys key;
 		bool encryptionEnabled = false;
 		bool checksumEnabled = true;
 		bool rawMessages = false;

--- a/src/xtea.cpp
+++ b/src/xtea.cpp
@@ -52,22 +52,34 @@ void apply_rounds(uint8_t* data, size_t length, Round round)
 
 }
 
-void encrypt(uint8_t* data, size_t length, const key& k)
+round_keys expand_key(const key& k)
 {
-	for (uint32_t i = 0, sum = 0, next_sum = sum + delta; i < 32; ++i, sum = next_sum, next_sum += delta) {
+	round_keys expanded;
+
+	for (uint32_t i = 0, sum = 0, next_sum = sum + delta; i < expanded.size(); i += 2, sum = next_sum, next_sum += delta) {
+		expanded[i] = sum + k[sum & 3];
+		expanded[i + 1] = next_sum + k[(next_sum >> 11) & 3];
+	}
+
+	return expanded;
+}
+
+void encrypt(uint8_t* data, size_t length, const round_keys& k)
+{
+	for (int32_t i = 0; i < k.size(); i += 2) {
 		apply_rounds(data, length, [&](uint32_t& left, uint32_t& right) {
-			left += ((right << 4 ^ right >> 5) + right) ^ (sum + k[sum & 3]);
-			right += ((left << 4 ^ left >> 5) + left) ^ (next_sum + k[(next_sum >> 11) & 3]);
+			left += ((right << 4 ^ right >> 5) + right) ^ k[i];
+			right += ((left << 4 ^ left >> 5) + left) ^ k[i + 1];
 		});
 	};
 }
 
-void decrypt(uint8_t* data, size_t length, const key& k)
+void decrypt(uint8_t* data, size_t length, const round_keys& k)
 {
-	for (uint32_t i = 0, sum = delta << 5, next_sum = sum - delta; i < 32; ++i, sum = next_sum, next_sum -= delta) {
+	for (int32_t i = k.size() - 1; i > 0; i -= 2) {
 		apply_rounds(data, length, [&](uint32_t& left, uint32_t& right) {
-			right -= ((left << 4 ^ left >> 5) + left) ^ (sum + k[(sum >> 11) & 3]);
-			left -= ((right << 4 ^ right >> 5) + right) ^ (next_sum + k[next_sum & 3]);
+			right -= ((left << 4 ^ left >> 5) + left) ^ k[i];
+			left -= ((right << 4 ^ right >> 5) + right) ^ k[i - 1];
 		});
 	};
 }

--- a/src/xtea.h
+++ b/src/xtea.h
@@ -23,9 +23,11 @@
 namespace xtea {
 
 using key = std::array<uint32_t, 4>;
+using round_keys = std::array<uint32_t, 64>;
 
-void encrypt(uint8_t* data, size_t length, const key& k);
-void decrypt(uint8_t* data, size_t length, const key& k);
+round_keys expand_key(const key& k);
+void encrypt(uint8_t* data, size_t length, const round_keys& k);
+void decrypt(uint8_t* data, size_t length, const round_keys& k);
 
 } // namespace xtea
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

XTEA key schedule works by spliting a 128bit key K into four 32bit block `K₀, K₁, K₂` and `K₃`, then for each round `r = 1,...,64` the round keys `Kr` are derived from the following equation:

![eqn](https://user-images.githubusercontent.com/16732610/114047386-08fcce00-9860-11eb-9522-f4710e7c1815.png)

Since XTEA key schedule is that easy, we can precompute all the round keys while setting up the key, and lookup the according round key in the array instead of computing it each round.

This optimization in micro benchmarks, makes an avarage decrease of runtime in encryption by 54.27% and 52.04% in decryption (benchmark sources attached). Obviusly due the caching, there is an increase of memory usage from 16 bytes to 256 bytes

<details><summary>google benchmark output</summary><pre>
$ ./bench --benchmark_min_time=10
2021-04-08T09:39:12-03:00
Running ./bench
Run on (8 X 3900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.25, 0.38, 0.45
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
xtea_new_encrypt/8           98.8 ns         98.8 ns    141710120
xtea_new_encrypt/64           732 ns          732 ns     19109309
xtea_new_encrypt/512         5860 ns         5860 ns      2390188
xtea_new_encrypt/4096       46861 ns        46860 ns       298642
xtea_new_encrypt/16384     187480 ns       187479 ns        74678
xtea_new_decrypt/8            108 ns          108 ns    129335746
xtea_new_decrypt/64           757 ns          757 ns     18484688
xtea_new_decrypt/512         5994 ns         5994 ns      2336057
xtea_new_decrypt/4096       47885 ns        47885 ns       292362
xtea_new_decrypt/16384     191449 ns       191448 ns        73129
xtea_cur_encrypt/8            262 ns          262 ns     53387273
xtea_cur_encrypt/64          1688 ns         1688 ns      8295362
xtea_cur_encrypt/512        12147 ns        12147 ns      1153560
xtea_cur_encrypt/4096       95694 ns        95693 ns       146295
xtea_cur_encrypt/16384     382121 ns       382117 ns        36638
xtea_cur_decrypt/8            249 ns          249 ns     56230334
xtea_cur_decrypt/64          1734 ns         1734 ns      8077328
xtea_cur_decrypt/512        11752 ns        11752 ns      1191466
xtea_cur_decrypt/4096       94188 ns        94188 ns       148643
xtea_cur_decrypt/16384     376084 ns       376083 ns        37224
</pre></details>

<details><summary>/proc/cpuinfo</summary><pre>
processor       : 7
vendor_id       : GenuineIntel
cpu family      : 6
model           : 58
model name      : Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz
stepping        : 9
microcode       : 0x17
cpu MHz         : 1906.228
cache size      : 8192 KB
physical id     : 0
siblings        : 8
core id         : 3
cpu cores       : 4
apicid          : 7
initial apicid  : 7
fpu             : yes
fpu_exception   : yes
cpuid level     : 13
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm cpuid_fault epb pti tpr_shadow vnmi flexpriority ept vpid fsgsbase smep erms xsaveopt dtherm ida arat pln pts
vmx flags       : vnmi preemption_timer invvpid ept_x_only flexpriority tsc_offset vtpr mtf vapic ept vpid unrestricted_guest
bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit srbds
bogomips        : 6784.24
clflush size    : 64
cache_alignment : 64
address sizes   : 36 bits physical, 48 bits virtual
power management:
</pre></details>

[bench.zip](https://github.com/otland/forgottenserver/files/6280983/bench.zip)
