### PR TITLE
fix for huge lag caused by incorrect container and addItem 

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2652,20 +2652,15 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 			Container* tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
 				//we need to find first empty container as fast as we can for non-stackable items
-				uint32_t maxSlots = tmpContainer->capacity();
-				uint32_t takenSlots = tmpContainer->size();
-
-				if (takenSlots <= maxSlots) {
-					uint32_t n = maxSlots - takenSlots;
-					while (n) {
-						if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
-							index = tmpContainer->capacity() - n;
-							*destItem = nullptr;
-							return tmpContainer;
-						}
-
-						n--;
+				uint32_t n = tmpContainer->capacity() - std::min(tmpContainer->capacity(), static_cast<uint32_t>(tmpContainer->size()));
+				while (n) {
+					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
+						index = tmpContainer->capacity() - n;
+						*destItem = nullptr;
+						return tmpContainer;
 					}
+
+					--n;
 				}
 
 				for (Item* tmpContainerItem : tmpContainer->getItemList()) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2652,15 +2652,20 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 			Container* tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
 				//we need to find first empty container as fast as we can for non-stackable items
-				uint32_t n = tmpContainer->capacity() - tmpContainer->size();
-				while (n) {
-					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
-						index = tmpContainer->capacity() - n;
-						*destItem = nullptr;
-						return tmpContainer;
-					}
+				uint32_t maxSlots = tmpContainer->capacity();
+				uint32_t takenSlots = tmpContainer->size();
 
-					n--;
+				if (takenSlots <= maxSlots) {
+					uint32_t n = maxSlots - takenSlots;
+					while (n) {
+						if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
+							index = tmpContainer->capacity() - n;
+							*destItem = nullptr;
+							return tmpContainer;
+						}
+
+						n--;
+					}
 				}
 
 				for (Item* tmpContainerItem : tmpContainer->getItemList()) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
add a check in order to ignore jumping through overflown containers

This change unlags /i when you have overflown container in your inventory.

**Issues addressed:** #3225 (this time I'm using my own code 😅)

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
