### PR TITLE
[12.00] Adding support for colored loot

### DIFF
--- a/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
+++ b/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
@@ -17,7 +17,7 @@ ec.onDropLoot = function(self, corpse)
 		end
 
 		if player then
-			local text = ("Loot of %s: %s"):format(mType:getNameDescription(), corpse:getContentDescription())
+			local text = ("Loot of %s: %s"):format(mType:getNameDescription(), corpse:getContentDescription(player:getClient().version >= 1200))
 			local party = player:getParty()
 			if party then
 				party:broadcastPartyLoot(text)

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -159,13 +159,13 @@ uint32_t Container::getWeight() const
 	return Item::getWeight() + totalWeight;
 }
 
-std::string Container::getContentDescription() const
+std::string Container::getContentDescription(bool colored /* = false*/) const
 {
 	std::ostringstream os;
-	return getContentDescription(os).str();
+	return getContentDescription(os, colored).str();
 }
 
-std::ostringstream& Container::getContentDescription(std::ostringstream& os) const
+std::ostringstream& Container::getContentDescription(std::ostringstream& os, bool colored /* = false*/) const
 {
 	bool firstitem = true;
 	for (ContainerIterator it = iterator(); it.hasNext(); it.advance()) {
@@ -182,7 +182,11 @@ std::ostringstream& Container::getContentDescription(std::ostringstream& os) con
 			os << ", ";
 		}
 
-		os << item->getNameDescription();
+		if (colored) {
+            os << '{' << item->getClientID() << '|' << item->getNameDescription() << '}';
+        } else {
+            os << item->getNameDescription();
+        }
 	}
 
 	if (firstitem) {

--- a/src/container.h
+++ b/src/container.h
@@ -85,7 +85,7 @@ class Container : public Item, public Cylinder
 
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 		bool unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, PropStream& propStream) override;
-		std::string getContentDescription() const;
+		std::string getContentDescription(bool colored = false) const;
 
 		size_t size() const {
 			return itemlist.size();
@@ -165,7 +165,7 @@ class Container : public Item, public Cylinder
 		ItemDeque itemlist;
 
 	private:
-		std::ostringstream& getContentDescription(std::ostringstream& os) const;
+		std::ostringstream& getContentDescription(std::ostringstream& os, bool colored = false) const;
 
 		uint32_t maxSize;
 		uint32_t totalWeight = 0;

--- a/src/game.h
+++ b/src/game.h
@@ -224,6 +224,9 @@ class Game
 		uint32_t getPlayersRecord() const {
 			return playersRecord;
 		}
+		uint16_t getItemsPriceCount() const {
+			return itemsSaleCount;
+		}
 
 		LightInfo getWorldLightInfo() const {
 			return {lightLevel, lightColor};
@@ -466,6 +469,7 @@ class Game
 		int16_t getWorldTime() { return worldTime; }
 		void updateWorldTime();
 
+		bool loadItemsPrice();
 		void loadMotdNum();
 		void saveMotdNum() const;
 		const std::string& getMotdHash() const { return motdHash; }
@@ -474,6 +478,7 @@ class Game
 
 		void sendOfflineTrainingDialog(Player* player);
 
+		const std::map<uint16_t, uint32_t>& getItemsPrice() const { return itemsPriceMap; }
 		const std::unordered_map<uint32_t, Player*>& getPlayers() const { return players; }
 		const std::map<uint32_t, Npc*>& getNpcs() const { return npcs; }
 
@@ -592,6 +597,9 @@ class Game
 
 		std::string motdHash;
 		uint32_t motdNum = 0;
+
+		std::map<uint16_t, uint32_t> itemsPriceMap;
+		uint16_t itemsSaleCount;
 
 		uint32_t lastStageLevel = 0;
 		bool stagesEnabled = false;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7086,10 +7086,10 @@ int LuaScriptInterface::luaContainerGetItemCountById(lua_State* L)
 
 int LuaScriptInterface::luaContainerGetContentDescription(lua_State* L)
 {
-	// container:getContentDescription()
+	// container:getContentDescription([colored = false])
 	Container* container = getUserdata<Container>(L, 1);
 	if (container) {
-		pushString(L, container->getContentDescription());
+		pushString(L, container->getContentDescription(getBoolean(L, 2, false)));
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -190,6 +190,12 @@ class Player final : public Creature, public Cylinder
 			return staminaMinutes;
 		}
 
+		void sendMarketStatistics() {
+			if (client) {
+				client->sendMarketStatistics();
+			}
+		}
+
 		bool addOfflineTrainingTries(skills_t skill, uint64_t tries);
 
 		void addOfflineTrainingTime(int32_t addTime) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2588,6 +2588,10 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	sendStats();
 	sendSkills();
 
+	if (version >= 1200) {
+		sendMarketStatistics();
+	}
+
 	//gameworld light-settings
 	sendWorldLight(g_game.getWorldLightInfo());
 
@@ -3245,4 +3249,21 @@ void ProtocolGame::parseExtendedOpcode(NetworkMessage& msg)
 
 	// process additional opcodes via lua script event
 	addGameTask(&Game::parsePlayerExtendedOpcode, player->getID(), opcode, buffer);
+}
+
+void ProtocolGame::sendMarketStatistics()
+{
+	NetworkMessage msg;
+	msg.addByte(0xCD);
+
+	msg.add<uint16_t>(g_game.getItemsPriceCount());
+	if (g_game.getItemsPriceCount() > 0) {
+		std::map<uint16_t, uint32_t> items = g_game.getItemsPrice();
+		for (const auto& it : items) {
+			msg.addItemId(it.first);
+			msg.add<uint32_t>(it.second);
+		}
+	}
+
+	writeToOutputBuffer(msg);
 }

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -177,6 +177,8 @@ class ProtocolGame final : public Protocol
 		void sendIcons(uint16_t icons);
 		void sendFYIBox(const std::string& message);
 
+		void sendMarketStatistics();
+
 		void sendDistanceShoot(const Position& from, const Position& to, uint8_t type);
 		void sendMagicEffect(const Position& pos, uint8_t type);
 		void sendCreatureHealth(const Creature* creature);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Items are now displayed with different coloured frames or corners which allows you to identify the approximate value of the item at a glance. Each item is highlighted in the respective colour in the loot message as well. This feature can be disabled in the client options.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

Co-Authored-By: Lucas Prazeres <9704501+LukSrT@users.noreply.github.com>
Co-Authored-By: slavi <slavidodo@gmail.com>