### PR TITLE
Dont halve damage when caster = target

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1019,12 +1019,10 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		bool playerCombatReduced = false;
 		if ((damageCopy.primary.value < 0 || damageCopy.secondary.value < 0) && caster) {
 			Player* targetPlayer = creature->getPlayer();
-			if (casterPlayer) {
-				if (targetPlayer && targetPlayer->getSkull() != SKULL_BLACK) {
-					damageCopy.primary.value /= 2;
-					damageCopy.secondary.value /= 2;
-					playerCombatReduced = true;
-				}
+			if (casterPlayer && targetPlayer && casterPlayer != targetPlayer && targetPlayer->getSkull() != SKULL_BLACK) {
+				damageCopy.primary.value /= 2;
+				damageCopy.secondary.value /= 2;
+				playerCombatReduced = true;
 			}
 		}
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -853,7 +853,7 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 
 		if (casterPlayer) {
 			Player* targetPlayer = target ? target->getPlayer() : nullptr;
-			if (targetPlayer && targetPlayer->getSkull() != SKULL_BLACK && damage.primary.type != COMBAT_HEALING) {
+			if (targetPlayer && casterPlayer != targetPlayer && targetPlayer->getSkull() != SKULL_BLACK && damage.primary.type != COMBAT_HEALING) {
 				damage.primary.value /= 2;
 				damage.secondary.value /= 2;
 			}


### PR DESCRIPTION
Currently damage was halved for player combat when caster was the same as target.
It should not halve this kind of damage.