### PR TITLE
RevScriptSys Monster enhanced attack conditions

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -277,32 +277,10 @@ function AbilityTableToSpell(ability)
 			if ability.effect then
 				spell:setCombatEffect(ability.effect)
 			end
-			if ability.condition then
-				if ability.condition.type then
-					spell:setConditionType(ability.condition.type)
-				end
-				local startDamage = 0
-				if ability.condition.startDamage then
-					startDamage = ability.condition.startDamage
-				end
-				if ability.condition.minDamage and ability.condition.maxDamage then
-					spell:setConditionDamage(ability.condition.minDamage, ability.condition.maxDamage, startDamage)
-				end
-				if ability.condition.duration then
-					spell:setConditionDuration(ability.condition.duration)
-				end
-				if ability.condition.interval then
-					spell:setConditionTickInterval(ability.condition.interval)
-				end
-			end
 		else
 			spell:setType(ability.name)
 			if ability.type then
-				if ability.name == "condition" then
-					spell:setConditionType(ability.type)
-				else
-					spell:setCombatType(ability.type)
-				end
+				spell:setCombatType(ability.type)
 			end
 			if ability.interval then
 				spell:setInterval(ability.interval)
@@ -341,15 +319,7 @@ function AbilityTableToSpell(ability)
 				spell:setCombatRing(ability.ring)
 			end
 			if ability.minDamage and ability.maxDamage then
-				if ability.name == "condition" then
-					local startDamage = 0
-					if ability.startDamage then
-						startDamage = ability.startDamage
-					end
-					spell:setConditionDamage(ability.minDamage, ability.maxDamage, startDamage)
-				else
-					spell:setCombatValue(ability.minDamage, ability.maxDamage)
-				end
+				spell:setCombatValue(ability.minDamage, ability.maxDamage)
 			end
 			if ability.effect then
 				spell:setCombatEffect(ability.effect)
@@ -362,6 +332,25 @@ function AbilityTableToSpell(ability)
 				if ability.drunkenness then
 					spell:setConditionDrunkenness(ability.drunkenness)
 				end
+			end
+		end
+		if ability.condition then
+			if ability.condition.type then
+				print(ability.condition.type)
+				spell:setConditionType(ability.condition.type)
+			end
+			local startDamage = 0
+			if ability.condition.startDamage then
+				startDamage = ability.condition.startDamage
+			end
+			if ability.condition.minDamage and ability.condition.maxDamage then
+				spell:setConditionDamage(ability.condition.minDamage, ability.condition.maxDamage, startDamage)
+			end
+			if ability.condition.duration then
+				spell:setConditionDuration(ability.condition.duration)
+			end
+			if ability.condition.interval then
+				spell:setConditionTickInterval(ability.condition.interval)
 			end
 		end
 	elseif ability.script then

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -260,7 +260,7 @@ registerMonsterType.immunities = function(mtype, mask)
 		end
 	end
 end
-function AbilityTableToSpell(ability)
+local function AbilityTableToSpell(ability)
 	local spell = MonsterSpell()
 	if ability.name then
 		if ability.name == "melee" then
@@ -336,7 +336,6 @@ function AbilityTableToSpell(ability)
 		end
 		if ability.condition then
 			if ability.condition.type then
-				print(ability.condition.type)
 				spell:setConditionType(ability.condition.type)
 			end
 			local startDamage = 0

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -260,130 +260,134 @@ registerMonsterType.immunities = function(mtype, mask)
 		end
 	end
 end
+function AbilityTableToSpell(ability)
+	local spell = MonsterSpell()
+	if ability.name then
+		if ability.name == "melee" then
+			spell:setType("melee")
+			if ability.attack and ability.skill then
+				spell:setAttackValue(ability.attack, ability.skill)
+			end
+			if ability.minDamage and ability.maxDamage then
+				spell:setCombatValue(ability.minDamage, ability.maxDamage)
+			end
+			if ability.interval then
+				spell:setInterval(ability.interval)
+			end
+			if ability.effect then
+				spell:setCombatEffect(ability.effect)
+			end
+			if ability.condition then
+				if ability.condition.type then
+					spell:setConditionType(ability.condition.type)
+				end
+				local startDamage = 0
+				if ability.condition.startDamage then
+					startDamage = ability.condition.startDamage
+				end
+				if ability.condition.minDamage and ability.condition.maxDamage then
+					spell:setConditionDamage(ability.condition.minDamage, ability.condition.maxDamage, startDamage)
+				end
+				if ability.condition.duration then
+					spell:setConditionDuration(ability.condition.duration)
+				end
+				if ability.condition.interval then
+					spell:setConditionTickInterval(ability.condition.interval)
+				end
+			end
+		else
+			spell:setType(ability.name)
+			if ability.type then
+				if ability.name == "condition" then
+					spell:setConditionType(ability.type)
+				else
+					spell:setCombatType(ability.type)
+				end
+			end
+			if ability.interval then
+				spell:setInterval(ability.interval)
+			end
+			if ability.chance then
+				spell:setChance(ability.chance)
+			end
+			if ability.range then
+				spell:setRange(ability.range)
+			end
+			if ability.duration then
+				spell:setConditionDuration(ability.duration)
+			end
+			if ability.speed then
+				if type(ability.speed) ~= "table" then
+					spell:setConditionSpeedChange(ability.speed)
+				elseif type(ability.speed) == "table" then
+					if ability.speed.min and ability.speed.max then
+						spell:setConditionSpeedChange(ability.speed.min, ability.speed.max)
+					end
+				end
+			end
+			if ability.target then
+				spell:setNeedTarget(ability.target)
+			end
+			if ability.length then
+				spell:setCombatLength(ability.length)
+			end
+			if ability.spread then
+				spell:setCombatSpread(ability.spread)
+			end
+			if ability.radius then
+				spell:setCombatRadius(ability.radius)
+			end
+			if ability.ring then
+				spell:setCombatRing(ability.ring)
+			end
+			if ability.minDamage and ability.maxDamage then
+				if ability.name == "condition" then
+					local startDamage = 0
+					if ability.startDamage then
+						startDamage = ability.startDamage
+					end
+					spell:setConditionDamage(ability.minDamage, ability.maxDamage, startDamage)
+				else
+					spell:setCombatValue(ability.minDamage, ability.maxDamage)
+				end
+			end
+			if ability.effect then
+				spell:setCombatEffect(ability.effect)
+			end
+			if ability.shootEffect then
+				spell:setCombatShootEffect(ability.shootEffect)
+			end
+			if ability.name == "drunk" then
+				spell:setConditionType(CONDITION_DRUNK)
+				if ability.drunkenness then
+					spell:setConditionDrunkenness(ability.drunkenness)
+				end
+			end
+		end
+	elseif ability.script then
+		spell:setScriptName(ability.script)
+		if ability.interval then
+			spell:setInterval(ability.interval)
+		end
+		if ability.chance then
+			spell:setChance(ability.chance)
+		end
+		if ability.minDamage and ability.maxDamage then
+			spell:setCombatValue(ability.minDamage, ability.maxDamage)
+		end
+		if ability.target then
+			spell:setNeedTarget(ability.target)
+		end
+		if ability.direction then
+			spell:setNeedDirection(ability.direction)
+		end
+	end
+	return spell
+end
 registerMonsterType.attacks = function(mtype, mask)
 	if type(mask.attacks) == "table" then
 		for _, attack in pairs(mask.attacks) do
-			local spell = MonsterSpell()
-			if attack.name then
-				if attack.name == "melee" then
-					spell:setType("melee")
-					if attack.attack and attack.skill then
-						spell:setAttackValue(attack.attack, attack.skill)
-					end
-					if attack.minDamage and attack.maxDamage then
-						spell:setCombatValue(attack.minDamage, attack.maxDamage)
-					end
-					if attack.interval then
-						spell:setInterval(attack.interval)
-					end
-					if attack.effect then
-						spell:setCombatEffect(attack.effect)
-					end
-					if attack.condition then
-						if attack.condition.type then
-							spell:setConditionType(attack.condition.type)
-						end
-						local startDamage = 0
-						if attack.condition.startDamage then
-							startDamage = attack.condition.startDamage
-						end
-						if attack.condition.minDamage and attack.condition.maxDamage then
-							spell:setConditionDamage(attack.condition.minDamage, attack.condition.maxDamage, startDamage)
-						end
-						if attack.condition.duration then
-							spell:setConditionDuration(attack.condition.duration)
-						end
-						if attack.condition.interval then
-							spell:setConditionTickInterval(attack.condition.interval)
-						end
-					end
-				else
-					spell:setType(attack.name)
-					if attack.type then
-						if attack.name == "combat" then
-							spell:setCombatType(attack.type)
-						else
-							spell:setConditionType(attack.type)
-						end
-					end
-					if attack.interval then
-						spell:setInterval(attack.interval)
-					end
-					if attack.chance then
-						spell:setChance(attack.chance)
-					end
-					if attack.range then
-						spell:setRange(attack.range)
-					end
-					if attack.duration then
-						spell:setConditionDuration(attack.duration)
-					end
-					if attack.speed then
-						if type(attack.speed) ~= "table" then
-							spell:setConditionSpeedChange(attack.speed)
-						elseif type(attack.speed) == "table" then
-							if attack.speed.min and attack.speed.max then
-								spell:setConditionSpeedChange(attack.speed.min, attack.speed.max)
-							end
-						end
-					end
-					if attack.target then
-						spell:setNeedTarget(attack.target)
-					end
-					if attack.length then
-						spell:setCombatLength(attack.length)
-					end
-					if attack.spread then
-						spell:setCombatSpread(attack.spread)
-					end
-					if attack.radius then
-						spell:setCombatRadius(attack.radius)
-					end
-					if attack.ring then
-						spell:setCombatRing(attack.ring)
-					end
-					if attack.minDamage and attack.maxDamage then
-						if attack.name == "combat" then
-							spell:setCombatValue(attack.minDamage, attack.maxDamage)
-						else
-							local startDamage = 0
-							if attack.startDamage then
-								startDamage = attack.startDamage
-							end
-							spell:setConditionDamage(attack.minDamage, attack.maxDamage, startDamage)
-						end
-					end
-					if attack.effect then
-						spell:setCombatEffect(attack.effect)
-					end
-					if attack.shootEffect then
-						spell:setCombatShootEffect(attack.shootEffect)
-					end
-					if attack.name == "drunk" then
-						spell:setConditionType(CONDITION_DRUNK)
-						if attack.drunkenness then
-							spell:setConditionDrunkenness(attack.drunkenness)
-						end
-					end
-				end
-			elseif attack.script then
-				spell:setScriptName(attack.script)
-				if attack.interval then
-					spell:setInterval(attack.interval)
-				end
-				if attack.chance then
-					spell:setChance(attack.chance)
-				end
-				if attack.minDamage and attack.maxDamage then
-					spell:setCombatValue(attack.minDamage, attack.maxDamage)
-				end
-				if attack.target then
-					spell:setNeedTarget(attack.target)
-				end
-				if attack.direction then
-					spell:setNeedDirection(attack.direction)
-				end
-			end
+			local spell = AbilityTableToSpell(attack)
 			mtype:addAttack(spell)
 		end
 	end
@@ -398,121 +402,7 @@ registerMonsterType.defenses = function(mtype, mask)
 		end
 		for _, defense in pairs(mask.defenses) do
 			if type(defense) == "table" then
-				local spell = MonsterSpell()
-				if defense.name then
-					if defense.name == "melee" then
-						spell:setType("melee")
-						if defense.attack and defense.skill then
-							spell:setAttackValue(defense.attack, defense.skill)
-						end
-						if defense.minDamage and defense.maxDamage then
-							spell:setCombatValue(defense.minDamage, defense.maxDamage)
-						end
-						if defense.interval then
-							spell:setInterval(defense.interval)
-						end
-						if defense.effect then
-							spell:setCombatEffect(defense.effect)
-						end
-						if defense.condition then
-							if defense.condition.type then
-								spell:setConditionType(defense.condition.type)
-							end
-							local startDamage = 0
-							if defense.condition.startDamage then
-								startDamage = defense.condition.startDamage
-							end
-							if defense.condition.minDamage and defense.condition.maxDamage then
-								spell:setConditionDamage(defense.condition.minDamage, defense.condition.maxDamage, startDamage)
-							end
-							if defense.condition.duration then
-								spell:setConditionDuration(defense.condition.duration)
-							end
-							if defense.condition.interval then
-								spell:setConditionTickInterval(defense.condition.interval)
-							end
-						end
-					else
-						spell:setType(defense.name)
-						if defense.type then
-							if defense.name == "combat" then
-								spell:setCombatType(defense.type)
-							else
-								spell:setConditionType(defense.type)
-							end
-						end
-						if defense.interval then
-							spell:setInterval(defense.interval)
-						end
-						if defense.chance then
-							spell:setChance(defense.chance)
-						end
-						if defense.range then
-							spell:setRange(defense.range)
-						end
-						if defense.duration then
-							spell:setConditionDuration(defense.duration)
-						end
-						if defense.speed then
-							if type(defense.speed) ~= "table" then
-								spell:setConditionSpeedChange(defense.speed)
-							elseif type(defense.speed) == "table" then
-								if defense.speed.min and defense.speed.max then
-									spell:setConditionSpeedChange(defense.speed.min, defense.speed.max)
-								end
-							end
-						end
-						if defense.target then
-							spell:setNeedTarget(defense.target)
-						end
-						if defense.length then
-							spell:setCombatLength(defense.length)
-						end
-						if defense.spread then
-							spell:setCombatSpread(defense.spread)
-						end
-						if defense.radius then
-							spell:setCombatRadius(defense.radius)
-						end
-						if defense.ring then
-							spell:setCombatRing(defense.ring)
-						end
-						if defense.minDamage and defense.maxDamage then
-							if defense.name == "combat" then
-								spell:setCombatValue(defense.minDamage, defense.maxDamage)
-							else
-								local startDamage = 0
-								if defense.startDamage then
-									startDamage = defense.startDamage
-								end
-								spell:setConditionDamage(defense.minDamage, defense.maxDamage, startDamage)
-							end
-						end
-						if defense.effect then
-							spell:setCombatEffect(defense.effect)
-						end
-						if defense.shootEffect then
-							spell:setCombatShootEffect(defense.shootEffect)
-						end
-					end
-				elseif defense.script then
-					spell:setScriptName(defense.script)
-					if defense.interval then
-						spell:setInterval(defense.interval)
-					end
-					if defense.chance then
-						spell:setChance(defense.chance)
-					end
-					if defense.minDamage and defense.maxDamage then
-						spell:setCombatValue(defense.minDamage, defense.maxDamage)
-					end
-					if defense.target then
-						spell:setNeedTarget(defense.target)
-					end
-					if defense.direction then
-						spell:setNeedDirection(defense.direction)
-					end
-				end
+				local spell = AbilityTableToSpell(defense)
 				mtype:addDefense(spell)
 			end
 		end

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -634,15 +634,16 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			if (spell->conditionType != CONDITION_NONE) {
 				ConditionType_t conditionType = spell->conditionType;
 
-				int32_t minDamage = spell->conditionMinDamage;
-				int32_t maxDamage = minDamage;
-
 				uint32_t tickInterval = 2000;
 				if (spell->tickInterval != 0) {
 					tickInterval = spell->tickInterval;
 				}
 
-				Condition* condition = getDamageCondition(conditionType, maxDamage, minDamage, spell->conditionStartDamage, tickInterval);
+				int32_t conMinDamage = std::abs(spell->conditionMinDamage);
+				int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
+				int32_t startDamage = std::abs(spell->conditionStartDamage);
+
+				Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
 				combat->addCondition(condition);
 			}
 
@@ -655,6 +656,22 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			if (spell->combatType == COMBAT_UNDEFINEDDAMAGE) {
 				std::cout << "[Warning - Monsters::deserializeSpell] - " << description << " - spell has undefined damage" << std::endl;
 				combat->setParam(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE);
+			}
+
+			if (spell->conditionType != CONDITION_NONE) {
+				ConditionType_t conditionType = spell->conditionType;
+
+				uint32_t tickInterval = 2000;
+				if (spell->tickInterval != 0) {
+					tickInterval = spell->tickInterval;
+				}
+
+				int32_t conMinDamage = std::abs(spell->conditionMinDamage);
+				int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
+				int32_t startDamage = std::abs(spell->conditionStartDamage);
+
+				Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
+				combat->addCondition(condition);
 			}
 
 			if (spell->combatType == COMBAT_PHYSICALDAMAGE) {
@@ -745,31 +762,22 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 		} else if (tmpName == "energyfield") {
 			combat->setParam(COMBAT_PARAM_CREATEITEM, ITEM_ENERGYFIELD_PVP);
 		} else if (tmpName == "condition") {
-			uint32_t tickInterval = 2000;
-
 			if (spell->conditionType == CONDITION_NONE) {
 				std::cout << "[Error - Monsters::deserializeSpell] - " << description << " - Condition is not set for: " << spell->name << std::endl;
 			}
 
+			ConditionType_t conditionType = spell->conditionType;
+
+			uint32_t tickInterval = 2000;
 			if (spell->tickInterval != 0) {
-				int32_t value = spell->tickInterval;
-				if (value > 0) {
-					tickInterval = value;
-				}
+				tickInterval = spell->tickInterval;
 			}
 
-			int32_t minDamage = std::abs(spell->conditionMinDamage);
-			int32_t maxDamage = std::abs(spell->conditionMaxDamage);
-			int32_t startDamage = 0;
+			int32_t conMinDamage = std::abs(spell->conditionMinDamage);
+			int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
+			int32_t startDamage = std::abs(spell->conditionStartDamage);
 
-			if (spell->conditionStartDamage != 0) {
-				int32_t value = std::abs(spell->conditionStartDamage);
-				if (value <= minDamage) {
-					startDamage = value;
-				}
-			}
-
-			Condition* condition = getDamageCondition(spell->conditionType, maxDamage, minDamage, startDamage, tickInterval);
+			Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
 			combat->addCondition(condition);
 		} else if (tmpName == "strength") {
 			//

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -621,6 +621,22 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			combat->setArea(area);
 		}
 
+		if (spell->conditionType != CONDITION_NONE) {
+			ConditionType_t conditionType = spell->conditionType;
+
+			uint32_t tickInterval = 2000;
+			if (spell->tickInterval != 0) {
+				tickInterval = spell->tickInterval;
+			}
+
+			int32_t conMinDamage = std::abs(spell->conditionMinDamage);
+			int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
+			int32_t startDamage = std::abs(spell->conditionStartDamage);
+
+			Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
+			combat->addCondition(condition);
+		}
+
 		std::string tmpName = asLowerCaseString(spell->name);
 
 		if (tmpName == "melee") {
@@ -629,22 +645,6 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			if (spell->attack > 0 && spell->skill > 0) {
 				sb.minCombatValue = 0;
 				sb.maxCombatValue = -Weapons::getMaxMeleeDamage(spell->skill, spell->attack);
-			}
-
-			if (spell->conditionType != CONDITION_NONE) {
-				ConditionType_t conditionType = spell->conditionType;
-
-				uint32_t tickInterval = 2000;
-				if (spell->tickInterval != 0) {
-					tickInterval = spell->tickInterval;
-				}
-
-				int32_t conMinDamage = std::abs(spell->conditionMinDamage);
-				int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
-				int32_t startDamage = std::abs(spell->conditionStartDamage);
-
-				Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
-				combat->addCondition(condition);
 			}
 
 			sb.range = 1;
@@ -656,22 +656,6 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			if (spell->combatType == COMBAT_UNDEFINEDDAMAGE) {
 				std::cout << "[Warning - Monsters::deserializeSpell] - " << description << " - spell has undefined damage" << std::endl;
 				combat->setParam(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE);
-			}
-
-			if (spell->conditionType != CONDITION_NONE) {
-				ConditionType_t conditionType = spell->conditionType;
-
-				uint32_t tickInterval = 2000;
-				if (spell->tickInterval != 0) {
-					tickInterval = spell->tickInterval;
-				}
-
-				int32_t conMinDamage = std::abs(spell->conditionMinDamage);
-				int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
-				int32_t startDamage = std::abs(spell->conditionStartDamage);
-
-				Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
-				combat->addCondition(condition);
 			}
 
 			if (spell->combatType == COMBAT_PHYSICALDAMAGE) {
@@ -765,20 +749,6 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			if (spell->conditionType == CONDITION_NONE) {
 				std::cout << "[Error - Monsters::deserializeSpell] - " << description << " - Condition is not set for: " << spell->name << std::endl;
 			}
-
-			ConditionType_t conditionType = spell->conditionType;
-
-			uint32_t tickInterval = 2000;
-			if (spell->tickInterval != 0) {
-				tickInterval = spell->tickInterval;
-			}
-
-			int32_t conMinDamage = std::abs(spell->conditionMinDamage);
-			int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
-			int32_t startDamage = std::abs(spell->conditionStartDamage);
-
-			Condition* condition = getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
-			combat->addCondition(condition);
 		} else if (tmpName == "strength") {
 			//
 		} else if (tmpName == "effect") {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
**Issues addressed:** <!-- Write here the issue number, if any. -->

- Fix #3485 
- Refactor parsing revscriptsys monster attack and defense to use a common helper function
- Allow conditions to be used with all predefine creature abilities. Conditions can be used with "melee", "combat", "speed", "condition", "outfit", "invisible", "*field", etc.. Conditions won't work with named spells such as "energy strike".


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

I verified conditions worked using these attack types. 
```
monster.attacks = {
	{name = "melee", attack = 10, skill = 100, condition = { type = CONDITION_FIRE, minDamage = 50, maxDamage = 200, duration = 5000, interval = 1000}},
        {name = "condition", chance = 1000, range = 1, condition = { type = CONDITION_ENERGY, minDamage = 10, maxDamage = 20, duration = 5000, interval = 1000}},
        {name = "combat", type = COMBAT_LIFEDRAIN, chance = 100, interval = 2*1000, minDamage = 0, maxDamage = -10, target = true, range = 7, condition = { type = CONDITION_CURSED, minDamage = 10, maxDamage = 20, duration = 5000, interval = 1000}},
        {name = "speed", chance = 100, interval = 2000, speed = -500, target = true, range = 7, condition = { type = CONDITION_DROWN, minDamage = 20, maxDamage = 20, duration = 5000, interval = 1000}},
        {name = "firefield", chance = 100, interval = 2000, target = true, range = 7, condition = { type = CONDITION_FREEZING, minDamage = 20, maxDamage = 50, duration = 5000, interval = 1000}}
}
```
