### PR TITLE
according to the name getNextPosition should return something

### DIFF
--- a/data/lib/core/position.lua
+++ b/data/lib/core/position.lua
@@ -16,6 +16,7 @@ function Position:getNextPosition(direction, steps)
 		self.x = self.x + offset.x * steps
 		self.y = self.y + offset.y * steps
 	end
+	return self
 end
 
 function Position:moveUpstairs()


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The name of this function is somewhat misleading, since in Lua we are used to functions starting with `get` returning something, so I've added the `return self`

before:
```lua
local position = player:getPosition()
position:getNextPosition(player:getDirection())
local tile = Tile(position)
```

after:
```lua
local tile = Tile(player:getPosition():getNextPosition(player:getDirection()))
```

This does not break compatibility with previous versions and gives us a new possibility, which should always have been the case.

**Issues addressed:** Nothing!