### PR TITLE
Fix const/ref usage on get ID ranges for actions

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -61,8 +61,8 @@ class Action : public Event
 			checkFloor = v;
 		}
 
-		std::vector<uint16_t>& getItemIdRange() {
-			return ids;
+		void clearItemIdRange() {
+			return ids.clear();
 		}
 		const std::vector<uint16_t>& getItemIdRange() const {
 			return ids;
@@ -71,8 +71,8 @@ class Action : public Event
 			ids.emplace_back(id);
 		}
 
-		std::vector<uint16_t>& getUniqueIdRange() {
-			return uids;
+		void clearUniqueIdRange() {
+			return uids.clear();
 		}
 		const std::vector<uint16_t>& getUniqueIdRange() const {
 			return uids;
@@ -81,8 +81,8 @@ class Action : public Event
 			uids.emplace_back(id);
 		}
 
-		std::vector<uint16_t>& getActionIdRange() {
-			return aids;
+		void clearActionIdRange() {
+			return aids.clear();
 		}
 		const std::vector<uint16_t>& getActionIdRange() const {
 			return aids;

--- a/src/actions.h
+++ b/src/actions.h
@@ -61,21 +61,30 @@ class Action : public Event
 			checkFloor = v;
 		}
 
-		std::vector<uint16_t> getItemIdRange() {
+		std::vector<uint16_t>& getItemIdRange() {
+			return ids;
+		}
+		const std::vector<uint16_t>& getItemIdRange() const {
 			return ids;
 		}
 		void addItemId(uint16_t id) {
 			ids.emplace_back(id);
 		}
 
-		std::vector<uint16_t> getUniqueIdRange() {
+		std::vector<uint16_t>& getUniqueIdRange() {
+			return uids;
+		}
+		const std::vector<uint16_t>& getUniqueIdRange() const {
 			return uids;
 		}
 		void addUniqueId(uint16_t id) {
 			uids.emplace_back(id);
 		}
 
-		std::vector<uint16_t> getActionIdRange() {
+		std::vector<uint16_t>& getActionIdRange() {
+			return aids;
+		}
+		const std::vector<uint16_t>& getActionIdRange() const {
 			return aids;
 		}
 		void addActionId(uint16_t id) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15406,9 +15406,9 @@ int LuaScriptInterface::luaActionRegister(lua_State* L)
 			return 1;
 		}
 		pushBoolean(L, g_actions->registerLuaEvent(action));
-		action->getActionIdRange().clear();
-		action->getItemIdRange().clear();
-		action->getUniqueIdRange().clear();
+		action->clearActionIdRange();
+		action->clearItemIdRange();
+		action->clearUniqueIdRange();
 	} else {
 		lua_pushnil(L);
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Avoid making extra copies of these vectors. Additionally fixes a bug with registering actions through revscriptsys, as that would clear the copy and not the actual vector inside the Action object (see `int LuaScriptInterface::luaActionRegister(lua_State* L)` at `luascript.cpp:15409`)

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
