### PR TITLE
Increase count limit to max safe integer

### DIFF
--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -100,13 +100,16 @@ function doPlayerBuyItemContainer(cid, containerid, itemid, count, cost, charges
 	return true
 end
 
+-- maximum representable value without precision loss, 53 bits mantissa from IEEE754
+local MAX_SAFE_INTEGER = 2 ^ 53 - 1
+
 function getCount(string)
 	local b, e = string:find("%d+")
 	local tonumber = tonumber(string:sub(b, e))
-	if tonumber > 2 ^ 32 - 1 then
-		print("Warning: Casting value to 32bit to prevent crash\n"..debug.traceback())
+	if tonumber > MAX_SAFE_INTEGER then
+		print("Warning: clamping value to "..MAX_SAFE_INTEGER.." to prevent crash\n"..debug.traceback())
 	end
-	return b and e and math.min(2 ^ 32 - 1, tonumber) or -1
+	return b and e and math.min(MAX_SAFE_INTEGER, tonumber) or -1
 end
 
 function Player.getTotalMoney(self)
@@ -120,10 +123,10 @@ end
 function getMoneyCount(string)
 	local b, e = string:find("%d+")
 	local tonumber = tonumber(string:sub(b, e))
-	if tonumber > 2 ^ 32 - 1 then
-		print("Warning: Casting value to 32bit to prevent crash\n"..debug.traceback())
+	if tonumber > MAX_SAFE_INTEGER then
+		print("Warning: clamping value to "..MAX_SAFE_INTEGER.." to prevent crash\n"..debug.traceback())
 	end
-	local money = b and e and math.min(2 ^ 32 - 1, tonumber) or -1
+	local money = b and e and math.min(MAX_SAFE_INTEGER, tonumber) or -1
 	if isValidMoney(money) then
 		return money
 	end


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
The limit is actually the 52 bits of the mantissa, not only 32 bits, due to how Lua represents numbers (IEEE 754 floating point, with 53 bits of mantissa)

After 2 ^ 53, the numbers don't progress with precision:

```lua
> print(string.format("%18.0f", math.pow(2, 53) - 1))
  9007199254740991
> print(string.format("%18.0f", math.pow(2, 53)))
  9007199254740992
> print(string.format("%18.0f", math.pow(2, 53) + 1))
  9007199254740992
> print(string.format("%18.0f", math.pow(2, 53) + 2))
  9007199254740994
> print(string.format("%18.0f", math.pow(2, 53) + 3))
  9007199254740996
```

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
