### PR TITLE
Fixed wrong plaguesmith loot id

### DIFF
--- a/data/monster/monsters/plaguesmith.xml
+++ b/data/monster/monsters/plaguesmith.xml
@@ -76,7 +76,7 @@
 		<item name="knight legs" chance="6250" />
 		<item name="steel shield" chance="20000" />
 		<item name="steel boots" chance="1123" />
-		<item id="3957" chance="100" /><!-- war horn -->
+		<item id="2079" chance="100" /><!-- war horn -->
 		<item name="piece of royal steel" chance="1234" />
 		<item name="piece of hell steel" chance="1010" />
 		<item name="piece of draconian steel" chance="1030" />


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
it was dropping "cornucopia" instead of "war horn"

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
