### PR TITLE
fix 'worlds' spelling typo

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -37557,7 +37557,7 @@
 		<attribute key="weight" value="1500" />
 		<attribute key="containerSize" value="20" />
 		<attribute key="slotType" value="backpack" />
-		<attribute key="description" value="It was awarded during the festivities of worlds 20th anniversary." />
+		<attribute key="description" value="It was awarded during the festivities of the worlds 20th anniversary." />
 	</item>
 	<item id="27052" article="a" name="birthday cake" />
 	<item id="27053" name="Ferumbras' Candy Hat" />


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
change 'worlds' to 'the worlds' in item id 27051 (birthday backpack) description to be consistent with other item descriptions (e.g. id=1982 or id=16003)

**Issues addressed:** n/a
