### PR TITLE
Make soul-regen zone configurable

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -94,6 +94,7 @@ forceMonsterTypesOnLoad = true
 cleanProtectionZones = false
 luaItemDesc = false
 showPlayerLogInConsole = true
+soulRegenerationAnyZone = false
 
 -- VIP and Depot limits
 -- NOTE: you can set custom limits per group in data/XML/groups.xml

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1044,7 +1044,7 @@ bool ConditionSoul::executeCondition(Creature* creature, int32_t interval)
 	internalSoulTicks += interval;
 
 	if (Player* player = creature->getPlayer()) {
-		if (player->getZone() != ZONE_PROTECTION) {
+		if (g_config.getBoolean(ConfigManager::SOUL_REGENERATION_ANY_ZONE) || player->getZone() != ZONE_PROTECTION) {
 			if (internalSoulTicks >= soulTicks) {
 				internalSoulTicks = 0;
 				player->changeSoul(soulGain);

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -247,6 +247,7 @@ bool ConfigManager::load()
 	boolean[ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS] = getGlobalBoolean(L, "onlyInvitedCanMoveHouseItems", true);
 	boolean[REMOVE_ON_DESPAWN] = getGlobalBoolean(L, "removeOnDespawn", true);
 	boolean[PLAYER_CONSOLE_LOGS] = getGlobalBoolean(L, "showPlayerLogInConsole", true);
+	boolean[SOUL_REGENERATION_ANY_ZONE] = getGlobalBoolean(L, "soulRegenerationAnyZone", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -68,6 +68,7 @@ class ConfigManager
 			ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS,
 			REMOVE_ON_DESPAWN,
 			PLAYER_CONSOLE_LOGS,
+			SOUL_REGENERATION_ANY_ZONE,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2015,6 +2015,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)
 	registerEnumIn("configKeys", ConfigManager::MAX_PACKETS_PER_SECOND)
 	registerEnumIn("configKeys", ConfigManager::PLAYER_CONSOLE_LOGS)
+	registerEnumIn("configKeys", ConfigManager::SOUL_REGENERATION_ANY_ZONE)
 
 	// os
 	registerMethod("os", "mtime", LuaScriptInterface::luaSystemTime);


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Make soul-regen zone configurable, if true regeneration works in any zone
- add soulRegenerationAnyZone config

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
