### PR TITLE
Remove redundant getExperienceForLevel implementation

### DIFF
--- a/data/global.lua
+++ b/data/global.lua
@@ -225,7 +225,3 @@ function getPlayerDatabaseInfo(name_or_guid)
 	result.free(query)
 	return info
 end
-
-function getExperienceForLevel(level)
-	return math.floor((((level - 6) * level + 17) * level - 12) / 6) * 100
-end

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1426,6 +1426,8 @@ function doSetCreatureLight(cid, lightLevel, lightColor, time)
 	return true
 end
 
+function getExperienceForLevel(level) return Game.getExperienceForLevel(level) end
+
 do
 	local combats = {
 		[COMBAT_PHYSICALDAMAGE] = 'physical',

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -265,9 +265,9 @@ end
 function Player.addLevel(self, amount, round)
 	local experience, level, amount = 0, self:getLevel(), amount or 1
 	if amount > 0 then
-		experience = getExperienceForLevel(level + amount) - (round and self:getExperience() or getExperienceForLevel(level))
+		experience = Game.getExperienceForLevel(level + amount) - (round and self:getExperience() or Game.getExperienceForLevel(level))
 	else
-		experience = -((round and self:getExperience() or getExperienceForLevel(level)) - getExperienceForLevel(level + amount))
+		experience = -((round and self:getExperience() or Game.getExperienceForLevel(level)) - Game.getExperienceForLevel(level + amount))
 	end
 	return self:addExperience(experience)
 end

--- a/data/talkactions/scripts/add_skill.lua
+++ b/data/talkactions/scripts/add_skill.lua
@@ -45,7 +45,7 @@ function onSay(player, words, param)
 	local ch = split[2]:sub(1, 1)
 	for i = 1, count do
 		if ch == "l" or ch == "e" then
-			target:addExperience(getExperienceForLevel(target:getLevel() + 1) - target:getExperience(), false)
+			target:addExperience(Game.getExperienceForLevel(target:getLevel() + 1) - target:getExperience(), false)
 		elseif ch == "m" then
 			target:addManaSpent(target:getVocation():getRequiredManaSpent(target:getBaseMagicLevel() + 1) - target:getManaSpent())
 		else

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2018,6 +2018,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Game", "loadMap", LuaScriptInterface::luaGameLoadMap);
 
 	registerMethod("Game", "getExperienceStage", LuaScriptInterface::luaGameGetExperienceStage);
+	registerMethod("Game", "getExperienceForLevel", LuaScriptInterface::luaGameGetExperienceForLevel);
 	registerMethod("Game", "getMonsterCount", LuaScriptInterface::luaGameGetMonsterCount);
 	registerMethod("Game", "getPlayerCount", LuaScriptInterface::luaGameGetPlayerCount);
 	registerMethod("Game", "getNpcCount", LuaScriptInterface::luaGameGetNpcCount);
@@ -4249,6 +4250,18 @@ int LuaScriptInterface::luaGameGetExperienceStage(lua_State* L)
 	// Game.getExperienceStage(level)
 	uint32_t level = getNumber<uint32_t>(L, 1);
 	lua_pushnumber(L, g_config.getExperienceStage(level));
+	return 1;
+}
+
+int LuaScriptInterface::luaGameGetExperienceForLevel(lua_State* L)
+{
+	// Game.getExperienceForLevel(level)
+	const uint32_t level = getNumber<uint32_t>(L, 1);
+	if (level == 0) {
+		lua_pushnumber(L, 0);
+	} else {
+		lua_pushnumber(L, Player::getExpForLevel(level));
+	}
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -547,6 +547,7 @@ class LuaScriptInterface
 		static int luaGameLoadMap(lua_State* L);
 
 		static int luaGameGetExperienceStage(lua_State* L);
+		static int luaGameGetExperienceForLevel(lua_State* L);
 		static int luaGameGetMonsterCount(lua_State* L);
 		static int luaGameGetPlayerCount(lua_State* L);
 		static int luaGameGetNpcCount(lua_State* L);

--- a/src/player.h
+++ b/src/player.h
@@ -182,7 +182,7 @@ class Player final : public Creature, public Cylinder
 		void addList() override;
 		void kickPlayer(bool displayEffect);
 
-		static uint64_t getExpForLevel(uint64_t lv) {
+		static uint64_t getExpForLevel(const uint64_t lv) {
 			return (((lv - 6ULL) * lv + 17ULL) * lv - 12ULL) / 6ULL * 100ULL;
 		}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Call the engine method instead so we don't have to maintain the same method in 2 places

**Issues addressed:** none


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
