### PR TITLE
Fix respawn taking twice as long as expected

### DIFF
--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -401,10 +401,6 @@ void Spawn::cleanup()
 		uint32_t spawnId = it->first;
 		Monster* monster = it->second;
 		if (monster->isRemoved()) {
-			if (spawnId != 0) {
-				spawnMap[spawnId].lastSpawn = OTSYS_TIME();
-			}
-
 			monster->decrementReferenceCounter();
 			it = spawnedMap.erase(it);
 		} else if (!isInSpawnZone(monster->getPosition()) && spawnId != 0) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
Spawn::checkSpawn calls Spawn::cleanup before performing checks, Spawn::cleanup checks if the monster is marked as removed, if it is we have to free it, which is okay, but I do not see any reason for updating it's last spawn time there.

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Remove redundant spawn time update.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** Closes #3885


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
