### PR TITLE
Ensure item is deleted if it's not added to corpse

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -49,7 +49,10 @@ function Container.createLootItem(self, item)
 			tmpItem:setText(item.text)
 		end
 
-		self:addItemEx(tmpItem)
+		local ret = self:addItemEx(tmpItem)
+		if ret ~= RETURNVALUE_NOERROR then
+			tmpItem:remove()
+		end
 	end
 	return true
 end


### PR DESCRIPTION
Currently if the item fails to add to corpse it will create memory leak, because we create item in memory and don't check if it was added properly to corpse.