### PR TITLE
Fix ProtocolGame::sendModalWindow

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3263,8 +3263,8 @@ void ProtocolGame::sendModalWindow(const ModalWindow& modalWindow)
 		msg.addByte(it.second);
 	}
 
-	msg.addByte(modalWindow.defaultEscapeButton);
 	msg.addByte(modalWindow.defaultEnterButton);
+	msg.addByte(modalWindow.defaultEscapeButton);
 	msg.addByte(modalWindow.priority ? 0x01 : 0x00);
 
 	writeToOutputBuffer(msg);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix sendModalWindow for QT clients because they have swapped default button bytes
<!-- Describe the changes that this pull request makes. -->

**How to reproduce:** <!-- Write here the issue number, if any. -->

1. go to a bed at any house and use it
2. modal window will open
3. press "enter" at your keyboard

**expected**: execution of the selected menu option

**what happen instead**: action canceled, window closed

and if you do the  steps above and press "esc" instead, it will execute the action...

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
