### PR TITLE
Fix: pzLock after death by damage condition 

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1389,7 +1389,11 @@ bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange)
 		return false;
 	}
 
-	if (g_game.combatBlockHit(damage, attacker, creature, false, false, field)) {
+	if (attacker && attacker->getPlayer() && attacker->getPlayer()->getLastLogout() != casterLogoutTime) {
+		if (g_game.combatBlockHit(damage, nullptr, creature, false, false, field)) {
+			return false;
+		}
+	} else if (g_game.combatBlockHit(damage, attacker, creature, false, false, field)) {
 		return false;
 	}
 

--- a/src/condition.h
+++ b/src/condition.h
@@ -309,6 +309,7 @@ class ConditionDamage final : public Condition
 		bool delayed = false;
 		bool field = false;
 		uint32_t owner = 0;
+		time_t casterLogoutTime = 0;
 
 		bool init();
 


### PR DESCRIPTION
Fix pzlock when a player with a skull dies and the killer/other player has damage condition from the killed player
current: when player die and other player has condition damage from this player after login he will get skull after condition deal damage to killer/target

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.
