### PR TITLE
Fixing The Pale Count's looktype and corpse ID

### DIFF
--- a/data/monster/monsters/the_pale_count.xml
+++ b/data/monster/monsters/the_pale_count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <monster name="The Pale Count" nameDescription="The Pale Count" race="blood" experience="28000" speed="300">
 	<health now="50000" max="50000" />
-	<look type="558" corpse="21279" />
+	<look type="557" corpse="21272" />
 	<targetchange interval="5000" chance="8" />
 	<flags>
 		<flag summonable="0" />


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixing The Pale Count's looktype and corpse ID. 

**Issues addressed:** It was previously using the looktype and corpse from a Gravedigger monster. Now it's using the correct values.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
