### PR TITLE
Removed draw well from teleport action

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -152,6 +152,7 @@
 	<!-- Other -->
 	<action itemid="430" script="other/teleport.lua" />
 	<action itemid="486" script="other/snow_heap.lua" />
+	<action itemid="1369" script="other/draw_well.lua" />
 	<action itemid="1386" script="other/teleport.lua" />
 	<action fromid="1728" toid="1731" script="other/watch.lua" />
 	<action fromid="1816" toid="1817" script="other/wall_mirror.lua" />

--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -152,7 +152,6 @@
 	<!-- Other -->
 	<action itemid="430" script="other/teleport.lua" />
 	<action itemid="486" script="other/snow_heap.lua" />
-	<action itemid="1369" script="other/teleport.lua" />
 	<action itemid="1386" script="other/teleport.lua" />
 	<action fromid="1728" toid="1731" script="other/watch.lua" />
 	<action fromid="1816" toid="1817" script="other/wall_mirror.lua" />

--- a/data/actions/scripts/other/draw_well.lua
+++ b/data/actions/scripts/other/draw_well.lua
@@ -1,5 +1,5 @@
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if item:getActionId() == 100 then
+	if item:getActionId() == actionIds.drawWell then
 		fromPosition.z = fromPosition.z + 1
 		player:teleportTo(fromPosition, false)
 		return true

--- a/data/actions/scripts/other/draw_well.lua
+++ b/data/actions/scripts/other/draw_well.lua
@@ -1,0 +1,7 @@
+function onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if item:getActionId() == 100 then
+		fromPosition.z = fromPosition.z + 1
+		player:teleportTo(fromPosition, false)
+		return true
+	end
+end

--- a/data/lib/core/actionids.lua
+++ b/data/lib/core/actionids.lua
@@ -1,6 +1,7 @@
 actionIds = {
 	sandHole = 100, -- hidden sand hole
 	pickHole = 105, -- hidden mud hole
+	drawWell = 106, -- draw well teleport
 	levelDoor = 1000, -- level door
 	citizenship = 30020, -- citizenship teleport
 	citizenshipLast = 30050, -- citizenship teleport last


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
No draw well at all should be teleporting players a floor down, that is not default action and would lead to scenarios like this:
![2022-02-22 03_40_09-baiakNFT 8 6](https://user-images.githubusercontent.com/4684880/155076903-bbee333a-2dc7-4fed-a0b6-79a724b33b44.png)


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
