### PR TITLE
Add missing parameters to npc.selfMoveTo

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -158,7 +158,8 @@ class Npc final : public Creature
 		void doSay(const std::string& text);
 		void doSayToPlayer(Player* player, const std::string& text);
 
-		void doMoveTo(const Position& pos);
+		bool doMoveTo(const Position& pos, int32_t minTargetDist = 1, int32_t maxTargetDist = 1,
+		              bool fullPathSearch = true, bool clearSight = true, int32_t maxSearchDist = 0);
 
 		int32_t getMasterRadius() const {
 			return masterRadius;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

You can now pass additional parameters to npc lua function `selfMoveTo`. This function will now also accept `Position`.
```
selfMoveTo(478, 200, 7)
selfMoveTo(Position(478, 200, 7))
```

The method is now:
```
selfMoveTo(x, y, z[, minTargetDist = 1[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[, maxSearchDist = 0]]]]])
selfMoveTo(position[, minTargetDist = 1[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[, maxSearchDist = 0]]]]])
```

And returns a boolean.

**Issues addressed:** Closes #1565.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
