### PR TITLE
fix casterPos for ultimate area spells

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -66,8 +66,12 @@ MatrixArea createArea(const std::vector<uint32_t>& vec, uint32_t rows)
 	return area;
 }
 
-std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, const Direction dir)
+std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, Direction dir)
 {
+	if (dir > DIRECTION_WEST) {
+		dir = DIRECTION_NONE;
+	}
+	
 	auto casterPos = getNextPosition(dir, targetPos);
 
 	std::vector<Tile*> vec;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
disable adjusting `casterPos` when direction is diagonal. In spell system diagonal direction is found only when there is no offset at both `x` and `y` axis.

**Issues addressed:** closes #3643

control tests performed:
- shooting burst arrows
- shooting area runes
- shooting wave spells

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
