### PR TITLE
Reduce broadcast range for container updates

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -221,7 +221,7 @@ bool Container::isHoldingItem(const Item* item) const
 void Container::onAddContainerItem(Item* item)
 {
 	SpectatorVec spectators;
-	g_game.map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);
+	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 
 	//send to client
 	for (Creature* spectator : spectators) {
@@ -237,7 +237,7 @@ void Container::onAddContainerItem(Item* item)
 void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem)
 {
 	SpectatorVec spectators;
-	g_game.map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);
+	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 
 	//send to client
 	for (Creature* spectator : spectators) {
@@ -253,7 +253,7 @@ void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newIt
 void Container::onRemoveContainerItem(uint32_t index, Item* item)
 {
 	SpectatorVec spectators;
-	g_game.map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);
+	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 
 	//send change to client
 	for (Creature* spectator : spectators) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Containers can never be opened if a player is more than 1 SQM away from it, hence we are doing unnecessary work here by sending updates to clients that are too far away from the container

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
