### PR TITLE
 Make monster loot count accept count higher than 100

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -18,40 +18,47 @@ function Container.createLootItem(self, item)
 	end
 
 	if itemCount > 0 then
-		local tmpItem = Game.createItem(item.itemId, math.min(itemCount, 100))
-		if not tmpItem then
+		local tmpItem = {}
+		while itemCount > 100 do
+			local itm = self:addItem(item.itemId, 100)
+			if itm then
+				tmpItem[#tmpItem + 1] = itm
+			end
+			itemCount = itemCount - 100
+		end
+
+		if itemCount > 0 then
+			local itm = self:addItem(item.itemId, itemCount)
+			if itm then
+				tmpItem[#tmpItem + 1] = itm
+			end
+		end
+
+		if #tmpItem == 0 then
 			return false
 		end
 
-		if tmpItem:isContainer() then
-			for i = 1, #item.childLoot do
-				if not tmpItem:createLootItem(item.childLoot[i]) then
-					tmpItem:remove()
-					return false
+		for index, tmp in pairs(tmpItem) do
+			if tmp:isContainer() then
+				for i = 1, #item.childLoot do
+					if not tmp:createLootItem(item.childLoot[i]) then
+						tmp:remove()
+						return false
+					end
 				end
 			end
 
-			if #item.childLoot > 0 and tmpItem:getSize() == 0 then
-				tmpItem:remove()
-				return true
+			if item.subType ~= -1 then
+				tmp:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
 			end
-		end
 
-		if item.subType ~= -1 then
-			tmpItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
-		end
+			if item.actionId ~= -1 then
+				tmp:setActionId(item.actionId)
+			end
 
-		if item.actionId ~= -1 then
-			tmpItem:setActionId(item.actionId)
-		end
-
-		if item.text and item.text ~= "" then
-			tmpItem:setText(item.text)
-		end
-
-		local ret = self:addItemEx(tmpItem)
-		if ret ~= RETURNVALUE_NOERROR then
-			tmpItem:remove()
+			if item.text and item.text ~= "" then
+				tmp:setText(item.text)
+			end
 		end
 	end
 	return true

--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -17,49 +17,45 @@ function Container.createLootItem(self, item)
 		end
 	end
 
-	if itemCount > 0 then
-		local tmpItem = {}
-		while itemCount > 100 do
-			local itm = self:addItem(item.itemId, 100)
-			if itm then
-				tmpItem[#tmpItem + 1] = itm
-			end
-			itemCount = itemCount - 100
-		end
-
-		if itemCount > 0 then
-			local itm = self:addItem(item.itemId, itemCount)
-			if itm then
-				tmpItem[#tmpItem + 1] = itm
-			end
-		end
-
-		if #tmpItem == 0 then
+	while itemCount > 0 do
+		local count = math.min(100, itemCount)
+		local tmpItem = Game.createItem(item.itemId, count)
+		if not tmpItem then
 			return false
 		end
 
-		for index, tmp in pairs(tmpItem) do
-			if tmp:isContainer() then
-				for i = 1, #item.childLoot do
-					if not tmp:createLootItem(item.childLoot[i]) then
-						tmp:remove()
-						return false
-					end
+		if tmpItem:isContainer() then
+			for i = 1, #item.childLoot do
+				if not tmpItem:createLootItem(item.childLoot[i]) then
+					tmpItem:remove()
+					return false
 				end
 			end
 
-			if item.subType ~= -1 then
-				tmp:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
-			end
-
-			if item.actionId ~= -1 then
-				tmp:setActionId(item.actionId)
-			end
-
-			if item.text and item.text ~= "" then
-				tmp:setText(item.text)
+			if #item.childLoot > 0 and tmpItem:getSize() == 0 then
+				tmpItem:remove()
+				return true
 			end
 		end
+
+		if item.subType ~= -1 then
+			tmpItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
+		end
+
+		if item.actionId ~= -1 then
+			tmpItem:setActionId(item.actionId)
+		end
+
+		if item.text and item.text ~= "" then
+			tmpItem:setText(item.text)
+		end
+
+		local ret = self:addItemEx(tmpItem)
+		if ret ~= RETURNVALUE_NOERROR then
+			tmpItem:remove()
+		end
+
+		itemCount = itemCount - count
 	end
 	return true
 end


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Make monster loot count accept count higher than 100
Credits Epuncker and MillhioreBT. 

Reopening this PR (original was #2875), it was discussed in #2906 to use a solution where the count is rolled once. If you want to roll multiple times just add multiple item entries.

**Issues addressed:** <!-- Write here the issue number, if any. -->
fixes #2859

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
