### PR TITLE
Add varying monster spawn

### DIFF
--- a/data/world/forgotten-spawn.xml
+++ b/data/world/forgotten-spawn.xml
@@ -379,7 +379,10 @@
 		<monster name="Troll" x="-4" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="103" centery="120" centerz="7" radius="5">
-		<monster name="Rabbit" x="-1" y="1" z="7" spawntime="180" />
+		<monsters x="-1" y="1" z="7" spawntime="180">
+			<monster name="Rabbit" chance="70" />
+			<monster name="Skunk" chance="30" />
+		</monsters>
 	</spawn>
 	<spawn centerx="86" centery="122" centerz="7" radius="1">
 		<npc name="Riona" x="0" y="0" z="7" spawntime="60" direction="3" />

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -23,13 +23,16 @@
 #include "tile.h"
 #include "position.h"
 
+#include <tuple>
+#include <vector>
+
 class Monster;
 class MonsterType;
 class Npc;
 
 struct spawnBlock_t {
 	Position pos;
-	MonsterType* mType;
+	std::vector<std::tuple<MonsterType*, uint16_t>> mTypes;
 	int64_t lastSpawn;
 	uint32_t interval;
 	Direction direction;
@@ -45,6 +48,7 @@ class Spawn
 		Spawn(const Spawn&) = delete;
 		Spawn& operator=(const Spawn&) = delete;
 
+		bool addBlock(spawnBlock_t sb);
 		bool addMonster(const std::string& name, const Position& pos, Direction dir, uint32_t interval);
 		void removeMonster(Monster* monster);
 
@@ -62,7 +66,6 @@ class Spawn
 	private:
 		//map of the spawned creatures
 		using SpawnedMap = std::multimap<uint32_t, Monster*>;
-		using spawned_pair = SpawnedMap::value_type;
 		SpawnedMap spawnedMap;
 
 		//map of creatures in the spawn
@@ -75,6 +78,7 @@ class Spawn
 		uint32_t checkSpawnEvent = 0;
 
 		static bool findPlayer(const Position& pos);
+		bool spawnMonster(uint32_t spawnId, spawnBlock_t sb, bool startup = false);
 		bool spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& pos, Direction dir, bool startup = false);
 		void checkSpawn();
 };


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Add ability to declare more than one type of monster that will be respawned after death:
```xml
	<spawn centerx="103" centery="120" centerz="7" radius="5">
		<monsters x="-1" y="1" z="7" spawntime="180">
			<monster name="Rabbit" chance="70" />
			<monster name="Skunk" chance="30" />
		</monsters>
	</spawn>
```

This can be of course mixed with single `monster` node:
```xml
	<spawn centerx="103" centery="120" centerz="7" radius="5">
		<monster name="Troll" x="4" y="-1" z="7" spawntime="60" />
		<monsters x="-1" y="1" z="7" spawntime="180">
			<monster name="Rabbit" chance="70" />
			<monster name="Skunk" chance="30" />
		</monsters>
	</spawn>
```

Total chance calculation could be done a bit better and less error prone, but as it's just an extra feature, I'll leave that to be improved by someone who likes math. 😎

Or chance could be mandatory, then the problem of auto-calculating what's left will be gone.

**Issues addressed:** #3600 

If nobody is interested in adding it to RME, I can do that too.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
