### PR TITLE
Drop loot when creature kills other creature

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1107,7 +1107,6 @@ void Monster::pushCreatures(Tile* tile)
 				}
 
 				monster->changeHealth(-monster->getHealth());
-				monster->setDropLoot(false);
 				removeCount++;
 			}
 


### PR DESCRIPTION
Probably fix #1918
Right now creature will kill if there is no space, if there is it will get pushed.
If you know correct behaviour let me know.