### PR TITLE
Fix potential crash in Player::getClientIcons

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -407,7 +407,7 @@ uint16_t Player::getClientIcons() const
 		icons |= ICON_REDSWORDS;
 	}
 
-	if (tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (tile && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		icons |= ICON_PIGEON;
 
 		// Don't show ICON_SWORDS if player is in protection zone.


### PR DESCRIPTION
Fixes a potential crash by checking if **tile** is not a null pointer in `Player::getClientIcons`