### PR TITLE
Fix weird std::move

### DIFF
--- a/src/teleport.h
+++ b/src/teleport.h
@@ -41,8 +41,8 @@ class Teleport final : public Item, public Cylinder
 		const Position& getDestPos() const {
 			return destPos;
 		}
-		void setDestPos(Position pos) {
-			destPos = std::move(pos);
+		void setDestPos(const Position& pos) {
+			destPos = pos;
 		}
 
 		bool checkInfinityLoop(Tile* destTile);


### PR DESCRIPTION
This code does nothing, pretty much. Use const reference and assign instead of copying and moving.