### PR TITLE
Missing `self` in function Player.getWeaponType

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -285,10 +285,10 @@ function Player.addSkill(self, skillId, value, round)
 	return self:addSkillTries(skillId, self:getVocation():getRequiredSkillTries(skillId, self:getSkillLevel(skillId) + value) - self:getSkillTries(skillId))
 end
 
-function Player.getWeaponType()
+function Player.getWeaponType(self)
 	local weapon = self:getSlotItem(CONST_SLOT_LEFT)
 	if weapon then
-		return ItemType(weapon:getId()):getWeaponType()
+		return weapon:getType():getWeaponType()
 	end
 	return WEAPON_NONE
 end


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This function is not used anywhere and that is why we had not realized that the function lacks the parameter `self` :D

**Issues addressed:** Nothing!