### PR TITLE
Update prevent infinite loop teleports

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -77,7 +77,7 @@ void Teleport::addThing(int32_t, Thing* thing)
 		return;
 	}
 
-	// Prevent infinity loop
+	// Prevent infinite loop
 	Teleport* destTeleport = destTile->getTeleportItem();
 	if (destTeleport) {
 		std::vector<Position> lastPositions = { getPosition() };
@@ -85,7 +85,7 @@ void Teleport::addThing(int32_t, Thing* thing)
 		while (true) {
 			const Position& nextPos = destTeleport->getDestPos();
 			if (std::find(lastPositions.begin(), lastPositions.end(), nextPos) != lastPositions.end()) {
-				std::cout << "Warning: possible infinity loop teleport. " << nextPos << std::endl;
+				std::cout << "Warning: possible infinite loop teleport. " << nextPos << std::endl;
 				return;
 			}
 

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -45,8 +45,6 @@ class Teleport final : public Item, public Cylinder
 			destPos = pos;
 		}
 
-		bool isHuge(const Tile* destTile);
-
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -45,7 +45,7 @@ class Teleport final : public Item, public Cylinder
 			destPos = pos;
 		}
 
-		bool checkInfinityLoop(Tile* destTile);
+		bool isHuge(const Tile* destTile);
 
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Currently you can still create infinite teleports loops, it is a matter of generating the loop in a given position and making two positions not related to the initial one enter an infinite loop, With the small changes that I made, now no type of immense or infinite loops will be a problem, also now everything is verified in a loop, eliminating the recursion of the code.

**Issues addressed:** Nothing!