### PR TITLE
Call onSpawn from internalPlaceCreature and fixed some related issues

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -464,6 +464,13 @@ class Creature : virtual public Thing
 			}
 		}
 
+		void setRemovable(bool isRemovable) {
+			removable = isRemovable;
+		}
+		bool isRemovable() const {
+			return removable;
+		}
+
 	protected:
 		virtual bool useCacheMap() const {
 			return false;
@@ -534,6 +541,9 @@ class Creature : virtual public Thing
 		bool hiddenHealth = false;
 		bool canUseDefense = true;
 		bool movementBlocked = false;
+
+		//exclusive to not allow the removal of this creature from lua
+		bool removable = true;
 
 		//creature script events
 		bool hasEventRegistered(CreatureEventType_t event) const {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -525,7 +525,7 @@ Player* Game::getPlayerByAccount(uint32_t acc)
 	return nullptr;
 }
 
-bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/)
+bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, bool artificial /*=false*/)
 {
 	if (creature->getParent()) {
 		return false;
@@ -538,12 +538,28 @@ bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool e
 	creature->incrementReferenceCounter();
 	creature->setID();
 	creature->addList();
+
+	if (Monster* monster = creature->getMonster()) {
+		creature->setRemovable(false);
+		if (g_events->eventMonsterOnSpawn(monster, pos, false, artificial) || forced) {
+			creature->setRemovable(true);
+			return true;
+		}
+
+		creature->removeList();
+		if (Tile* tile = creature->getTile()) {
+			tile->removeCreature(creature);
+		}
+
+		return false;
+	}
+
 	return true;
 }
 
-bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, MagicEffectClasses magicEffect /*= CONST_ME_TELEPORT*/)
+bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, MagicEffectClasses magicEffect /*= CONST_ME_TELEPORT*/, bool artificial /*=false*/)
 {
-	if (!internalPlaceCreature(creature, pos, extendedPos, forced)) {
+	if (!internalPlaceCreature(creature, pos, extendedPos, forced, artificial)) {
 		return false;
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -525,7 +525,7 @@ Player* Game::getPlayerByAccount(uint32_t acc)
 	return nullptr;
 }
 
-bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, bool artificial /*=false*/)
+bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, VariantMap variantMap /*={}*/)
 {
 	if (creature->getParent()) {
 		return false;
@@ -541,8 +541,18 @@ bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool e
 
 	if (Monster* monster = creature->getMonster()) {
 		creature->setRemovable(false);
-		if (g_events->eventMonsterOnSpawn(monster, pos, false, artificial) || forced) {
+		Creature* master = variantMap.getCreature("master");
+		if (master) {
+			monster->setMaster(master);
+			master->setRemovable(false);
+		}
+
+		if (g_events->eventMonsterOnSpawn(monster, pos, false, variantMap.getBoolean("artificial")) || forced) {
 			creature->setRemovable(true);
+			if (master) {
+				master->setRemovable(true);
+			}
+
 			return true;
 		}
 
@@ -557,9 +567,9 @@ bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool e
 	return true;
 }
 
-bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, MagicEffectClasses magicEffect /*= CONST_ME_TELEPORT*/, bool artificial /*=false*/)
+bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, MagicEffectClasses magicEffect /*= CONST_ME_TELEPORT*/, VariantMap variantMap /*={}*/)
 {
-	if (!internalPlaceCreature(creature, pos, extendedPos, forced, artificial)) {
+	if (!internalPlaceCreature(creature, pos, extendedPos, forced, variantMap)) {
 		return false;
 	}
 

--- a/src/game.h
+++ b/src/game.h
@@ -187,7 +187,7 @@ class Game
 		  * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 		  * \param forced If true, placing the creature will not fail because of obstacles (creatures/items)
 		  */
-		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, bool artificial = false);
+		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, VariantMap variantMap = {});
 
 		/**
 		  * Place Creature on the map.
@@ -196,7 +196,7 @@ class Game
 		  * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 		  * \param force If true, placing the creature will not fail because of obstacles (creatures/items)
 		  */
-		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT, bool artificial = false);
+		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT, VariantMap variantMap = {});
 
 		/**
 		  * Remove Creature from the map.

--- a/src/game.h
+++ b/src/game.h
@@ -187,7 +187,7 @@ class Game
 		  * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 		  * \param forced If true, placing the creature will not fail because of obstacles (creatures/items)
 		  */
-		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false);
+		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, bool artificial = false);
 
 		/**
 		  * Place Creature on the map.
@@ -196,7 +196,7 @@ class Game
 		  * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 		  * \param force If true, placing the creature will not fail because of obstacles (creatures/items)
 		  */
-		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT);
+		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT, bool artificial = false);
 
 		/**
 		  * Remove Creature from the map.

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4756,7 +4756,9 @@ int LuaScriptInterface::luaGameCreateMonster(lua_State* L)
 	bool extended = getBoolean(L, 3, false);
 	bool force = getBoolean(L, 4, false);
 	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 5, CONST_ME_TELEPORT);
-	if (g_game.placeCreature(monster, position, extended, force, magicEffect, true)) {
+	VariantMap varMap;
+	varMap["artificial"] = true;
+	if (g_game.placeCreature(monster, position, extended, force, magicEffect, varMap)) {
 		pushUserdata<Monster>(L, monster);
 		setMetatable(L, -1, "Monster");
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4756,14 +4756,9 @@ int LuaScriptInterface::luaGameCreateMonster(lua_State* L)
 	bool extended = getBoolean(L, 3, false);
 	bool force = getBoolean(L, 4, false);
 	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 5, CONST_ME_TELEPORT);
-	if (g_events->eventMonsterOnSpawn(monster, position, false, true) || force) {
-		if (g_game.placeCreature(monster, position, extended, force, magicEffect)) {
-			pushUserdata<Monster>(L, monster);
-			setMetatable(L, -1, "Monster");
-		} else {
-			delete monster;
-			lua_pushnil(L);
-		}
+	if (g_game.placeCreature(monster, position, extended, force, magicEffect, true)) {
+		pushUserdata<Monster>(L, monster);
+		setMetatable(L, -1, "Monster");
 	} else {
 		delete monster;
 		lua_pushnil(L);
@@ -8334,7 +8329,7 @@ int LuaScriptInterface::luaCreatureRemove(lua_State* L)
 	}
 
 	Creature* creature = *creaturePtr;
-	if (!creature) {
+	if (!creature || !creature->isRemovable()) {
 		lua_pushnil(L);
 		return 1;
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -74,6 +74,52 @@ struct LuaVariant {
 	uint32_t number = 0;
 };
 
+struct VariantMap : public std::map<std::string, std::variant<bool, int32_t, Creature*>>
+{
+	public:
+		bool getBoolean(const std::string& key) {
+			try {
+				const auto& variant = (*this).at(key);
+				if (!std::holds_alternative<bool>(variant)) {
+					return false;
+				}
+
+				return std::get<bool>(variant);
+			}
+			catch (const std::out_of_range&) {
+				return false;
+			}
+		};
+
+		int32_t getNumber(const std::string& key) {
+			try {
+				const auto& variant = (*this).at(key);
+				if (!std::holds_alternative<int32_t>(variant)) {
+					return -1;
+				}
+
+				return std::get<int32_t>(variant);
+			}
+			catch (const std::out_of_range&) {
+				return -1;
+			}
+		};
+
+		Creature* getCreature(const std::string& key) {
+			try {
+				const auto& variant = (*this).at(key);
+				if (!std::holds_alternative<Creature*>(variant)) {
+					return nullptr;
+				}
+
+				return std::get<Creature*>(variant);
+			}
+			catch (const std::out_of_range&) {
+				return nullptr;
+			}
+		};
+};
+
 struct LuaTimerEventDesc {
 	int32_t scriptId = -1;
 	int32_t function = -1;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -995,10 +995,11 @@ void Monster::onThinkDefense(uint32_t interval)
 
 			Monster* summon = Monster::createMonster(summonBlock.name);
 			if (summon) {
-				if (g_game.placeCreature(summon, getPosition(), false, summonBlock.force)) {
+				VariantMap varMap;
+				varMap["master"] = this;
+				if (g_game.placeCreature(summon, getPosition(), false, summonBlock.force, CONST_ME_TELEPORT, varMap)) {
 					summon->setDropLoot(false);
 					summon->setSkillLoss(false);
-					summon->setMaster(this);
 					g_game.addMagicEffect(getPosition(), CONST_ME_MAGIC_BLUE);
 				} else {
 					delete summon;

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -310,9 +310,6 @@ bool Spawn::spawnMonster(uint32_t spawnId, spawnBlock_t sb, bool startup/* = fal
 bool Spawn::spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& pos, Direction dir, bool startup/*= false*/)
 {
 	std::unique_ptr<Monster> monster_ptr(new Monster(mType));
-	if (!g_events->eventMonsterOnSpawn(monster_ptr.get(), pos, startup, false)) {
-		return false;
-	}
 
 	if (startup) {
 		//No need to send out events to the surrounding since there is no one out there to listen!


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These changes propose to move the place where the onSpawn event for monsters is called from, since it is currently called from a place where it is not safe, for example:
```lua
function Monster:onSpawn(position, startup, artificial)
        print(self:getId()) -- Output: 0 ???
	self:remove() -- CRASH!!!
	-- In case of being an summon
	print(self:getMaster()) -- Output: nil ???
	
	-- With the proposed changes:
	print(self:getId()) -- Output: correct ID!
	self:remove() -- ignored, this not allowed
	print(self:getMaster()) -- correct!
	
	-- With the new changes you can get the master, but it will be protected
	self:getMaster():remove() -- the master cannot be eliminated since this in turn would eliminate the summon and this is not allowed
	return true
end
```
With these changes the previous code already works correctly.

Note: If you currently have a way to crash the server and it is related to the logic of this `onSpawn` event, comment here to try to find a solution, for now these are the problems I have addressed.

Regarding the code I don't know if it's perfectly optimized or if it's the best way to do it, I'm open to ideas.

**Issues addressed:** Nothing!