### PR TITLE
The equivalent of #3609 but for the onItemMoved event

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1144,6 +1144,11 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 				}
 
 				ret = toCylinder->queryAdd(index, *item, count, flags);
+
+				if (actorPlayer && fromPos && toPos) {
+					g_events->eventPlayerOnItemMoved(actorPlayer, toItem, count, *toPos, *fromPos, toCylinder, fromCylinder);
+				}
+
 				toItem = nullptr;
 			}
 		}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
As the title says, Player.onItemMoved not being called when switching items in inventory.

### Important
I am not 100% sure if the method should be called exactly where I have declared it, but I hope you can help me and tell me if it is ok or if this should be moved to another place ;)

**Similar Issues addressed:** #3609