### PR TITLE
fixed levitate and parcel walking accuracy

### DIFF
--- a/data/spells/scripts/support/levitate.lua
+++ b/data/spells/scripts/support/levitate.lua
@@ -6,10 +6,10 @@ local function levitate(creature, parameter)
 		toPosition:getNextPosition(creature:getDirection())
 
 		local tile = Tile(parameter == "up" and Position(fromPosition.x, fromPosition.y, fromPosition.z - 1) or toPosition)
-		if not tile or not tile:getGround() and not tile:hasFlag(parameter == "up" and TILESTATE_IMMOVABLEBLOCKSOLID or TILESTATE_BLOCKSOLID) then
+		if not tile or not tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
 			tile = Tile(toPosition.x, toPosition.y, toPosition.z + (parameter == "up" and -1 or 1))
 
-			if tile and tile:getGround() and not tile:hasFlag(bit.bor(TILESTATE_IMMOVABLEBLOCKSOLID, TILESTATE_FLOORCHANGE)) then
+			if tile and tile:getGround() and not tile:hasFlag(ILESTATE_IMMOVABLEBLOCKSOLID) then
 				return creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
 			end
 		end

--- a/data/spells/scripts/support/levitate.lua
+++ b/data/spells/scripts/support/levitate.lua
@@ -9,7 +9,7 @@ local function levitate(creature, parameter)
 		if not tile or not tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
 			tile = Tile(toPosition.x, toPosition.y, toPosition.z + (parameter == "up" and -1 or 1))
 
-			if tile and tile:getGround() and not tile:hasFlag(ILESTATE_IMMOVABLEBLOCKSOLID) then
+			if tile and tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
 				return creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
 			end
 		end

--- a/data/spells/scripts/support/levitate.lua
+++ b/data/spells/scripts/support/levitate.lua
@@ -1,5 +1,6 @@
 local function levitate(creature, parameter)
 	local fromPosition = creature:getPosition()
+	parameter = parameter:trim():lower()
 
 	if parameter == "up" and fromPosition.z ~= 8 or parameter == "down" and fromPosition.z ~= 7 then
 		local toPosition = creature:getPosition()

--- a/data/spells/scripts/support/levitate.lua
+++ b/data/spells/scripts/support/levitate.lua
@@ -10,7 +10,14 @@ local function levitate(creature, parameter)
 			tile = Tile(toPosition.x, toPosition.y, toPosition.z + (parameter == "up" and -1 or 1))
 
 			if tile and tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
-				return creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
+				local fromPos = creature:getPosition()
+				local moved = creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
+
+				if moved then
+					fromPos:sendMagicEffect(CONST_ME_TELEPORT)
+				end
+
+				return moved
 			end
 		end
 	end
@@ -25,6 +32,5 @@ function onCastSpell(creature, variant)
 		return false
 	end
 
-	creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 	return true
 end

--- a/data/spells/scripts/support/levitate.lua
+++ b/data/spells/scripts/support/levitate.lua
@@ -13,7 +13,7 @@ local function levitate(creature, parameter)
 				local fromPos = creature:getPosition()
 				local moved = creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
 
-				if moved then
+				if moved == RETURNVALUE_NOERROR then
 					fromPos:sendMagicEffect(CONST_ME_TELEPORT)
 				end
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -806,7 +806,7 @@ ReturnValue Game::internalMoveCreature(Creature* creature, Direction direction, 
 			Tile* tmpTile = map.getTile(currentPos.x, currentPos.y, currentPos.getZ() - 1);
 			if (tmpTile == nullptr || (tmpTile->getGround() == nullptr && !tmpTile->hasFlag(TILESTATE_BLOCKSOLID))) {
 				tmpTile = map.getTile(destPos.x, destPos.y, destPos.getZ() - 1);
-				if (tmpTile && tmpTile->getGround() && !tmpTile->hasFlag(TILESTATE_BLOCKSOLID)) {
+				if (tmpTile && tmpTile->getGround() && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID)) {
 					flags |= FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE;
 
 					if (!tmpTile->hasFlag(TILESTATE_FLOORCHANGE)) {
@@ -822,7 +822,7 @@ ReturnValue Game::internalMoveCreature(Creature* creature, Direction direction, 
 			Tile* tmpTile = map.getTile(destPos.x, destPos.y, destPos.z);
 			if (tmpTile == nullptr || (tmpTile->getGround() == nullptr && !tmpTile->hasFlag(TILESTATE_BLOCKSOLID))) {
 				tmpTile = map.getTile(destPos.x, destPos.y, destPos.z + 1);
-				if (tmpTile && tmpTile->hasHeight(3)) {
+				if (tmpTile && tmpTile->hasHeight(3) && !tmpTile->hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID)) {
 					flags |= FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE;
 					player->setDirection(direction);
 					destPos.z++;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- make levitate and parcel behaviour more accurate
- remove floorchange check from levitate, replace checked tilestate to immovableblocksolid

needs testing

expected behaviour:
- **POSSIBLE:** levitating/parcel walking to tiles blocked by furniture
- **POSSIBLE:** levitating/parcel walking to tiles like 459
- **NOT POSSIBLE:** levitating/parcel walking to walls, immovable obstacles or unwalkable grounds
- **NOT POSSIBLE** levitating/parcel walking to tiles with PVP magic walls

**Issues addressed:** closes #3680


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
