### PR TITLE
Remove dead code (loadAccount)

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1165,8 +1165,6 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin)
 		// mounted player moved to pz on login, update mount status
 		onChangeZone(getZone());
 
-		Account account = IOLoginData::loadAccount(accountNumber);
-
 		if (g_config.getBoolean(ConfigManager::PLAYER_CONSOLE_LOGS)) {
 			std::cout << name << " has logged in." << std::endl;
 		}


### PR DESCRIPTION
This code was originally used for updatePremium, but since premium rework it is obsolete.