### PR TITLE
Fixed pz locked players bypassing white skull timer

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -890,6 +890,10 @@ void Player::sendPing()
 			return;
 		}
 
+		if (pzLocked) {
+			return;
+		}
+
 		if (!g_creatureEvents->playerLogout(this)) {
 			return;
 		}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixed pz locked players bypassing white skull timer
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
closes #3754 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
