### PR TITLE
fix update magic level percentage after spending mana

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1712,6 +1712,7 @@ void Player::addManaSpent(uint64_t amount)
 
 	if (sendUpdateStats) {
 		sendStats();
+		sendSkills();
 	}
 }
 
@@ -1748,6 +1749,7 @@ void Player::removeManaSpent(uint64_t amount, bool notify/* = false*/)
 
 		if (sendUpdateStats || oldPercent != magLevelPercent) {
 			sendStats();
+			sendSkills();
 		}
 	}
 }


### PR DESCRIPTION
Fix magic level percentage update after cast spell/spend mana
