### PR TITLE
Fix getDirectionTo method

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -461,6 +461,10 @@ Position getNextPosition(Direction direction, Position pos)
 
 Direction getDirectionTo(const Position& from, const Position& to)
 {
+	if (from == to) {
+		return DIRECTION_NONE;
+	}
+	
 	Direction dir;
 
 	int32_t x_offset = Position::getOffsetX(from, to);


### PR DESCRIPTION
This pull request fixes getDirectionTo helper method, which returns some weird direction instead of none if from == to.

By the way it also fixes #3643