### PR TITLE
Add possibility to register movement events with actionId

### DIFF
--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -367,6 +367,18 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, slots_t slot)
 		default: slotp = 0; break;
 	}
 
+	if (item->hasAttribute(ITEM_ATTRIBUTE_ACTIONID)) {
+		MoveListMap::iterator it = actionIdMap.find(item->getActionId());
+		if (it != actionIdMap.end()) {
+			std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
+			for (MoveEvent& moveEvent : moveEventList) {
+				if ((moveEvent.getSlot() & slotp) != 0) {
+					return &moveEvent;
+				}
+			}
+		}
+	}
+
 	auto it = itemIdMap.find(item->getID());
 	if (it != itemIdMap.end()) {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Add the possibility to register movement events (equip/deequip) with actionId

@Tazer89

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
