### PR TITLE
Fix #3951 Bank NPC transfer errors

### DIFF
--- a/data/npc/scripts/bank.lua
+++ b/data/npc/scripts/bank.lua
@@ -233,6 +233,12 @@ local function creatureSayCallback(cid, type, msg)
 			end
 		end
 	elseif npcHandler.topic[cid] == topicList.TRANSFER_PLAYER_GOLD then
+		local currencyValue = tonumber(msg)
+		if not currencyValue or currencyValue < 1 then
+			npcHandler:say("Please tell me the amount of gold you would like to transfer, make sure to specify a number.", cid)
+			npcHandler.topic[cid] = topicList.TRANSFER_PLAYER_GOLD
+			return true
+		end
 		count[cid] = getMoneyCount(msg)
 		if player:getBankBalance() < count[cid] then
 			npcHandler:say("There is not enough gold in your account.", cid)
@@ -248,6 +254,11 @@ local function creatureSayCallback(cid, type, msg)
 		end
 	elseif npcHandler.topic[cid] == topicList.TRANSFER_PLAYER_WHO then
 		transfer[cid] = getPlayerDatabaseInfo(msg)
+		if not transfer[cid] then
+			npcHandler:say("Hmm, my ledgers have no records of anyone with the name "..msg..". Please ensure the name is correct.", cid)
+			npcHandler.topic[cid] = topicList.TRANSFER_PLAYER_WHO
+			return true
+		end
 		if player:getName() == transfer[cid].name then
 			npcHandler:say("Fill in this field with person who receives your gold!", cid)
 			npcHandler.topic[cid] = topicList.NONE


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Resolves 2 errors in bank NPC when trying to transfer money to another player.
- If you specified a word instead of a number, NPC would throw a console error. Now it will repeat the question and ask specifically for a number.
- If you specified a player name that didnt exist, NPC would throw a console error. Now it will inform user that it failed to find anyone with that name, and that he should make sure the name is correct. 
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3951

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
