### PR TITLE
[12.00] Adding support for colored loot

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -182,7 +182,7 @@ std::ostringstream& Container::getContentDescription(std::ostringstream& os) con
 			os << ", ";
 		}
 
-		os << item->getNameDescription();
+		os << '{' << item->getClientID() << '|' << item->getNameDescription() << '}';
 	}
 
 	if (firstitem) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Items are now displayed with different coloured frames or corners which allows you to identify the approximate value of the item at a glance. Each item is highlighted in the respective colour in the loot message as well. This feature can be disabled in the client options.

**Only works together with #3748**

![image](https://user-images.githubusercontent.com/26801045/138918629-5f0108ae-ecee-49af-a5b0-f2022ffcecd9.png)
![image](https://user-images.githubusercontent.com/26801045/138918686-b62be8c1-f1f0-4cc4-8507-0ca6b9fc8c7d.png)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
