### PR TITLE
Revscriptsys monster fixes

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -123,13 +123,13 @@ registerMonsterType.flags = function(mtype, mask)
 		if mask.flags.staticAttackChance then
 			mtype:staticAttackChance(mask.flags.staticAttackChance)
 		end
-		if mask.flags.canWalkOnEnergy then
+		if mask.flags.canWalkOnEnergy ~= nil then
 			mtype:canWalkOnEnergy(mask.flags.canWalkOnEnergy)
 		end
-		if mask.flags.canWalkOnFire then
+		if mask.flags.canWalkOnFire ~= nil then
 			mtype:canWalkOnFire(mask.flags.canWalkOnFire)
 		end
-		if mask.flags.canWalkOnPoison then
+		if mask.flags.canWalkOnPoison ~= nil then
 			mtype:canWalkOnPoison(mask.flags.canWalkOnPoison)
 		end
 	end
@@ -400,6 +400,9 @@ registerMonsterType.defenses = function(mtype, mask)
 						spell:setType("melee")
 						if defense.attack and defense.skill then
 							spell:setAttackValue(defense.attack, defense.skill)
+						end
+						if attack.minDamage and attack.maxDamage then
+							spell:setCombatValue(attack.minDamage, attack.maxDamage)
 						end
 						if defense.interval then
 							spell:setInterval(defense.interval)

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -89,6 +89,9 @@ registerMonsterType.flags = function(mtype, mask)
 		if mask.flags.convinceable ~= nil then
 			mtype:isConvinceable(mask.flags.convinceable)
 		end
+		if mask.flags.summonable ~= nil then
+			mtype.isSummonable(mask.flags.summonable)
+		end
 		if mask.flags.illusionable ~= nil then
 			mtype:isIllusionable(mask.flags.illusionable)
 		end

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -401,8 +401,8 @@ registerMonsterType.defenses = function(mtype, mask)
 						if defense.attack and defense.skill then
 							spell:setAttackValue(defense.attack, defense.skill)
 						end
-						if attack.minDamage and attack.maxDamage then
-							spell:setCombatValue(attack.minDamage, attack.maxDamage)
+						if defense.minDamage and defense.maxDamage then
+							spell:setCombatValue(defense.minDamage, defense.maxDamage)
 						end
 						if defense.interval then
 							spell:setInterval(defense.interval)
@@ -502,7 +502,7 @@ registerMonsterType.defenses = function(mtype, mask)
 					if defense.target then
 						spell:setNeedTarget(defense.target)
 					end
-					if attack.direction then
+					if defense.direction then
 						spell:setNeedDirection(attack.direction)
 					end
 				end

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -13,6 +13,11 @@ MonsterType.register = function(self, mask)
 	return registerMonsterType(self, mask)
 end
 
+registerMonsterType.name = function(mtype, mask)
+	if mask.name then
+		mtype:name(mask.name)
+	end
+end
 registerMonsterType.description = function(mtype, mask)
 	if mask.description then
 		mtype:nameDescription(mask.description)

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -503,7 +503,7 @@ registerMonsterType.defenses = function(mtype, mask)
 						spell:setNeedTarget(defense.target)
 					end
 					if defense.direction then
-						spell:setNeedDirection(attack.direction)
+						spell:setNeedDirection(defense.direction)
 					end
 				end
 				mtype:addDefense(spell)

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -367,6 +367,9 @@ registerMonsterType.attacks = function(mtype, mask)
 				if attack.target then
 					spell:setNeedTarget(attack.target)
 				end
+				if attack.direction then
+					spell:setNeedDirection(attack.direction)
+				end
 			end
 			mtype:addAttack(spell)
 		end
@@ -486,6 +489,9 @@ registerMonsterType.defenses = function(mtype, mask)
 					end
 					if defense.target then
 						spell:setNeedTarget(defense.target)
+					end
+					if attack.direction then
+						spell:setNeedDirection(attack.direction)
 					end
 				end
 				mtype:addDefense(spell)

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -123,6 +123,15 @@ registerMonsterType.flags = function(mtype, mask)
 		if mask.flags.staticAttackChance then
 			mtype:staticAttackChance(mask.flags.staticAttackChance)
 		end
+		if mask.flags.canWalkOnEnergy then
+			mtype:canWalkOnEnergy(mask.flags.canWalkOnEnergy)
+		end
+		if mask.flags.canWalkOnFire then
+			mtype:canWalkOnFire(mask.flags.canWalkOnFire)
+		end
+		if mask.flags.canWalkOnPoison then
+			mtype:canWalkOnPoison(mask.flags.canWalkOnPoison)
+		end
 	end
 end
 registerMonsterType.light = function(mtype, mask)

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -255,6 +255,9 @@ registerMonsterType.attacks = function(mtype, mask)
 					if attack.attack and attack.skill then
 						spell:setAttackValue(attack.attack, attack.skill)
 					end
+					if attack.minDamage and attack.maxDamage then
+						spell:setCombatValue(attack.minDamage, attack.maxDamage)
+					end
 					if attack.interval then
 						spell:setInterval(attack.interval)
 					end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2849,6 +2849,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("MonsterSpell", "setCombatType", LuaScriptInterface::luaMonsterSpellSetCombatType);
 	registerMethod("MonsterSpell", "setAttackValue", LuaScriptInterface::luaMonsterSpellSetAttackValue);
 	registerMethod("MonsterSpell", "setNeedTarget", LuaScriptInterface::luaMonsterSpellSetNeedTarget);
+	registerMethod("MonsterSpell", "setNeedDirection", LuaScriptInterface::luaMonsterSpellSetNeedDirection);
 	registerMethod("MonsterSpell", "setCombatLength", LuaScriptInterface::luaMonsterSpellSetCombatLength);
 	registerMethod("MonsterSpell", "setCombatSpread", LuaScriptInterface::luaMonsterSpellSetCombatSpread);
 	registerMethod("MonsterSpell", "setCombatRadius", LuaScriptInterface::luaMonsterSpellSetCombatRadius);
@@ -13923,6 +13924,19 @@ int LuaScriptInterface::luaMonsterSpellSetNeedTarget(lua_State* L)
 	MonsterSpell* spell = getUserdata<MonsterSpell>(L, 1);
 	if (spell) {
 		spell->needTarget = getBoolean(L, 2);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterSpellSetNeedDirection(lua_State* L)
+{
+	// monsterSpell:setNeedDirection(bool)
+	MonsterSpell* spell = getUserdata<MonsterSpell>(L, 1);
+	if (spell) {
+		spell->needDirection = getBoolean(L, 2);
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2763,8 +2763,11 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("MonsterType", "canPushItems", LuaScriptInterface::luaMonsterTypeCanPushItems);
 	registerMethod("MonsterType", "canPushCreatures", LuaScriptInterface::luaMonsterTypeCanPushCreatures);
 
-	registerMethod("MonsterType", "name", LuaScriptInterface::luaMonsterTypeName);
+	registerMethod("MonsterType", "canWalkOnEnergy", LuaScriptInterface::luaMonsterTypeCanWalkOnEnergy);
+	registerMethod("MonsterType", "canWalkOnFire", LuaScriptInterface::luaMonsterTypeCanWalkOnFire);
+	registerMethod("MonsterType", "canWalkOnPoison", LuaScriptInterface::luaMonsterTypeCanWalkOnPoison);
 
+	registerMethod("MonsterType", "name", LuaScriptInterface::luaMonsterTypeName);
 	registerMethod("MonsterType", "nameDescription", LuaScriptInterface::luaMonsterTypeNameDescription);
 
 	registerMethod("MonsterType", "health", LuaScriptInterface::luaMonsterTypeHealth);
@@ -12832,6 +12835,57 @@ int LuaScriptInterface::luaMonsterTypeCanPushCreatures(lua_State* L)
 			pushBoolean(L, monsterType->info.canPushCreatures);
 		} else {
 			monsterType->info.canPushCreatures = getBoolean(L, 2);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterTypeCanWalkOnEnergy(lua_State* L)
+{
+	// get: monsterType:canWalkOnEnergy() set: monsterType:canWalkOnEnergy(bool)
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, monsterType->info.canWalkOnEnergy);
+		} else {
+			monsterType->info.canWalkOnEnergy = getBoolean(L, 2);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterTypeCanWalkOnFire(lua_State* L)
+{
+	// get: monsterType:canWalkOnFire() set: monsterType:canWalkOnFire(bool)
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, monsterType->info.canWalkOnFire);
+		} else {
+			monsterType->info.canWalkOnFire = getBoolean(L, 2);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterTypeCanWalkOnPoison(lua_State* L)
+{
+	// get: monsterType:canWalkOnPoison() set: monsterType:canWalkOnPoison(bool)
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		if (lua_gettop(L) == 1) {
+			pushBoolean(L, monsterType->info.canWalkOnPoison);
+		} else {
+			monsterType->info.canWalkOnPoison = getBoolean(L, 2);
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1265,6 +1265,10 @@ class LuaScriptInterface
 		static int luaMonsterTypeCanPushItems(lua_State* L);
 		static int luaMonsterTypeCanPushCreatures(lua_State* L);
 
+		static int luaMonsterTypeCanWalkOnEnergy(lua_State* L);
+		static int luaMonsterTypeCanWalkOnFire(lua_State* L);
+		static int luaMonsterTypeCanWalkOnPoison(lua_State* L);
+
 		static int luaMonsterTypeName(lua_State* L);
 		static int luaMonsterTypeNameDescription(lua_State* L);
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1342,6 +1342,7 @@ class LuaScriptInterface
 		static int luaMonsterSpellSetCombatType(lua_State* L);
 		static int luaMonsterSpellSetAttackValue(lua_State* L);
 		static int luaMonsterSpellSetNeedTarget(lua_State* L);
+		static int luaMonsterSpellSetNeedDirection(lua_State* L);
 		static int luaMonsterSpellSetCombatLength(lua_State* L);
 		static int luaMonsterSpellSetCombatSpread(lua_State* L);
 		static int luaMonsterSpellSetCombatRadius(lua_State* L);


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fix a couple issues with registering monsters via revscriptsys system

**Issues addressed:** <!-- Write here the issue number, if any. -->

- Couldn't set canWalkOnFIELD flags
- Couldn't set summonable flag
- Couldn't use min/max damage attribute for melee attacks, it was only possible to use attack/skill
- Couldn't set direction of attacks or defenses declared using scripts, this is possible in the XML interface
- Couldn't override the ingame creature name, the value/name used to register the monster is the monster name by default. The ability to override the name is necessary for creatures like "red butterfly" and "demon goblin"

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
