### PR TITLE
fix a bug with diagonal spells not having area

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1306,7 +1306,10 @@ const MatrixArea& AreaCombat::getArea(const Position& centerPos, const Position&
 void AreaCombat::setupArea(const std::vector<uint32_t>& vec, uint32_t rows)
 {
 	auto area = createArea(vec, rows);
-	areas.resize(4);
+	if (areas.size() == 0) {
+		areas.resize(4);
+	}
+
 	areas[DIRECTION_EAST] = area.rotate90();
 	areas[DIRECTION_SOUTH] = area.rotate180();
 	areas[DIRECTION_WEST] = area.rotate270();


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
add a check for vector size to prevent resizing back to 4 after ext area was set up

**Issues addressed:** Closes #3494

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide