### PR TITLE
FIX: Container will not decay in house after server load

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -724,6 +724,7 @@ void Container::internalAddThing(uint32_t, Thing* thing)
 
 void Container::startDecaying()
 {
+	g_game.startDecay(this);
 	for (Item* item : itemlist) {
 		item->startDecaying();
 	}

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -725,6 +725,7 @@ void Container::internalAddThing(uint32_t, Thing* thing)
 void Container::startDecaying()
 {
 	Item::startDecaying();
+	
 	for (Item* item : itemlist) {
 		item->startDecaying();
 	}

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -724,7 +724,7 @@ void Container::internalAddThing(uint32_t, Thing* thing)
 
 void Container::startDecaying()
 {
-	g_game.startDecay(this);
+	Item::startDecaying();
 	for (Item* item : itemlist) {
 		item->startDecaying();
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ x] I have followed [proper The Forgotten Server code styling][code].
- [ x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This change makes sure containers decay (usually corpses). Previously **_only_** the contents of a container would be marked to decay by the `container::startDecaying()` function call. This issue is obvious when decyable containers are loaded from the database or other places. 

The issue of unrotting corpses is reproducable when placing a corpse in a house before killing the server. When the server goes back online the corpse will never decay.  This is because the house-loading code in  `IOMapSerialize::loadItem` calls `item->startDecaying();` on all items, and currently this fails to add the corpse itself to the state of decaying items.  This is probably an oversight, as `item::startDecaying();` already calls `g_game.startDecay(this);`, but `container::startDecaying()` does not. 

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
