### PR TITLE
[12.70] Premium players can store 15,000 in depot

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -102,7 +102,7 @@ showPlayerLogInConsole = true
 vipFreeLimit = 20
 vipPremiumLimit = 100
 depotFreeLimit = 2000
-depotPremiumLimit = 10000
+depotPremiumLimit = 15000
 
 -- World Light
 -- NOTE: if defaultWorldLight is set to true the world light algorithm will

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -291,7 +291,7 @@ bool ConfigManager::load()
 	integer[VIP_FREE_LIMIT] = getGlobalNumber(L, "vipFreeLimit", 20);
 	integer[VIP_PREMIUM_LIMIT] = getGlobalNumber(L, "vipPremiumLimit", 100);
 	integer[DEPOT_FREE_LIMIT] = getGlobalNumber(L, "depotFreeLimit", 2000);
-	integer[DEPOT_PREMIUM_LIMIT] = getGlobalNumber(L, "depotPremiumLimit", 10000);
+	integer[DEPOT_PREMIUM_LIMIT] = getGlobalNumber(L, "depotPremiumLimit", 15000);
 
 	expStages = loadXMLStages();
 	if (expStages.empty()) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
The Depot item limit of 10,000 items for Premium Account players has been raised to 15,000.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3758

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
