### PR TITLE
Fix condition update stats

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -500,6 +500,7 @@ void ConditionAttributes::updateStats(Player* player)
 
 	if (needUpdateStats) {
 		player->sendStats();
+		player->sendSkills();
 	}
 }
 
@@ -578,6 +579,7 @@ void ConditionAttributes::endCondition(Creature* creature)
 
 		if (needUpdateStats) {
 			player->sendStats();
+			player->sendSkills();
 		}
 	}
 


### PR DESCRIPTION
Condition doesn't update all stats, for example magic level

try: 
local condition = createConditionObject(CONDITION_ATTRIBUTES)
condition:setParameter(CONDITION_PARAM_STAT_MAGICPOINTSPERCENT, 200)
condition:setParameter(CONDITION_PARAM_TICKS, conditionTime)

