### PR TITLE
Better Handling Of Depot Chest And Lockers

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -366,7 +366,6 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 			DepotLocker* myDepotLocker = player->getDepotLocker(depot->getDepotId());
 			myDepotLocker->setParent(depot->getParent()->getTile());
 			openContainer = myDepotLocker;
-			player->setLastDepotId(depot->getDepotId());
 		} else {
 			openContainer = container;
 		}

--- a/src/container.h
+++ b/src/container.h
@@ -69,6 +69,13 @@ class Container : public Item, public Cylinder
 			return this;
 		}
 
+		virtual DepotChest* getDepotChest() {
+			return nullptr;
+		}
+		virtual const DepotChest* getDepotChest() const {
+			return nullptr;
+		}
+
 		virtual DepotLocker* getDepotLocker() {
 			return nullptr;
 		}
@@ -132,7 +139,7 @@ class Container : public Item, public Cylinder
 				uint32_t flags, Creature* actor = nullptr) const override;
 		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
 				uint32_t flags) const override final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override final;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
 		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
 				uint32_t& flags) override final;
 

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -23,7 +23,7 @@
 #include "tools.h"
 
 DepotChest::DepotChest(uint16_t type) :
-	Container(type), maxDepotItems(2000) {}
+	Container(type), maxDepotItems(2000), depotId(0) {}
 
 ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t count,
 		uint32_t flags, Creature* actor/* = nullptr*/) const
@@ -54,7 +54,26 @@ ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t cou
 		}
 	}
 
-	return Container::queryAdd(index, thing, count, flags, actor);
+	ReturnValue ret = Container::queryAdd(index, thing, count, flags, actor);
+	if (ret == RETURNVALUE_NOERROR) {
+		if (owner) {
+			owner->setLastDepotId(depotId);
+		}
+	}
+
+	return ret;
+}
+
+ReturnValue DepotChest::queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor /*= nullptr */) const
+{
+	ReturnValue ret = Container::queryRemove(thing, count, flags, actor);
+	if (ret == RETURNVALUE_NOERROR) {
+		if (owner) {
+			owner->setLastDepotId(depotId);
+		}
+	}
+
+	return ret;
 }
 
 void DepotChest::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -21,20 +21,36 @@
 #define FS_DEPOTCHEST_H_6538526014684E3DBC92CC12815B6766
 
 #include "container.h"
+#include "player.h"
 
 class DepotChest final : public Container
 {
 	public:
 		explicit DepotChest(uint16_t type);
 
+		DepotChest* getDepotChest() override {
+			return this;
+		}
+		const DepotChest* getDepotChest() const override {
+			return this;
+		}
+
 		//serialization
 		void setMaxDepotItems(uint32_t maxitems) {
 			maxDepotItems = maxitems;
 		}
 
+		uint16_t getDepotId() const {
+			return depotId;
+		}
+		void setDepotId(uint16_t depotId) {
+			this->depotId = depotId;
+		}
+
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
 
 		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
@@ -49,8 +65,15 @@ class DepotChest final : public Container
 			return parent;
 		}
 
+		Player* getOwner() const {
+			return owner;
+		}
+
 	private:
+		uint16_t depotId;
 		uint32_t maxDepotItems;
+
+		Player* owner;
 };
 
 #endif

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -68,6 +68,9 @@ class DepotChest final : public Container
 		Player* getOwner() const {
 			return owner;
 		}
+		void setOwner(Player* owner) {
+			this->owner = owner;
+		}
 
 	private:
 		uint16_t depotId;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1290,7 +1290,7 @@ ReturnValue Game::internalAddItem(Cylinder* toCylinder, Item* item, int32_t inde
 	toCylinder = toCylinder->queryDestination(index, *item, &toItem, flags);
 
 	//check if we can add this item
-	ReturnValue ret = toCylinder->queryAdd(index, *item, item->getItemCount(), flags);
+	ReturnValue ret = toCylinder->queryAdd(index, *item, item->getItemCount(), flags, dynamic_cast<Creature*>(toCylinder));
 	if (ret != RETURNVALUE_NOERROR) {
 		return ret;
 	}
@@ -1381,7 +1381,7 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 	}
 
 	//check if we can remove this item
-	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE);
+	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE, dynamic_cast<Creature*>(cylinder));
 	if (ret != RETURNVALUE_NOERROR) {
 		return ret;
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3628,7 +3628,7 @@ int LuaScriptInterface::luaGetDepotId(lua_State* L)
 	if (DepotLocker* depotLocker = container->getDepotLocker()) {
 		lua_pushnumber(L, depotLocker->getDepotId());
 		return 1;
-	} else if if (DepotChest* depotChest = container->getDepotChest()) {
+	} else if (DepotChest* depotChest = container->getDepotChest()) {
 		lua_pushnumber(L, depotChest->getDepotId());
 		return 1;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -69,6 +69,10 @@ Player::~Player()
 		it.second->removeInbox(inbox);
 	}
 
+	for (const auto& it : depotChests) {
+		it.second->setOwner(nullptr);
+	}
+
 	inbox->decrementReferenceCounter();
 
 	storeInbox->setParent(nullptr);
@@ -829,6 +833,8 @@ DepotChest* Player::getDepotChest(uint32_t depotId, bool autoCreate)
 
 	it = depotChests.emplace(depotId, new DepotChest(ITEM_DEPOT)).first;
 	it->second->setMaxDepotItems(getMaxDepotItems());
+	it->second->setDepotId(depotId);
+	it->second->setOwner(this);
 	return it->second;
 }
 


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
* The function `isDepot(uid)` now checks if the container is a `DepotChest` or a `DepotLocker`, after all this is part of the player's private depots.
* The function `getDepotId(uid)` now also returns the depotId if the container is a `DepotChest`
* Now `depotChests` are only saved if their content is modified, such as adding or removing an `Item` within a `DepotChest`

¡Suggestions to improve the code are welcome if you wish!

**Issues addressed:** #2251 #3637