### PR TITLE
Fix skill status when item decays

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -324,6 +324,7 @@ uint16_t Item::getSubType() const
 	return count;
 }
 
+Player* Item::getHoldingPlayer() { return dynamic_cast<Player*>(getTopParent()); }
 const Player* Item::getHoldingPlayer() const { return dynamic_cast<const Player*>(getTopParent()); }
 
 void Item::setSubType(uint16_t n)

--- a/src/item.h
+++ b/src/item.h
@@ -734,6 +734,7 @@ public:
 	void setID(uint16_t newid);
 
 	// Returns the player that is holding this item in his inventory
+	Player* getHoldingPlayer();
 	const Player* getHoldingPlayer() const;
 
 	WeaponType_t getWeaponType() const { return items[id].weaponType; }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4708,21 +4708,3 @@ void Player::updateRegeneration()
 		condition->setParam(CONDITION_PARAM_MANATICKS, vocation->getManaGainTicks() * 1000);
 	}
 }
-
-bool Player::isEquippedItem(const Item* item) const
-{
-	bool isEquiped = false;
-	if (!item) {
-		return isEquiped;
-	}
-
-	static const slots_t allSlots[] = {CONST_SLOT_RIGHT, CONST_SLOT_LEFT, CONST_SLOT_HEAD, CONST_SLOT_NECKLACE, CONST_SLOT_ARMOR, CONST_SLOT_LEGS, CONST_SLOT_FEET, CONST_SLOT_RING};
-	for (slots_t slot : allSlots) {
-		Item* checkitem = inventory[slot];
-		if (checkitem and checkitem == item) {
-			isEquiped = true;
-			break;
-		}
-	}
-	return isEquiped;
-}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4708,3 +4708,21 @@ void Player::updateRegeneration()
 		condition->setParam(CONDITION_PARAM_MANATICKS, vocation->getManaGainTicks() * 1000);
 	}
 }
+
+bool Player::isEquippedItem(const Item* item) const
+{
+	bool isEquiped = false;
+	if (!item) {
+		return isEquiped;
+	}
+
+	static const slots_t allSlots[] = {CONST_SLOT_RIGHT, CONST_SLOT_LEFT, CONST_SLOT_HEAD, CONST_SLOT_NECKLACE, CONST_SLOT_ARMOR, CONST_SLOT_LEGS, CONST_SLOT_FEET, CONST_SLOT_RING};
+	for (slots_t slot : allSlots) {
+		Item* checkitem = inventory[slot];
+		if (checkitem and checkitem == item) {
+			isEquiped = true;
+			break;
+		}
+	}
+	return isEquiped;
+}


### PR DESCRIPTION
Steps to reproduce the bug:

Equip an item that give you some bonus skill and decay to another item or 0.
When it decay, you will continue with that bonus.

part of fix:
https://github.com/opentibiabr/canary/blob/77e037dd72063279754e6efa8ae97a5843981111/src/game/game.cpp#L6474

full fix:
checks if the item is being carried by the player and also check if the item is equipped to avoid skill changes when the item decay inside backpack (not equipped).


