### PR TITLE
Monster onSpawned equivalent to onLogin in monsters

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -39,4 +39,5 @@
 	<!-- Monster methods -->
 	<event class="Monster" method="onDropLoot" enabled="1" />
 	<event class="Monster" method="onSpawn" enabled="0" />
+	<event class="Monster" method="onSpawned" enabled="0" />
 </events>

--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -15,3 +15,9 @@ function Monster:onSpawn(position, startup, artificial)
 		return true
 	end
 end
+
+function Monster:onSpawned(position, startup, artificial, forced)
+	if EventCallback.onSpawned then
+		EventCallback.onSpawned(self, position, startup, artificial, forced)
+	end
+end

--- a/data/scripts/lib/event_callbacks.lua
+++ b/data/scripts/lib/event_callbacks.lua
@@ -57,6 +57,7 @@ ec.onInventoryUpdate = {}
 -- Monster
 ec.onDropLoot = {}
 ec.onSpawn = {}
+ec.onSpawned = {}
 
 EventCallback = {
 	register = function (self, triggerIndex)

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -122,6 +122,8 @@ bool Events::load()
 				info.monsterOnDropLoot = event;
 			} else if (methodName == "onSpawn") {
 				info.monsterOnSpawn = event;
+			} else if (methodName == "onSpawned") {
+				info.monsterOnSpawned = event;
 			} else {
 				std::cout << "[Warning - Events::load] Unknown monster method: " << methodName << std::endl;
 			}
@@ -158,6 +160,34 @@ bool Events::eventMonsterOnSpawn(Monster* monster, const Position& position, boo
 	LuaScriptInterface::pushBoolean(L, artificial);
 
 	return scriptInterface.callFunction(4);
+}
+
+void Events::eventMonsterOnSpawned(Monster* monster, const Position& position, bool startup, bool artificial, bool forced /*= false*/)
+{
+	// Monster:onSpawned(position, startup, artificial, forced)
+	if (info.monsterOnSpawned == -1) {
+		return;
+	}
+
+	if (!scriptInterface.reserveScriptEnv()) {
+		std::cout << "[Error - Events::monsterOnSpawned] Call stack overflow" << std::endl;
+		return;
+	}
+
+	ScriptEnvironment* env = scriptInterface.getScriptEnv();
+	env->setScriptId(info.monsterOnSpawned, &scriptInterface);
+
+	lua_State* L = scriptInterface.getLuaState();
+	scriptInterface.pushFunction(info.monsterOnSpawned);
+
+	LuaScriptInterface::pushUserdata<Monster>(L, monster);
+	LuaScriptInterface::setMetatable(L, -1, "Monster");
+	LuaScriptInterface::pushPosition(L, position);
+	LuaScriptInterface::pushBoolean(L, startup);
+	LuaScriptInterface::pushBoolean(L, artificial);
+	LuaScriptInterface::pushBoolean(L, forced);
+
+	scriptInterface.callVoidFunction(5);
 }
 
 // Creature

--- a/src/events.h
+++ b/src/events.h
@@ -58,6 +58,7 @@ class Events
 		// Monster
 		int32_t monsterOnDropLoot = -1;
 		int32_t monsterOnSpawn = -1;
+		int32_t monsterOnSpawned = -1;
 	};
 
 	public:
@@ -104,6 +105,7 @@ class Events
 		// Monster
 		void eventMonsterOnDropLoot(Monster* monster, Container* corpse);
 		bool eventMonsterOnSpawn(Monster* monster, const Position& position, bool startup, bool artificial);
+		void eventMonsterOnSpawned(Monster* monster, const Position& position, bool startup, bool artificial, bool forced = false);
 
 		int32_t getScriptId(EventInfoId eventInfoId) {
 			switch (eventInfoId)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4758,6 +4758,7 @@ int LuaScriptInterface::luaGameCreateMonster(lua_State* L)
 	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 5, CONST_ME_TELEPORT);
 	if (g_events->eventMonsterOnSpawn(monster, position, false, true) || force) {
 		if (g_game.placeCreature(monster, position, extended, force, magicEffect)) {
+			g_events->eventMonsterOnSpawned(monster, position, false, true, force);
 			pushUserdata<Monster>(L, monster);
 			setMetatable(L, -1, "Monster");
 		} else {

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -326,6 +326,7 @@ bool Spawn::spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& p
 		}
 	}
 
+	g_events->eventMonsterOnSpawned(monster_ptr.get(), pos, startup, false);
 	Monster* monster = monster_ptr.release();
 	monster->setDirection(dir);
 	monster->setSpawn(this);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These changes propose a new event for monsters: `onSpawned`.
many people still do not fully understand the event `onSpawn`, This event is used to verify certain things of a monster that does not yet exist, this monster, since it does not exist, has certain restrictions, such as not having a defined ID and other things.

With this new event we will make sure to act on a monster that already exists and was successfully placed on the map.

We currently can't do this with auto-spawned monsters with the spawn system:
```lua
local m = Game.createMonster(...)
if m then
-- m:somethingMethod(...)
end
```
with this event it will be possible to handle the monster properly without having to opt for a custom generation system from lua.

### Notes
it is possible that there is a different way to deal with this small inconvenience when using `onSpawn`, I even have some other ideas like returning a function in `onSpawn` to act on the correctly spawned monster, something like this:
```lua
local ec = EventCallback

function ec.onSpawn(monster, position, startup, artificial)
	local mType = monster:getType()
	if mType:getName() == "Demon" then
		return false
	end

	return function (monster, position, startup, artificial)
		-- Yeah, I'm not a demon and I'm already alive on the map :D
	end
end

ec:register(--[[0]])
```
however I think it's too much trouble to create the interface to return a function, save the reference on the side of C++, and then call her back.., but we can try it if this PR is not very satisfactory, maybe other ideas?

I personally find the idea of ​​returning a function sexy, this way we would avoid having another event.

**Issues addressed:** Nothing!