### PR TITLE
Fix expression parenthesizing to avoid confusion

### DIFF
--- a/src/luascript.h
+++ b/src/luascript.h
@@ -293,7 +293,7 @@ class LuaScriptInterface
 		}
 
 		template<typename T>
-		static typename std::enable_if<(std::is_integral<T>::value && (std::is_signed<T>::value) || std::is_floating_point<T>::value), T>::type
+		static typename std::enable_if<(std::is_integral<T>::value && std::is_signed<T>::value) || std::is_floating_point<T>::value, T>::type
 			getNumber(lua_State* L, int32_t arg)
 		{
 			double num = lua_tonumber(L, arg);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -596,7 +596,7 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 	}
 
 	//skip checks for sight line in case fromPos and toPos cross the ground floor
-	if (fromPos.z < 8 && toPos.z > 7 || fromPos.z > 7 && toPos.z < 8) {
+	if ((fromPos.z < 8 && toPos.z > 7) || (fromPos.z > 7 && toPos.z < 8)) {
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Some ugly lack of parenthesizing can be confusing to read. We don't have warnings cranked up enough to yell at this though.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
