### PR TITLE
Make monsters walk to spawn by chunked path

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -211,11 +211,11 @@ void Creature::onWalk()
 				forceUpdateFollowPath = true;
 			}
 		} else {
+			stopEventWalk();
+
 			if (listWalkDir.empty()) {
 				onWalkComplete();
 			}
-
-			stopEventWalk();
 		}
 	}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2548,6 +2548,9 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Monster", "selectTarget", LuaScriptInterface::luaMonsterSelectTarget);
 	registerMethod("Monster", "searchTarget", LuaScriptInterface::luaMonsterSearchTarget);
 
+	registerMethod("Monster", "isWalkingToSpawn", LuaScriptInterface::luaMonsterIsWalkingToSpawn);
+	registerMethod("Monster", "walkToSpawn", LuaScriptInterface::luaMonsterWalkToSpawn);
+
 	// Npc
 	registerClass("Npc", "Creature", LuaScriptInterface::luaNpcCreate);
 	registerMetaMethod("Npc", "__eq", LuaScriptInterface::luaUserdataCompare);
@@ -10569,6 +10572,30 @@ int LuaScriptInterface::luaMonsterSearchTarget(lua_State* L)
 	if (monster) {
 		TargetSearchType_t searchType = getNumber<TargetSearchType_t>(L, 2, TARGETSEARCH_DEFAULT);
 		pushBoolean(L, monster->searchTarget(searchType));
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterIsWalkingToSpawn(lua_State* L)
+{
+	// monster:isWalkingToSpawn()
+	Monster* monster = getUserdata<Monster>(L, 1);
+	if (monster) {
+		pushBoolean(L, monster->isWalkingToSpawn());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterWalkToSpawn(lua_State* L)
+{
+	// monster:walkToSpawn()
+	Monster* monster = getUserdata<Monster>(L, 1);
+	if (monster) {
+		pushBoolean(L, monster->walkToSpawn());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1060,6 +1060,9 @@ class LuaScriptInterface
 		static int luaMonsterSelectTarget(lua_State* L);
 		static int luaMonsterSearchTarget(lua_State* L);
 
+		static int luaMonsterIsWalkingToSpawn(lua_State* L);
+		static int luaMonsterWalkToSpawn(lua_State* L);
+
 		// Npc
 		static int luaNpcCreate(lua_State* L);
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -482,17 +482,13 @@ void Monster::onCreatureLeave(Creature* creature)
 	//update targetList
 	if (isOpponent(creature)) {
 		removeTarget(creature);
-		if (targetList.empty()) {
+		updateIdleStatus();
+
+		if (!isSummon() && targetList.empty()) {
 			int32_t walkToSpawnRadius = g_config.getNumber(ConfigManager::DEFAULT_WALKTOSPAWNRADIUS);
 			if (walkToSpawnRadius > 0 && !Position::areInRange(position, masterPos, walkToSpawnRadius, walkToSpawnRadius)) {
-				std::vector<Direction> dirList;
-				if (getPathTo(masterPos, dirList, 0, 0, true, true)) {
-					startAutoWalk(dirList);
-					return;
-				}
+				walkToSpawn();
 			}
-
-			updateIdleStatus();
 		}
 	}
 }
@@ -681,10 +677,6 @@ void Monster::updateIdleStatus()
 		idle = std::find_if(conditions.begin(), conditions.end(), [](Condition* condition) {
 			return condition->isAggressive();
 		}) == conditions.end();
-	}
-
-	if (idle) {
-		idle = listWalkDir.empty();
 	}
 
 	setIdle(idle);
@@ -1024,9 +1016,39 @@ void Monster::onThinkYell(uint32_t interval)
 	}
 }
 
+bool Monster::walkToSpawn()
+{
+	if (walkingToSpawn || !spawn || !targetList.empty()) {
+		return false;
+	}
+
+	int32_t distance = std::max<int32_t>(Position::getDistanceX(position, masterPos), Position::getDistanceY(position, masterPos));
+	if (distance == 0) {
+		return false;
+	}
+
+	listWalkDir.clear();
+	if (!getPathTo(masterPos, listWalkDir, 0, std::max<int32_t>(0, distance - 5), true, true, distance)) {
+		return false;
+	}
+
+	walkingToSpawn = true;
+	startAutoWalk();
+	return true;
+}
+
 void Monster::onWalk()
 {
 	Creature::onWalk();
+}
+
+void Monster::onWalkComplete()
+{
+	// Continue walking to spawn
+	if (walkingToSpawn) {
+		walkingToSpawn = false;
+		walkToSpawn();
+	}
 }
 
 bool Monster::pushItem(Item* item)
@@ -1133,20 +1155,20 @@ void Monster::pushCreatures(Tile* tile)
 
 bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 {
-	if (listWalkDir.empty() && (isIdle || getHealth() <= 0)) {
+	if (!walkingToSpawn && (isIdle || getHealth() <= 0)) {
 		//we don't have anyone watching, might as well stop walking
 		eventWalk = 0;
 		return false;
 	}
 
 	bool result = false;
-	if (listWalkDir.empty() && (!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
+	if (!walkingToSpawn && (!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
 		if (getTimeSinceLastMove() >= 1000) {
 			randomStepping = true;
 			//choose a random direction
 			result = getRandomStep(getPosition(), direction);
 		}
-	} else if ((isSummon() && isMasterInRange) || followCreature || !listWalkDir.empty()) {
+	} else if ((isSummon() && isMasterInRange) || followCreature || walkingToSpawn) {
 		randomStepping = false;
 		result = Creature::getNextStep(direction, flags);
 		if (result) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -132,7 +132,13 @@ class Monster final : public Creature
 
 		void drainHealth(Creature* attacker, int32_t damage) override;
 		void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
+
+		bool isWalkingToSpawn() const {
+			return walkingToSpawn;
+		}
+		bool walkToSpawn();
 		void onWalk() override;
+		void onWalkComplete() override;
 		bool getNextStep(Direction& direction, uint32_t& flags) override;
 		void onFollowCreatureComplete(const Creature* creature) override;
 
@@ -200,10 +206,11 @@ class Monster final : public Creature
 
 		Position masterPos;
 
+		bool ignoreFieldDamage = false;
 		bool isIdle = true;
 		bool isMasterInRange = false;
 		bool randomStepping = false;
-		bool ignoreFieldDamage = false;
+		bool walkingToSpawn = false;
 
 		void onCreatureEnter(Creature* creature);
 		void onCreatureLeave(Creature* creature);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Monster will now think a little more about where he wants to go. Also added lua function that will force the monster to walk back, even when config is set to 0. Config value is used for lured monsters, also added a bit more checks about summons/not-placed-by-map-monsters.

**Issues addressed:** #3600.

Supersedes PR: #3610.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
