### PR TITLE
Fix potential crash in MoveEvents::getEvent

### DIFF
--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -371,7 +371,7 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, slots_t slot)
 	if (it != itemIdMap.end()) {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 		for (MoveEvent& moveEvent : moveEventList) {
-			if (moveEvent && (moveEvent.getSlot() & slotp) != 0) {
+			if (moveEvent != nullptr && (moveEvent.getSlot() & slotp) != 0) {
 				return &moveEvent;
 			}
 		}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Fix potential crash in MoveEvents when equipping items that has registered different events.

@SaiyansKing 

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
