### PR TITLE
Move speed change warning so it's hit by xml speed spells which only have a min speed

### DIFF
--- a/data/monster/monsters/bazir.xml
+++ b/data/monster/monsters/bazir.xml
@@ -36,7 +36,7 @@
 		<attack name="manadrain" interval="1000" chance="10" radius="8" target="0" min="-400" max="-700">
 			<attribute key="areaEffect" value="greenshimmer" />
 		</attack>
-		<attack name="speed" interval="1000" chance="12" radius="6" target="0" speedchange="-1900" duration="60000">
+		<attack name="speed" interval="1000" chance="12" radius="6" target="0" speedchange="-1000" duration="60000">
 			<attribute key="areaEffect" value="poison" />
 		</attack>
 		<attack name="effect" interval="1000" chance="8" radius="5" target="0">

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -354,14 +354,14 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 					return false;
 				}
 
-				if (minSpeedChange < -1000) {
-					std::cout << "[Warning - Monsters::deserializeSpell] - " << description << " - you cannot reduce a creatures speed below -1000 (100%)" << std::endl;
-					minSpeedChange = -1000;
-				}
-
 				if (maxSpeedChange == 0) {
 					maxSpeedChange = minSpeedChange; // static speedchange value
 				}
+			}
+
+			if (minSpeedChange < -1000) {
+				std::cout << "[Warning - Monsters::deserializeSpell] - " << description << " - you cannot reduce a creatures speed below -1000 (100%)" << std::endl;
+				minSpeedChange = -1000;
 			}
 
 			ConditionType_t conditionType;


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ x] I have followed [proper The Forgotten Server code styling][code].
- [ x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

see title

**Issues addressed:** <!-- Write here the issue number, if any. -->

Fixed bazir which is the only monster to trigger this warning.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
