### PR TITLE
Remove unused countmin attribute from monster loot

### DIFF
--- a/data/monster/monsters/execowtioner.xml
+++ b/data/monster/monsters/execowtioner.xml
@@ -48,7 +48,7 @@
 		<voice sentence="Your sentence is death!" />
 	</voices>
 	<loot>
-		<item id="2148" countmin="10" countmax="100" chance="100000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="100000" /><!-- gold coin -->
 		<item id="2148" countmax="98" chance="100000" /><!-- gold coin -->
 		<item id="2152" countmax="3" chance="67610" /><!-- platinum coin -->
 		<item id="9971" chance="390" />	<!-- gold ingot -->

--- a/data/monster/monsters/minotaur_amazon.xml
+++ b/data/monster/monsters/minotaur_amazon.xml
@@ -57,7 +57,7 @@
 	<loot>
 		<item id="7368" countmax="5" chance="3040" /><!-- assassin star -->
 		<item id="23575" chance="19830" /><!-- cowbell -->
-		<item id="2148" countmin="9" countmax="100" chance="100000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="100000" /><!-- gold coin -->
 		<item id="2148" countmax="96" chance="60000" /><!-- gold coin -->
 		<item id="2671" chance="60780" /><!-- ham -->
 		<item id="2666" chance="4920" /><!-- meat -->

--- a/data/monster/monsters/moohtant.xml
+++ b/data/monster/monsters/moohtant.xml
@@ -53,7 +53,7 @@
 		<voice sentence="Raaaargh!" />
 	</voices>
 	<loot>
-		<item id="2148" countmin="10" countmax="100" chance="100000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="100000" /><!-- gold coin -->
 		<item id="2148" countmax="95" chance="60000" /><!-- gold coin -->
 		<item id="2152" countmax="2" chance="58160" /><!-- platinum coin -->
 		<item id="23554" countmax="2" chance="15740" /><!-- moohtant horn -->

--- a/data/monster/monsters/worm_priestess.xml
+++ b/data/monster/monsters/worm_priestess.xml
@@ -59,8 +59,8 @@
 		<voice sentence="From the earthy depths he comes and brings freedom!" />
 	</voices>
 	<loot>
-		<item id="2148" countmin="2" countmax="100" chance="100000" /><!-- gold coin -->
-		<item id="2148" countmin="2" countmax="50" chance="60000" /><!-- gold coin -->
+		<item id="2148" countmax="100" chance="100000" /><!-- gold coin -->
+		<item id="2148" countmax="50" chance="60000" /><!-- gold coin -->
 		<item id="2152" countmax="3" chance="41130" /><!-- platinum coin -->
 		<item id="12429" chance="15850" /><!-- purple robe -->
 		<item id="7589" countmax="3" chance="12380" /><!-- strong mana potion -->


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

see title

**Issues addressed:** <!-- Write here the issue number, if any. -->

The attribute was present in 4 monster files