### PR TITLE
fix Items::getItemIdByName

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -554,7 +554,13 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 	it.name = itemNode.attribute("name").as_string();
 
-	nameToItems.insert({ asLowerCaseString(it.name), id });
+	if (!it.name.empty()) {
+		std::string lowerCaseName = asLowerCaseString(it.name);
+		auto result = nameToItems.find(lowerCaseName);
+		if (result == nameToItems.end()) {
+			nameToItems.insert({ std::move(lowerCaseName), id });
+		}
+	}
 
 	pugi::xml_attribute articleAttribute = itemNode.attribute("article");
 	if (articleAttribute) {
@@ -1398,8 +1404,11 @@ const ItemType& Items::getItemIdByClientId(uint16_t spriteId) const
 
 uint16_t Items::getItemIdByName(const std::string& name)
 {
-	auto result = nameToItems.find(asLowerCaseString(name));
+	if (name.empty()) {
+		return 0;
+	}
 
+	auto result = nameToItems.find(asLowerCaseString(name));
 	if (result == nameToItems.end())
 		return 0;
 

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -556,9 +556,8 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 	if (!it.name.empty()) {
 		std::string lowerCaseName = asLowerCaseString(it.name);
-		auto result = nameToItems.find(lowerCaseName);
-		if (result == nameToItems.end()) {
-			nameToItems.insert({ std::move(lowerCaseName), id });
+		if (nameToItems.find(lowerCaseName) == nameToItems.end()) {
+			nameToItems.emplace(std::move(lowerCaseName), id);
 		}
 	}
 

--- a/src/items.h
+++ b/src/items.h
@@ -391,7 +391,7 @@ class ItemType
 class Items
 {
 	public:
-		using NameMap = std::unordered_multimap<std::string, uint16_t>;
+		using NameMap = std::unordered_map<std::string, uint16_t>;
 		using InventoryVector = std::vector<uint16_t>;
 
 		Items();


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Prevent empty names from being added to nameToItems and prevent Items::getItemByName return a valid item id when the name is empty.
Make sure the Items::getItemIdByName behavior is exact: for each item id there will be only one name and the name will be the first found in items.xml.
Changed NameMap from unordered_multimap to unordered_map since multiple keys is useless now and probably before.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
