### PR TITLE
Add ability to remove player's skills

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -263,26 +263,66 @@ function Player.removeTotalMoney(self, amount)
 end
 
 function Player.addLevel(self, amount, round)
-	local experience, level, amount = 0, self:getLevel(), amount or 1
+	round = round or false
+	local level, amount = self:getLevel(), amount or 1
 	if amount > 0 then
-		experience = Game.getExperienceForLevel(level + amount) - (round and self:getExperience() or Game.getExperienceForLevel(level))
+		return self:addExperience(Game.getExperienceForLevel(level + amount) - (round and self:getExperience() or Game.getExperienceForLevel(level)))
 	else
-		experience = -((round and self:getExperience() or Game.getExperienceForLevel(level)) - Game.getExperienceForLevel(level + amount))
+		return self:removeExperience(((round and self:getExperience() or Game.getExperienceForLevel(level)) - Game.getExperienceForLevel(level + amount)))
 	end
-	return self:addExperience(experience)
 end
 
 function Player.addMagicLevel(self, value)
-	return self:addManaSpent(self:getVocation():getRequiredManaSpent(self:getBaseMagicLevel() + value + 1) - self:getManaSpent())
+	local currentMagLevel = self:getBaseMagicLevel()
+	local sum = 0
+
+	if value > 0 then
+		while value > 0 do
+			sum = sum + self:getVocation():getRequiredManaSpent(currentMagLevel + value)
+			value = value - 1
+		end
+
+		return self:addManaSpent(sum - self:getManaSpent())
+	else
+		value = math.min(currentMagLevel, math.abs(value))
+		while value > 0 do
+			sum = sum + self:getVocation():getRequiredManaSpent(currentMagLevel - value + 1)
+			value = value - 1
+		end
+
+		return self:removeManaSpent(sum + self:getManaSpent())
+	end
+end
+
+function Player.addSkillLevel(self, skillId, value)
+	local currentSkillLevel = self:getSkillLevel(skillId)
+	local sum = 0
+
+	if value > 0 then
+		while value > 0 do
+			sum = sum + self:getVocation():getRequiredSkillTries(skillId, currentSkillLevel + value)
+			value = value - 1
+		end
+
+		return self:addSkillTries(skillId, sum - self:getSkillTries(skillId))
+	else
+		value = math.min(currentSkillLevel, math.abs(value))
+		while value > 0 do
+			sum = sum + self:getVocation():getRequiredSkillTries(skillId, currentSkillLevel - value + 1)
+			value = value - 1
+		end
+
+		return self:removeSkillTries(skillId, sum + self:getSkillTries(skillId), true)
+	end
 end
 
 function Player.addSkill(self, skillId, value, round)
 	if skillId == SKILL_LEVEL then
-		return self:addLevel(value, round)
+		return self:addLevel(value, round or false)
 	elseif skillId == SKILL_MAGLEVEL then
 		return self:addMagicLevel(value)
 	end
-	return self:addSkillTries(skillId, self:getVocation():getRequiredSkillTries(skillId, self:getSkillLevel(skillId) + value) - self:getSkillTries(skillId))
+	return self:addSkillLevel(skillId, value)
 end
 
 function Player.getWeaponType(self)

--- a/data/talkactions/scripts/add_skill.lua
+++ b/data/talkactions/scripts/add_skill.lua
@@ -11,9 +11,15 @@ local function getSkillId(skillName)
 		return SKILL_SHIELD
 	elseif skillName:sub(1, 4) == "fish" then
 		return SKILL_FISHING
-	else
+	elseif skillName:sub(1, 4) == "fist" then
 		return SKILL_FIST
+	elseif skillName:sub(1, 1) == "m" then
+		return SKILL_MAGLEVEL
+	elseif skillName == "level" or skillName:sub(1, 1) == "l" or skillName:sub(1, 1) == "e" then
+		return SKILL_LEVEL
 	end
+
+	return nil
 end
 
 function onSay(player, words, param)
@@ -42,16 +48,12 @@ function onSay(player, words, param)
 		count = tonumber(split[3])
 	end
 
-	local ch = split[2]:sub(1, 1)
-	for i = 1, count do
-		if ch == "l" or ch == "e" then
-			target:addExperience(Game.getExperienceForLevel(target:getLevel() + 1) - target:getExperience(), false)
-		elseif ch == "m" then
-			target:addManaSpent(target:getVocation():getRequiredManaSpent(target:getBaseMagicLevel() + 1) - target:getManaSpent())
-		else
-			local skillId = getSkillId(split[2])
-			target:addSkillTries(skillId, target:getVocation():getRequiredSkillTries(skillId, target:getSkillLevel(skillId) + 1) - target:getSkillTries(skillId))
-		end
+	local skillId = getSkillId(split[2])
+	if not skillId then
+		player:sendCancelMessage("Unknown skill.")
+		return false
 	end
+
+	target:addSkill(skillId, count)
 	return false
 end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2386,6 +2386,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Player", "setMaxMana", LuaScriptInterface::luaPlayerSetMaxMana);
 	registerMethod("Player", "getManaSpent", LuaScriptInterface::luaPlayerGetManaSpent);
 	registerMethod("Player", "addManaSpent", LuaScriptInterface::luaPlayerAddManaSpent);
+	registerMethod("Player", "removeManaSpent", LuaScriptInterface::luaPlayerRemoveManaSpent);
 
 	registerMethod("Player", "getBaseMaxHealth", LuaScriptInterface::luaPlayerGetBaseMaxHealth);
 	registerMethod("Player", "getBaseMaxMana", LuaScriptInterface::luaPlayerGetBaseMaxMana);
@@ -2395,6 +2396,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Player", "getSkillPercent", LuaScriptInterface::luaPlayerGetSkillPercent);
 	registerMethod("Player", "getSkillTries", LuaScriptInterface::luaPlayerGetSkillTries);
 	registerMethod("Player", "addSkillTries", LuaScriptInterface::luaPlayerAddSkillTries);
+	registerMethod("Player", "removeSkillTries", LuaScriptInterface::luaPlayerRemoveSkillTries);
 	registerMethod("Player", "getSpecialSkill", LuaScriptInterface::luaPlayerGetSpecialSkill);
 	registerMethod("Player", "addSpecialSkill", LuaScriptInterface::luaPlayerAddSpecialSkill);
 
@@ -8391,7 +8393,7 @@ int LuaScriptInterface::luaPlayerAddExperience(lua_State* L)
 	// player:addExperience(experience[, sendText = false])
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		int64_t experience = getNumber<int64_t>(L, 2);
+		uint64_t experience = getNumber<uint64_t>(L, 2);
 		bool sendText = getBoolean(L, 3, false);
 		player->addExperience(nullptr, experience, sendText);
 		pushBoolean(L, true);
@@ -8406,7 +8408,7 @@ int LuaScriptInterface::luaPlayerRemoveExperience(lua_State* L)
 	// player:removeExperience(experience[, sendText = false])
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		int64_t experience = getNumber<int64_t>(L, 2);
+		uint64_t experience = getNumber<uint64_t>(L, 2);
 		bool sendText = getBoolean(L, 3, false);
 		player->removeExperience(experience, sendText);
 		pushBoolean(L, true);
@@ -8539,6 +8541,19 @@ int LuaScriptInterface::luaPlayerAddManaSpent(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaPlayerRemoveManaSpent(lua_State* L)
+{
+	// player:removeManaSpent(amount[, notify = true])
+	Player* player = getUserdata<Player>(L, 1);
+	if (player) {
+		player->removeManaSpent(getNumber<uint64_t>(L, 2), getBoolean(L, 3, true));
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int LuaScriptInterface::luaPlayerGetBaseMaxHealth(lua_State* L)
 {
 	// player:getBaseMaxHealth()
@@ -8623,6 +8638,21 @@ int LuaScriptInterface::luaPlayerAddSkillTries(lua_State* L)
 		skills_t skillType = getNumber<skills_t>(L, 2);
 		uint64_t tries = getNumber<uint64_t>(L, 3);
 		player->addSkillAdvance(skillType, tries);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerRemoveSkillTries(lua_State* L)
+{
+	// player:removeSkillTries(skillType, tries[, notify = true])
+	Player* player = getUserdata<Player>(L, 1);
+	if (player) {
+		skills_t skillType = getNumber<skills_t>(L, 2);
+		uint64_t tries = getNumber<uint64_t>(L, 3);
+		player->removeSkillTries(skillType, tries, getBoolean(L, 4, true));
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -898,6 +898,7 @@ class LuaScriptInterface
 		static int luaPlayerSetMaxMana(lua_State* L);
 		static int luaPlayerGetManaSpent(lua_State* L);
 		static int luaPlayerAddManaSpent(lua_State* L);
+		static int luaPlayerRemoveManaSpent(lua_State* L);
 
 		static int luaPlayerGetBaseMaxHealth(lua_State* L);
 		static int luaPlayerGetBaseMaxMana(lua_State* L);
@@ -907,6 +908,7 @@ class LuaScriptInterface
 		static int luaPlayerGetSkillPercent(lua_State* L);
 		static int luaPlayerGetSkillTries(lua_State* L);
 		static int luaPlayerAddSkillTries(lua_State* L);
+		static int luaPlayerRemoveSkillTries(lua_State* L);
 		static int luaPlayerGetSpecialSkill(lua_State* L);
 		static int luaPlayerAddSpecialSkill(lua_State* L);
 

--- a/src/player.h
+++ b/src/player.h
@@ -642,7 +642,9 @@ class Player final : public Creature, public Cylinder
 		void drainHealth(Creature* attacker, int32_t damage) override;
 		void drainMana(Creature* attacker, int32_t manaLoss);
 		void addManaSpent(uint64_t amount);
+		void removeManaSpent(uint64_t amount, bool notify = false);
 		void addSkillAdvance(skills_t skill, uint64_t count);
+		void removeSkillTries(skills_t skill, uint64_t count, bool notify = false);
 
 		int32_t getArmor() const override;
 		int32_t getDefense() const override;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Talkaction `/addskill` can handle negative values for magic level & skills. It already handled (before somebody broke it, so I have fixed it too) removing player's level, therefor I did not change it's words.

**Issues addressed:** Closes #377.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
