### PR TITLE
Fix skinning corpse

### DIFF
--- a/data/scripts/actions/tools/skinning.lua
+++ b/data/scripts/actions/tools/skinning.lua
@@ -176,7 +176,12 @@ function skinning.onUse(player, item, fromPosition, target, toPosition, isHotkey
 	else
 		target:remove()
 	end
-	if target.itemid == 13583 and player:getStorageValue(PlayerStorageKeys.mutatedPumpkin) <= os.time() then
+	if target:getId() == 13583 then
+		if player:getStorageValue(PlayerStorageKeys.mutatedPumpkin) > os.time() then
+			player:sendCancelMessage("You already used your knife on the corpse.")
+			return true
+		end
+
 		player:setStorageValue(PlayerStorageKeys.mutatedPumpkin, os.time() + 4 * 60 * 60)
 		player:say("Happy Halloween!", TALKTYPE_MONSTER_SAY)
 		player:getPosition():sendMagicEffect(CONST_ME_GIFT_WRAPS)
@@ -184,9 +189,6 @@ function skinning.onUse(player, item, fromPosition, target, toPosition, isHotkey
 		local reward = math.random(1, #skin)
 		player:addItem(skin[reward].newItem, skin[reward].amount or 1)
 		effect = CONST_ME_HITAREA
-	else
-		player:sendCancelMessage("You already used your knife on the corpse.")
-		return true
 	end
 	if toPosition.x == CONTAINER_POSITION then
 		toPosition = player:getPosition()


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Fix skinning

### Now
- Effect when skinning a corpse, work with all corpses.
- Message that has already skinning will only appear with id 13583.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
