### PR TITLE
Fix saving account storages

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4471,7 +4471,7 @@ bool Game::saveAccountStorageValues() const
 
 	for (const auto& accountIt : g_game.accountStorageMap) {
 		if (accountIt.second.empty()) {
-			break;
+			continue;
 		}
 
 		DBInsert accountStorageQuery("INSERT INTO `account_storage` (`account_id`, `key`, `value`) VALUES");


### PR DESCRIPTION
Break breaks the loop, so it cancels the save for all accounts, it should be continue for empty storages.