### PR TITLE
Update fluids.lua

### DIFF
--- a/data/actions/scripts/other/fluids.lua
+++ b/data/actions/scripts/other/fluids.lua
@@ -33,8 +33,8 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 			item:transform(item:getId(), 0)
 			return true
 		elseif target.type ~= 0 and item.type == 0 then
-			target:transform(target:getId(), 0)
 			item:transform(item:getId(), target.type)
+			target:transform(target:getId(), 0)
 			return true
 		end
 	end


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
change order between 2 lines of code

### Issue addressed
Using an empty fluid container on a filled container would make them both empty containers.
The script should copy the fluid type from the target container before transforming the target container to en empty one.
It was doing the reverse: transforming an empty one, then copying no fluid type
