### PR TITLE
Make removeCondition support userdata

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2725,7 +2725,6 @@ void LuaScriptInterface::registerFunctions()
 	registerClass("Condition", "", LuaScriptInterface::luaConditionCreate);
 	registerMetaMethod("Condition", "__eq", LuaScriptInterface::luaUserdataCompare);
 	registerMetaMethod("Condition", "__gc", LuaScriptInterface::luaConditionDelete);
-	registerMethod("Condition", "delete", LuaScriptInterface::luaConditionDelete);
 
 	registerMethod("Condition", "getId", LuaScriptInterface::luaConditionGetId);
 	registerMethod("Condition", "getSubId", LuaScriptInterface::luaConditionGetSubId);
@@ -7714,17 +7713,23 @@ int LuaScriptInterface::luaCreatureAddCondition(lua_State* L)
 
 int LuaScriptInterface::luaCreatureRemoveCondition(lua_State* L)
 {
-	// creature:removeCondition(conditionType[, conditionId = CONDITIONID_COMBAT[, subId = 0[, force = false]]])
+	// creature:removeCondition(conditionType or condition[, conditionId = CONDITIONID_COMBAT[, subId = 0[, force = false]]])
 	Creature* creature = getUserdata<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
+	
+	Condition* condition = nullptr;
+	if (isUserdata(L, 2)) {
+		condition = getUserdata<Condition>(L, 2);
+	} else {
+		ConditionType_t conditionType = getNumber<ConditionType_t>(L, 2);
+		ConditionId_t conditionId = getNumber<ConditionId_t>(L, 3, CONDITIONID_COMBAT);
+		uint32_t subId = getNumber<uint32_t>(L, 4, 0);
+		condition = creature->getCondition(conditionType, conditionId, subId);
+	}
 
-	ConditionType_t conditionType = getNumber<ConditionType_t>(L, 2);
-	ConditionId_t conditionId = getNumber<ConditionId_t>(L, 3, CONDITIONID_COMBAT);
-	uint32_t subId = getNumber<uint32_t>(L, 4, 0);
-	Condition* condition = creature->getCondition(conditionType, conditionId, subId);
 	if (condition) {
 		bool force = getBoolean(L, 5, false);
 		creature->removeCondition(condition, force);


### PR DESCRIPTION
This pr makes the creature:removeCondition being able to take condition userdata as the first parameter.
Additionaly it hides condition:delete from lua, because calling this on added condition to creature produces a crash.
condition:delete isn't really needed as __gc will collect our conditions anyway.