### PR TITLE
Prevent possible crash in the event onSpawn

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -655,7 +655,9 @@ void Monster::setIdle(bool idle)
 	isIdle = idle;
 
 	if (!isIdle) {
-		g_game.addCreatureCheck(this);
+		if (getParent() != nullptr) {
+			g_game.addCreatureCheck(this);
+		}
 	} else {
 		onIdleStatus();
 		clearTargetList();


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
If the monster stops being inactive in the onSpawn event, and it cannot be placed in the world, then we will have a null pointer in the verification vector of creatures, with this small change we will avoid a possible crash

### Ways to make the monster stop being inactive
```lua
function Monster:onSpawn(position, startup, artificial)
   self:addHealth(1)
   return true
end
```
```lua
function Monster:onSpawn(position, startup, artificial)
   self:setIdle(false)
   return true
end
```
and any function that makes idle false

**Issues addressed:** Nothing!