### PR TITLE
FIXED: Item::equals issue with custom attributes

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -210,7 +210,13 @@ bool Item::equals(const Item* otherItem) const
 	const auto& attributeList = attributes->attributes;
 	const auto& otherAttributeList = otherAttributes->attributes;
 	for (const auto& attribute : attributeList) {
-		if (ItemAttributes::isStrAttrType(attribute.type)) {
+		if (ItemAttributes::isIntAttrType(attribute.type)) {
+			for (const auto& otherAttribute : otherAttributeList) {
+				if (attribute.type == otherAttribute.type && attribute.value.integer != otherAttribute.value.integer) {
+					return false;
+				}
+			}
+		} else if (ItemAttributes::isStrAttrType(attribute.type)) {
 			for (const auto& otherAttribute : otherAttributeList) {
 				if (attribute.type == otherAttribute.type && *attribute.value.string != *otherAttribute.value.string) {
 					return false;
@@ -218,7 +224,7 @@ bool Item::equals(const Item* otherItem) const
 			}
 		} else {
 			for (const auto& otherAttribute : otherAttributeList) {
-				if (attribute.type == otherAttribute.type && attribute.value.integer != otherAttribute.value.integer) {
+				if (attribute.type == otherAttribute.type && *attribute.value.custom != *otherAttribute.value.custom) {
 					return false;
 				}
 			}

--- a/src/item.h
+++ b/src/item.h
@@ -222,6 +222,14 @@ class ItemAttributes
 
 			CustomAttribute() : value(boost::blank()) {}
 
+			bool operator==(const CustomAttribute& otherAttr) const {
+				return value == otherAttr.value;
+			}
+
+			bool operator!=(const CustomAttribute& otherAttr) const {
+				return value != otherAttr.value;
+			}
+
 			template<typename T>
 			explicit CustomAttribute(const T& v) : value(v) {}
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix the `Item::equals` method as we seem to forget to adapt it for the new CustomAttribute attributes.

If you have any suggestions feel free to mention them, since I'm not 100% sure if anything else is needed, but as this one works perfectly for me, so far...

**Issues addressed:** #3783
The guy @Zbizu has a solution in his repository. I don't know which one is better, but you can give your opinion and I will change it if necessary.