### PR TITLE
Move party exp-share range

### DIFF
--- a/src/party.cpp
+++ b/src/party.cpp
@@ -386,7 +386,7 @@ bool Party::canUseSharedExperience(const Player* player) const
 		return false;
 	}
 
-	if (!Position::areInRange<EXPERIENCE_SHARE_RADIUS, EXPERIENCE_SHARE_RADIUS, 1>(leader->getPosition(), player->getPosition())) {
+	if (!Position::areInRange<EXPERIENCE_SHARE_FLOORS, EXPERIENCE_SHARE_FLOORS, 1>(leader->getPosition(), player->getPosition())) {
 		return false;
 	}
 

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -386,7 +386,7 @@ bool Party::canUseSharedExperience(const Player* player) const
 		return false;
 	}
 
-	if (!Position::areInRange<EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_RANGE, 1>(leader->getPosition(), player->getPosition())) {
+	if (!Position::areInRange<EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_FLOORS>(leader->getPosition(), player->getPosition())) {
 		return false;
 	}
 

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -386,7 +386,7 @@ bool Party::canUseSharedExperience(const Player* player) const
 		return false;
 	}
 
-	if (!Position::areInRange<EXPERIENCE_SHARE_FLOORS, EXPERIENCE_SHARE_FLOORS, 1>(leader->getPosition(), player->getPosition())) {
+	if (!Position::areInRange<EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_RANGE, 1>(leader->getPosition(), player->getPosition())) {
 		return false;
 	}
 

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -386,7 +386,7 @@ bool Party::canUseSharedExperience(const Player* player) const
 		return false;
 	}
 
-	if (!Position::areInRange<30, 30, 1>(leader->getPosition(), player->getPosition())) {
+	if (!Position::areInRange<EXPERIENCE_SHARE_RADIUS, EXPERIENCE_SHARE_RADIUS, 1>(leader->getPosition(), player->getPosition())) {
 		return false;
 	}
 

--- a/src/party.h
+++ b/src/party.h
@@ -28,7 +28,7 @@ class Party;
 
 using PlayerVector = std::vector<Player*>;
 
-static constexpr int32_t EXPERIENCE_SHARE_FLOORS = 30;
+static constexpr int32_t EXPERIENCE_SHARE_RANGE = 30;
 
 class Party
 {

--- a/src/party.h
+++ b/src/party.h
@@ -29,6 +29,7 @@ class Party;
 using PlayerVector = std::vector<Player*>;
 
 static constexpr int32_t EXPERIENCE_SHARE_RANGE = 30;
+static constexpr int32_t EXPERIENCE_SHARE_FLOORS = 1;
 
 class Party
 {

--- a/src/party.h
+++ b/src/party.h
@@ -28,7 +28,7 @@ class Party;
 
 using PlayerVector = std::vector<Player*>;
 
-static constexpr int32_t EXPERIENCE_SHARE_RADIUS = 30;
+static constexpr int32_t EXPERIENCE_SHARE_FLOORS = 30;
 
 class Party
 {

--- a/src/party.h
+++ b/src/party.h
@@ -28,6 +28,8 @@ class Party;
 
 using PlayerVector = std::vector<Player*>;
 
+static constexpr int32_t EXPERIENCE_SHARE_RADIUS = 30;
+
 class Party
 {
 	public:


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Move party experience-share range
- Add `EXPERIENCE_SHARE_RANGE = 30` and `EXPERIENCE_SHARE_FLOORS = 1` on party.h

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
