### PR TITLE
Move onShareExperience callback from party event

### DIFF
--- a/data/events/scripts/party.lua
+++ b/data/events/scripts/party.lua
@@ -23,27 +23,5 @@ function Party:onDisband()
 end
 
 function Party:onShareExperience(exp)
-	local sharedExperienceMultiplier = 1.20 --20%
-	local vocationsIds = {}
-	local rawExp = exp
-
-	local vocationId = self:getLeader():getVocation():getBase():getId()
-	if vocationId ~= VOCATION_NONE then
-		table.insert(vocationsIds, vocationId)
-	end
-
-	for _, member in ipairs(self:getMembers()) do
-		vocationId = member:getVocation():getBase():getId()
-		if not table.contains(vocationsIds, vocationId) and vocationId ~= VOCATION_NONE then
-			table.insert(vocationsIds, vocationId)
-		end
-	end
-
-	local size = #vocationsIds
-	if size > 1 then
-		sharedExperienceMultiplier = 1.0 + ((size * (5 * (size - 1) + 10)) / 100)
-	end
-
-	exp = math.ceil((exp * sharedExperienceMultiplier) / (#self:getMembers() + 1))
 	return hasEventCallback(EVENT_CALLBACK_ONSHAREEXPERIENCE) and EventCallback(EVENT_CALLBACK_ONSHAREEXPERIENCE, self, exp, rawExp) or exp
 end

--- a/data/scripts/eventcallbacks/party/default_onShareExperience.lua
+++ b/data/scripts/eventcallbacks/party/default_onShareExperience.lua
@@ -1,0 +1,29 @@
+local ec = EventCallback
+
+ec.onShareExperience = function(self, exp)
+	local sharedExperienceMultiplier = 1.20 --20%
+	local vocationsIds = {}
+	local rawExp = exp
+
+	local vocationId = self:getLeader():getVocation():getBase():getId()
+	if vocationId ~= VOCATION_NONE then
+	table.insert(vocationsIds, vocationId)
+	end
+
+	for _, member in ipairs(self:getMembers()) do
+	vocationId = member:getVocation():getBase():getId()
+	if not table.contains(vocationsIds, vocationId) and vocationId ~= VOCATION_NONE then
+	table.insert(vocationsIds, vocationId)
+	end
+	end
+
+	local size = #vocationsIds
+	if size > 1 then
+	sharedExperienceMultiplier = 1.0 + ((size * (5 * (size - 1) + 10)) / 100)
+	end
+
+	exp = math.ceil((exp * sharedExperienceMultiplier) / (#self:getMembers() + 1))
+	return exp
+end
+
+ec:register()

--- a/data/scripts/eventcallbacks/party/default_onShareExperience.lua
+++ b/data/scripts/eventcallbacks/party/default_onShareExperience.lua
@@ -7,19 +7,19 @@ ec.onShareExperience = function(self, exp)
 
 	local vocationId = self:getLeader():getVocation():getBase():getId()
 	if vocationId ~= VOCATION_NONE then
-	table.insert(vocationsIds, vocationId)
+		table.insert(vocationsIds, vocationId)
 	end
 
 	for _, member in ipairs(self:getMembers()) do
-	vocationId = member:getVocation():getBase():getId()
-	if not table.contains(vocationsIds, vocationId) and vocationId ~= VOCATION_NONE then
-	table.insert(vocationsIds, vocationId)
-	end
+		vocationId = member:getVocation():getBase():getId()
+		if not table.contains(vocationsIds, vocationId) and vocationId ~= VOCATION_NONE then
+			table.insert(vocationsIds, vocationId)
+		end
 	end
 
 	local size = #vocationsIds
 	if size > 1 then
-	sharedExperienceMultiplier = 1.0 + ((size * (5 * (size - 1) + 10)) / 100)
+		sharedExperienceMultiplier = 1.0 + ((size * (5 * (size - 1) + 10)) / 100)
 	end
 
 	exp = math.ceil((exp * sharedExperienceMultiplier) / (#self:getMembers() + 1))


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Move onShareExperience callback from party event.
- Add party folder with default file for onShareExperience event callback.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
