### PR TITLE
ci: Run `apt-get update` before installing packages

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: >
+          sudo apt-get update
           sudo apt-get install git cmake build-essential libluajit-5.1-dev libmysqlclient-dev
           libboost-date-time-dev libboost-system-dev libboost-iostreams-dev libboost-filesystem-dev
           libpugixml-dev libcrypto++-dev libfmt-dev


### PR DESCRIPTION
Otherwise packages can fail to install due to stale index.
