### PR TITLE
onParsePacket in Events/Callback

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -31,6 +31,7 @@
 	<event class="Player" method="onLoseExperience" enabled="0" />
 	<event class="Player" method="onGainSkillTries" enabled="1" />
 	<event class="Player" method="onWrapItem" enabled="1" />
+	<event class="Player" method="onParsePacket" enabled="0" />
 
 	<!-- Monster methods -->
 	<event class="Monster" method="onDropLoot" enabled="1" />

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -211,3 +211,6 @@ function Player:onWrapItem(item)
 		end
 	end
 end
+
+function Player:onParsePacket(recvbyte, msg)
+end

--- a/src/events.h
+++ b/src/events.h
@@ -61,6 +61,7 @@ class Events
 		int32_t playerOnLoseExperience = -1;
 		int32_t playerOnGainSkillTries = -1;
 		int32_t playerOnWrapItem = -1;
+		int32_t playerOnParsePacket = -1;
 
 		// Monster
 		int32_t monsterOnDropLoot = -1;
@@ -103,6 +104,7 @@ class Events
 		void eventPlayerOnLoseExperience(Player* player, uint64_t& exp);
 		void eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_t& tries);
 		void eventPlayerOnWrapItem(Player* player, Item* item);
+		void eventPlayerOnParsePacket(Player* player, uint8_t recvbyte, const NetworkMessage& msg);
 
 		// Monster
 		void eventMonsterOnDropLoot(Monster* monster, Container* corpse);

--- a/src/events.h
+++ b/src/events.h
@@ -22,6 +22,7 @@
 
 #include "luascript.h"
 #include "const.h"
+#include "networkmessage.h"
 
 class Party;
 class ItemType;

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -44,6 +44,10 @@ class NetworkMessage
 		enum { MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10 };
 
 		NetworkMessage() = default;
+		NetworkMessage(const NetworkMessage& other) {
+			info = other.info;
+			memcpy(&buffer, &other.buffer, sizeof(other.buffer) / sizeof(other.buffer[0]));
+		}
 
 		void reset() {
 			info = {};


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This event allows filtering all packets captured by a player.

If #3834 is merged then we can use EventCallback to have concrete callbacks for each type of recvbyte, here is an example:
```lua
local ec = EventCallback

function ec.onParsePacket(player, recvbyte, msg)
    print("TEST 1", player, recvbyte, msg:getByte())
end

ec:recvbyte(0x90)
ec:register(1)

function ec.onParsePacket(player, recvbyte, msg)
    print("TEST 2", player, recvbyte, msg:getByte())
end

ec:recvbyte(0x90)
ec:register(2)
```
If no recvbyte is declared, then the event will be called regardless of the recvbyte, example:
```lua
local ec = EventCallback

function ec.onParsePacket(player, recvbyte, msg)
    print("TEST 1", player, recvbyte, msg:getByte())
end

ec:register(1)

function ec.onParsePacket(player, recvbyte, msg)
    print("TEST 2", player, recvbyte, msg:getByte())
end

ec:register(2)
```

If someone wants to intentionally delete the network message, he can do it, however the interpreter will not collapse, since the object will have been correctly deleted and no attempt will be made to access a dead object, this has always been the case.

The method `delete` exists only for network messages that we create ourselves and we want to delete at a certain point to save the garbage collector work, because it is not really mandatory to have to clean the object manually.

Regardless of the PR preferred by the majority and whatever the one that merges, I want to give all the credits to @nekiro 

**Issues addressed:** Nothing!