### PR TITLE
Fix mass healing & potions not enabling party shared experience

### DIFF
--- a/data/actions/scripts/other/potions.lua
+++ b/data/actions/scripts/other/potions.lua
@@ -152,11 +152,11 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	else
 		if potion.health then
-			doTargetCombat(0, target, COMBAT_HEALING, potion.health[1], potion.health[2])
+			doTargetCombat(player, target, COMBAT_HEALING, potion.health[1], potion.health[2])
 		end
 
 		if potion.mana then
-			doTargetCombat(0, target, COMBAT_MANADRAIN, potion.mana[1], potion.mana[2])
+			doTargetCombat(player, target, COMBAT_MANADRAIN, potion.mana[1], potion.mana[2])
 		end
 
 		if potion.antidote then

--- a/data/spells/scripts/healing/mass_healing.lua
+++ b/data/spells/scripts/healing/mass_healing.lua
@@ -10,7 +10,7 @@ function onCastSpell(creature, variant)
 	for _, target in ipairs(combat:getTargets(creature, variant)) do
 		local master = target:getMaster()
 		if target:isPlayer() or master and master:isPlayer() then
-			doTargetCombat(0, target, COMBAT_HEALING, min, max)
+			doTargetCombat(creature, target, COMBAT_HEALING, min, max)
 		end
 	end
 	return true


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Pass spell caster / potion user to `doTargetCombat` so it calls `Player::onTargetCreatureGainHealth` and adds "party ticks".

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** Closes #3579.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
