### PR TITLE
Remove leftover reserved item ID range

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -332,10 +332,6 @@ bool Items::loadFromOtb(const std::string& file)
 					if (!stream.read<uint16_t>(serverId)) {
 						return false;
 					}
-
-					if (serverId > 30000 && serverId < 30100) {
-						serverId -= 30000;
-					}
 					break;
 				}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The range was moved in this commit https://github.com/otland/forgottenserver/commit/5eca49a00e6f0d39a4538e7273f38a0273b3f472 but these lines for the OTB are still left over

**Issues addressed:** A user had an issue with these leftover lines in this thread https://otland.net/threads/cannot-create-items-from-id-30001-to-30100.274443


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
