### PR TITLE
CreatureEvent onParsePacket

### DIFF
--- a/data/creaturescripts/creaturescripts.xml
+++ b/data/creaturescripts/creaturescripts.xml
@@ -8,4 +8,6 @@
 	<event type="death" name="PlayerDeath" script="playerdeath.lua" />
 	<event type="death" name="DropLoot" script="droploot.lua" />
 	<event type="extendedopcode" name="ExtendedOpcode" script="extendedopcode.lua" />
+
+	<!-- <event type="parsepacket" recvbyte="130" name="ParsePacket" script="parsepacket.lua" /> -->
 </creaturescripts>

--- a/data/creaturescripts/scripts/parsepacket.lua
+++ b/data/creaturescripts/scripts/parsepacket.lua
@@ -1,4 +1,4 @@
-function onParsePacket(player, msg)
+function onParsePacket(player, recvbyte, msg)
 	-- structure for parseUseItem packet, recbyte: 130 (0x82)
 	local pos = msg:getPosition()
 	local clientId = msg:getU16()

--- a/data/creaturescripts/scripts/parsepacket.lua
+++ b/data/creaturescripts/scripts/parsepacket.lua
@@ -1,0 +1,9 @@
+function onParsePacket(player, msg)
+	-- structure for parseUseItem packet, recbyte: 130 (0x82)
+	local pos = msg:getPosition()
+	local clientId = msg:getU16()
+	local stackpos = msg:getByte()
+	local index = msg:getByte()
+	print(("Player: %s wants to use item at position (%d, %d, %d) with sprite id %d"):format(player:getName(), pos.x, pos.y, pos.z, clientId))
+	msg:delete()
+end

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -161,6 +161,10 @@ do
 			self:type("extendedopcode")
 			self:onExtendedOpcode(value)
 			return
+		elseif key == "onParsePacket" then
+			self:type("parsepacket")
+			self:onParsePacket(value)
+			return
 		end
 		rawset(self, key, value)
 	end

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1521,7 +1521,7 @@ bool Creature::unregisterCreatureEvent(const std::string& name)
 	return true;
 }
 
-CreatureEventList Creature::getCreatureEvents(CreatureEventType_t type)
+CreatureEventList Creature::getCreatureEvents(CreatureEventType_t type, uint8_t recvbyte /*= 0*/)
 {
 	CreatureEventList tmpEventList;
 
@@ -1535,6 +1535,10 @@ CreatureEventList Creature::getCreatureEvents(CreatureEventType_t type)
 		}
 
 		if (creatureEvent->getEventType() == type) {
+			if (type == CREATURE_EVENT_PARSE_PACKET && creatureEvent->getRecvbyte() != recvbyte) {
+				continue;
+			}
+
 			tmpEventList.push_back(creatureEvent);
 		}
 	}

--- a/src/creature.h
+++ b/src/creature.h
@@ -555,7 +555,7 @@ class Creature : virtual public Thing
 		bool hasEventRegistered(CreatureEventType_t event) const {
 			return (0 != (scriptEventsBitField & (static_cast<uint32_t>(1) << event)));
 		}
-		CreatureEventList getCreatureEvents(CreatureEventType_t type);
+		CreatureEventList getCreatureEvents(CreatureEventType_t type, uint8_t recvbyte = 0);
 
 		void updateMapCache();
 		void updateTileCache(const Tile* tile, int32_t dx, int32_t dy);

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -626,7 +626,7 @@ void CreatureEvent::executeExtendedOpcode(Player* player, uint8_t opcode, const 
 	scriptInterface->callVoidFunction(3);
 }
 
-void CreatureEvent::executeParsePacket(Player* player, NetworkMessage_ptr message)
+void CreatureEvent::executeParsePacket(Player* player, uint8_t recvbyte, NetworkMessage_ptr message)
 {
 	//onParsePacket(player, msg)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -644,8 +644,10 @@ void CreatureEvent::executeParsePacket(Player* player, NetworkMessage_ptr messag
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
+	lua_pushnumber(L, recvbyte);
+
 	LuaScriptInterface::pushSharedPtr(L, message);
 	LuaScriptInterface::setMetatable(L, -1, "NetworkMessage");
 
-	return scriptInterface->callVoidFunction(2);
+	return scriptInterface->callVoidFunction(3);
 }

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -22,6 +22,7 @@
 #include "creatureevent.h"
 #include "tools.h"
 #include "player.h"
+#include "pugicast.h"
 
 CreatureEvents::CreatureEvents() :
 	scriptInterface("CreatureScript Interface")
@@ -211,9 +212,22 @@ bool CreatureEvent::configureEvent(const pugi::xml_node& node)
 		type = CREATURE_EVENT_MANACHANGE;
 	} else if (tmpStr == "extendedopcode") {
 		type = CREATURE_EVENT_EXTENDED_OPCODE;
+	} else if (tmpStr == "parsepacket") {
+		type = CREATURE_EVENT_PARSE_PACKET;
 	} else {
 		std::cout << "[Error - CreatureEvent::configureEvent] Invalid type for creature event: " << eventName << std::endl;
 		return false;
+	}
+
+	if (type == CREATURE_EVENT_PARSE_PACKET) {
+		// look for recvbyte
+		pugi::xml_attribute recvbyteAttribute = node.attribute("recvbyte");
+		if (!recvbyteAttribute) {
+			std::cout << "[Error - CreatureEvent::configureEvent] Missing recvbyte for parse packet creature event: " << eventName << std::endl;
+			return false;
+		}
+
+		recvbyte = static_cast<uint8_t>(pugi::cast<uint16_t>(recvbyteAttribute.value()));
 	}
 
 	loaded = true;
@@ -260,6 +274,9 @@ std::string CreatureEvent::getScriptEventName() const
 		case CREATURE_EVENT_EXTENDED_OPCODE:
 			return "onExtendedOpcode";
 
+		case CREATURE_EVENT_PARSE_PACKET:
+			return "onParsePacket";
+
 		case CREATURE_EVENT_NONE:
 		default:
 			return std::string();
@@ -272,6 +289,10 @@ void CreatureEvent::copyEvent(CreatureEvent* creatureEvent)
 	scriptInterface = creatureEvent->scriptInterface;
 	scripted = creatureEvent->scripted;
 	loaded = creatureEvent->loaded;
+
+	if (type == CREATURE_EVENT_PARSE_PACKET) {
+		recvbyte = creatureEvent->getRecvbyte();
+	}
 }
 
 void CreatureEvent::clearEvent()
@@ -280,6 +301,7 @@ void CreatureEvent::clearEvent()
 	scriptInterface = nullptr;
 	scripted = false;
 	loaded = false;
+	recvbyte = 0;
 }
 
 bool CreatureEvent::executeOnLogin(Player* player) const
@@ -602,4 +624,28 @@ void CreatureEvent::executeExtendedOpcode(Player* player, uint8_t opcode, const 
 	LuaScriptInterface::pushString(L, buffer);
 
 	scriptInterface->callVoidFunction(3);
+}
+
+void CreatureEvent::executeParsePacket(Player* player, NetworkMessage_ptr message)
+{
+	//onParsePacket(player, msg)
+	if (!scriptInterface->reserveScriptEnv()) {
+		std::cout << "[Error - CreatureEvent::executeParsePacket] Call stack overflow" << std::endl;
+		return;
+	}
+
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
+
+	lua_State* L = scriptInterface->getLuaState();
+
+	scriptInterface->pushFunction(scriptId);
+
+	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::setMetatable(L, -1, "Player");
+
+	LuaScriptInterface::pushSharedPtr(L, message);
+	LuaScriptInterface::setMetatable(L, -1, "NetworkMessage");
+
+	return scriptInterface->callVoidFunction(2);
 }

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -23,6 +23,7 @@
 #include "luascript.h"
 #include "baseevents.h"
 #include "enums.h"
+#include "networkmessage.h"
 
 class CreatureEvent;
 using CreatureEvent_ptr = std::unique_ptr<CreatureEvent>;
@@ -41,6 +42,7 @@ enum CreatureEventType_t {
 	CREATURE_EVENT_HEALTHCHANGE,
 	CREATURE_EVENT_MANACHANGE,
 	CREATURE_EVENT_EXTENDED_OPCODE, // otclient additional network opcodes
+	CREATURE_EVENT_PARSE_PACKET,
 };
 
 class CreatureEvent final : public Event
@@ -68,6 +70,12 @@ class CreatureEvent final : public Event
 		void setLoaded(bool b) {
 			loaded = b;
 		}
+		void setRecvbyte(uint8_t recvbyte) {
+			this->recvbyte = recvbyte;
+		}
+		uint8_t getRecvbyte() {
+			return recvbyte;
+		}
 
 		void clearEvent();
 		void copyEvent(CreatureEvent* creatureEvent);
@@ -85,6 +93,7 @@ class CreatureEvent final : public Event
 		void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 		void executeManaChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 		void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);
+		void executeParsePacket(Player* player, NetworkMessage_ptr message);
 		//
 
 	private:
@@ -93,6 +102,7 @@ class CreatureEvent final : public Event
 		std::string eventName;
 		CreatureEventType_t type;
 		bool loaded;
+		uint8_t recvbyte; // only for parse packet creaturescript
 };
 
 class CreatureEvents final : public BaseEvents

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -93,7 +93,7 @@ class CreatureEvent final : public Event
 		void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 		void executeManaChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 		void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);
-		void executeParsePacket(Player* player, NetworkMessage_ptr message);
+		void executeParsePacket(Player* player, uint8_t recvbyte, NetworkMessage_ptr message);
 		//
 
 	private:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5492,6 +5492,25 @@ void Game::playerAnswerModalWindow(uint32_t playerId, uint32_t modalWindowId, ui
 	}
 }
 
+void Game::playerExecuteParsePacketEvent(uint32_t playerId, uint8_t recvbyte, const NetworkMessage& msg)
+{
+	Player* player = getPlayerByID(playerId);
+	if (!player) {
+		return;
+	}
+
+	CreatureEventList creatureEventList = player->getCreatureEvents(CREATURE_EVENT_PARSE_PACKET, recvbyte);
+	if (creatureEventList.empty()) {
+		return;
+	}
+
+	NetworkMessage_ptr message = std::make_shared<NetworkMessage>(msg);
+	for (CreatureEvent* creatureEvent : creatureEventList) {
+		creatureEvent->executeParsePacket(player, message);
+		message->setBufferPosition(1);
+	}
+}
+
 void Game::addPlayer(Player* player)
 {
 	const std::string& lowercase_name = asLowerCaseString(player->getName());

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5506,7 +5506,7 @@ void Game::playerExecuteParsePacketEvent(uint32_t playerId, uint8_t recvbyte, co
 
 	NetworkMessage_ptr message = std::make_shared<NetworkMessage>(msg);
 	for (CreatureEvent* creatureEvent : creatureEventList) {
-		creatureEvent->executeParsePacket(player, message);
+		creatureEvent->executeParsePacket(player, recvbyte, message);
 		message->setBufferPosition(1);
 	}
 }

--- a/src/game.h
+++ b/src/game.h
@@ -337,6 +337,7 @@ class Game
 		void playerDebugAssert(uint32_t playerId, const std::string& assertLine, const std::string& date, const std::string& description, const std::string& comment);
 		void playerAnswerModalWindow(uint32_t playerId, uint32_t modalWindowId, uint8_t button, uint8_t choice);
 		void playerReportRuleViolation(uint32_t playerId, const std::string& targetName, uint8_t reportType, uint8_t reportReason, const std::string& comment, const std::string& translation);
+		void playerExecuteParsePacketEvent(uint32_t playerId, uint8_t recvbyte, const NetworkMessage& msg);
 
 		bool internalStartTrade(Player* player, Player* tradePartner, Item* tradeItem);
 		void internalCloseTrade(Player* player, bool sendCancel = true);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1492,6 +1492,7 @@ class LuaScriptInterface
 		static int luaCreateCreatureEvent(lua_State* L);
 		static int luaCreatureEventType(lua_State* L);
 		static int luaCreatureEventRegister(lua_State* L);
+		static int luaCreatureEventRecvbyte(lua_State* L);
 		static int luaCreatureEventOnCallback(lua_State* L);
 
 		// MoveEvents

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -21,12 +21,16 @@
 #define FS_NETWORKMESSAGE_H_B853CFED58D1413A87ACED07B2926E03
 
 #include "const.h"
+#include "memory"
 
 class Item;
 class Creature;
 class Player;
 struct Position;
 class RSA;
+
+class NetworkMessage;
+using NetworkMessage_ptr = std::shared_ptr<NetworkMessage>;
 
 class NetworkMessage
 {
@@ -44,6 +48,10 @@ class NetworkMessage
 		enum { MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10 };
 
 		NetworkMessage() = default;
+		NetworkMessage(const NetworkMessage& other) {
+			info = other.info;
+			memcpy(&buffer, &other.buffer, sizeof(other.buffer) / sizeof(other.buffer[0]));
+		}
 
 		void reset() {
 			info = {};

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -526,6 +526,10 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 		}
 	}
 
+	if (player->hasEventRegistered(CREATURE_EVENT_PARSE_PACKET)) {
+		addGameTask(&Game::playerExecuteParsePacketEvent, player->getID(), recvbyte, msg);
+	}
+
 	switch (recvbyte) {
 		case 0x14: g_dispatcher.addTask(createTask(std::bind(&ProtocolGame::logout, getThis(), true, false))); break;
 		case 0x1D: addGameTask(&Game::playerReceivePingBack, player->getID()); break;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This is basically the same as Nekiro proposed in his PR, However, I made some small modifications that make the onParsePacket event have the same possibilities as the other events.

previously we could not create two events with the same recvbyte, now we can.
* This is because now the message is handled by a shared smart pointer, this guarantees that the object will not be deleted manually from lua causing (problems or crashing) in the following events of the same recvbyte.

The way we create network messages has been changed, now they will always be created wrapped in a shared pointer, nothing changes and everything remains the same, this was changed only to have compatibility with this new onParsePacket event

The method `creature:getEvents(type)` now has a new parameter `uint8_t` `creature:getEvents(type[, recvbyte = 0])`
* This new parameter will be mandatory if the event type is `CREATURE_EVENT_PARSE_PACKET` this will return the list of parse_packet events with the specified recvbyte
* why not return the whole list of parse_packets? In my opinion, it is only necessary to return events that are actually running, no one should register a parse_packet event with recvbyte 0

### The suggestions are welcome :D

### Notes
Maybe this does not seem necessary today, since the handling of bytes is always faster and cleaner from the sources, however, this opens the possibility of experimentation, this means that anyone can investigate and test the message structures, and maybe create something beautiful, who knows? XD

**PR Base addressed:** #2978

**Credits:** @nekiro

# Examples

<details>
<summary>classic interface: parsepacket.lua</summary>

```lua
function onParsePacket(player, recvbyte, msg)
	-- structure for parseUseItem packet, recbyte: 130 (0x82)
	local pos = msg:getPosition()
	local clientId = msg:getU16()
	local stackpos = msg:getByte()
	local index = msg:getByte()
	print(("Player: %s wants to use item at position (%d, %d, %d) with sprite id %d"):format(player:getName(), pos.x, pos.y, pos.z, clientId))
	msg:delete()
end

```

</details>

<details>
<summary>revscript interface: parsepacket.lua</summary>

```lua
local creatureEvent = CreatureEvent("ParsePacket")
function creatureEvent.onParsePacket(player, recvbyte, msg)
	-- structure for parseUseItem packet, recbyte: 130 (0x82)
	local pos = msg:getPosition()
	local clientId = msg:getU16()
	local stackpos = msg:getByte()
	local index = msg:getByte()
	print(("Player: %s wants to use item at position (%d, %d, %d) with sprite id %d"):format(player:getName(), pos.x, pos.y, pos.z, clientId))
	msg:delete()
end

creatureEvent:recvbyte(130)
creatureEvent:resgister()
```

</details>