### PR TITLE
Improve Monster::getDanceStep cache

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1277,6 +1277,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 	uint32_t centerToDist = std::max<uint32_t>(distance_x, distance_y);
 
 	std::vector<Direction> dirList;
+	dirList.reserve(4);
 
 	if (!keepDistance || offset_y >= 0) {
 		uint32_t tmpDist = std::max<uint32_t>(distance_x, std::abs((creaturePos.getY() - 1) - centerPos.getY()));

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1339,7 +1339,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 		}
 	}
 
-	if (directions <= 4) {
+	if (directions != -1) {
 		direction = dirList[uniform_random(0, directions)];
 		return true;
 	}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1276,8 +1276,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 
 	uint32_t centerToDist = std::max<uint32_t>(distance_x, distance_y);
 
-	std::array<Direction, 4> dirList;
-	size_t directions = static_cast<size_t>(-1);
+	std::vector<Direction> dirList;
 
 	if (!keepDistance || offset_y >= 0) {
 		uint32_t tmpDist = std::max<uint32_t>(distance_x, std::abs((creaturePos.getY() - 1) - centerPos.getY()));
@@ -1289,7 +1288,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList[++directions] = DIRECTION_NORTH;
+				dirList.push_back(DIRECTION_NORTH);
 			}
 		}
 	}
@@ -1304,7 +1303,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList[++directions] = DIRECTION_SOUTH;
+				dirList.push_back(DIRECTION_SOUTH);
 			}
 		}
 	}
@@ -1319,7 +1318,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList[++directions] = DIRECTION_EAST;
+				dirList.push_back(DIRECTION_EAST);
 			}
 		}
 	}
@@ -1334,13 +1333,14 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList[++directions] = DIRECTION_WEST;
+				dirList.push_back(DIRECTION_WEST);
 			}
 		}
 	}
 
-	if (directions != -1) {
-		direction = dirList[uniform_random(0, directions)];
+	if (!dirList.empty()) {
+		std::shuffle(dirList.begin(), dirList.end(), getRandomGenerator());
+		direction = dirList[uniform_random(0, dirList.size() - 1)];
 		return true;
 	}
 	return false;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1276,7 +1276,8 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 
 	uint32_t centerToDist = std::max<uint32_t>(distance_x, distance_y);
 
-	std::vector<Direction> dirList;
+	std::array<Direction, 4> dirList;
+	size_t directions = static_cast<size_t>(-1);
 
 	if (!keepDistance || offset_y >= 0) {
 		uint32_t tmpDist = std::max<uint32_t>(distance_x, std::abs((creaturePos.getY() - 1) - centerPos.getY()));
@@ -1288,7 +1289,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList.push_back(DIRECTION_NORTH);
+				dirList[++directions] = DIRECTION_NORTH;
 			}
 		}
 	}
@@ -1303,7 +1304,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList.push_back(DIRECTION_SOUTH);
+				dirList[++directions] = DIRECTION_SOUTH;
 			}
 		}
 	}
@@ -1318,7 +1319,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList.push_back(DIRECTION_EAST);
+				dirList[++directions] = DIRECTION_EAST;
 			}
 		}
 	}
@@ -1333,14 +1334,13 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction,
 			}
 
 			if (result) {
-				dirList.push_back(DIRECTION_WEST);
+				dirList[++directions] = DIRECTION_WEST;
 			}
 		}
 	}
 
-	if (!dirList.empty()) {
-		std::shuffle(dirList.begin(), dirList.end(), getRandomGenerator());
-		direction = dirList[uniform_random(0, dirList.size() - 1)];
+	if (directions <= 4) {
+		direction = dirList[uniform_random(0, directions)];
 		return true;
 	}
 	return false;


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Improve random step cache, remove unnecessary allocation with reserve an exact heap size


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
