### PR TITLE
A new way to manage player storages

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -63,11 +63,22 @@ do
 		elseif key == "actionid" then
 			return 0
 		end
-		return methods[key]
+
+		local value = methods[key]
+		if not value and creatureType == THING_TYPE_PLAYER then
+			return methods.getStorageValue(self, key)
+		end
+
+		return value
 	end
 	rawgetmetatable("Player").__index = CreatureIndex
 	rawgetmetatable("Monster").__index = CreatureIndex
 	rawgetmetatable("Npc").__index = CreatureIndex
+
+	local function PlayerNewIndex(self, key, value)
+		getmetatable(self).setStorageValue(self, key, value)
+	end
+	rawgetmetatable("Player").__newindex = PlayerNewIndex
 end
 
 do


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
With this change we add a new way to handle player storages via the `__index` metamethod of the `Player` metatable
Here a example:
```lua
player.storage[1250] = 100
print(player.storage[1250]) -- output: 100
player.storage[1250] = -1
print(player.storage[1250]) -- output: -1

print(player.storage[1251]) -- output: -1
```

Account storage:
```lua
player.accountStorage[1250] = 100
print(player.accountStorage[1250]) -- output: 100
player.accountStorage[1250] = -1
print(player.accountStorage[1250]) -- output: -1

print(player.accountStorage[1251]) -- output: -1
```

**Issues addressed:** Nothing!