### PR TITLE
add notpad++ backups and tfs icon to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,11 @@ pip-log.txt
 .*.swp
 .*.swo
 
+# Notepad++ backups
+*.bak
+
 #############
 ## TFS / OT
 #############
 config.lua
+theforgottenserver.ico


### PR DESCRIPTION
### Changes Proposed
I'm sick of seeing .bak files every time I type `git status`. I also want to use my icon without risk of pushing it by accident.