### PR TITLE
Remove condition by Condition parameters (fixes #3544)

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7764,29 +7764,32 @@ int LuaScriptInterface::luaCreatureRemoveCondition(lua_State* L)
 {
 	// creature:removeCondition(conditionType[, conditionId = CONDITIONID_COMBAT[, subId = 0[, force = false]]])
 	// creature:removeCondition(condition[, force = false])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	Creature* const creature = getUserdata<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Condition* condition = nullptr;
-
+	Condition* creatureCondition = nullptr;
 	bool force = false;
 
 	if (isUserdata(L, 2)) {
-		condition = getUserdata<Condition>(L, 2);
+		const Condition* const condition = getUserdata<Condition>(L, 2);
+		const ConditionType_t conditionType = condition->getType();
+		const ConditionId_t conditionId = condition->getId();
+		const uint32_t subId = condition->getSubId();
+		creatureCondition = creature->getCondition(conditionType, conditionId, subId);
 		force = getBoolean(L, 3, false);
 	} else {
-		ConditionType_t conditionType = getNumber<ConditionType_t>(L, 2);
-		ConditionId_t conditionId = getNumber<ConditionId_t>(L, 3, CONDITIONID_COMBAT);
-		uint32_t subId = getNumber<uint32_t>(L, 4, 0);
-		condition = creature->getCondition(conditionType, conditionId, subId);
+		const ConditionType_t conditionType = getNumber<ConditionType_t>(L, 2);
+		const ConditionId_t conditionId = getNumber<ConditionId_t>(L, 3, CONDITIONID_COMBAT);
+		const uint32_t subId = getNumber<uint32_t>(L, 4, 0);
+		creatureCondition = creature->getCondition(conditionType, conditionId, subId);
 		force = getBoolean(L, 5, false);
 	}
 
-	if (condition) {
-		creature->removeCondition(condition, force);
+	if (creatureCondition) {
+		creature->removeCondition(creatureCondition, force);
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A copy of the Condition object was added to the creature in `LuaScriptInterface::luaCreatureAddCondition`, therefore `Creature::removeCondition` could not remove the condition properly, as the Condition object that was constructed from Userdata did not match the one stored in the creature's condition list.

Also applied const correctness.

**Issues addressed:** closes #3544 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
