### PR TITLE
Clear Npc spectators on reset

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -112,6 +112,7 @@ void Npc::reset()
 
 	parameters.clear();
 	shopPlayerSet.clear();
+	spectators.clear();
 }
 
 void Npc::reload()


### PR DESCRIPTION
Followup to https://github.com/otland/forgottenserver/pull/3559

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Clear spectator set on Npc resets, e.g. on reloading, before we re-populate the spectator set with surrounding players
In practice it's not an issue, since we can never double-populate, since std::set entries are unique

**Issues addressed:**


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
