### PR TITLE
Fix const/ref usage on get ID ranges for moveEvents

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15780,10 +15780,10 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 			return 1;
 		}
 		pushBoolean(L, g_moveEvents->registerLuaEvent(moveevent));
-		moveevent->getItemIdRange().clear();
-		moveevent->getActionIdRange().clear();
-		moveevent->getUniqueIdRange().clear();
-		moveevent->getPosList().clear();
+		moveevent->clearItemIdRange();
+		moveevent->clearActionIdRange();
+		moveevent->clearUniqueIdRange();
+		moveevent->clearPosList();
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/movement.h
+++ b/src/movement.h
@@ -160,25 +160,37 @@ class MoveEvent final : public Event
 		void setTileItem(bool b) {
 			tileItem = b;
 		}
-		std::vector<uint32_t> getItemIdRange() {
+		void clearItemIdRange() {
+			return itemIdRange.clear();
+		}
+		const std::vector<uint32_t>& getItemIdRange() const {
 			return itemIdRange;
 		}
 		void addItemId(uint32_t id) {
 			itemIdRange.emplace_back(id);
 		}
-		std::vector<uint32_t> getActionIdRange() {
+		void clearActionIdRange() {
+			return actionIdRange.clear();
+		}
+		const std::vector<uint32_t>& getActionIdRange() const {
 			return actionIdRange;
 		}
 		void addActionId(uint32_t id) {
 			actionIdRange.emplace_back(id);
 		}
-		std::vector<uint32_t> getUniqueIdRange() {
+		void clearUniqueIdRange() {
+			return uniqueIdRange.clear();
+		}
+		const std::vector<uint32_t>& getUniqueIdRange() const {
 			return uniqueIdRange;
 		}
 		void addUniqueId(uint32_t id) {
 			uniqueIdRange.emplace_back(id);
 		}
-		std::vector<Position> getPosList() {
+		void clearPosList() {
+			return posList.clear();
+		}
+		const std::vector<Position>& getPosList() const {
 			return posList;
 		}
 		void addPosList(Position pos) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Avoid making extra copies of these vectors. Additionally fixes a bug with registering actions through revscriptsys, as that would clear the copy and not the actual vector inside the MoveEvent object (see int LuaScriptInterface::luaMoveEventRegister(lua_State* L) at luascript.cpp:15768)

**Notes:** This is a copy and paste of the PR #3539 of @ranisalt but I did it for MoveEvent, to avoid future problems