### PR TITLE
Use bitset instead of converting u8 to bitset

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -716,7 +716,7 @@ bool IOLoginData::savePlayer(Player* player)
 	if (!player->isOffline()) {
 		query << "`onlinetime` = `onlinetime` + " << (time(nullptr) - player->lastLoginSaved) << ',';
 	}
-	query << "`blessings` = " << static_cast<uint32_t>(player->blessings);
+	query << "`blessings` = " << static_cast<uint32_t>(player->blessings.to_ulong());
 	query << " WHERE `id` = " << player->getGUID();
 
 	DBTransaction transaction;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -716,7 +716,7 @@ bool IOLoginData::savePlayer(Player* player)
 	if (!player->isOffline()) {
 		query << "`onlinetime` = `onlinetime` + " << (time(nullptr) - player->lastLoginSaved) << ',';
 	}
-	query << "`blessings` = " << static_cast<uint32_t>(player->blessings.to_ulong());
+	query << "`blessings` = " << player->blessings.to_ulong();
 	query << " WHERE `id` = " << player->getGUID();
 
 	DBTransaction transaction;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -19,8 +19,6 @@
 
 #include "otpch.h"
 
-#include <bitset>
-
 #include "bed.h"
 #include "chat.h"
 #include "combat.h"
@@ -2017,16 +2015,15 @@ void Player::death(Creature* lastHitCreature)
 			}
 		}
 
-		std::bitset<6> bitset(blessings);
-		if (bitset[5]) {
+		if (blessings.test(5)) {
 			if (lastHitPlayer) {
-				bitset.reset(5);
-				blessings = bitset.to_ulong();
+				blessings.reset(5);
 			} else {
-				blessings = 32;
+				blessings.reset();
+				blessings.set(5);
 			}
 		} else {
-			blessings = 0;
+			blessings.reset();
 		}
 
 		sendStats();
@@ -3904,15 +3901,13 @@ bool Player::isPromoted() const
 
 double Player::getLostPercent() const
 {
-	int32_t blessingCount = std::bitset<5>(blessings).count();
-
 	int32_t deathLosePercent = g_config.getNumber(ConfigManager::DEATH_LOSE_PERCENT);
 	if (deathLosePercent != -1) {
 		if (isPromoted()) {
 			deathLosePercent -= 3;
 		}
 
-		deathLosePercent -= blessingCount;
+		deathLosePercent -= blessings.count();
 		return std::max<int32_t>(0, deathLosePercent) / 100.;
 	}
 
@@ -3928,7 +3923,7 @@ double Player::getLostPercent() const
 	if (isPromoted()) {
 		percentReduction += 30;
 	}
-	percentReduction += blessingCount * 8;
+	percentReduction += blessings.count() * 8;
 	return lossPercent * (1 - (percentReduction / 100.)) / 100.;
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -38,6 +38,8 @@
 #include "mounts.h"
 #include "storeinbox.h"
 
+#include <bitset>
+
 class House;
 class NetworkMessage;
 class Weapon;
@@ -314,13 +316,13 @@ class Player final : public Creature, public Cylinder
 		}
 
 		void addBlessing(uint8_t blessing) {
-			blessings |= blessing;
+			blessings.set(blessing);
 		}
 		void removeBlessing(uint8_t blessing) {
-			blessings &= ~blessing;
+			blessings.reset(blessing);
 		}
-		bool hasBlessing(uint8_t value) const {
-			return (blessings & (static_cast<uint8_t>(1) << value)) != 0;
+		bool hasBlessing(uint8_t blessing) const {
+			return blessings.test(blessing);
 		}
 
 		bool isOffline() const {
@@ -1296,7 +1298,7 @@ class Player final : public Creature, public Cylinder
 		int16_t lastDepotId = -1;
 
 		uint8_t soul = 0;
-		uint8_t blessings = 0;
+		std::bitset<6> blessings;
 		uint8_t levelPercent = 0;
 		uint8_t magLevelPercent = 0;
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Not sure why we are converting to bitset each time we want to use blessings somewhere, so I changed occurences to bitset, so we work directly on the variable from player class

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


I have not tested these changes, so I would appreciate if someone could do that.