### PR TITLE
Add player check to pitfall holes

### DIFF
--- a/data/movements/movements.xml
+++ b/data/movements/movements.xml
@@ -3,6 +3,7 @@
 	<!-- Decaying tiles -->
 	<movevent event="StepIn" itemid="293" script="decay.lua" />
 	<movevent event="StepIn" itemid="461" script="decay.lua" />
+	<movevent event="StepIn" itemid="3310" script="decay.lua" />
 
 	<!-- (Depot & Level) tiles -->
 	<movevent event="StepIn" itemid="416" script="tiles.lua" />

--- a/data/movements/scripts/decay.lua
+++ b/data/movements/scripts/decay.lua
@@ -1,4 +1,8 @@
 function onStepIn(creature, item, position, fromPosition)
+	if not creature:isPlayer() or creature:isInGhostMode() then
+		return true
+	end
+
 	item:transform(item.itemid + 1)
 	item:decay()
 	return true


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Added check so only players could trigger them decaying tiles where you step up and fall
Yes, official behavior
Also added a missing pitfall
![2022-02-22 07_22_39-12rlmap86 otbm_ - Remere's Map Editor](https://user-images.githubusercontent.com/4684880/155113237-09c1cc6a-f33e-4876-bdd6-c72c1eb24bd5.png)


<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
