### PR TITLE
Fixed overwriting weapons with Revscript

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16041,8 +16041,13 @@ int LuaScriptInterface::luaWeaponAction(lua_State* L)
 int LuaScriptInterface::luaWeaponRegister(lua_State* L)
 {
 	// weapon:register()
-	Weapon* weapon = getUserdata<Weapon>(L, 1);
-	if (weapon) {
+	Weapon** weaponPtr = getRawUserdata<Weapon>(L, 1);
+	if (!weaponPtr) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (auto* weapon = *weaponPtr) {
 		if (weapon->weaponType == WEAPON_DISTANCE || weapon->weaponType == WEAPON_AMMO) {
 			weapon = getUserdata<WeaponDistance>(L, 1);
 		} else if (weapon->weaponType == WEAPON_WAND) {
@@ -16064,6 +16069,7 @@ int LuaScriptInterface::luaWeaponRegister(lua_State* L)
 
 		weapon->configureWeapon(it);
 		pushBoolean(L, g_weapons->registerLuaEvent(weapon));
+		*weaponPtr = nullptr; // Remove luascript reference
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -135,11 +135,9 @@ bool Weapons::registerEvent(Event_ptr event, const pugi::xml_node&)
 	return result.second;
 }
 
-bool Weapons::registerLuaEvent(Weapon* event)
+bool Weapons::registerLuaEvent(Weapon* weapon)
 {
-	Weapon_ptr weapon{ event };
-	weapons[weapon->getID()] = weapon.release();
-
+	weapons[weapon->getID()] = weapon;
 	return true;
 }
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
With these changes you will be able to overwrite weapons with Revscripts, since currently when doing so the server suffers from a crash for referencing an already released weapon

I have tried these changes and they work great, but if you have any other way to approach the problem feel free to say something about it or even propose other changes.

Credits: @SaiyansKing

### Steps to follow to check if this solves the problem
Once the changes are applied you can try creating a weapon like in Revscript like this:
`data/scripts/snowball.lua`
```lua
local weapon = Weapon(WEAPON_DISTANCE)
weapon:id(2111)
weapon:action("removecount")
weapon:register()
```

Remember not to remove this weapon from `weapons.xml`
```xml
<distance id="2111" action="removecount" /> <!-- snowball -->
```

Once the server is starting it should not cause a crash!
Finally with this we show that the changes allow us to even create the same weapon in xml and revscript without any problem

**Issues addressed:** Fixes possible Weapon null dereference
**Backward compatibility:** Yes
**Compatibility with XML:** Yes
