### PR TITLE
missing runeSpellName method in RuneSpell

### DIFF
--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1510,6 +1510,7 @@ class LuaScriptInterface
 		static int luaSpellRuneLevel(lua_State* L);
 		static int luaSpellRuneMagicLevel(lua_State* L);
 		static int luaSpellRuneId(lua_State* L);
+		static int luaSpellRuneSpellName(lua_State* L);
 		static int luaSpellCharges(lua_State* L);
 		static int luaSpellAllowFarUse(lua_State* L);
 		static int luaSpellBlockWalls(lua_State* L);

--- a/src/spells.h
+++ b/src/spells.h
@@ -117,6 +117,12 @@ class Spell : public BaseSpell
 		void setName(std::string n) {
 			name = n;
 		}
+		const std::string& getSpellName() const {
+			return spellName;
+		}
+		void setSpellName(std::string n) {
+			spellName = n;
+		}
 		uint8_t getId() const {
 			return spellId;
 		}
@@ -313,6 +319,7 @@ class Spell : public BaseSpell
 		bool premium = false;
 
 		std::string name;
+		std::string spellName;
 };
 
 class InstantSpell final : public TalkAction, public Spell


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These changes add a method that should always have been there for runes. `runeSpellName`
```lua
local combat = Combat()
combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ICEDAMAGE)
combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ICEAREA)
combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ICE)
combat:setArea(createCombatArea(AREA_CIRCLE3X3))

function onGetFormulaValues(player, level, magicLevel)
    local min = (level / 5) + (magicLevel * 1.2) + 7
    local max = (level / 5) + (magicLevel * 2.85) + 16
    return -min, -max
end

combat:setCallback(CALLBACK_PARAM_LEVELMAGICVALUE, "onGetFormulaValues")

local rune = Spell(SPELL_RUNE)
function rune.onCastSpell(creature, variant, isHotkey)
    return combat:execute(creature, variant)
end

rune:name("Avalanche Rune 2")
rune:group("attack")
rune:vocation("sorcerer", "master sorcerer")
rune:runeId(2294)
rune:runeSpellName("adevo grav avalanche xd")
rune:charges(1)
rune:id(24)
rune:cooldown(40 * 1000)
rune:groupCooldown(4 * 1000)
rune:level(60)
rune:magicLevel(14)
rune:mana(1100)
rune:allowFarUse(true)
rune:isPremium(true)
rune:register()
```

![image](https://user-images.githubusercontent.com/28090948/156874008-db3dd62e-8ff9-4c43-9611-7a78cdbb2650.png)


**Issues addressed:** Nothing!