### PR TITLE
gm access doors

### DIFF
--- a/data/movements/scripts/level_door.lua
+++ b/data/movements/scripts/level_door.lua
@@ -3,7 +3,7 @@ function onStepIn(creature, item, position, fromPosition)
 		return false
 	end
 
-	if creature:getLevel() < item.actionid - actionIds.levelDoor then
+	if creature:getLevel() < item.actionid - actionIds.levelDoor and not creature:getGroup():getAccess() then
 		creature:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Only the worthy may pass.")
 		creature:teleportTo(fromPosition, true)
 		return false

--- a/data/movements/scripts/quest_door.lua
+++ b/data/movements/scripts/quest_door.lua
@@ -3,7 +3,7 @@ function onStepIn(creature, item, position, fromPosition)
 		return false
 	end
 
-	if creature:getStorageValue(item.actionid) == -1 then
+	if creature:getStorageValue(item.actionid) == -1 and not creature:getGroup():getAccess() then
 		creature:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The door seems to be sealed against unwanted intruders.")
 		creature:teleportTo(fromPosition, true)
 		return false

--- a/data/scripts/actions/others/doors.lua
+++ b/data/scripts/actions/others/doors.lua
@@ -58,7 +58,7 @@ local door = Action()
 function door.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local itemId = item:getId()
 	if table.contains(closedQuestDoors, itemId) then
-		if player:getStorageValue(item.actionid) ~= -1 then
+		if player:getStorageValue(item.actionid) ~= -1 or player:getGroup():getAccess() then
 			item:transform(itemId + 1)
 			player:teleportTo(toPosition, true)
 		else
@@ -66,7 +66,7 @@ function door.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		end
 		return true
 	elseif table.contains(closedLevelDoors, itemId) then
-		if item.actionid > 0 and player:getLevel() >= item.actionid - actionIds.levelDoor then
+		if item.actionid > 0 and player:getLevel() >= item.actionid - actionIds.levelDoor or player:getGroup():getAccess() then
 			item:transform(itemId + 1)
 			player:teleportTo(toPosition, true)
 		else


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

now gms can access gate of expertise and quest doors without requirements



<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
