### PR TITLE
fix crash and leak in action:register and moveevent:register

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -61,31 +61,22 @@ class Action : public Event
 			checkFloor = v;
 		}
 
-		void clearItemIdRange() {
-			return ids.clear();
-		}
-		const std::vector<uint16_t>& getItemIdRange() const {
-			return ids;
+		std::vector<uint16_t> borrowItemIdRange() {
+			return std::move(ids);
 		}
 		void addItemId(uint16_t id) {
 			ids.emplace_back(id);
 		}
 
-		void clearUniqueIdRange() {
-			return uids.clear();
-		}
-		const std::vector<uint16_t>& getUniqueIdRange() const {
-			return uids;
+		std::vector<uint16_t> borrowUniqueIdRange() {
+			return std::move(uids);
 		}
 		void addUniqueId(uint16_t id) {
 			uids.emplace_back(id);
 		}
 
-		void clearActionIdRange() {
-			return aids.clear();
-		}
-		const std::vector<uint16_t>& getActionIdRange() const {
-			return aids;
+		std::vector<uint16_t> borrowActionIdRange() {
+			return std::move(aids);
 		}
 		void addActionId(uint16_t id) {
 			aids.emplace_back(id);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15726,9 +15726,6 @@ int LuaScriptInterface::luaActionRegister(lua_State* L)
 			return 1;
 		}
 		pushBoolean(L, g_actions->registerLuaEvent(action));
-		action->clearActionIdRange();
-		action->clearItemIdRange();
-		action->clearUniqueIdRange();
 	} else {
 		lua_pushnil(L);
 	}
@@ -16085,20 +16082,11 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 	// moveevent:register()
 	MoveEvent* moveevent = getUserdata<MoveEvent>(L, 1);
 	if (moveevent) {
-		if ((moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP) && moveevent->getSlot() == SLOTP_WHEREEVER) {
-			uint32_t id = moveevent->getItemIdRange().at(0);
-			ItemType& it = Item::items.getItemType(id);
-			moveevent->setSlot(it.slotPosition);
-		}
 		if (!moveevent->isScripted()) {
 			pushBoolean(L, g_moveEvents->registerLuaFunction(moveevent));
 			return 1;
 		}
 		pushBoolean(L, g_moveEvents->registerLuaEvent(moveevent));
-		moveevent->clearItemIdRange();
-		moveevent->clearActionIdRange();
-		moveevent->clearUniqueIdRange();
-		moveevent->clearPosList();
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -221,34 +221,28 @@ bool MoveEvents::registerLuaFunction(MoveEvent* event)
 		}
 	}
 
-	if (moveEvent->getItemIdRange().size() > 0) {
-		if (moveEvent->getItemIdRange().size() == 1) {
-			uint32_t id = moveEvent->getItemIdRange().at(0);
-			addEvent(*moveEvent, id, itemIdMap);
-			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-				ItemType& it = Item::items.getItemType(id);
-				it.wieldInfo = moveEvent->getWieldInfo();
-				it.minReqLevel = moveEvent->getReqLevel();
-				it.minReqMagicLevel = moveEvent->getReqMagLv();
-				it.vocationString = moveEvent->getVocationString();
-			}
-		} else {
-			uint32_t iterId = 0;
-			while (++iterId < moveEvent->getItemIdRange().size()) {
-				if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-					ItemType& it = Item::items.getItemType(moveEvent->getItemIdRange().at(iterId));
-					it.wieldInfo = moveEvent->getWieldInfo();
-					it.minReqLevel = moveEvent->getReqLevel();
-					it.minReqMagicLevel = moveEvent->getReqMagLv();
-					it.vocationString = moveEvent->getVocationString();
-				}
-				addEvent(*moveEvent, moveEvent->getItemIdRange().at(iterId), itemIdMap);
-			}
-		}
-	} else {
-		return false;
+	bool success = false;
+	auto itemIdRange = moveEvent->borrowItemIdRange();
+
+	if ((eventType == MOVE_EVENT_EQUIP || eventType == MOVE_EVENT_DEEQUIP) && moveEvent->getSlot() == SLOTP_WHEREEVER) {
+		uint32_t id = itemIdRange.at(0);
+		ItemType& it = Item::items.getItemType(id);
+		moveEvent->setSlot(it.slotPosition);
 	}
-	return true;
+
+	for (auto itemId : itemIdRange) {
+		success = true;
+		if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
+			ItemType& it = Item::items.getItemType(itemId);
+			it.wieldInfo = moveEvent->getWieldInfo();
+			it.minReqLevel = moveEvent->getReqLevel();
+			it.minReqMagicLevel = moveEvent->getReqMagLv();
+			it.vocationString = moveEvent->getVocationString();
+		}
+		addEvent(std::move(*moveEvent), itemId, itemIdMap);
+	}
+
+	return success;
 }
 
 bool MoveEvents::registerLuaEvent(MoveEvent* event)
@@ -270,66 +264,46 @@ bool MoveEvents::registerLuaEvent(MoveEvent* event)
 			}
 		}
 	}
+	auto itemIdRange = moveEvent->borrowItemIdRange();
+	auto actionIdRange = moveEvent->borrowActionIdRange();
+	auto uniqueIdRange = moveEvent->borrowUniqueIdRange();
+	auto posList = moveEvent->borrowPosList();
+	bool success = false;
 
-	if (moveEvent->getItemIdRange().size() > 0) {
-		if (moveEvent->getItemIdRange().size() == 1) {
-			uint32_t id = moveEvent->getItemIdRange().at(0);
-			addEvent(*moveEvent, id, itemIdMap);
-			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-				ItemType& it = Item::items.getItemType(id);
-				it.wieldInfo = moveEvent->getWieldInfo();
-				it.minReqLevel = moveEvent->getReqLevel();
-				it.minReqMagicLevel = moveEvent->getReqMagLv();
-				it.vocationString = moveEvent->getVocationString();
-			}
-		} else {
-			auto v = moveEvent->getItemIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-					ItemType& it = Item::items.getItemType(*i);
-					it.wieldInfo = moveEvent->getWieldInfo();
-					it.minReqLevel = moveEvent->getReqLevel();
-					it.minReqMagicLevel = moveEvent->getReqMagLv();
-					it.vocationString = moveEvent->getVocationString();
-				}
-				addEvent(*moveEvent, *i, itemIdMap);
-			}
-		}
-	} else if (moveEvent->getActionIdRange().size() > 0) {
-		if (moveEvent->getActionIdRange().size() == 1) {
-			int32_t id = moveEvent->getActionIdRange().at(0);
-			addEvent(*moveEvent, id, actionIdMap);
-		} else {
-			auto v = moveEvent->getActionIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, actionIdMap);
-			}
-		}
-	} else if (moveEvent->getUniqueIdRange().size() > 0) {
-		if (moveEvent->getUniqueIdRange().size() == 1) {
-			int32_t id = moveEvent->getUniqueIdRange().at(0);
-			addEvent(*moveEvent, id, uniqueIdMap);
-		} else {
-			auto v = moveEvent->getUniqueIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, uniqueIdMap);
-			}
-		}
-	} else if (moveEvent->getPosList().size() > 0) {
-		if (moveEvent->getPosList().size() == 1) {
-			Position pos = moveEvent->getPosList().at(0);
-			addEvent(*moveEvent, pos, positionMap);
-		} else {
-			auto v = moveEvent->getPosList();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, positionMap);
-			}
-		}
-	} else {
-		return false;
+	if ((eventType == MOVE_EVENT_EQUIP || eventType == MOVE_EVENT_DEEQUIP) && moveEvent->getSlot() == SLOTP_WHEREEVER) {
+		uint32_t id = itemIdRange.at(0);
+		ItemType& it = Item::items.getItemType(id);
+		moveEvent->setSlot(it.slotPosition);
 	}
 
-	return true;
+	for (auto itemId : itemIdRange) {
+		success = true;
+		if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
+			ItemType& it = Item::items.getItemType(itemId);
+			it.wieldInfo = moveEvent->getWieldInfo();
+			it.minReqLevel = moveEvent->getReqLevel();
+			it.minReqMagicLevel = moveEvent->getReqMagLv();
+			it.vocationString = moveEvent->getVocationString();
+		}
+		addEvent(std::move(*moveEvent), itemId, itemIdMap);
+	}
+
+	for (auto actionId : actionIdRange) {
+		success = true;
+		addEvent(std::move(*moveEvent), actionId, actionIdMap);
+	}
+
+	for (auto uniqueId : uniqueIdRange) {
+		success = true;
+		addEvent(std::move(*moveEvent), uniqueId, uniqueIdMap);
+	}
+
+	for (auto pos : posList) {
+		success = true;
+		addEvent(std::move(*moveEvent), pos, positionMap);
+	}
+
+	return success;
 }
 
 void MoveEvents::addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map)

--- a/src/movement.h
+++ b/src/movement.h
@@ -160,38 +160,26 @@ class MoveEvent final : public Event
 		void setTileItem(bool b) {
 			tileItem = b;
 		}
-		void clearItemIdRange() {
-			return itemIdRange.clear();
-		}
-		const std::vector<uint32_t>& getItemIdRange() const {
-			return itemIdRange;
+		std::vector<uint32_t> borrowItemIdRange() {
+			return std::move(itemIdRange);
 		}
 		void addItemId(uint32_t id) {
 			itemIdRange.emplace_back(id);
 		}
-		void clearActionIdRange() {
-			return actionIdRange.clear();
-		}
-		const std::vector<uint32_t>& getActionIdRange() const {
-			return actionIdRange;
+		std::vector<uint32_t> borrowActionIdRange() {
+			return std::move(actionIdRange);
 		}
 		void addActionId(uint32_t id) {
 			actionIdRange.emplace_back(id);
 		}
-		void clearUniqueIdRange() {
-			return uniqueIdRange.clear();
-		}
-		const std::vector<uint32_t>& getUniqueIdRange() const {
-			return uniqueIdRange;
+		std::vector<uint32_t> borrowUniqueIdRange() {
+			return std::move(uniqueIdRange);
 		}
 		void addUniqueId(uint32_t id) {
 			uniqueIdRange.emplace_back(id);
 		}
-		void clearPosList() {
-			return posList.clear();
-		}
-		const std::vector<Position>& getPosList() const {
-			return posList;
+		std::vector<Position> borrowPosList() {
+			return std::move(posList);
 		}
 		void addPosList(Position pos) {
 			posList.emplace_back(pos);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Better registerLuaEvent code, allow to register the same action/moveevent to aid, uid, item id and position.
No use after delete anymore in action:register and moveevent:register.
No memory leak/waste of memory since we borrow/steal the vector from the original event making the future copies copy empty vector.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3692

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
