### PR TITLE
Use pragma to avoid -Werror=unused-function on signals

### DIFF
--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -176,7 +176,7 @@ void dispatchSignalHandler(int signal)
 			// hold the thread until other threads end
 			g_scheduler.join();
 			g_databaseTasks.join();
-			g_dispatcher.join();			
+			g_dispatcher.join();
 			break;
 #endif
 		default:

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -176,12 +176,7 @@ void dispatchSignalHandler(int signal)
 			// hold the thread until other threads end
 			g_scheduler.join();
 			g_databaseTasks.join();
-			g_dispatcher.join();
-			g_dispatcher2.join();
-			g_dispatcher3.join();
-			g_multitasks.join();
-			g_stats.join();
-		    g_cams.join();
+			g_dispatcher.join();			
 			break;
 #endif
 		default:

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -58,17 +58,12 @@ extern LuaEnvironment g_luaEnvironment;
 
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 void sigbreakHandler()
 {
 	//Dispatcher thread
 	std::cout << "SIGBREAK received, shutting game server down..." << std::endl;
-	g_game.setGameState(GAME_STATE_SHUTDOWN);
-}
-
-void sigtermHandler()
-{
-	//Dispatcher thread
-	std::cout << "SIGTERM received, shutting game server down..." << std::endl;
 	g_game.setGameState(GAME_STATE_SHUTDOWN);
 }
 
@@ -140,6 +135,15 @@ void sighupHandler()
 	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
 }
 
+#pragma GCC diagnostic pop
+
+void sigtermHandler()
+{
+	//Dispatcher thread
+	std::cout << "SIGTERM received, shutting game server down..." << std::endl;
+	g_game.setGameState(GAME_STATE_SHUTDOWN);
+}
+
 void sigintHandler()
 {
 	//Dispatcher thread
@@ -173,6 +177,11 @@ void dispatchSignalHandler(int signal)
 			g_scheduler.join();
 			g_databaseTasks.join();
 			g_dispatcher.join();
+			g_dispatcher2.join();
+			g_dispatcher3.join();
+			g_multitasks.join();
+			g_stats.join();
+		    g_cams.join();
 			break;
 #endif
 		default:


### PR DESCRIPTION
Avoiding compilation errors in cases where the -Werror flag is used

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
* fix the compilation error for those who use the -Werror flag

" error: ‘void {anonymous}::sigbreakHandler()’ defined but not used [-Werror=unused-function]"

https://prnt.sc/1u3hn16

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
