### PR TITLE
Display deprecated method culprit

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -302,12 +302,12 @@ setCombatFormula = Combat.setFormula
 setCombatParam = Combat.setParameter
 
 Combat.setCondition = function(...)
-	print("[Warning] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
 	Combat.addCondition(...)
 end
 
 setCombatCondition = function(...)
-	print("[Warning] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future")
 	Combat.addCondition(...)
 end
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

```
[Warning - data/spells/scripts/attack/paralyze_rune.lua] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future
[Warning - data/spells/scripts/attack/paralyze_rune.lua] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future
[Warning - data/actions/scripts/other/fluids.lua] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future
```

Messages are duplicated for some reason, in case of fluids it's reasonable, since more items are loading that script, but only one entry loads paralyze_rune from spells.xml 🤔

If someone wants to investigate, this should be resolved in other PR, IMHO.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** Closes #2629.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
