### PR TITLE
Reset idle time on reconnect

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -282,7 +282,7 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	sendAddCreature(player, player->getPosition(), 0, false);
 	player->lastIP = player->getIP();
 	player->lastLoginSaved = std::max<time_t>(time(nullptr), player->lastLoginSaved + 1);
-	player->resetIdleTime()
+	player->resetIdleTime();
 	acceptPackets = true;
 }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -282,6 +282,7 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	sendAddCreature(player, player->getPosition(), 0, false);
 	player->lastIP = player->getIP();
 	player->lastLoginSaved = std::max<time_t>(time(nullptr), player->lastLoginSaved + 1);
+	player->resetIdleTime()
 	acceptPackets = true;
 }
 


### PR DESCRIPTION
Reconnecting should reset idle time, because currently if you exit the client and log back in (reconnect, while your character is still in-game) and you do it in right time, you gonna get kicked out instantly back to character list.

So, reconnecting should reset idle time.