### PR TITLE
Inventory vector clear when reload items

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -225,6 +225,7 @@ void Items::clear()
 	items.clear();
 	clientIdToServerIdMap.clear();
 	nameToItems.clear();
+	inventory.clear();
 }
 
 bool Items::reload()


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
When many `/reload items` were made, the `inventory vector` was filling with each reload until reaching the point that when entering the world it caused CipClient to suffer a crash or paralyze in case of using OTC

**Issues addressed:** #3407