### PR TITLE
critical problem in revscriptsys globalevent think

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16381,6 +16381,13 @@ int LuaScriptInterface::luaGlobalEventRegister(lua_State* L)
 			pushBoolean(L, false);
 			return 1;
 		}
+		
+		if (globalevent->getEventType() == GLOBALEVENT_NONE && globalevent->getInterval() == 0) {
+			std::cout << "[Error - LuaScriptInterface::luaGlobalEventRegister] No interval for globalevent with name " << globalevent->getName() << std::endl;
+			pushBoolean(L, false);
+			return 1;
+		}
+		
 		pushBoolean(L, g_globalEvents->registerLuaEvent(globalevent));
 	} else {
 		lua_pushnil(L);


### PR DESCRIPTION
When we create a `globalevent` of type `think` and we forget `globalevent:interval(milliseconds)` before `globalevent:register()`, the script is registered with the interval 0. As this is not checked before, no warning is given and the server runs the script non-stop causing 100% cpu. With this check, we guarantee that the script will not be registered if it does not have a set interval.

The bug can be tested with this simple code:
```
local globalEvent = GlobalEvent('bugThink')
function globalEvent.onTime()
	print('CPU says: "stop, it hurts!"')
	return true
end
-- globalEvent:interval(1000)
globalEvent:register()
```

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
