### PR TITLE
Replace LuaVariant with std::variant

### DIFF
--- a/src/luascript.h
+++ b/src/luascript.h
@@ -25,6 +25,7 @@
 #include "position.h"
 #include "outfit.h"
 #include "mounts.h"
+#include "luavariant.h"
 #include <fmt/format.h>
 
 class Thing;
@@ -45,15 +46,6 @@ enum {
 	EVENT_ID_USER = 1000,
 };
 
-enum LuaVariantType_t {
-	VARIANT_NONE,
-
-	VARIANT_NUMBER,
-	VARIANT_POSITION,
-	VARIANT_TARGETPOSITION,
-	VARIANT_STRING,
-};
-
 enum LuaDataType {
 	LuaData_Unknown,
 
@@ -65,13 +57,6 @@ enum LuaDataType {
 	LuaData_Monster,
 	LuaData_Npc,
 	LuaData_Tile,
-};
-
-struct LuaVariant {
-	LuaVariantType_t type = VARIANT_NONE;
-	std::string text;
-	Position pos;
-	uint32_t number = 0;
 };
 
 struct LuaTimerEventDesc {
@@ -351,7 +336,6 @@ class LuaScriptInterface
 		static Position getPosition(lua_State* L, int32_t arg);
 		static Outfit_t getOutfit(lua_State* L, int32_t arg);
 		static Outfit getOutfitClass(lua_State* L, int32_t arg);
-		static LuaVariant getVariant(lua_State* L, int32_t arg);
 		static InstantSpell* getInstantSpell(lua_State* L, int32_t arg);
 		static Reflect getReflect(lua_State* L, int32_t arg);
 

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -13,26 +13,26 @@ enum LuaVariantType_t {
 };
 
 class LuaVariant {
-public:
-	uint32_t getNumber() const { return std::get<VARIANT_NUMBER>(v); }
-	const Position& getPosition() const { return std::get<VARIANT_POSITION>(v); }
-	const Position& getTargetPosition() const { return std::get<VARIANT_TARGETPOSITION>(v); }
-	const std::string& getString() const { return std::get<VARIANT_STRING>(v); }
+	public:
+		uint32_t getNumber() const { return std::get<VARIANT_NUMBER>(variant); }
+		const Position& getPosition() const { return std::get<VARIANT_POSITION>(variant); }
+		const Position& getTargetPosition() const { return std::get<VARIANT_TARGETPOSITION>(variant); }
+		const std::string& getString() const { return std::get<VARIANT_STRING>(variant); }
 
-	bool isNumber() const { return v.index() == VARIANT_NUMBER; }
-	bool isPosition() const { return v.index() == VARIANT_POSITION; }
-	bool isTargetPosition() const { return v.index() == VARIANT_TARGETPOSITION; }
-	bool isString() const { return v.index() == VARIANT_STRING; }
+		bool isNumber() const { return variant.index() == VARIANT_NUMBER; }
+		bool isPosition() const { return variant.index() == VARIANT_POSITION; }
+		bool isTargetPosition() const { return variant.index() == VARIANT_TARGETPOSITION; }
+		bool isString() const { return variant.index() == VARIANT_STRING; }
 
-	void setNumber(uint32_t value) { v.emplace<VARIANT_NUMBER>(value); }
-	void setPosition(const Position& value) { v.emplace<VARIANT_POSITION>(value); }
-	void setTargetPosition(const Position& value) { v.emplace<VARIANT_TARGETPOSITION>(value); }
-	void setString(const std::string& value) { v.emplace<VARIANT_STRING>(value); }
+		void setNumber(uint32_t value) { variant.emplace<VARIANT_NUMBER>(value); }
+		void setPosition(const Position& value) { variant.emplace<VARIANT_POSITION>(value); }
+		void setTargetPosition(const Position& value) { variant.emplace<VARIANT_TARGETPOSITION>(value); }
+		void setString(const std::string& value) { variant.emplace<VARIANT_STRING>(value); }
 
-	auto type() const { return static_cast<LuaVariantType_t>(v.index()); }
+		auto type() const { return static_cast<LuaVariantType_t>(variant.index()); }
 
-private:
-	std::variant<uint32_t, Position, Position, std::string> v;
+	private:
+		std::variant<uint32_t, Position, Position, std::string> variant;
 };
 
 #endif

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -3,8 +3,6 @@
 
 #include <variant>
 
-using LuaVariant = std::variant<uint32_t, Position, Position, std::string>;
-
 enum LuaVariantType_t {
 	VARIANT_NUMBER = 0,
 	VARIANT_POSITION = 1,
@@ -12,6 +10,29 @@ enum LuaVariantType_t {
 	VARIANT_STRING = 3,
 
 	VARIANT_NONE = std::variant_npos,
+};
+
+class LuaVariant {
+public:
+	uint32_t getNumber() const { return std::get<VARIANT_NUMBER>(v); }
+	const Position& getPosition() const { return std::get<VARIANT_POSITION>(v); }
+	const Position& getTargetPosition() const { return std::get<VARIANT_TARGETPOSITION>(v); }
+	const std::string& getString() const { return std::get<VARIANT_STRING>(v); }
+
+	bool isNumber() const { return v.index() == VARIANT_NUMBER; }
+	bool isPosition() const { return v.index() == VARIANT_POSITION; }
+	bool isTargetPosition() const { return v.index() == VARIANT_TARGETPOSITION; }
+	bool isString() const { return v.index() == VARIANT_STRING; }
+
+	void setNumber(uint32_t value) { v.emplace<VARIANT_NUMBER>(value); }
+	void setPosition(const Position& value) { v.emplace<VARIANT_POSITION>(value); }
+	void setTargetPosition(const Position& value) { v.emplace<VARIANT_TARGETPOSITION>(value); }
+	void setString(const std::string& value) { v.emplace<VARIANT_STRING>(value); }
+
+	auto type() const { return static_cast<LuaVariantType_t>(v.index()); }
+
+private:
+	std::variant<uint32_t, Position, Position, std::string> v;
 };
 
 #endif

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -1,0 +1,17 @@
+#ifndef FS_LUAVARIANT_H
+#define FS_LUAVARIANT_H
+
+#include <variant>
+
+using LuaVariant = std::variant<uint32_t, Position, Position, std::string>;
+
+enum LuaVariantType_t {
+	VARIANT_NUMBER = 0,
+	VARIANT_POSITION = 1,
+	VARIANT_TARGETPOSITION = 2,
+	VARIANT_STRING = 3,
+
+	VARIANT_NONE = std::variant_npos,
+};
+
+#endif

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -283,9 +283,9 @@ bool CombatSpell::castSpell(Creature* creature)
 		LuaVariant var;
 
 		if (needDirection) {
-			var.emplace<VARIANT_POSITION>(Spells::getCasterPosition(creature, creature->getDirection()));
+			var.setPosition(Spells::getCasterPosition(creature, creature->getDirection()));
 		} else {
-			var.emplace<VARIANT_POSITION>(creature->getPosition());
+			var.setPosition(creature->getPosition());
 		}
 
 		return executeCastSpell(creature, var);
@@ -309,14 +309,14 @@ bool CombatSpell::castSpell(Creature* creature, Creature* target)
 
 		if (combat->hasArea()) {
 			if (needTarget) {
-				var.emplace<VARIANT_POSITION>(target->getPosition());
+				var.setPosition(target->getPosition());
 			} else if (needDirection) {
-				var.emplace<VARIANT_POSITION>(Spells::getCasterPosition(creature, creature->getDirection()));
+				var.setPosition(Spells::getCasterPosition(creature, creature->getDirection()));
 			} else {
-				var.emplace<VARIANT_POSITION>(creature->getPosition());
+				var.setPosition(creature->getPosition());
 			}
 		} else {
-			var.emplace<VARIANT_NUMBER>(target->getID());
+			var.setNumber(target->getID());
 		}
 		return executeCastSpell(creature, var);
 	}
@@ -860,7 +860,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 	LuaVariant var;
 
 	if (selfTarget) {
-		var.emplace<VARIANT_NUMBER>(player->getID());
+		var.setNumber(player->getID());
 	} else if (needTarget || casterTargetOrDirection) {
 		Creature* target = nullptr;
 		bool useDirection = false;
@@ -922,11 +922,11 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 				return false;
 			}
 
-			var.emplace<VARIANT_NUMBER>(target->getID());
+			var.setNumber(target->getID());
 		} else {
-			var.emplace<VARIANT_POSITION>(Spells::getCasterPosition(player, player->getDirection()));
+			var.setPosition(Spells::getCasterPosition(player, player->getDirection()));
 
-			if (!playerInstantSpellCheck(player, std::get<VARIANT_POSITION>(var))) {
+			if (!playerInstantSpellCheck(player, var.getPosition())) {
 				return false;
 			}
 		}
@@ -961,15 +961,15 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			}
 		}
 
-		var.emplace<VARIANT_STRING>(param);
+		var.setString(param);
 	} else {
 		if (needDirection) {
-			var.emplace<VARIANT_POSITION>(Spells::getCasterPosition(player, player->getDirection()));
+			var.setPosition(Spells::getCasterPosition(player, player->getDirection()));
 		} else {
-			var.emplace<VARIANT_POSITION>(player->getPosition());
+			var.setPosition(player->getPosition());
 		}
 
-		if (!playerInstantSpellCheck(player, std::get<VARIANT_POSITION>(var))) {
+		if (!playerInstantSpellCheck(player, var.getPosition())) {
 			return false;
 		}
 	}
@@ -1005,15 +1005,15 @@ bool InstantSpell::castSpell(Creature* creature)
 				return false;
 			}
 
-			var.emplace<VARIANT_NUMBER>(target->getID());
+			var.setNumber(target->getID());
 			return internalCastSpell(creature, var);
 		}
 
 		return false;
 	} else if (needDirection) {
-		var.emplace<VARIANT_POSITION>(Spells::getCasterPosition(creature, creature->getDirection()));
+		var.setPosition(Spells::getCasterPosition(creature, creature->getDirection()));
 	} else {
-		var.emplace<VARIANT_POSITION>(creature->getPosition());
+		var.setPosition(creature->getPosition());
 	}
 
 	return internalCastSpell(creature, var);
@@ -1023,7 +1023,7 @@ bool InstantSpell::castSpell(Creature* creature, Creature* target)
 {
 	if (needTarget) {
 		LuaVariant var;
-		var.emplace<VARIANT_NUMBER>(target->getID());
+		var.setNumber(target->getID());
 		return internalCastSpell(creature, var);
 	}
 	return castSpell(creature);
@@ -1162,14 +1162,14 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 			if (toTile) {
 				const Creature* visibleCreature = toTile->getBottomVisibleCreature(player);
 				if (visibleCreature) {
-					var.emplace<VARIANT_NUMBER>(visibleCreature->getID());
+					var.setNumber(visibleCreature->getID());
 				}
 			}
 		} else {
-			var.emplace<VARIANT_NUMBER>(target->getCreature()->getID());
+			var.setNumber(target->getCreature()->getID());
 		}
 	} else {
-		var.emplace<VARIANT_POSITION>(toPosition);
+		var.setPosition(toPosition);
 	}
 
 	if (!internalCastSpell(player, var, isHotkey)) {
@@ -1178,7 +1178,7 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 
 	postCastSpell(player);
 
-	target = g_game.getCreatureByID(std::get<VARIANT_NUMBER>(var));
+	target = g_game.getCreatureByID(var.getNumber());
 	if (getPzLock() && target) {
 		player->onAttackedCreature(target->getCreature());
 	}
@@ -1193,14 +1193,14 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 bool RuneSpell::castSpell(Creature* creature)
 {
 	LuaVariant var;
-	var.emplace<VARIANT_NUMBER>(creature->getID());
+	var.setNumber(creature->getID());
 	return internalCastSpell(creature, var, false);
 }
 
 bool RuneSpell::castSpell(Creature* creature, Creature* target)
 {
 	LuaVariant var;
-	var.emplace<VARIANT_NUMBER>(target->getID());
+	var.setNumber(target->getID());
 	return internalCastSpell(creature, var, false);
 }
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -1178,9 +1178,11 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 
 	postCastSpell(player);
 
-	target = g_game.getCreatureByID(var.getNumber());
-	if (getPzLock() && target) {
-		player->onAttackedCreature(target->getCreature());
+	if (var.isNumber()) {
+		target = g_game.getCreatureByID(var.getNumber());
+		if (getPzLock() && target) {
+			player->onAttackedCreature(target->getCreature());
+		}
 	}
 
 	if (hasCharges && item && g_config.getBoolean(ConfigManager::REMOVE_RUNE_CHARGES)) {

--- a/src/spells.h
+++ b/src/spells.h
@@ -4,7 +4,6 @@
 #ifndef FS_SPELLS_H_D78A7CCB7080406E8CAA6B1D31D3DA71
 #define FS_SPELLS_H_D78A7CCB7080406E8CAA6B1D31D3DA71
 
-#include "luascript.h"
 #include "player.h"
 #include "actions.h"
 #include "talkaction.h"

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -362,7 +362,7 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int
 {
 	if (scripted) {
 		LuaVariant var;
-		var.emplace<VARIANT_NUMBER>(target->getID());
+		var.setNumber(target->getID());
 		executeUseWeapon(player, var);
 	} else {
 		CombatDamage damage;
@@ -388,7 +388,7 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Tile* tile) const
 {
 	if (scripted) {
 		LuaVariant var;
-		var.emplace<VARIANT_TARGETPOSITION>(tile->getPosition());
+		var.setTargetPosition(tile->getPosition());
 		executeUseWeapon(player, var);
 	} else {
 		Combat::postCombatEffects(player, tile->getPosition(), params);

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -6,6 +6,7 @@
 #include "combat.h"
 #include "configmanager.h"
 #include "game.h"
+#include "luavariant.h"
 #include "pugicast.h"
 #include "weapons.h"
 
@@ -361,8 +362,7 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int
 {
 	if (scripted) {
 		LuaVariant var;
-		var.type = VARIANT_NUMBER;
-		var.number = target->getID();
+		var.emplace<VARIANT_NUMBER>(target->getID());
 		executeUseWeapon(player, var);
 	} else {
 		CombatDamage damage;
@@ -388,8 +388,7 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Tile* tile) const
 {
 	if (scripted) {
 		LuaVariant var;
-		var.type = VARIANT_TARGETPOSITION;
-		var.pos = tile->getPosition();
+		var.emplace<VARIANT_TARGETPOSITION>(tile->getPosition());
 		executeUseWeapon(player, var);
 	} else {
 		Combat::postCombatEffects(player, tile->getPosition(), params);

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -4,7 +4,6 @@
 #ifndef FS_WEAPONS_H_69D1993478AA42948E24C0B90B8F5BF5
 #define FS_WEAPONS_H_69D1993478AA42948E24C0B90B8F5BF5
 
-#include "luascript.h"
 #include "player.h"
 #include "baseevents.h"
 #include "combat.h"


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Replaces custom `LuaVariant` class with `std::variant` with the same types. This reduces memory size of each instance from 56 bytes to 40 bytes, and allows for some code cleaning.

**Issues addressed:**
Closes #1481

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
