### PR TITLE
Fix the client crash when you open the missions window

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2366,8 +2366,10 @@ void ProtocolGame::sendQuestLine(const Quest* quest)
 	msg.add<uint16_t>(quest->getID());
 	msg.addByte(quest->getMissionsCount(player));
 
+	uint16_t missionId = 0;
 	for (const Mission& mission : quest->getMissions()) {
 		if (mission.isStarted(player)) {
+			msg.add<uint16_t>(++missionId);
 			msg.addString(mission.getName(player));
 			msg.addString(mission.getDescription(player));
 		}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The client 12.81 now needs the index of the mission that is sent to him, I do not know if it is the best way or if we need to identify the missions in another way that is not the index of the list

**Issues addressed:** Nothing!