### PR TITLE
make death screen optional (WIP)

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -722,7 +722,7 @@ void Creature::onDeath()
 		setMaster(nullptr);
 	}
 
-	if (droppedCorpse) {
+	if (droppedCorpse && this->getPlayer() == nullptr) {
 		g_game.removeCreature(this, false);
 	}
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- remove death screen (to do: make it toggleable)
- rewire everything so it works without destroying the references
- TO DO: move to lua everything that doesn't need to be hardcoded
- TO DO: add enableDeathScreen (bool) to config.lua and restore the legacy death screen when enabled

**Issues addressed:**
#3535

Current status of the PR:
- you don't get disconnected on death anymore
- the death window doesn't show up
- everything else should be working as usual. If it doesn't, report it here

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
