### PR TITLE
Drop boost::filesystem in favor of std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,13 +61,12 @@ else ()
     find_package(Lua REQUIRED)
 endif ()
 
-find_package(Boost 1.66.0 REQUIRED COMPONENTS date_time system filesystem iostreams)
+find_package(Boost 1.66.0 REQUIRED COMPONENTS date_time system iostreams)
 
 include_directories(${Boost_INCLUDE_DIRS} ${Crypto++_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${MYSQL_INCLUDE_DIR} ${PUGIXML_INCLUDE_DIR})
 target_link_libraries(tfs PRIVATE
         Boost::date_time
         Boost::system
-        Boost::filesystem
         Boost::iostreams
         fmt::fmt
         ${CMAKE_THREAD_LIBS_INIT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ FROM alpine:3.15.0
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
   boost-iostreams \
   boost-system \
-  boost-filesystem \
   crypto++ \
   fmt \
   gmp \

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -3,9 +3,10 @@
 
 #include "otpch.h"
 
-#include "script.h"
-#include <boost/filesystem.hpp>
 #include "configmanager.h"
+#include "script.h"
+
+#include <filesystem>
 
 extern LuaEnvironment g_luaEnvironment;
 extern ConfigManager g_config;
@@ -23,7 +24,7 @@ Scripts::~Scripts()
 
 bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload)
 {
-	namespace fs = boost::filesystem;
+	namespace fs = std::filesystem;
 
 	const auto dir = fs::current_path() / "data" / folderName;
 	if (!fs::exists(dir) || !fs::is_directory(dir)) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

No need to use Boost, we can use STL now that C++17 is enabled.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
