### PR TITLE
fix case mismatch in gs_wyda_death.lua

### DIFF
--- a/data/scripts/creaturescripts/gs_wyda_death.lua
+++ b/data/scripts/creaturescripts/gs_wyda_death.lua
@@ -2,8 +2,8 @@ local creatureevent = CreatureEvent("GiantSpiderWyda")
 
 function creatureevent.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUnjustified, mostDamageUnjustified)
 	creature:say("It seems this was just an illusion.", TALKTYPE_MONSTER_SAY)
-	if mostdamagekiller:isPlayer() then
-		mostdamagekiller:addAchievement("Someone's Bored")
+	if mostDamageKiller:isPlayer() then
+		mostDamageKiller:addAchievement("Someone's Bored")
 	end
 	return true
 end


### PR DESCRIPTION
**PR solves this:** the script is unable to get `mostDamageKiller` due to variables being case sensitive