### PR TITLE
Fixed wrong ring ID in loot

### DIFF
--- a/data/monster/monsters/arachir_the_ancient_one.xml
+++ b/data/monster/monsters/arachir_the_ancient_one.xml
@@ -59,7 +59,7 @@
 		<item name="black pearl" chance="8980" />
 		<item name="gold coin" countmax="98" chance="100000" />
 		<item name="platinum coin" countmax="5" chance="50000" />
-		<item name="ring of healing (faster regeneration)" chance="11111" />
+		<item name="ring of healing" chance="11111" />
 		<item id="2229" chance="10000" /><!-- skull -->
 		<item name="vampire shield" chance="6300" />
 		<item name="bloody edge" chance="1200" />

--- a/data/monster/monsters/diblis_the_fair.xml
+++ b/data/monster/monsters/diblis_the_fair.xml
@@ -53,7 +53,7 @@
 		<item name="black pearl" chance="8900" countmax="2" />
 		<item name="gold coin" chance="100000" countmax="99" />
 		<item name="platinum coin" chance="50000" countmax="5" />
-		<item name="ring of healing (faster regeneration)" chance="14111" />
+		<item name="ring of healing" chance="14111" />
 		<item id="2229" chance="15000" /><!-- skull -->
 		<item name="vampire shield" chance="2100" />
 		<item name="strong health potion" chance="1500" />

--- a/data/monster/monsters/lost_basher.xml
+++ b/data/monster/monsters/lost_basher.xml
@@ -55,7 +55,7 @@
 		<item name="piggy bank" chance="4450" />
 		<item name="gold coin" countmax="100" chance="60000" />
 		<item name="platinum coin" countmax="2" chance="70000" />
-		<item name="dwarven ring (hard drinking)" chance="2560" />
+		<item name="dwarven ring" chance="2560" />
 		<item name="fire axe" chance="310" />
 		<item name="war axe" chance="120" />
 		<item name="knight legs" chance="310" />

--- a/data/monster/monsters/lost_husher.xml
+++ b/data/monster/monsters/lost_husher.xml
@@ -65,7 +65,7 @@
 	<loot>
 		<item name="gold coin" countmax="100" chance="50000" />
 		<item name="platinum coin" countmax="2" chance="58670" />
-		<item name="dwarven ring (hard drinking)" chance="2870" />
+		<item name="dwarven ring" chance="2870" />
 		<item name="fire axe" chance="330" />
 		<item name="skull staff" chance="280" />
 		<item name="guardian shield" chance="830" />

--- a/data/monster/monsters/sir_valorcrest.xml
+++ b/data/monster/monsters/sir_valorcrest.xml
@@ -52,7 +52,7 @@
 		<item name="gold coin" chance="100000" countmax="93" />
 		<item name="platinum coin" chance="50000" countmax="5" />
 		<item name="sword ring" chance="1400" />
-		<item name="ring of healing (faster regeneration)" chance="17111" />
+		<item name="ring of healing" chance="17111" />
 		<item id="2229" chance="15000" /><!-- skull -->
 		<item name="vampire shield" chance="6300" />
 		<item name="chaos mace" chance="250" />

--- a/data/monster/monsters/the_snapper.xml
+++ b/data/monster/monsters/the_snapper.xml
@@ -35,7 +35,7 @@
 	<loot>
 		<item name="gold coin" countmax="100" chance="50675" />
 		<item name="gold coin" countmax="94" chance="50675" />
-		<item name="life ring (faster regeneration)" chance="100000" />
+		<item name="life ring" chance="100000" />
 		<item name="plate armor" chance="35800" />
 		<item name="knight armor" chance="4025" />
 		<item name="plate legs" chance="44025" />

--- a/data/monster/monsters/zevelon_duskbringer.xml
+++ b/data/monster/monsters/zevelon_duskbringer.xml
@@ -56,7 +56,7 @@
 		<item name="black pearl" chance="8000" />
 		<item name="gold coin" chance="100000" countmax="75" />
 		<item name="platinum coin" chance="50000" countmax="5" />
-		<item name="ring of healing (faster regeneration)" chance="11111" />
+		<item name="ring of healing" chance="11111" />
 		<item name="vampire shield" chance="4500" />
 		<item name="strong health potion" chance="4000" />
 		<item name="vampire lord token" chance="100000" />

--- a/data/monster/monsters/zombie.xml
+++ b/data/monster/monsters/zombie.xml
@@ -49,7 +49,7 @@
 	</voices>
 	<loot>
 		<item name="gold coin" countmax="65" chance="82000" />
-		<item name="life ring (faster regeneration)" chance="1000" />
+		<item name="life ring" chance="1000" />
 		<item name="halberd" chance="3750" />
 		<item name="mace" chance="7250" />
 		<item name="battle hammer" chance="7000" />


### PR DESCRIPTION
Co-Authored-By: torresmon <70948057+peloverde@users.noreply.github.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These monsters were dropping the equipped version of the ring, instead of the correct one
<!-- Describe the changes that this pull request makes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
