### PR TITLE
Fix problem in forceMonsterTypesOnLoad

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -77,7 +77,7 @@ bool Monsters::loadFromXml(bool reloading /*= false*/)
 	bool forceLoad = g_config.getBoolean(ConfigManager::FORCE_MONSTERTYPE_LOAD);
 
 	for (auto it : unloadedMonsters) {
-		if (forceLoad || reloading && monsters.find(it.first) != monsters.end()) {
+		if ((forceLoad || reloading) && monsters.find(it.first) != monsters.end()) {
 			loadMonster(it.second, it.first, reloading);
 		}
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
I was having trouble with the countmax of the loot and noticed that #monsterType:getLoot() was always returning me the wrong value.

Example loot demon:
<item name="gold coin" countmax="30" chance="100000" />

### Current behavior:
Dropping more than 30 gold coins which is the maximum amount.

### Expected behavior:
Drop up to a maximum of 30 gold coins.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
