### PR TITLE
Fixed construction kits not useable on browse field

### DIFF
--- a/data/actions/scripts/other/construction_kits.lua
+++ b/data/actions/scripts/other/construction_kits.lua
@@ -19,13 +19,16 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return false
 	end
 
-	if fromPosition.x == CONTAINER_POSITION then
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Put the construction kit on the floor first.")
-	elseif not Tile(fromPosition):getHouse() then
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You may construct this only inside a house.")
+	local tile = Tile(item:getPosition())
+	if tile and tile:getHouse() then
+		if fromPosition.x ~= CONTAINER_POSITION or item:getParent():getId() == ITEM_BROWSEFIELD then
+			item:transform(kit)
+			fromPosition:sendMagicEffect(CONST_ME_POFF)
+		else
+			player:sendTextMessage(MESSAGE_STATUS_SMALL, "Put the construction kit on the floor first.")
+		end
 	else
-		item:transform(kit)
-		fromPosition:sendMagicEffect(CONST_ME_POFF)
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You may construct this only inside a house.")
 	end
 	return true
 end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1527,6 +1527,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(ITEM_GROUP_DOOR)
 	registerEnum(ITEM_GROUP_DEPRECATED)
 
+	registerEnum(ITEM_BROWSEFIELD)
 	registerEnum(ITEM_BAG)
 	registerEnum(ITEM_SHOPPING_BAG)
 	registerEnum(ITEM_GOLD_COIN)


### PR DESCRIPTION
Co-Authored-By: Zbizu <Zbizu@users.noreply.github.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Added check if item getParent is browse field
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
fixes #2013

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
