### PR TITLE
[1.4] 10.98 forwards compatibility with new OTB and RME

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -616,6 +616,22 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 			break;
 		}
 
+		//12+ compatibility
+		case ATTR_OPENCONTAINER:
+		case ATTR_TIER: {
+			if (!propStream.skip(1)) {
+				return ATTR_READ_ERROR;
+			}
+			break;
+		}
+
+		case ATTR_PODIUMOUTFIT: {
+			if (!propStream.skip(15)) {
+				return ATTR_READ_ERROR;
+			}
+			break;
+		}
+
 		//these should be handled through derived classes
 		//If these are called then something has changed in the items.xml since the map was saved
 		//just read the values

--- a/src/item.h
+++ b/src/item.h
@@ -106,6 +106,11 @@ enum AttrTypes_t {
 	ATTR_WRAPID = 36,
 	ATTR_STOREITEM = 37,
 	ATTR_ATTACK_SPEED = 38,
+
+	// version 12.x
+	ATTR_OPENCONTAINER = 39,
+	ATTR_PODIUMOUTFIT = 40,
+	ATTR_TIER = 41,
 };
 
 enum Attr_ReadValue {

--- a/src/itemloader.h
+++ b/src/itemloader.h
@@ -39,6 +39,7 @@ enum itemgroup_t {
 	ITEM_GROUP_FLUID,
 	ITEM_GROUP_DOOR, //deprecated
 	ITEM_GROUP_DEPRECATED,
+	ITEM_GROUP_PODIUM,
 
 	ITEM_GROUP_LAST
 };
@@ -103,6 +104,11 @@ enum clientVersion_t {
 	CLIENT_VERSION_1035 = 55,
 	CLIENT_VERSION_1076 = 56,
 	CLIENT_VERSION_1098 = 57,
+	CLIENT_VERSION_10100 = 58,
+	CLIENT_VERSION_1272 = 59,
+	CLIENT_VERSION_1281 = 60,
+
+	CLIENT_VERSION_LAST = CLIENT_VERSION_1281
 };
 
 enum rootattrib_ {
@@ -176,6 +182,8 @@ enum itemflags_t {
 	FLAG_ANIMATION = 1 << 24,
 	FLAG_FULLTILE = 1 << 25, // unused
 	FLAG_FORCEUSE = 1 << 26,
+	FLAG_AMMO = 1 << 27, // unused
+	FLAG_REPORTABLE = 1 << 28, // unused
 };
 
 //1-byte aligned structs

--- a/src/itemloader.h
+++ b/src/itemloader.h
@@ -150,6 +150,7 @@ enum itemattrib_t {
 	ITEM_ATTR_WRITEABLE3, //deprecated
 
 	ITEM_ATTR_WAREID,
+	ITEM_ATTR_CLASSIFICATION,
 
 	ITEM_ATTR_LAST
 };

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -395,6 +395,13 @@ bool Items::loadFromOtb(const std::string& file)
 					break;
 				}
 
+				case ITEM_ATTR_CLASSIFICATION: {
+					if (!stream.skip(1)) {
+						return false;
+					}
+					break;
+				}
+
 				default: {
 					//skip unknown attributes
 					if (!stream.skip(datalen)) {
@@ -436,6 +443,7 @@ bool Items::loadFromOtb(const std::string& file)
 			case ITEM_GROUP_FLUID:
 			case ITEM_GROUP_CHARGES:
 			case ITEM_GROUP_DEPRECATED:
+			case ITEM_GROUP_PODIUM:
 				break;
 			default:
 				return false;


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Make the server parse (and ignore) new attributes so 10.98 with new spr/dat/otb can be used together with 12.81 OTB.

**Note:** This change is for branch 1.4 (10.98)

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
