### PR TITLE
fixed bugs in mount system

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3358,9 +3358,14 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit)
 		}
 
 		changeSpeed(player, speedChange);
+
 		player->setCurrentMount(mount->id);
-	} else if (player->isMounted()) {
-		player->dismount();
+	} else {
+		if (player->isMounted()) {
+			player->dismount();
+		}
+
+		player->wasMounted = false;
 	}
 
 	if (player->canWear(outfit.lookType, outfit.lookAddons)) {
@@ -3371,6 +3376,10 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit)
 		}
 
 		internalCreatureChangeOutfit(player, outfit);
+	}
+
+	if (player->isMounted()) {
+		player->onChangeZone(player->getZone());
 	}
 }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3010,7 +3010,6 @@ void ProtocolGame::sendOutfitWindow()
 	msg.addByte(0xC8);
 
 	Outfit_t currentOutfit = player->getDefaultOutfit();
-	bool mounted = currentOutfit.lookMount != 0;
 
 	if (currentOutfit.lookType == 0) {
 		Outfit_t newOutfit;
@@ -3023,6 +3022,7 @@ void ProtocolGame::sendOutfitWindow()
 		currentOutfit.lookMount = currentMount->clientId;
 	}
 
+	bool mounted = currentOutfit.lookMount != 0;
 	AddOutfit(msg, currentOutfit);
 
 	// mount color bytes are required here regardless of having one


### PR DESCRIPTION
Co-Authored-By: Zbizu <Zbizu@users.noreply.github.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
bugs addressed:
bug 1: enabling mount in pz through set outfit dialog was allowing to ride a mount in pz
bug 2: players who opened "set outfit" in pz had mount checkbox disabled despite preferring to have a mount
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
