### PR TITLE
Use single list as waiting queue

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -31,17 +31,17 @@ namespace {
 std::deque<std::pair<int64_t, uint32_t>> waitList; // (timeout, player guid)
 auto priorityEnd = waitList.end();
 
-auto findClient(const Player& player) {
+auto findClient(uint32_t guid) {
 	std::size_t slot = 1;
 	for (auto it = waitList.begin(), end = waitList.end(); it != end; ++it, ++slot) {
-		if (it->second == player.getGUID()) {
+		if (it->second == guid) {
 			return std::make_pair(it, slot);
 		}
 	}
 	return std::make_pair(waitList.end(), slot);
 }
 
-int64_t getWaitTime(std::size_t slot)
+constexpr int64_t getWaitTime(std::size_t slot)
 {
 	if (slot < 5) {
 		return 5;
@@ -56,7 +56,7 @@ int64_t getWaitTime(std::size_t slot)
 	}
 }
 
-int64_t getTimeout(std::size_t slot)
+constexpr int64_t getTimeout(std::size_t slot)
 {
 	// timeout is set to 15 seconds longer than expected retry attempt
 	return getWaitTime(slot) + 15;
@@ -85,7 +85,7 @@ std::size_t clientLogin(const Player& player)
 	}
 
 	std::size_t slot;
-	std::tie(it, slot) = findClient(player);
+	std::tie(it, slot) = findClient(player.getGUID());
 	if (it != waitList.end()) {
 		// If server has capacity for this client, let him in even though his current slot might be higher than 0.
 		if ((g_game.getPlayersOnline() + slot) <= maxPlayers) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -25,7 +25,7 @@ extern CreatureEvents* g_creatureEvents;
 
 namespace {
 
-std::deque<std::pair<std::size_t, uint32_t>> waitList; // (timeout, player guid)
+std::deque<std::pair<int64_t, uint32_t>> waitList; // (timeout, player guid)
 auto priorityEnd = waitList.end();
 
 auto findClient(const Player& player) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3,51 +3,42 @@
 
 #include "otpch.h"
 
-#include "protocolgame.h"
-
-#include "outputmessage.h"
-
-#include "player.h"
-
-#include "configmanager.h"
 #include "actions.h"
+#include "ban.h"
+#include "configmanager.h"
 #include "game.h"
 #include "iologindata.h"
 #include "iomarket.h"
-#include "ban.h"
+#include "outputmessage.h"
+#include "player.h"
+#include "protocolgame.h"
 #include "scheduler.h"
 #include "podium.h"
 
+#include <boost/range/adaptor/reversed.hpp>
 #include <fmt/format.h>
 
-extern ConfigManager g_config;
 extern Actions actions;
-extern CreatureEvents* g_creatureEvents;
 extern Chat* g_chat;
+extern ConfigManager g_config;
+extern CreatureEvents* g_creatureEvents;
 
 namespace {
 
-using WaitList = std::deque<std::pair<int64_t, uint32_t>>; // (timeout, player guid)
+std::deque<std::pair<std::size_t, uint32_t>> waitList; // (timeout, player guid)
+auto priorityEnd = waitList.end();
 
-WaitList priorityWaitList, waitList;
-
-std::tuple<WaitList&, WaitList::iterator, WaitList::size_type> findClient(const Player& player) {
-	const auto fn = [&](const WaitList::value_type& it) { return it.second == player.getGUID(); };
-
-	auto it = std::find_if(priorityWaitList.begin(), priorityWaitList.end(), fn);
-	if (it != priorityWaitList.end()) {
-		return std::make_tuple(std::ref(priorityWaitList), it, std::distance(it, priorityWaitList.end()) + 1);
+auto findClient(const Player& player) {
+	std::size_t slot = 1;
+	for (auto it = waitList.begin(), end = waitList.end(); it != end; ++it, ++slot) {
+		if (it->second == player.getGUID()) {
+			return std::make_pair(it, slot);
+		}
 	}
-
-	it = std::find_if(waitList.begin(), waitList.end(), fn);
-	if (it != waitList.end()) {
-		return std::make_tuple(std::ref(waitList), it, priorityWaitList.size() + std::distance(it, waitList.end()) + 1);
-	}
-
-	return std::make_tuple(std::ref(waitList), waitList.end(), priorityWaitList.size() + waitList.size());
+	return std::make_pair(waitList.end(), slot);
 }
 
-uint8_t getWaitTime(std::size_t slot)
+int64_t getWaitTime(std::size_t slot)
 {
 	if (slot < 5) {
 		return 5;
@@ -68,57 +59,49 @@ int64_t getTimeout(std::size_t slot)
 	return getWaitTime(slot) + 15;
 }
 
-void cleanupList(WaitList& list)
+std::size_t clientLogin(const Player& player)
 {
+	if (player.hasFlag(PlayerFlag_CanAlwaysLogin) || player.getAccountType() >= ACCOUNT_TYPE_GAMEMASTER) {
+		return true;
+	}
+
+	uint32_t maxPlayers = static_cast<uint32_t>(g_config.getNumber(ConfigManager::MAX_PLAYERS));
+	if (maxPlayers == 0 || (waitList.empty() && g_game.getPlayersOnline() < maxPlayers)) {
+		return true;
+	}
+
 	int64_t time = OTSYS_TIME();
 
-	auto it = list.begin();
-	while (it != list.end()) {
-		if (it->first <= time) {
-			it = list.erase(it);
+	auto it = waitList.begin(), end = waitList.end();
+	while (it != end) {
+		if ((it->first - time) <= 0) {
+			it = waitList.erase(it);
 		} else {
 			++it;
 		}
 	}
-}
 
-std::size_t clientLogin(const Player& player)
-{
-	// Currentslot = position in wait list, 0 for direct access
-	if (player.hasFlag(PlayerFlag_CanAlwaysLogin) || player.getAccountType() >= ACCOUNT_TYPE_GAMEMASTER) {
-		return 0;
-	}
-
-	cleanupList(priorityWaitList);
-	cleanupList(waitList);
-
-	uint32_t maxPlayers = static_cast<uint32_t>(g_config.getNumber(ConfigManager::MAX_PLAYERS));
-	if (maxPlayers == 0 || (priorityWaitList.empty() && waitList.empty() && g_game.getPlayersOnline() < maxPlayers)) {
-		return 0;
-	}
-
-	auto result = findClient(player);
-	if (std::get<1>(result) != std::get<0>(result).end()) {
-		auto currentSlot = std::get<2>(result);
-		// If server has capacity for this client, let him in even though his current slot might be higher than 0.
-		if ((g_game.getPlayersOnline() + currentSlot) <= maxPlayers) {
-			std::get<0>(result).erase(std::get<1>(result));
-			return 0;
+	std::size_t slot;
+	std::tie(it, slot) = findClient(player);
+	if (it != waitList.end()) {
+		if ((g_game.getPlayersOnline() + slot) <= maxPlayers) {
+			//should be able to login now
+			waitList.erase(it);
+			return true;
 		}
 
 		//let them wait a bit longer
-		std::get<1>(result)->second = OTSYS_TIME() + (getTimeout(currentSlot) * 1000);
-		return currentSlot;
+		it->first = time + (getTimeout(slot) * 1000);
+		return false;
 	}
 
-	auto currentSlot = priorityWaitList.size();
 	if (player.isPremium()) {
-		priorityWaitList.emplace_back(OTSYS_TIME() + (getTimeout(++currentSlot) * 1000), player.getGUID());
+		slot = std::distance(waitList.begin(), priorityEnd);
+		priorityEnd = waitList.emplace(priorityEnd, time + (getTimeout(slot + 1) * 1000), player.getGUID());
 	} else {
-		currentSlot += waitList.size();
-		waitList.emplace_back(OTSYS_TIME() + (getTimeout(++currentSlot) * 1000), player.getGUID());
+		waitList.emplace_back(time + (getTimeout(waitList.size() + 1) * 1000), player.getGUID());
 	}
-	return currentSlot;
+	return false;
 }
 
 }

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3,25 +3,28 @@
 
 #include "otpch.h"
 
-#include "actions.h"
-#include "ban.h"
+#include "protocolgame.h"
+
+#include "outputmessage.h"
+
+#include "player.h"
+
 #include "configmanager.h"
+#include "actions.h"
 #include "game.h"
 #include "iologindata.h"
 #include "iomarket.h"
-#include "outputmessage.h"
-#include "player.h"
-#include "protocolgame.h"
+#include "ban.h"
 #include "scheduler.h"
 #include "podium.h"
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <fmt/format.h>
 
-extern Actions actions;
-extern Chat* g_chat;
 extern ConfigManager g_config;
+extern Actions actions;
 extern CreatureEvents* g_creatureEvents;
+extern Chat* g_chat;
 
 namespace {
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Replaces the pair of queues (priority waitlist + standard waitlist) with a single list, keeping a token to the boundary. Reduces code complexity for calculating the length and finding a new slot.

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
