### PR TITLE
Change default value to NULL for conditions

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS `players` (
   `posx` int NOT NULL DEFAULT '0',
   `posy` int NOT NULL DEFAULT '0',
   `posz` int NOT NULL DEFAULT '0',
-  `conditions` blob NOT NULL,
+  `conditions` blob DEFAULT NULL,
   `cap` int NOT NULL DEFAULT '400',
   `sex` int NOT NULL DEFAULT '0',
   `lastlogin` bigint unsigned NOT NULL DEFAULT '0',


### PR DESCRIPTION
Honestly, idk why it's NOT NULL as this is binary, but it only triggers me when I manually add entries thru phpmyadmin and it spits out errors, cause conditions cannot be null.

Default value for this should be null, this should not affect anything in loading and will fix that annoyance.