### PR TITLE
Add summon max count in MonsterType:addSummon

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -174,7 +174,7 @@ end
 registerMonsterType.summons = function(mtype, mask)
 	if type(mask.summons) == "table" then
 		for k, v in pairs(mask.summons) do
-			mtype:addSummon(v.name, v.interval, v.chance)
+			mtype:addSummon(v.name, v.interval, v.chance, v.max or 0)
 		end
 	end
 end

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -174,7 +174,7 @@ end
 registerMonsterType.summons = function(mtype, mask)
 	if type(mask.summons) == "table" then
 		for k, v in pairs(mask.summons) do
-			mtype:addSummon(v.name, v.interval, v.chance, v.max or 0)
+			mtype:addSummon(v.name, v.interval, v.chance, v.max or -1)
 		end
 	end
 end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14100,14 +14100,14 @@ int LuaScriptInterface::luaMonsterTypeGetSummonList(lua_State* L)
 
 int LuaScriptInterface::luaMonsterTypeAddSummon(lua_State* L)
 {
-	// monsterType:addSummon(name, interval, chance[, max = 0])
+	// monsterType:addSummon(name, interval, chance[, max = -1])
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		summonBlock_t summon;
 		summon.name = getString(L, 2);
 		summon.speed = getNumber<int32_t>(L, 3);
 		summon.chance = getNumber<int32_t>(L, 4);
-		summon.max = getNumber<int32_t>(L, 5, 0);
+		summon.max = getNumber<int32_t>(L, 5, -1);
 		monsterType->info.summons.push_back(summon);
 		pushBoolean(L, true);
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -14100,13 +14100,14 @@ int LuaScriptInterface::luaMonsterTypeGetSummonList(lua_State* L)
 
 int LuaScriptInterface::luaMonsterTypeAddSummon(lua_State* L)
 {
-	// monsterType:addSummon(name, interval, chance)
+	// monsterType:addSummon(name, interval, chance[, max = 0])
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		summonBlock_t summon;
 		summon.name = getString(L, 2);
 		summon.speed = getNumber<int32_t>(L, 3);
 		summon.chance = getNumber<int32_t>(L, 4);
+		summon.max = getNumber<int32_t>(L, 5, 0);
 		monsterType->info.summons.push_back(summon);
 		pushBoolean(L, true);
 	} else {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
@emil92b test pls 😎 

~~I'm actually uncertain if there is 0 by default or some garbage value. Looking at the summoning logic probably the latter. 💩~~ 

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add configurable max summon count in MonsterType:addSummon.

**Issues addressed:** Closes #3882

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
