### PR TITLE
Better handling of DepotLocker and DepotChest

### DIFF
--- a/data/actions/scripts/other/fluids.lua
+++ b/data/actions/scripts/other/fluids.lua
@@ -33,8 +33,8 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 			item:transform(item:getId(), 0)
 			return true
 		elseif target.type ~= 0 and item.type == 0 then
-			target:transform(target:getId(), 0)
 			item:transform(item:getId(), target.type)
+			target:transform(target:getId(), 0)
 			return true
 		end
 	end

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -393,11 +393,10 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 		Container* openContainer;
 
 		//depot container
-		if (DepotLocker* depot = container->getDepotLocker()) {
-			DepotLocker* myDepotLocker = player->getDepotLocker(depot->getDepotId());
-			myDepotLocker->setParent(depot->getParent()->getTile());
+		if (DepotLocker* depotLocker = container->getDepotLocker()) {
+			DepotLocker* myDepotLocker = player->getDepotLocker(depotLocker->getLockerId());
+			myDepotLocker->setParent(depotLocker->getParent()->getTile());
 			openContainer = myDepotLocker;
-			player->setLastDepotId(depot->getDepotId());
 		} else {
 			openContainer = container;
 		}

--- a/src/container.h
+++ b/src/container.h
@@ -69,6 +69,13 @@ class Container : public Item, public Cylinder
 			return this;
 		}
 
+		virtual DepotChest* getDepotChest() {
+			return nullptr;
+		}
+		virtual const DepotChest* getDepotChest() const {
+			return nullptr;
+		}
+
 		virtual DepotLocker* getDepotLocker() {
 			return nullptr;
 		}
@@ -132,7 +139,7 @@ class Container : public Item, public Cylinder
 				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
 				uint32_t flags) const override final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override final;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
 				uint32_t& flags) override final;
 

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -54,7 +54,26 @@ ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t cou
 		}
 	}
 
-	return Container::queryAdd(index, thing, count, flags, actor);
+	ReturnValue ret = Container::queryAdd(index, thing, count, flags, actor);
+	if (ret == RETURNVALUE_NOERROR) {
+		if (owner) {
+			owner->setLastDepotId(depotId);
+		}
+	}
+
+	return ret;
+}
+
+ReturnValue DepotChest::queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor /*= nullptr */) const
+{
+	ReturnValue ret = Container::queryRemove(thing, count, flags, actor);
+	if (ret == RETURNVALUE_NOERROR) {
+		if (owner) {
+			owner->setLastDepotId(depotId);
+		}
+	}
+
+	return ret;
 }
 
 void DepotChest::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -32,9 +32,24 @@ class DepotChest final : public Container
 			maxDepotItems = maxitems;
 		}
 
+		uint16_t getDepotId() const {
+			return depotId;
+		}
+		void setDepotId(uint16_t depotId) {
+			this->depotId = depotId;
+		}
+
+		Player* getOwner() const {
+			return owner;
+		}
+		void setOwner(Player* owner) {
+			this->owner = owner;
+		}
+
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
 
 		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
@@ -50,7 +65,10 @@ class DepotChest final : public Container
 		}
 
 	private:
+		uint16_t depotId;
 		uint32_t maxDepotItems;
+
+		Player* owner;
 };
 
 #endif

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -21,6 +21,7 @@
 #define FS_DEPOTCHEST_H_6538526014684E3DBC92CC12815B6766
 
 #include "container.h"
+#include "player.h"
 
 class DepotChest final : public Container
 {

--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -22,12 +22,12 @@
 #include "depotlocker.h"
 
 DepotLocker::DepotLocker(uint16_t type) :
-	Container(type, 3), depotId(0) {}
+	Container(type, 3), lockerId(0) {}
 
 Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	if (attr == ATTR_DEPOT_ID) {
-		if (!propStream.read<uint16_t>(depotId)) {
+		if (!propStream.read<uint16_t>(lockerId)) {
 			return ATTR_READ_ERROR;
 		}
 		return ATTR_READ_CONTINUE;

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -42,11 +42,11 @@ class DepotLocker final : public Container
 		//serialization
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 
-		uint16_t getDepotId() const {
-			return depotId;
+		uint16_t getLockerId() const {
+			return lockerId;
 		}
-		void setDepotId(uint16_t depotId) {
-			this->depotId = depotId;
+		void setLockerId(uint16_t lockerId) {
+			this->lockerId = lockerId;
 		}
 
 		//cylinder implementations
@@ -61,7 +61,7 @@ class DepotLocker final : public Container
 		}
 
 	private:
-		uint16_t depotId;
+		uint16_t lockerId;
 };
 
 #endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1278,7 +1278,7 @@ ReturnValue Game::internalAddItem(Cylinder* toCylinder, Item* item, int32_t inde
 	toCylinder = toCylinder->queryDestination(index, *item, &toItem, flags);
 
 	//check if we can add this item
-	ReturnValue ret = toCylinder->queryAdd(index, *item, item->getItemCount(), flags);
+	ReturnValue ret = toCylinder->queryAdd(index, *item, item->getItemCount(), flags, dynamic_cast<Creature*>(toCylinder));
 	if (ret != RETURNVALUE_NOERROR) {
 		return ret;
 	}
@@ -1369,7 +1369,7 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 	}
 
 	//check if we can remove this item
-	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE);
+	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE, dynamic_cast<Creature*>(cylinder));
 	if (ret != RETURNVALUE_NOERROR) {
 		return ret;
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3596,7 +3596,7 @@ int LuaScriptInterface::luaGetLockerId(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, depotLocker->getDepotId());
+	lua_pushnumber(L, depotLocker->getLockerId());
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -443,6 +443,7 @@ class LuaScriptInterface
 		static int luaDoPlayerAddItem(lua_State* L);
 
 		//get item info
+		static int luaGetLockerId(lua_State* L);
 		static int luaGetDepotId(lua_State* L);
 
 		//get world info
@@ -455,6 +456,7 @@ class LuaScriptInterface
 		static int luaGetSubTypeName(lua_State* L);
 
 		//type validation
+		static int luaIsLocker(lua_State* L);
 		static int luaIsDepot(lua_State* L);
 		static int luaIsMoveable(lua_State* L);
 		static int luaIsValidUID(lua_State* L);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -71,6 +71,10 @@ Player::~Player()
 		it.second->removeInbox(inbox);
 	}
 
+	for (const auto& it : depotChests) {
+		it.second->setOwner(nullptr);
+	}
+
 	inbox->decrementReferenceCounter();
 
 	storeInbox->setParent(nullptr);
@@ -790,22 +794,24 @@ DepotChest* Player::getDepotChest(uint32_t depotId, bool autoCreate)
 
 	it = depotChests.emplace(depotId, new DepotChest(ITEM_DEPOT)).first;
 	it->second->setMaxDepotItems(getMaxDepotItems());
+	it->second->setDepotId(depotId);
+	it->second->setOwner(this);
 	return it->second;
 }
 
-DepotLocker* Player::getDepotLocker(uint32_t depotId)
+DepotLocker* Player::getDepotLocker(uint32_t lockerId)
 {
-	auto it = depotLockerMap.find(depotId);
+	auto it = depotLockerMap.find(lockerId);
 	if (it != depotLockerMap.end()) {
 		inbox->setParent(it->second.get());
 		return it->second.get();
 	}
 
-	it = depotLockerMap.emplace(depotId, new DepotLocker(ITEM_LOCKER1)).first;
-	it->second->setDepotId(depotId);
+	it = depotLockerMap.emplace(lockerId, new DepotLocker(ITEM_LOCKER1)).first;
+	it->second->setLockerId(lockerId);
 	it->second->internalAddThing(Item::CreateItem(ITEM_MARKET));
 	it->second->internalAddThing(inbox);
-	it->second->internalAddThing(getDepotChest(depotId, true));
+	it->second->internalAddThing(getDepotChest(lockerId, true));
 	return it->second.get();
 }
 


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Now we can verify if a container is a `DepotLocker` or a `DepotChest`.
When we modify the content of a DepotChest, the lastDepotId of the player who owns the deposit is updated

> **Suggestions to improve the code are welcome if you wish**
**Issues addressed:** #2251