### PR TITLE
Use client viewport in hardcode-range

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -279,7 +279,7 @@ ReturnValue Actions::canUseFar(const Creature* creature, const Position& toPos, 
 		return creaturePos.z > toPos.z ? RETURNVALUE_FIRSTGOUPSTAIRS : RETURNVALUE_FIRSTGODOWNSTAIRS;
 	}
 
-	if (!Position::areInRange<7, 5>(toPos, creaturePos)) {
+	if (!Position::areInRange<Map::maxClientViewportX - 1, Map::maxClientViewportY - 1>(toPos, creaturePos)) {
 		return RETURNVALUE_TOOFARAWAY;
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2209,7 +2209,7 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position& fromPos, uin
 		return;
 	}
 
-	if (!Position::areInRange<7, 5, 0>(creature->getPosition(), player->getPosition())) {
+	if (!Position::areInRange<Map::maxClientViewportX - 1, Map::maxClientViewportY - 1, 0>(creature->getPosition(), player->getPosition())) {
 		return;
 	}
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -1013,7 +1013,7 @@ bool InstantSpell::canThrowSpell(const Creature* creature, const Creature* targe
 	const Position& fromPos = creature->getPosition();
 	const Position& toPos = target->getPosition();
 	if (fromPos.z != toPos.z ||
-			(range == -1 && !g_game.canThrowObjectTo(fromPos, toPos, checkLineOfSight, true, 7, 5)) ||
+			(range == -1 && !g_game.canThrowObjectTo(fromPos, toPos, checkLineOfSight, true, Map::maxClientViewportX - 1, Map::maxClientViewportY - 1)) ||
 			(range != -1 && !g_game.canThrowObjectTo(fromPos, toPos, checkLineOfSight, true, range, range))) {
 		return false;
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Use client viewport in hardcode-range.

**NOTE 1**:
If code below doesn't follow viewport, we will have dumb monsters and players casting spell/item from far away. It's something to discussed.
```
Monster::canSee()
{
    return Creature::canSee(getPosition(), pos, 9, 9);

    to

    return Creature::canSee(getPosition(), pos,
        Map::maxClientViewportX + 1, Map::maxClientViewportX + 1);
}
```

**NOTE 2**:
18/14 should change for maxClientViewport, how was it done in #3456
```
Game::internalCreatureSay()
{
...
    map.getSpectators(spectators, *pos, true, false, 18, 18, 14, 14);

    to

    map.getSpectators(spectators, *pos, true, false,
        (Map::maxClientViewportX * 2) + 2, (Map::maxClientViewportX * 2) + 2,
        (Map::maxClientViewportY * 2) + 2, (Map::maxClientViewportY * 2) + 2);
...
}
````

I'll wait confirmation, then i change this into a new commit

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
