### PR TITLE
Fixing mistake when removing charm item

### DIFF
--- a/data/scripts/actions/others/blessing_charms.lua
+++ b/data/scripts/actions/others/blessing_charms.lua
@@ -18,7 +18,7 @@ function blessingCharms.onUse(player, item, fromPosition, target, toPosition, is
 		player:addBlessing(blessItem.id)
 		player:say(blessItem.text, TALKTYPE_MONSTER_SAY)
 		player:getPosition():sendMagicEffect(blessItem.effect)
-		item:remove()
+		item:remove(1)
 	end
 	return true
 end


### PR DESCRIPTION
Charm items are stackable so item:remove() ends up removing whole stack instead of just one out of the stack.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Charm items are stackable. In case of the player clicking to use one of charms on the stacks, the scripts ends up removing the whole stack because of how _item:remove_ was set up previously. 

**Issues addressed:** Fixing a mistake where the script would remove the whole stack of charms instead of just one under usage.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
