### PR TITLE
Restructure vcpkg jobs

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -200,3 +200,4 @@ jobs:
         with:
           name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=on-${{ github.sha }}
           path: ${{ github.workspace }}
+

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -21,25 +21,17 @@ on:
       - CMakeLists.txt
 
 jobs:
-  job:
+  unix:
     name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       max-parallel: 8
       matrix:
-        name: [ubuntu-gcc, ubuntu-clang, macos-clang, windows-msvc]
+        name: [ubuntu-gcc, ubuntu-clang, macos-clang]
         buildtype: [Debug, Release]
         luajit: [on, off]
         include:
-          - name: windows-msvc
-            os: windows
-            cxx: cl.exe
-            cc: cl.exe
-            triplet: x64-windows
-            packages: >
-              boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
-              lua luajit libmariadb pugixml cryptopp fmt
           - name: ubuntu-gcc
             os: ubuntu
             cxx: g++
@@ -87,10 +79,6 @@ jobs:
         run: brew install luajit pkgconfig
         if: contains( matrix.os, 'macos')
 
-      - name: Windows - remove C:/mysql*
-        run: rm -r -fo C:/mysql-5.7.21-winx64
-        if: contains( matrix.os, 'windows')
-
       - name: Set Environment vars
         run: |
           echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
@@ -122,6 +110,77 @@ jobs:
           name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ runner.workspace }}/build/tfs
         if: "! contains( matrix.os, 'windows')"
+
+      - name: Prepare datapack contents
+        run: find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
+        shell: bash
+
+      - name: Upload datapack contents
+        uses: actions/upload-artifact@v2
+        with:
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          path: ${{ github.workspace }}
+
+  windows:
+    name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        name: [windows-msvc]
+        buildtype: [Debug, Release]
+        luajit: [on]
+        include:
+          - name: windows-msvc
+            os: windows
+            cxx: cl.exe
+            cc: cl.exe
+            triplet: x64-windows
+            packages: >
+              boost-asio boost-iostreams boost-system boost-filesystem boost-variant boost-lockfree
+              lua luajit libmariadb pugixml cryptopp fmt
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Get latest CMake
+        # Using 'latest' branch, the latest CMake is installed.
+        uses: lukka/get-cmake@latest
+
+      - name: Windows - remove C:/mysql*
+        run: rm -r -fo C:/mysql-5.7.21-winx64
+        if: contains( matrix.os, 'windows')
+
+      - name: Set Environment vars
+        run: |
+          echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
+          echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV
+
+      - name: Run vcpkg
+        uses: lukka/run-vcpkg@main
+        with:
+          vcpkgArguments: ${{ matrix.packages }}
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
+          vcpkgTriplet: ${{ matrix.triplet }}
+          vcpkgGitCommitId: 5568f110b509a9fd90711978a7cb76bae75bb092
+
+      - name: Build with CMake
+        uses: lukka/run-cmake@main
+        with:
+          useVcpkgToolchainFile: true
+          buildDirectory: ${{ runner.workspace }}/build
+          cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+          cmakeAppendedArgs: '-G Ninja -DCMAKE_BUILD_TYPE="${{ matrix.buildtype }}" -DUSE_LUAJIT="${{ matrix.luajit }}"'
+
+      - name: dir
+        run: find $RUNNER_WORKSPACE
+        shell: bash
 
       - name: Upload artifact binary (exe)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -109,7 +109,6 @@ jobs:
         with:
           name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ runner.workspace }}/build/tfs
-        if: "! contains( matrix.os, 'windows')"
 
       - name: Prepare datapack contents
         run: find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
@@ -122,7 +121,7 @@ jobs:
           path: ${{ github.workspace }}
 
   windows:
-    name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
+    name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}-luajit=on
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -130,7 +129,6 @@ jobs:
       matrix:
         name: [windows-msvc]
         buildtype: [Debug, Release]
-        luajit: [on]
         include:
           - name: windows-msvc
             os: windows
@@ -155,7 +153,6 @@ jobs:
 
       - name: Windows - remove C:/mysql*
         run: rm -r -fo C:/mysql-5.7.21-winx64
-        if: contains( matrix.os, 'windows')
 
       - name: Set Environment vars
         run: |
@@ -176,7 +173,7 @@ jobs:
           useVcpkgToolchainFile: true
           buildDirectory: ${{ runner.workspace }}/build
           cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
-          cmakeAppendedArgs: '-G Ninja -DCMAKE_BUILD_TYPE="${{ matrix.buildtype }}" -DUSE_LUAJIT="${{ matrix.luajit }}"'
+          cmakeAppendedArgs: '-G Ninja -DCMAKE_BUILD_TYPE="${{ matrix.buildtype }}" -DUSE_LUAJIT="on"'
 
       - name: dir
         run: find $RUNNER_WORKSPACE
@@ -185,16 +182,14 @@ jobs:
       - name: Upload artifact binary (exe)
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=on-${{ github.sha }}
           path: ${{ runner.workspace }}/build/tfs.exe
-        if: contains( matrix.os, 'windows')
 
       - name: Upload artifact binary (dlls)
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=on-${{ github.sha }}
           path: ${{ runner.workspace }}/build/*.dll
-        if: contains( matrix.os, 'windows')
 
       - name: Prepare datapack contents
         run: find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
@@ -203,5 +198,5 @@ jobs:
       - name: Upload datapack contents
         uses: actions/upload-artifact@v2
         with:
-          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tfs-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=on-${{ github.sha }}
           path: ${{ github.workspace }}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Restructure vcpkg github action
Instead of having a consolidated job for both unix and windows, keep them as separate jobs. 

<!-- Describe the changes that this pull request makes. -->
Changed from one consolidated job into two separate jobs.
One job `unix` for ubuntu and macos
One job `windows` for windows

Removed luajit=off from windows job

**Issues addressed:** <!-- Write here the issue number, if any. -->
Omitted the two failing windows jobs. (related to luajit=off). 
Two windows compile actions are already working, for debug and release, I also tested the compiling tutorial in the wiki with a success. I don't think the two failing actions are of any value to us, and is just annoying. Especially since nobody seems to care about fixing them. (I have no idea how to fix them). 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

<https://github.com/Znote/forgottenserver/actions/runs/1073447752>
![image](https://user-images.githubusercontent.com/1552144/127264568-ed58a25f-c027-4cee-bfcc-3485fe223de2.png)
