### PR TITLE
Fix wrongs ids from costume bag (common, deluxe) and present (explosive)

### DIFF
--- a/data/scripts/actions/others/costume_bag.lua
+++ b/data/scripts/actions/others/costume_bag.lua
@@ -1,6 +1,6 @@
 local config = {
-	[7737] = {"orc warrior", "pirate cutthroat", "dworc voodoomaster", "dwarf guard", "minotaur mage"}, -- common
-	[7739] = {"serpent spawn", "demon", "juggernaut", "behemoth", "ashmunrah"}, -- deluxe
+	[9075] = {"orc warrior", "pirate cutthroat", "dworc voodoomaster", "dwarf guard", "minotaur mage"}, -- common
+	[9077] = {"serpent spawn", "demon", "juggernaut", "behemoth", "ashmunrah"}, -- deluxe
 	[9076] = {"quara hydromancer", "diabolic imp", "banshee", "frost giant", "lich"} -- uncommon
 }
 

--- a/data/scripts/actions/others/explosive_present.lua
+++ b/data/scripts/actions/others/explosive_present.lua
@@ -7,5 +7,5 @@ function explosivePresent.onUse(player, item, fromPosition, target, toPosition, 
 	return true
 end
 
-explosivePresent:id(8110)
+explosivePresent:id(9074)
 explosivePresent:register()

--- a/data/scripts/actions/others/suspicious_surprise_bag.lua
+++ b/data/scripts/actions/others/suspicious_surprise_bag.lua
@@ -6,7 +6,7 @@ local config = {
 	{chanceFrom = 8328, chanceTo = 9141, itemId = 6574}, -- bar of chocolate
 	{chanceFrom = 9142, chanceTo = 9654, itemId = 6394}, -- cream cake
 	{chanceFrom = 9655, chanceTo = 9850, itemId = 7377}, -- ice cream cone
-	{chanceFrom = 9851, chanceTo = 9986, itemId = 9074}, -- present
+	{chanceFrom = 9851, chanceTo = 9986, itemId = 9074}, -- explosive present
 	{chanceFrom = 9987, chanceTo = 10000, itemId = 7487} -- toy mouse
 }
 

--- a/data/scripts/actions/others/suspicious_surprise_bag.lua
+++ b/data/scripts/actions/others/suspicious_surprise_bag.lua
@@ -6,7 +6,7 @@ local config = {
 	{chanceFrom = 8328, chanceTo = 9141, itemId = 6574}, -- bar of chocolate
 	{chanceFrom = 9142, chanceTo = 9654, itemId = 6394}, -- cream cake
 	{chanceFrom = 9655, chanceTo = 9850, itemId = 7377}, -- ice cream cone
-	{chanceFrom = 9851, chanceTo = 9986, itemId = 8110}, -- present
+	{chanceFrom = 9851, chanceTo = 9986, itemId = 9074}, -- present
 	{chanceFrom = 9987, chanceTo = 10000, itemId = 7487} -- toy mouse
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Change wrong ids
- Costume bag (Common; from 7737 to 9075) (Deluxe; from 7739 to 9077)
- Present (Explosive; from 8110 to 9074)

7737, 7739 and 8110 does not contain editorsuffix tag.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
