### PR TITLE
Fix OnItemMoved event when the last item of a stackable stack is move…

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1274,7 +1274,13 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 	}
 
 	if (actorPlayer && fromPos && toPos) {
-		g_events->eventPlayerOnItemMoved(actorPlayer, moveItem, count, *fromPos, *toPos, fromCylinder, toCylinder);
+		if (updateItem) {
+			g_events->eventPlayerOnItemMoved(actorPlayer, updateItem, count, *fromPos, *toPos, fromCylinder, toCylinder);
+		} else if (moveItem) {
+			g_events->eventPlayerOnItemMoved(actorPlayer, moveItem, count, *fromPos, *toPos, fromCylinder, toCylinder);
+		} else {
+			g_events->eventPlayerOnItemMoved(actorPlayer, item, count, *fromPos, *toPos, fromCylinder, toCylinder);
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
…d into another stack

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Followup to https://github.com/otland/forgottenserver/pull/3916
A crash would occur when moving, for example, a stack of a single gold coin into another stack of gold coins.
The crash would only occur when the last item of a stack was being moved, aka. the stack being destroyed.

Old output of this scenario: 
![](https://i.imgur.com/clHIWXe.png)

New output of this scenario:
```
==========================
=== Player:onItemMoved ===
==========================
{
    ["toCylinder"] = userdata: 0x06b4fc80,
    ["fromCylinder"] = userdata: 0x06b4fc58,
    ["count"] = 5,
    ["toPosition"] = {
        ["y"] = 64,
        ["x"] = 65535,
        ["z"] = 0,
        ["stackpos"] = 0
    },
    ["item"] = {
        ["type"] = 100,
        ["itemid"] = 2148,
        ["uid"] = 65544,
        ["actionid"] = 0
    },
    ["fromPosition"] = {
        ["y"] = 66,
        ["x"] = 65535,
        ["z"] = 1,
        ["stackpos"] = 0
    }
}
==========================
```

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
