### PR TITLE
Fix nullptr dereference in action:register()

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15726,9 +15726,6 @@ int LuaScriptInterface::luaActionRegister(lua_State* L)
 			return 1;
 		}
 		pushBoolean(L, g_actions->registerLuaEvent(action));
-		action->clearActionIdRange();
-		action->clearItemIdRange();
-		action->clearUniqueIdRange();
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16087,15 +16087,13 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 			ItemType& it = Item::items.getItemType(id);
 			moveevent->setSlot(it.slotPosition);
 		}
+
 		if (!moveevent->isScripted()) {
 			pushBoolean(L, g_moveEvents->registerLuaFunction(moveevent));
 			return 1;
 		}
+
 		pushBoolean(L, g_moveEvents->registerLuaEvent(moveevent));
-		moveevent->clearItemIdRange();
-		moveevent->clearActionIdRange();
-		moveevent->clearUniqueIdRange();
-		moveevent->clearPosList();
 	} else {
 		lua_pushnil(L);
 	}


### PR DESCRIPTION
g_actions->registerLuaEvent(action) frees action pointer, but then we proceed to dereference it, which is in first place redundant.

Probably fix #3692 