### PR TITLE
Fix memory leak on luaPlayerShowTextDialog - double ref

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9429,13 +9429,10 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 	}
 
 	Item* item;
-	bool fixMemoryLeak = false;
 	if (isNumber(L, 2)) {
 		item = Item::CreateItem(getNumber<uint16_t>(L, 2));
-		fixMemoryLeak = true;
 	} else if (isString(L, 2)) {
 		item = Item::CreateItem(Item::items.getItemIdByName(getString(L, 2)));
-		fixMemoryLeak = true;
 	} else if (isUserdata(L, 2)) {
 		if (getUserdataType(L, 2) != LuaData_Item) {
 			pushBoolean(L, false);
@@ -9465,14 +9462,6 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 	item->setParent(player);
 	player->setWriteItem(item, length);
 	player->sendTextWindow(item, length, canWrite);
-
-	if (fixMemoryLeak) {
-		// Player::setWriteItem and Item::CreateItem will add reference so we'll end
-		// up with 2 references and since we'll have 2 references the memory allocated
-		// will never be destroyed to avoid that we decrement one reference here
-		item->decrementReferenceCounter();
-	}
-
 	pushBoolean(L, true);
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9460,7 +9460,9 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 	}
 
 	item->setParent(player);
-	player->setWriteItem(item, length);
+	player->windowTextId++;
+	player->writeItem = item;
+	player->maxWriteLen = length;
 	player->sendTextWindow(item, length, canWrite);
 	pushBoolean(L, true);
 	return 1;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9429,10 +9429,13 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 	}
 
 	Item* item;
+	bool fixMemoryLeak = false;
 	if (isNumber(L, 2)) {
 		item = Item::CreateItem(getNumber<uint16_t>(L, 2));
+		fixMemoryLeak = true;
 	} else if (isString(L, 2)) {
 		item = Item::CreateItem(Item::items.getItemIdByName(getString(L, 2)));
+		fixMemoryLeak = true;
 	} else if (isUserdata(L, 2)) {
 		if (getUserdataType(L, 2) != LuaData_Item) {
 			pushBoolean(L, false);
@@ -9462,6 +9465,14 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 	item->setParent(player);
 	player->setWriteItem(item, length);
 	player->sendTextWindow(item, length, canWrite);
+
+	if (fixMemoryLeak) {
+		// Player::setWriteItem and Item::CreateItem will add reference so we'll end
+		// up with 2 references and since we'll have 2 references the memory allocated
+		// will never be destroyed to avoid that we decrement one reference here
+		item->decrementReferenceCounter();
+	}
+
 	pushBoolean(L, true);
 	return 1;
 }


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Fix memory leak on luaPlayerShowTextDialog - double ref

- `Player::setWriteItem` and `Item::CreateItem` will add reference so we'll end up with 2 references and since we'll have 2 references the memory allocated will never be destroyed.

@SaiyansKing 

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
