### PR TITLE
[12.00] Adding support for colored loot

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -10,7 +10,7 @@ function Container.createLootItem(self, item)
 	local itemCount = 0
 	local randvalue = getLootRandom()
 	local itemType = ItemType(item.itemId)
-	
+
 	if randvalue < item.chance then
 		if itemType:isStackable() then
 			itemCount = randvalue % item.maxCount + 1
@@ -21,12 +21,12 @@ function Container.createLootItem(self, item)
 
 	while itemCount > 0 do
 		local count = math.min(100, itemCount)
-		
+
 		local subType = count
 		if itemType:isFluidContainer() then
 			subType = math.max(0, item.subType)
 		end
-		
+
 		local tmpItem = Game.createItem(item.itemId, subType)
 		if not tmpItem then
 			return false
@@ -66,4 +66,18 @@ function Container.createLootItem(self, item)
 		itemCount = itemCount - count
 	end
 	return true
+end
+
+function Container:getContentDescription()
+	local items = self:getItems()
+	if items and #items > 0 then
+		local loot = {}
+		for i = 1, #items do
+			loot[#loot+1] = string.format("{%d|%s}", items[i]:getType():getClientId(), items[i]:getNameDescription(items[i]:getSubType(), true))
+		end
+
+		return table.concat(loot, ", ")
+	end
+
+	return "nothing"
 end

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -182,7 +182,7 @@ std::ostringstream& Container::getContentDescription(std::ostringstream& os) con
 			os << ", ";
 		}
 
-		os << item->getNameDescription();
+		os << '{' << item->getClientID() << '|' << item->getNameDescription() << '}';
 	}
 
 	if (firstitem) {

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -159,38 +159,6 @@ uint32_t Container::getWeight() const
 	return Item::getWeight() + totalWeight;
 }
 
-std::string Container::getContentDescription() const
-{
-	std::ostringstream os;
-	return getContentDescription(os).str();
-}
-
-std::ostringstream& Container::getContentDescription(std::ostringstream& os) const
-{
-	bool firstitem = true;
-	for (ContainerIterator it = iterator(); it.hasNext(); it.advance()) {
-		Item* item = *it;
-
-		Container* container = item->getContainer();
-		if (container && !container->empty()) {
-			continue;
-		}
-
-		if (firstitem) {
-			firstitem = false;
-		} else {
-			os << ", ";
-		}
-
-		os << '{' << item->getClientID() << '|' << item->getNameDescription() << '}';
-	}
-
-	if (firstitem) {
-		os << "nothing";
-	}
-	return os;
-}
-
 Item* Container::getItemByIndex(size_t index) const
 {
 	if (index >= size()) {

--- a/src/container.h
+++ b/src/container.h
@@ -85,7 +85,6 @@ class Container : public Item, public Cylinder
 
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 		bool unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, PropStream& propStream) override;
-		std::string getContentDescription() const;
 
 		size_t size() const {
 			return itemlist.size();
@@ -165,8 +164,6 @@ class Container : public Item, public Cylinder
 		ItemDeque itemlist;
 
 	private:
-		std::ostringstream& getContentDescription(std::ostringstream& os) const;
-
 		uint32_t maxSize;
 		uint32_t totalWeight = 0;
 		uint32_t serializationCount = 0;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2275,7 +2275,6 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Container", "getSize", LuaScriptInterface::luaContainerGetSize);
 	registerMethod("Container", "getCapacity", LuaScriptInterface::luaContainerGetCapacity);
 	registerMethod("Container", "getEmptySlots", LuaScriptInterface::luaContainerGetEmptySlots);
-	registerMethod("Container", "getContentDescription", LuaScriptInterface::luaContainerGetContentDescription);
 	registerMethod("Container", "getItems", LuaScriptInterface::luaContainerGetItems);
 	registerMethod("Container", "getItemHoldingCount", LuaScriptInterface::luaContainerGetItemHoldingCount);
 	registerMethod("Container", "getItemCountById", LuaScriptInterface::luaContainerGetItemCountById);
@@ -7106,18 +7105,6 @@ int LuaScriptInterface::luaContainerGetItemCountById(lua_State* L)
 
 	int32_t subType = getNumber<int32_t>(L, 3, -1);
 	lua_pushnumber(L, container->getItemTypeCount(itemId, subType));
-	return 1;
-}
-
-int LuaScriptInterface::luaContainerGetContentDescription(lua_State* L)
-{
-	// container:getContentDescription()
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
-		pushString(L, container->getContentDescription());
-	} else {
-		lua_pushnil(L);
-	}
 	return 1;
 }
 
@@ -16421,13 +16408,13 @@ int LuaScriptInterface::luaGlobalEventRegister(lua_State* L)
 			pushBoolean(L, false);
 			return 1;
 		}
-		
+
 		if (globalevent->getEventType() == GLOBALEVENT_NONE && globalevent->getInterval() == 0) {
 			std::cout << "[Error - LuaScriptInterface::luaGlobalEventRegister] No interval for globalevent with name " << globalevent->getName() << std::endl;
 			pushBoolean(L, false);
 			return 1;
 		}
-		
+
 		pushBoolean(L, g_globalEvents->registerLuaEvent(globalevent));
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -760,7 +760,6 @@ class LuaScriptInterface
 		static int luaContainerGetSize(lua_State* L);
 		static int luaContainerGetCapacity(lua_State* L);
 		static int luaContainerGetEmptySlots(lua_State* L);
-		static int luaContainerGetContentDescription(lua_State* L);
 		static int luaContainerGetItems(lua_State* L);
 		static int luaContainerGetItemHoldingCount(lua_State* L);
 		static int luaContainerGetItemCountById(lua_State* L);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->

Items are now displayed with different coloured frames or corners which allows you to identify the approximate value of the item at a glance. Each item is highlighted in the respective colour in the loot message as well. This feature can be disabled in the client options.

Only works together with #3748

![image](https://user-images.githubusercontent.com/26801045/140375518-ba0f2d27-008a-4f3e-9680-5e89c994142e.png)
![image](https://user-images.githubusercontent.com/26801045/140375536-cc17b975-a7e0-4698-a474-280b52b245e8.png)


**Issues addressed:** <!-- Write here the issue number, if any. -->
 #3758 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
