### PR TITLE
Fix depot saving

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -366,7 +366,6 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 			DepotLocker* myDepotLocker = player->getDepotLocker(depot->getDepotId());
 			myDepotLocker->setParent(depot->getParent()->getTile());
 			openContainer = myDepotLocker;
-			player->setLastDepotId(depot->getDepotId());
 		} else {
 			openContainer = container;
 		}

--- a/src/container.h
+++ b/src/container.h
@@ -132,7 +132,7 @@ class Container : public Item, public Cylinder
 				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
 				uint32_t flags) const override final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override final;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
 				uint32_t& flags) override final;
 

--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -20,6 +20,7 @@
 #include "otpch.h"
 
 #include "depotlocker.h"
+#include "player.h"
 
 DepotLocker::DepotLocker(uint16_t type) :
 	Container(type, 3), depotId(0) {}
@@ -35,9 +36,24 @@ Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 	return Item::readAttr(attr, propStream);
 }
 
-ReturnValue DepotLocker::queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature*) const
+ReturnValue DepotLocker::queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature* actor) const
 {
+	Player* actorPlayer = actor ? actor->getPlayer() : nullptr;
+	if (actorPlayer) {
+		actorPlayer->setLastDepotId(depotId);
+	}
+
 	return RETURNVALUE_NOTENOUGHROOM;
+}
+
+ReturnValue DepotLocker::queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor /*= nullptr */) const
+{
+	Player* actorPlayer = actor ? actor->getPlayer() : nullptr;
+	if (actorPlayer) {
+		actorPlayer->setLastDepotId(depotId);
+	}
+
+	return Container::queryRemove(thing, count, flags, actor);
 }
 
 void DepotLocker::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -52,6 +52,7 @@ class DepotLocker final : public Container
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
 
 		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1290,7 +1290,7 @@ ReturnValue Game::internalAddItem(Cylinder* toCylinder, Item* item, int32_t inde
 	toCylinder = toCylinder->queryDestination(index, *item, &toItem, flags);
 
 	//check if we can add this item
-	ReturnValue ret = toCylinder->queryAdd(index, *item, item->getItemCount(), flags);
+	ReturnValue ret = toCylinder->queryAdd(index, *item, item->getItemCount(), flags, dynamic_cast<Player*>(toCylinder));
 	if (ret != RETURNVALUE_NOERROR) {
 		return ret;
 	}
@@ -1381,7 +1381,7 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 	}
 
 	//check if we can remove this item
-	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE);
+	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE, dynamic_cast<Player*>(cylinder));
 	if (ret != RETURNVALUE_NOERROR) {
 		return ret;
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8321,7 +8321,6 @@ int LuaScriptInterface::luaPlayerGetDepotChest(lua_State* L)
 	bool autoCreate = getBoolean(L, 3, false);
 	DepotChest* depotChest = player->getDepotChest(depotId, autoCreate);
 	if (depotChest) {
-		player->setLastDepotId(depotId); // FIXME: workaround for #2251
 		pushUserdata<Item>(L, depotChest);
 		setItemMetatable(L, -1, depotChest);
 	} else {


### PR DESCRIPTION
### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Fix modified depot items saving

**Issues addressed:** <!-- Write here the issue number, if any. -->
#2251

Depots should now properly save after any modification to it.
Before we had that ugly workaround from PR above, which failed in some cases.
For example, when adding item to offline player (like mailbox does it). It was specifically important for older protocols, when we used lockers to store parcels instead of inbox, but this also could happen in case of offline adding items to depot directly I believe.
