### PR TITLE
Dont hardcode size of 3 for depot locker

### DIFF
--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -22,7 +22,7 @@
 #include "depotlocker.h"
 
 DepotLocker::DepotLocker(uint16_t type) :
-	Container(type, 3), depotId(0) {}
+	Container(type), depotId(0) {}
 
 Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 {


### PR DESCRIPTION
Use value from items.xml, this is handy for people that want custom size of depot lockers, sometimes happens.