### PR TITLE
Fix certain scenarios where the house protection would fail to apply

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -430,9 +430,8 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, Item* 
 	}
 
 	if (g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		if (HouseTile* houseTile = dynamic_cast<HouseTile*>(item->getTile())) {
-			House* house = houseTile->getHouse();
-			if (house && !house->isInvited(player)) {
+		if (const HouseTile* const houseTile = dynamic_cast<const HouseTile*>(item->getTile())) {
+			if (!item->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
 				player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 				return false;
 			}
@@ -475,6 +474,15 @@ bool Actions::useItemEx(Player* player, const Position& fromPos, const Position&
 	if (isHotkey) {
 		uint16_t subType = item->getSubType();
 		showUseHotkeyMessage(player, item, player->getItemTypeCount(item->getID(), subType != item->getItemCount() ? subType : -1));
+	}
+
+	if (g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+		if (const HouseTile* const houseTile = dynamic_cast<const HouseTile*>(item->getTile())) {
+			if (!item->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
+				player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
+				return false;
+			}
+		}
 	}
 
 	if (action->executeUse(player, item, fromPos, action->getTarget(player, creature, toPos, toStackPos), toPos, isHotkey)) {

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -303,7 +303,15 @@ ReturnValue Container::queryAdd(int32_t index, const Thing& thing, uint32_t coun
 		}
 	}
 
-	const Cylinder* topParent = getTopParent();
+	const Cylinder* const topParent = getTopParent();
+	if (actor && g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+		if (const HouseTile* const houseTile = dynamic_cast<const HouseTile*>(topParent->getTile())) {
+			if (!topParent->getCreature() && !houseTile->getHouse()->isInvited(actor->getPlayer())) {
+				return RETURNVALUE_PLAYERISNOTINVITED;
+			}
+		}
+	}
+
 	if (topParent != this) {
 		return topParent->queryAdd(INDEX_WHEREEVER, *item, count, flags | FLAG_CHILDISOWNER, actor);
 	}
@@ -381,9 +389,13 @@ ReturnValue Container::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 		return RETURNVALUE_NOTMOVEABLE;
 	}
 
-	const HouseTile* houseTile = dynamic_cast<const HouseTile*>(getTopParent());
-	if (houseTile) {
-		return houseTile->queryRemove(thing, count, flags, actor);
+	if (actor && g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+		const Cylinder* const topParent = getTopParent();
+		if (const HouseTile* const houseTile = dynamic_cast<const HouseTile*>(topParent->getTile())) {
+			if (!topParent->getCreature() && !houseTile->getHouse()->isInvited(actor->getPlayer())) {
+				return RETURNVALUE_PLAYERISNOTINVITED;
+			}
+		}
 	}
 
 	return RETURNVALUE_NOERROR;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2618,10 +2618,9 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 	}
 
 	if (g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		if (HouseTile* houseTile = dynamic_cast<HouseTile*>(tradeItem->getTile())) {
-			House* house = houseTile->getHouse();
-			if (house && !house->isInvited(player)) {
-				player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		if (const HouseTile* const houseTile = dynamic_cast<const HouseTile*>(tradeItem->getTile())) {
+			if (!tradeItem->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
+				player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 				return;
 			}
 		}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -125,7 +125,7 @@ void House::updateDoorDescription() const
 	}
 }
 
-AccessHouseLevel_t House::getHouseAccessLevel(const Player* player)
+AccessHouseLevel_t House::getHouseAccessLevel(const Player* player) const
 {
 	if (!player) {
 		return HOUSE_OWNER;
@@ -277,7 +277,7 @@ bool House::getAccessList(uint32_t listId, std::string& list) const
 	return door->getAccessList(list);
 }
 
-bool House::isInvited(const Player* player)
+bool House::isInvited(const Player* player) const
 {
 	return getHouseAccessLevel(player) != HOUSE_NOT_INVITED;
 }
@@ -499,7 +499,7 @@ void AccessList::addGuildRank(const std::string& name, const std::string& rankNa
 	}
 }
 
-bool AccessList::isInList(const Player* player)
+bool AccessList::isInList(const Player* player) const
 {
 	if (allowEveryone) {
 		return true;

--- a/src/house.h
+++ b/src/house.h
@@ -39,7 +39,7 @@ class AccessList
 		void addGuild(const std::string& name);
 		void addGuildRank(const std::string& name, const std::string& rankName);
 
-		bool isInList(const Player* player);
+		bool isInList(const Player* player) const;
 
 		void getList(std::string& list) const;
 
@@ -142,9 +142,9 @@ class House
 		void setAccessList(uint32_t listId, const std::string& textlist);
 		bool getAccessList(uint32_t listId, std::string& list) const;
 
-		bool isInvited(const Player* player);
+		bool isInvited(const Player* player) const;
 
-		AccessHouseLevel_t getHouseAccessLevel(const Player* player);
+		AccessHouseLevel_t getHouseAccessLevel(const Player* player) const;
 		bool kickPlayer(Player* player, Player* target);
 
 		void setEntryPos(Position pos) {

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -90,10 +90,9 @@ ReturnValue HouseTile::queryAdd(int32_t index, const Thing& thing, uint32_t coun
 			return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
 		}
 
-		if (actor) {
-			Player* actorPlayer = actor->getPlayer();
-			if (!house->isInvited(actorPlayer)) {
-				return RETURNVALUE_CANNOTTHROW;
+		if (actor && g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+			if (!house->isInvited(actor->getPlayer())) {
+				return RETURNVALUE_PLAYERISNOTINVITED;
 			}
 		}
 	}
@@ -137,9 +136,8 @@ ReturnValue HouseTile::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 	}
 
 	if (actor && g_config.getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		Player* actorPlayer = actor->getPlayer();
-		if (!house->isInvited(actorPlayer)) {
-			return RETURNVALUE_NOTPOSSIBLE;
+		if (!house->isInvited(actor->getPlayer())) {
+			return RETURNVALUE_PLAYERISNOTINVITED;
 		}
 	}
 	return Tile::queryRemove(thing, count, flags);

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -41,7 +41,7 @@ class HouseTile final : public DynamicTile
 		void addThing(int32_t index, Thing* thing) override;
 		void internalAddThing(uint32_t index, Thing* thing) override;
 
-		House* getHouse() {
+		House* getHouse() const {
 			return house;
 		}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes these scenarios:
1. Still being able to remove or add items from a container that is placed inside of a house tile, if the container was already open prior to being uninvited from the house
2. Being able to use useable items, like runes out of a house door or from a container placed in a house door, if it was already open prior to being uninvited from the house
3. `houseTile` always being `nullptr` inside of `Container::queryRemove`, since the cast was not done properly, and even after fixing the cast, it had wrong behaviour afterwards

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
