### PR TITLE
Normalize include guards to FS_<FILENAME>_H

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_ACCOUNT_H_34817537BA2B4CB7B71AA562AFBB118F
-#define FS_ACCOUNT_H_34817537BA2B4CB7B71AA562AFBB118F
+#ifndef FS_ACCOUNT_H
+#define FS_ACCOUNT_H
 
 #include "enums.h"
 
@@ -17,4 +17,4 @@ struct Account {
 	Account() = default;
 };
 
-#endif
+#endif // FS_ACCOUNT_H

--- a/src/actions.h
+++ b/src/actions.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_ACTIONS_H_87F60C5F587E4B84948F304A6451E6E6
-#define FS_ACTIONS_H_87F60C5F587E4B84948F304A6451E6E6
+#ifndef FS_ACTIONS_H
+#define FS_ACTIONS_H
 
 #include "baseevents.h"
 #include "enums.h"
@@ -133,4 +133,4 @@ class Actions final : public BaseEvents
 		LuaScriptInterface scriptInterface;
 };
 
-#endif
+#endif // FS_ACTIONS_H

--- a/src/ban.h
+++ b/src/ban.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_BAN_H_CADB975222D745F0BDA12D982F1006E3
-#define FS_BAN_H_CADB975222D745F0BDA12D982F1006E3
+#ifndef FS_BAN_H
+#define FS_BAN_H
 
 struct BanInfo {
 	std::string bannedBy;
@@ -39,4 +39,4 @@ class IOBan
 		static bool isPlayerNamelocked(uint32_t playerId);
 };
 
-#endif
+#endif // FS_BAN_H

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_BASEEVENTS_H_9994E32C91CE4D95912A5FDD1F41884A
-#define FS_BASEEVENTS_H_9994E32C91CE4D95912A5FDD1F41884A
+#ifndef FS_BASEEVENTS_H
+#define FS_BASEEVENTS_H
 
 #include "luascript.h"
 
@@ -80,4 +80,4 @@ class CallBack
 		bool loaded = false;
 };
 
-#endif
+#endif // FS_BASEEVENTS_H

--- a/src/bed.h
+++ b/src/bed.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_BED_H_84DE19758D424C6C9789189231946BFF
-#define FS_BED_H_84DE19758D424C6C9789189231946BFF
+#ifndef FS_BED_H
+#define FS_BED_H
 
 #include "item.h"
 
@@ -58,4 +58,4 @@ class BedItem final : public Item
 		uint32_t sleeperGUID;
 };
 
-#endif
+#endif // FS_BED_H

--- a/src/chat.h
+++ b/src/chat.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CHAT_H_F1574642D0384ABFAB52B7ED906E5628
-#define FS_CHAT_H_F1574642D0384ABFAB52B7ED906E5628
+#ifndef FS_CHAT_H
+#define FS_CHAT_H
 
 #include "const.h"
 #include "luascript.h"
@@ -145,4 +145,4 @@ class Chat
 		PrivateChatChannel dummyPrivate;
 };
 
-#endif
+#endif // FS_CHAT_H

--- a/src/combat.h
+++ b/src/combat.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_COMBAT_H_B02CE79230FC43708699EE91FCC8F7CC
-#define FS_COMBAT_H_B02CE79230FC43708699EE91FCC8F7CC
+#ifndef FS_COMBAT_H
+#define FS_COMBAT_H
 
 #include "thing.h"
 #include "condition.h"
@@ -219,4 +219,4 @@ class MagicField final : public Item
 		int64_t createTime;
 };
 
-#endif
+#endif // FS_COMBAT_H

--- a/src/condition.h
+++ b/src/condition.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CONDITION_H_F92FF8BDDD5B4EA59E2B1BB5C9C0A086
-#define FS_CONDITION_H_F92FF8BDDD5B4EA59E2B1BB5C9C0A086
+#ifndef FS_CONDITION_H
+#define FS_CONDITION_H
 
 #include "fileloader.h"
 #include "enums.h"
@@ -446,4 +446,4 @@ class ConditionDrunk final : public Condition
 		bool updateCondition(const Condition* addCondition) override;
 };
 
-#endif
+#endif // FS_CONDITION_H

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CONFIGMANAGER_H_6BDD23BD0B8344F4B7C40E8BE6AF6F39
-#define FS_CONFIGMANAGER_H_6BDD23BD0B8344F4B7C40E8BE6AF6F39
+#ifndef FS_CONFIGMANAGER_H
+#define FS_CONFIGMANAGER_H
 
 #include <utility>
 #include <vector>
@@ -149,4 +149,4 @@ class ConfigManager
 		bool loaded = false;
 };
 
-#endif
+#endif // FS_CONFIGMANAGER_H

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CONNECTION_H_FC8E1B4392D24D27A2F129D8B93A6348
-#define FS_CONNECTION_H_FC8E1B4392D24D27A2F129D8B93A6348
+#ifndef FS_CONNECTION_H
+#define FS_CONNECTION_H
 
 #include <unordered_set>
 
@@ -125,4 +125,4 @@ class Connection : public std::enable_shared_from_this<Connection>
 		bool receivedLastChar = false;
 };
 
-#endif
+#endif // FS_CONNECTION_H

--- a/src/const.h
+++ b/src/const.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CONST_H_0A49B5996F074465BF44B90F4F780E8B
-#define FS_CONST_H_0A49B5996F074465BF44B90F4F780E8B
+#ifndef FS_CONST_H
+#define FS_CONST_H
 
 static constexpr int32_t NETWORKMESSAGE_MAXSIZE = 24590;
 static constexpr int32_t MIN_MARKET_FEE = 20;
@@ -703,4 +703,4 @@ static constexpr int32_t PSTRG_MOUNTS_CURRENTMOUNT = (PSTRG_MOUNTS_RANGE_START +
 
 #define IS_IN_KEYRANGE(key, range) (key >= PSTRG_##range##_START && ((key - PSTRG_##range##_START) <= PSTRG_##range##_SIZE))
 
-#endif
+#endif // FS_CONST_H

--- a/src/container.h
+++ b/src/container.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CONTAINER_H_5590165FD8A2451B98D71F13CD3ED8DC
-#define FS_CONTAINER_H_5590165FD8A2451B98D71F13CD3ED8DC
+#ifndef FS_CONTAINER_H
+#define FS_CONTAINER_H
 
 #include <queue>
 
@@ -166,4 +166,4 @@ class Container : public Item, public Cylinder
 		friend class IOMapSerialize;
 };
 
-#endif
+#endif // FS_CONTAINER_H

--- a/src/creature.h
+++ b/src/creature.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CREATURE_H_5363C04015254E298F84E6D59A139508
-#define FS_CREATURE_H_5363C04015254E298F84E6D59A139508
+#ifndef FS_CREATURE_H
+#define FS_CREATURE_H
 
 #include "map.h"
 #include "position.h"
@@ -567,4 +567,4 @@ class Creature : virtual public Thing
 		friend class LuaScriptInterface;
 };
 
-#endif
+#endif // FS_CREATURE_H

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CREATUREEVENT_H_73FCAF4608CB41399D53C919316646A9
-#define FS_CREATUREEVENT_H_73FCAF4608CB41399D53C919316646A9
+#ifndef FS_CREATUREEVENT_H
+#define FS_CREATUREEVENT_H
 
 #include "luascript.h"
 #include "baseevents.h"
@@ -113,4 +113,4 @@ class CreatureEvents final : public BaseEvents
 		LuaScriptInterface scriptInterface;
 };
 
-#endif
+#endif // FS_CREATUREEVENT_H

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_CYLINDER_H_54BBCEB2A5B7415DAD837E4D58115150
-#define FS_CYLINDER_H_54BBCEB2A5B7415DAD837E4D58115150
+#ifndef FS_CYLINDER_H
+#define FS_CYLINDER_H
 
 #include "enums.h"
 #include "thing.h"
@@ -230,4 +230,4 @@ class VirtualCylinder final : public Cylinder
 		}
 };
 
-#endif
+#endif // FS_CYLINDER_H

--- a/src/database.h
+++ b/src/database.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_DATABASE_H_A484B0CDFDE542838F506DCE3D40C693
-#define FS_DATABASE_H_A484B0CDFDE542838F506DCE3D40C693
+#ifndef FS_DATABASE_H
+#define FS_DATABASE_H
 
 #include <boost/lexical_cast.hpp>
 
@@ -223,4 +223,4 @@ class DBTransaction
 		TransactionStates_t state = STATE_NO_START;
 };
 
-#endif
+#endif // FS_DATABASE_H

--- a/src/databasemanager.h
+++ b/src/databasemanager.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_DATABASEMANAGER_H_2B75821C555E4D1D83E32B20D683217C
-#define FS_DATABASEMANAGER_H_2B75821C555E4D1D83E32B20D683217C
+#ifndef FS_DATABASEMANAGER_H
+#define FS_DATABASEMANAGER_H
 #include "database.h"
 
 class DatabaseManager
@@ -19,4 +19,5 @@ class DatabaseManager
 		static bool getDatabaseConfig(const std::string& config, int32_t& value);
 		static void registerDatabaseConfig(const std::string& config, int32_t value);
 };
-#endif
+
+#endif // FS_DATABASEMANAGER_H

--- a/src/databasetasks.h
+++ b/src/databasetasks.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_DATABASETASKS_H_9CBA08E9F5FEBA7275CCEE6560059576
-#define FS_DATABASETASKS_H_9CBA08E9F5FEBA7275CCEE6560059576
+#ifndef FS_DATABASETASKS_H
+#define FS_DATABASETASKS_H
 
 #include <condition_variable>
 #include "thread_holder_base.h"
@@ -41,4 +41,4 @@ class DatabaseTasks : public ThreadHolder<DatabaseTasks>
 
 extern DatabaseTasks g_databaseTasks;
 
-#endif
+#endif // FS_DATABASETASKS_H

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_DEFINITIONS_H_877452FEC245450C9F96B8FD268D8963
-#define FS_DEFINITIONS_H_877452FEC245450C9F96B8FD268D8963
+#ifndef FS_DEFINITIONS_H
+#define FS_DEFINITIONS_H
 
 static constexpr auto STATUS_SERVER_NAME = "The Forgotten Server";
 static constexpr auto STATUS_SERVER_VERSION = "1.5";
@@ -60,4 +60,4 @@ static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 #endif
 #endif
 
-#endif
+#endif // FS_DEFINITIONS_H

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_DEPOTCHEST_H_6538526014684E3DBC92CC12815B6766
-#define FS_DEPOTCHEST_H_6538526014684E3DBC92CC12815B6766
+#ifndef FS_DEPOTCHEST_H
+#define FS_DEPOTCHEST_H
 
 #include "container.h"
 
@@ -37,5 +37,4 @@ class DepotChest final : public Container
 		uint32_t maxDepotItems;
 };
 
-#endif
-
+#endif // FS_DEPOTCHEST_H

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_DEPOTLOCKER_H_53AD8E0606A34070B87F792611F4F3F8
-#define FS_DEPOTLOCKER_H_53AD8E0606A34070B87F792611F4F3F8
+#ifndef FS_DEPOTLOCKER_H
+#define FS_DEPOTLOCKER_H
 
 #include "container.h"
 #include "inbox.h"
@@ -48,5 +48,4 @@ class DepotLocker final : public Container
 		uint16_t depotId;
 };
 
-#endif
-
+#endif // FS_DEPOTLOCKER_H

--- a/src/enums.h
+++ b/src/enums.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_ENUMS_H_003445999FEE4A67BCECBE918B0124CE
-#define FS_ENUMS_H_003445999FEE4A67BCECBE918B0124CE
+#ifndef FS_ENUMS_H
+#define FS_ENUMS_H
 
 enum RuleViolationType_t : uint8_t {
 	REPORT_TYPE_NAME = 0,
@@ -637,4 +637,4 @@ struct Reflect {
 	uint16_t chance = 0;
 };
 
-#endif
+#endif // FS_ENUMS_H

--- a/src/events.h
+++ b/src/events.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_EVENTS_H_BD444CC0EE167E5777E4C90C766B36DC
-#define FS_EVENTS_H_BD444CC0EE167E5777E4C90C766B36DC
+#ifndef FS_EVENTS_H
+#define FS_EVENTS_H
 
 #include "luascript.h"
 #include "const.h"
@@ -120,4 +120,4 @@ class Events
 		EventsInfo info;
 };
 
-#endif
+#endif // FS_EVENTS_H

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_FILELOADER_H_9B663D19E58D42E6BFACFE5B09D7A05E
-#define FS_FILELOADER_H_9B663D19E58D42E6BFACFE5B09D7A05E
+#ifndef FS_FILELOADER_H
+#define FS_FILELOADER_H
 
 #include <limits>
 #include <vector>
@@ -148,4 +148,4 @@ class PropWriteStream
 		std::vector<char> buffer;
 };
 
-#endif
+#endif // FS_FILELOADER_H

--- a/src/game.h
+++ b/src/game.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_GAME_H_3EC96D67DD024E6093B3BAC29B7A6D7F
-#define FS_GAME_H_3EC96D67DD024E6093B3BAC29B7A6D7F
+#ifndef FS_GAME_H
+#define FS_GAME_H
 
 #include "account.h"
 #include "combat.h"
@@ -598,4 +598,4 @@ class Game
 		bool useLastStageLevel = false;
 };
 
-#endif
+#endif // FS_GAME_H

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_GLOBALEVENT_H_B3FB9B848EA3474B9AFC326873947E3C
-#define FS_GLOBALEVENT_H_B3FB9B848EA3474B9AFC326873947E3C
+#ifndef FS_GLOBALEVENT_H
+#define FS_GLOBALEVENT_H
 #include "baseevents.h"
 
 #include "const.h"
@@ -107,4 +107,4 @@ class GlobalEvent final : public Event
 		uint32_t interval = 0;
 };
 
-#endif
+#endif // FS_GLOBALEVENT_H

--- a/src/groups.h
+++ b/src/groups.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_GROUPS_H_EE39438337D148E1983FB79D936DD8F3
-#define FS_GROUPS_H_EE39438337D148E1983FB79D936DD8F3
+#ifndef FS_GROUPS_H
+#define FS_GROUPS_H
 
 struct Group {
 	std::string name;
@@ -22,4 +22,4 @@ class Groups {
 		std::vector<Group> groups;
 };
 
-#endif
+#endif // FS_GROUPS_H

--- a/src/guild.h
+++ b/src/guild.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_GUILD_H_C00F0A1D732E4BA88FF62ACBE74D76BC
-#define FS_GUILD_H_C00F0A1D732E4BA88FF62ACBE74D76BC
+#ifndef FS_GUILD_H
+#define FS_GUILD_H
 
 class Player;
 
@@ -73,4 +73,4 @@ namespace IOGuild
 	uint32_t getGuildIdByName(const std::string& name);
 };
 
-#endif
+#endif // FS_GUILD_H

--- a/src/house.h
+++ b/src/house.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_HOUSE_H_EB9732E7771A438F9CD0EFA8CB4C58C4
-#define FS_HOUSE_H_EB9732E7771A438F9CD0EFA8CB4C58C4
+#ifndef FS_HOUSE_H
+#define FS_HOUSE_H
 
 #include <set>
 #include <unordered_set>
@@ -296,4 +296,4 @@ class Houses
 		HouseMap houseMap;
 };
 
-#endif
+#endif // FS_HOUSE_H

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_HOUSETILE_H_57D59BEC1CE741D9B142BFC54634505B
-#define FS_HOUSETILE_H_57D59BEC1CE741D9B142BFC54634505B
+#ifndef FS_HOUSETILE_H
+#define FS_HOUSETILE_H
 
 #include "tile.h"
 
@@ -35,4 +35,4 @@ class HouseTile final : public DynamicTile
 		House* house;
 };
 
-#endif
+#endif // FS_HOUSETILE_H

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_INBOX_H_C3EF10190329447883B9C3479234EE5C
-#define FS_INBOX_H_C3EF10190329447883B9C3479234EE5C
+#ifndef FS_INBOX_H
+#define FS_INBOX_H
 
 #include "container.h"
 
@@ -29,5 +29,4 @@ class Inbox final : public Container
 		}
 };
 
-#endif
-
+#endif // FS_INBOX_H

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_IOLOGINDATA_H_28B0440BEC594654AC0F4E1A5E42B2EF
-#define FS_IOLOGINDATA_H_28B0440BEC594654AC0F4E1A5E42B2EF
+#ifndef FS_IOLOGINDATA_H
+#define FS_IOLOGINDATA_H
 
 #include "account.h"
 #include "player.h"
@@ -50,4 +50,4 @@ class IOLoginData
 		static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert, PropWriteStream& propWriteStream);
 };
 
-#endif
+#endif // FS_IOLOGINDATA_H

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_IOMAP_H_8085D4B1037A44288494A52FDBB775E4
-#define FS_IOMAP_H_8085D4B1037A44288494A52FDBB775E4
+#ifndef FS_IOMAP_H
+#define FS_IOMAP_H
 
 #include "item.h"
 #include "map.h"
@@ -139,4 +139,4 @@ class IOMap
 		std::string errorString;
 };
 
-#endif
+#endif // FS_IOMAP_H

--- a/src/iomapserialize.h
+++ b/src/iomapserialize.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_IOMAPSERIALIZE_H_7E903658F34E44F9BE03A713B55A3D6D
-#define FS_IOMAPSERIALIZE_H_7E903658F34E44F9BE03A713B55A3D6D
+#ifndef FS_IOMAPSERIALIZE_H
+#define FS_IOMAPSERIALIZE_H
 
 #include "database.h"
 #include "map.h"
@@ -26,4 +26,4 @@ class IOMapSerialize
 		static bool loadItem(PropStream& propStream, Cylinder* parent);
 };
 
-#endif
+#endif // FS_IOMAPSERIALIZE_H

--- a/src/iomarket.h
+++ b/src/iomarket.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_IOMARKET_H_B981E52C218C42D3B9EF726EBF0E92C9
-#define FS_IOMARKET_H_B981E52C218C42D3B9EF726EBF0E92C9
+#ifndef FS_IOMARKET_H
+#define FS_IOMARKET_H
 
 #include "enums.h"
 #include "database.h"
@@ -44,4 +44,4 @@ class IOMarket
 		std::map<uint16_t, MarketStatistics> saleStatistics;
 };
 
-#endif
+#endif // FS_IOMARKET_H

--- a/src/item.h
+++ b/src/item.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_ITEM_H_009A319FB13D477D9EEFFBBD9BB83562
-#define FS_ITEM_H_009A319FB13D477D9EEFFBBD9BB83562
+#ifndef FS_ITEM_H
+#define FS_ITEM_H
 
 #include "cylinder.h"
 #include "thing.h"
@@ -1090,4 +1090,4 @@ class Item : virtual public Thing
 using ItemList = std::list<Item*>;
 using ItemDeque = std::deque<Item*>;
 
-#endif
+#endif // FS_ITEM_H

--- a/src/itemloader.h
+++ b/src/itemloader.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_ITEMLOADER_H_107F1D3EECC94CD0A0F528843010D5D4
-#define FS_ITEMLOADER_H_107F1D3EECC94CD0A0F528843010D5D4
+#ifndef FS_ITEMLOADER_H
+#define FS_ITEMLOADER_H
 
 #include "fileloader.h"
 
@@ -189,4 +189,5 @@ struct lightBlock2 {
 
 #pragma pack()
 /////////OTB specific//////////////
-#endif
+
+#endif // FS_ITEMLOADER_H

--- a/src/items.h
+++ b/src/items.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_ITEMS_H_4E2221634ABA45FE85BA50F710669B3C
-#define FS_ITEMS_H_4E2221634ABA45FE85BA50F710669B3C
+#ifndef FS_ITEMS_H
+#define FS_ITEMS_H
 
 #include "const.h"
 #include "enums.h"
@@ -515,4 +515,5 @@ class Items
 				std::vector<uint16_t> vec;
 		} clientIdToServerIdMap;
 };
-#endif
+
+#endif // FS_ITEMS_H

--- a/src/lockfree.h
+++ b/src/lockfree.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_LOCKFREE_H_8C707AEB7C7235A2FBC5D4EDDF03B008
-#define FS_LOCKFREE_H_8C707AEB7C7235A2FBC5D4EDDF03B008
+#ifndef FS_LOCKFREE_H
+#define FS_LOCKFREE_H
 
 #if _MSC_FULL_VER >= 190023918 // Workaround for VS2015 Update 2. Boost.Lockfree is a header-only library, so this should be safe to do.
 #define _ENABLE_ATOMIC_ALIGNMENT_FIX
@@ -64,4 +64,4 @@ class LockfreePoolingAllocator
 		}
 };
 
-#endif
+#endif // FS_LOCKFREE_H

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_LUASCRIPT_H_5344B2BC907E46E3943EA78574A212D8
-#define FS_LUASCRIPT_H_5344B2BC907E46E3943EA78574A212D8
+#ifndef FS_LUASCRIPT_H
+#define FS_LUASCRIPT_H
 
 #if __has_include("luajit/lua.hpp")
 #include <luajit/lua.hpp>
@@ -1643,4 +1643,4 @@ class LuaEnvironment : public LuaScriptInterface
 		friend class CombatSpell;
 };
 
-#endif
+#endif // FS_LUASCRIPT_H

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -35,4 +35,4 @@ class LuaVariant {
 		std::variant<uint32_t, Position, Position, std::string> variant;
 };
 
-#endif
+#endif // FS_LUAVARIANT_H

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MAILBOX_H_D231C6BE8D384CAAA3AE410C1323F9DB
-#define FS_MAILBOX_H_D231C6BE8D384CAAA3AE410C1323F9DB
+#ifndef FS_MAILBOX_H
+#define FS_MAILBOX_H
 
 #include "item.h"
 #include "cylinder.h"
@@ -47,4 +47,4 @@ class Mailbox final : public Item, public Cylinder
 		static bool canSend(const Item* item);
 };
 
-#endif
+#endif // FS_MAILBOX_H

--- a/src/map.h
+++ b/src/map.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MAP_H_E3953D57C058461F856F5221D359DAFA
-#define FS_MAP_H_E3953D57C058461F856F5221D359DAFA
+#ifndef FS_MAP_H
+#define FS_MAP_H
 
 #include "position.h"
 #include "item.h"
@@ -287,4 +287,4 @@ class Map
 		friend class IOMap;
 };
 
-#endif
+#endif // FS_MAP_H

--- a/src/monster.h
+++ b/src/monster.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MONSTER_H_9F5EEFE64314418CA7DA41D1B9409DD0
-#define FS_MONSTER_H_9F5EEFE64314418CA7DA41D1B9409DD0
+#ifndef FS_MONSTER_H
+#define FS_MONSTER_H
 
 #include "tile.h"
 #include "monsters.h"
@@ -268,4 +268,4 @@ class Monster final : public Creature
 		friend class LuaScriptInterface;
 };
 
-#endif
+#endif // FS_MONSTER_H

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MONSTERS_H_776E8327BCE2450EB7C4A260785E6C0D
-#define FS_MONSTERS_H_776E8327BCE2450EB7C4A260785E6C0D
+#ifndef FS_MONSTERS_H
+#define FS_MONSTERS_H
 
 #include "creature.h"
 
@@ -245,4 +245,4 @@ class Monsters
 		bool loaded = false;
 };
 
-#endif
+#endif // FS_MONSTERS_H

--- a/src/mounts.h
+++ b/src/mounts.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MOUNTS_H_73716D11906A4C5C9F4A7B68D34C9BA6
-#define FS_MOUNTS_H_73716D11906A4C5C9F4A7B68D34C9BA6
+#ifndef FS_MOUNTS_H
+#define FS_MOUNTS_H
 
 struct Mount
 {
@@ -33,4 +33,4 @@ class Mounts
 		std::vector<Mount> mounts;
 };
 
-#endif
+#endif // FS_MOUNTS_H

--- a/src/movement.h
+++ b/src/movement.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MOVEMENT_H_5E0D2626D4634ACA83AC6509518E5F49
-#define FS_MOVEMENT_H_5E0D2626D4634ACA83AC6509518E5F49
+#ifndef FS_MOVEMENT_H
+#define FS_MOVEMENT_H
 
 #include "baseevents.h"
 #include "item.h"
@@ -242,4 +242,4 @@ class MoveEvent final : public Event
 		std::vector<Position> posList;
 };
 
-#endif
+#endif // FS_MOVEMENT_H

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_NETWORKMESSAGE_H_B853CFED58D1413A87ACED07B2926E03
-#define FS_NETWORKMESSAGE_H_B853CFED58D1413A87ACED07B2926E03
+#ifndef FS_NETWORKMESSAGE_H
+#define FS_NETWORKMESSAGE_H
 
 #include "const.h"
 
@@ -165,4 +165,4 @@ class NetworkMessage
 		}
 };
 
-#endif // #ifndef __NETWORK_MESSAGE_H__
+#endif // FS_NETWORKMESSAGE_H

--- a/src/npc.h
+++ b/src/npc.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_NPC_H_B090D0CB549D4435AFA03647195D156F
-#define FS_NPC_H_B090D0CB549D4435AFA03647195D156F
+#ifndef FS_NPC_H
+#define FS_NPC_H
 
 #include "creature.h"
 #include "luascript.h"
@@ -236,4 +236,4 @@ class Npc final : public Creature
 		friend class NpcScriptInterface;
 };
 
-#endif
+#endif // FS_NPC_H

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -1,7 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#define FS_OTPCH_H_F00C737DA6CA4C8D90F57430C614367F
+#ifndef FS_OTPCH_H
+#define FS_OTPCH_H
 
 // Definitions should be global.
 #include "definitions.h"
@@ -26,3 +27,5 @@
 #include <boost/asio.hpp>
 
 #include <pugixml.hpp>
+
+#endif // FS_OTPCH_H

--- a/src/outfit.h
+++ b/src/outfit.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_OUTFIT_H_C56E7A707E3F422C8C93D9BE09916AA3
-#define FS_OUTFIT_H_C56E7A707E3F422C8C93D9BE09916AA3
+#ifndef FS_OUTFIT_H
+#define FS_OUTFIT_H
 
 #include "enums.h"
 
@@ -50,4 +50,4 @@ class Outfits
 		std::vector<Outfit> outfits[PLAYERSEX_LAST + 1];
 };
 
-#endif
+#endif // FS_OUTFIT_H

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_OUTPUTMESSAGE_H_C06AAED85C7A43939F22D229297C0CC1
-#define FS_OUTPUTMESSAGE_H_C06AAED85C7A43939F22D229297C0CC1
+#ifndef FS_OUTPUTMESSAGE_H
+#define FS_OUTPUTMESSAGE_H
 
 #include "networkmessage.h"
 #include "connection.h"
@@ -87,4 +87,4 @@ class OutputMessagePool
 		std::vector<Protocol_ptr> bufferedProtocols;
 };
 
-#endif
+#endif // FS_OUTPUTMESSAGE_H

--- a/src/party.h
+++ b/src/party.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PARTY_H_41D4D7CF417C4CC99FAE94D552255044
-#define FS_PARTY_H_41D4D7CF417C4CC99FAE94D552255044
+#ifndef FS_PARTY_H
+#define FS_PARTY_H
 
 #include "player.h"
 #include "monsters.h"
@@ -90,4 +90,4 @@ class Party
 		bool sharedExpEnabled = false;
 };
 
-#endif
+#endif // FS_PARTY_H

--- a/src/player.h
+++ b/src/player.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PLAYER_H_4083D3D3A05B4EDE891B31BB720CD06F
-#define FS_PLAYER_H_4083D3D3A05B4EDE891B31BB720CD06F
+#ifndef FS_PLAYER_H
+#define FS_PLAYER_H
 
 #include "creature.h"
 #include "container.h"
@@ -1386,4 +1386,4 @@ class Player final : public Creature, public Cylinder
 		friend class ProtocolGame;
 };
 
-#endif
+#endif // FS_PLAYER_H

--- a/src/podium.h
+++ b/src/podium.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PODIUM_H_CF65BECF5129B787F25DF96395759CCA
-#define FS_PODIUM_H_CF65BECF5129B787F25DF96395759CCA
+#ifndef FS_PODIUM_H
+#define FS_PODIUM_H
 
 #include "item.h"
 
@@ -61,4 +61,4 @@ class Podium final : public Item
 		Direction direction = DIRECTION_SOUTH;
 };
 
-#endif
+#endif // FS_PODIUM_H

--- a/src/position.h
+++ b/src/position.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_POSITION_H_5B684192F7034FB8857C8280D2CC6C75
-#define FS_POSITION_H_5B684192F7034FB8857C8280D2CC6C75
+#ifndef FS_POSITION_H
+#define FS_POSITION_H
 
 enum Direction : uint8_t {
 	DIRECTION_NORTH = 0,
@@ -119,4 +119,4 @@ struct Position
 std::ostream& operator<<(std::ostream&, const Position&);
 std::ostream& operator<<(std::ostream&, const Direction&);
 
-#endif
+#endif // FS_POSITION_H

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PROTOCOL_H_D71405071ACF4137A4B1203899DE80E1
-#define FS_PROTOCOL_H_D71405071ACF4137A4B1203899DE80E1
+#ifndef FS_PROTOCOL_H
+#define FS_PROTOCOL_H
 
 #include "connection.h"
 #include "xtea.h"
@@ -84,4 +84,4 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		bool rawMessages = false;
 };
 
-#endif
+#endif // FS_PROTOCOL_H

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PROTOCOLGAME_H_FACA2A2D1A9348B78E8FD7E8003EBB87
-#define FS_PROTOCOLGAME_H_FACA2A2D1A9348B78E8FD7E8003EBB87
+#ifndef FS_PROTOCOLGAME_H
+#define FS_PROTOCOLGAME_H
 
 #include "protocol.h"
 #include "chat.h"
@@ -337,4 +337,4 @@ class ProtocolGame final : public Protocol
 		bool acceptPackets = false;
 };
 
-#endif
+#endif // FS_PROTOCOLGAME_H

--- a/src/protocollogin.h
+++ b/src/protocollogin.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PROTOCOLLOGIN_H_1238F4B473074DF2ABC595C29E81C46D
-#define FS_PROTOCOLLOGIN_H_1238F4B473074DF2ABC595C29E81C46D
+#ifndef FS_PROTOCOLLOGIN_H
+#define FS_PROTOCOLLOGIN_H
 
 #include "protocol.h"
 
@@ -30,4 +30,4 @@ class ProtocolLogin : public Protocol
 		void getCharacterList(const std::string& accountName, const std::string& password, const std::string& token, uint16_t version);
 };
 
-#endif
+#endif // FS_PROTOCOLLOGIN_H

--- a/src/protocolold.h
+++ b/src/protocolold.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PROTOCOLOLD_H_5487B862FE144AE0904D098A3238E161
-#define FS_PROTOCOLOLD_H_5487B862FE144AE0904D098A3238E161
+#ifndef FS_PROTOCOLOLD_H
+#define FS_PROTOCOLOLD_H
 
 #include "protocol.h"
 
@@ -27,4 +27,4 @@ class ProtocolOld final : public Protocol
 		void disconnectClient(const std::string& message);
 };
 
-#endif
+#endif // FS_PROTOCOLOLD_H

--- a/src/protocolstatus.h
+++ b/src/protocolstatus.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_STATUS_H_8B28B354D65B4C0483E37AD1CA316EB4
-#define FS_STATUS_H_8B28B354D65B4C0483E37AD1CA316EB4
+#ifndef FS_PROTOCOLSTATUS_H
+#define FS_PROTOCOLSTATUS_H
 
 #include "networkmessage.h"
 #include "protocol.h"
@@ -31,4 +31,4 @@ class ProtocolStatus final : public Protocol
 		static std::map<uint32_t, int64_t> ipConnectMap;
 };
 
-#endif
+#endif // FS_PROTOCOLSTATUS_H

--- a/src/pugicast.h
+++ b/src/pugicast.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_PUGICAST_H_07810DF7954D411EB14A16C3ED2A7548
-#define FS_PUGICAST_H_07810DF7954D411EB14A16C3ED2A7548
+#ifndef FS_PUGICAST_H
+#define FS_PUGICAST_H
 
 #include <boost/lexical_cast.hpp>
 
@@ -20,4 +20,4 @@ namespace pugi {
 	}
 }
 
-#endif
+#endif // FS_PUGICAST_H

--- a/src/quests.h
+++ b/src/quests.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_QUESTS_H_16E44051F23547BE8097F8EA9FCAACA0
-#define FS_QUESTS_H_16E44051F23547BE8097F8EA9FCAACA0
+#ifndef FS_QUESTS_H
+#define FS_QUESTS_H
 
 #include "player.h"
 #include "networkmessage.h"
@@ -128,4 +128,4 @@ class TrackedQuest
 		uint16_t missionId = 0;
 };
 
-#endif
+#endif // FS_QUESTS_H

--- a/src/raids.h
+++ b/src/raids.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_RAIDS_H_3583C7C054584881856D55765DEDAFA9
-#define FS_RAIDS_H_3583C7C054584881856D55765DEDAFA9
+#ifndef FS_RAIDS_H
+#define FS_RAIDS_H
 
 #include "const.h"
 #include "position.h"
@@ -209,4 +209,4 @@ class ScriptEvent final : public RaidEvent, public Event
 		std::string getScriptEventName() const override;
 };
 
-#endif
+#endif // FS_RAIDS_H

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_RSA_H_C4E277DA8E884B578DDBF0566F504E91
-#define FS_RSA_H_C4E277DA8E884B578DDBF0566F504E91
+#ifndef FS_RSA_H
+#define FS_RSA_H
 
 #include <cryptopp/rsa.h>
 
@@ -24,4 +24,4 @@ class RSA
 		CryptoPP::RSA::PrivateKey pk;
 };
 
-#endif
+#endif // FS_RSA_H

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SCHEDULER_H_2905B3D5EAB34B4BA8830167262D2DC1
-#define FS_SCHEDULER_H_2905B3D5EAB34B4BA8830167262D2DC1
+#ifndef FS_SCHEDULER_H
+#define FS_SCHEDULER_H
 
 #include "tasks.h"
 #include <unordered_map>
@@ -53,4 +53,4 @@ class Scheduler : public ThreadHolder<Scheduler>
 
 extern Scheduler g_scheduler;
 
-#endif
+#endif // FS_SCHEDULER_H

--- a/src/script.h
+++ b/src/script.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SCRIPTS_H
-#define FS_SCRIPTS_H
+#ifndef FS_SCRIPT_H
+#define FS_SCRIPT_H
 
 #include "luascript.h"
 #include "enums.h"
@@ -21,4 +21,4 @@ class Scripts
 		LuaScriptInterface scriptInterface;
 };
 
-#endif
+#endif // FS_SCRIPT_H

--- a/src/scriptmanager.h
+++ b/src/scriptmanager.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SCRIPTMANAGER_H_F9428B7803A44FB88EB1A915CFD37F8B
-#define FS_SCRIPTMANAGER_H_F9428B7803A44FB88EB1A915CFD37F8B
+#ifndef FS_SCRIPTMANAGER_H
+#define FS_SCRIPTMANAGER_H
 
 class ScriptingManager
 {
@@ -22,4 +22,4 @@ class ScriptingManager
 		bool loadScriptSystems();
 };
 
-#endif
+#endif // FS_SCRIPTMANAGER_H

--- a/src/server.h
+++ b/src/server.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SERVER_H_984DA68ABF744127850F90CC710F281B
-#define FS_SERVER_H_984DA68ABF744127850F90CC710F281B
+#ifndef FS_SERVER_H
+#define FS_SERVER_H
 
 #include "connection.h"
 #include "signals.h"
@@ -137,4 +137,4 @@ bool ServiceManager::add(uint16_t port)
 	return service_port->add_service(std::make_shared<Service<ProtocolType>>());
 }
 
-#endif
+#endif // FS_SERVER_H

--- a/src/signals.h
+++ b/src/signals.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SIGNALHANDLINGTHREAD_H_01C6BF08B0EFE9E200175D108CF0B35F
-#define FS_SIGNALHANDLINGTHREAD_H_01C6BF08B0EFE9E200175D108CF0B35F
+#ifndef FS_SIGNALS_H
+#define FS_SIGNALS_H
 
 #include <boost/asio.hpp>
 
@@ -16,4 +16,4 @@ class Signals
 		void asyncWait();
 };
 
-#endif
+#endif // FS_SIGNALS_H

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SPAWN_H_1A86089E080846A9AE53ED12E7AE863B
-#define FS_SPAWN_H_1A86089E080846A9AE53ED12E7AE863B
+#ifndef FS_SPAWN_H
+#define FS_SPAWN_H
 
 #include "tile.h"
 #include "position.h"
@@ -88,4 +88,4 @@ class Spawns
 		bool started = false;
 };
 
-#endif
+#endif // FS_SPAWN_H

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SPECTATORS_H_D78A7CCB7080406E8CAA6B1D31D3DA71
-#define FS_SPECTATORS_H_D78A7CCB7080406E8CAA6B1D31D3DA71
+#ifndef FS_SPECTATORS_H
+#define FS_SPECTATORS_H
 
 #include <vector>
 
@@ -49,4 +49,4 @@ private:
 	Vec vec;
 };
 
-#endif
+#endif // FS_SPECTATORS_H

--- a/src/spells.h
+++ b/src/spells.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_SPELLS_H_D78A7CCB7080406E8CAA6B1D31D3DA71
-#define FS_SPELLS_H_D78A7CCB7080406E8CAA6B1D31D3DA71
+#ifndef FS_SPELLS_H
+#define FS_SPELLS_H
 
 #include "player.h"
 #include "actions.h"
@@ -429,4 +429,4 @@ class RuneSpell final : public Action, public Spell
 		bool hasCharges = false;
 };
 
-#endif
+#endif // FS_SPELLS_H

--- a/src/storeinbox.h
+++ b/src/storeinbox.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_STOREINBOX_H_074FB99DD3FEDB823AAD2D2CD6F10119
-#define FS_STOREINBOX_H_074FB99DD3FEDB823AAD2D2CD6F10119
+#ifndef FS_STOREINBOX_H
+#define FS_STOREINBOX_H
 
 #include "container.h"
 
@@ -30,4 +30,4 @@ class StoreInbox final : public Container
 		}
 };
 
-#endif
+#endif // FS_STOREINBOX_H

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TALKACTION_H_E6AABAC0F89843469526ADF310F3131C
-#define FS_TALKACTION_H_E6AABAC0F89843469526ADF310F3131C
+#ifndef FS_TALKACTION_H
+#define FS_TALKACTION_H
 
 #include "luascript.h"
 #include "baseevents.h"
@@ -96,4 +96,4 @@ class TalkActions final : public BaseEvents
 		LuaScriptInterface scriptInterface;
 };
 
-#endif
+#endif // FS_TALKACTION_H

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TASKS_H_A66AC384766041E59DCA059DAB6E1976
-#define FS_TASKS_H_A66AC384766041E59DCA059DAB6E1976
+#ifndef FS_TASKS_H
+#define FS_TASKS_H
 
 #include <condition_variable>
 #include "thread_holder_base.h"
@@ -71,4 +71,4 @@ class Dispatcher : public ThreadHolder<Dispatcher> {
 
 extern Dispatcher g_dispatcher;
 
-#endif
+#endif // FS_TASKS_H

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TELEPORT_H_873B7F7F1DB24101A7ACFB54B25E0ABC
-#define FS_TELEPORT_H_873B7F7F1DB24101A7ACFB54B25E0ABC
+#ifndef FS_TELEPORT_H
+#define FS_TELEPORT_H
 
 #include "tile.h"
 
@@ -53,4 +53,4 @@ class Teleport final : public Item, public Cylinder
 		Position destPos;
 };
 
-#endif
+#endif // FS_TELEPORT_H

--- a/src/thing.h
+++ b/src/thing.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_THING_H_6F16A8E566AF4ACEAE02CF32A7246144
-#define FS_THING_H_6F16A8E566AF4ACEAE02CF32A7246144
+#ifndef FS_THING_H
+#define FS_THING_H
 
 #include "position.h"
 
@@ -66,4 +66,4 @@ class Thing
 		}
 };
 
-#endif
+#endif // FS_THING_H

--- a/src/thread_holder_base.h
+++ b/src/thread_holder_base.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_THREAD_HOLDER_H_BEB56FC46748E71D15A5BF0773ED2E67
-#define FS_THREAD_HOLDER_H_BEB56FC46748E71D15A5BF0773ED2E67
+#ifndef FS_THREAD_HOLDER_BASE_H
+#define FS_THREAD_HOLDER_BASE_H
 
 #include <thread>
 #include <atomic>
@@ -40,4 +40,4 @@ class ThreadHolder
 		std::thread thread;
 };
 
-#endif
+#endif // FS_THREAD_HOLDER_BASE_H

--- a/src/tile.h
+++ b/src/tile.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TILE_H_96C7EE7CF8CD48E59D5D554A181F0C56
-#define FS_TILE_H_96C7EE7CF8CD48E59D5D554A181F0C56
+#ifndef FS_TILE_H
+#define FS_TILE_H
 
 #include "cylinder.h"
 #include "item.h"
@@ -368,4 +368,4 @@ class StaticTile final : public Tile
 		}
 };
 
-#endif
+#endif // FS_TILE_H

--- a/src/tools.h
+++ b/src/tools.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TOOLS_H_5F9A9742DA194628830AA1C64909AE43
-#define FS_TOOLS_H_5F9A9742DA194628830AA1C64909AE43
+#ifndef FS_TOOLS_H
+#define FS_TOOLS_H
 
 #include <random>
 
@@ -78,4 +78,4 @@ int64_t OTSYS_TIME();
 
 SpellGroup_t stringToSpellGroup(const std::string& value);
 
-#endif
+#endif // FS_TOOLS_H

--- a/src/town.h
+++ b/src/town.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TOWN_H_3BE21D2293B44AA4A3D22D25BE1B9350
-#define FS_TOWN_H_3BE21D2293B44AA4A3D22D25BE1B9350
+#ifndef FS_TOWN_H
+#define FS_TOWN_H
 
 #include "position.h"
 
@@ -79,4 +79,4 @@ class Towns
 		TownMap townMap;
 };
 
-#endif
+#endif // FS_TOWN_H

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_TRASHHOLDER_H_BA162024D67B4D388147F5EE06F33098
-#define FS_TRASHHOLDER_H_BA162024D67B4D388147F5EE06F33098
+#ifndef FS_TRASHHOLDER_H
+#define FS_TRASHHOLDER_H
 
 #include "item.h"
 #include "cylinder.h"
@@ -38,4 +38,4 @@ class TrashHolder final : public Item, public Cylinder
 		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 };
 
-#endif
+#endif // FS_TRASHHOLDER_H

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_VOCATION_H_ADCAA356C0DB44CEBA994A0D678EC92D
-#define FS_VOCATION_H_ADCAA356C0DB44CEBA994A0D678EC92D
+#ifndef FS_VOCATION_H
+#define FS_VOCATION_H
 
 #include "enums.h"
 #include "item.h"
@@ -126,4 +126,4 @@ class Vocations
 		std::map<uint16_t, Vocation> vocationsMap;
 };
 
-#endif
+#endif // FS_VOCATION_H

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_WEAPONS_H_69D1993478AA42948E24C0B90B8F5BF5
-#define FS_WEAPONS_H_69D1993478AA42948E24C0B90B8F5BF5
+#ifndef FS_WEAPONS_H
+#define FS_WEAPONS_H
 
 #include "player.h"
 #include "baseevents.h"
@@ -291,4 +291,4 @@ class WeaponWand final : public Weapon
 		int32_t maxChange = 0;
 };
 
-#endif
+#endif // FS_WEAPONS_H

--- a/src/wildcardtree.h
+++ b/src/wildcardtree.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_WILDCARDTREE_H_054C9BA46A1D4EA4B7C77ECE60ED4DEB
-#define FS_WILDCARDTREE_H_054C9BA46A1D4EA4B7C77ECE60ED4DEB
+#ifndef FS_WILDCARDTREE_H
+#define FS_WILDCARDTREE_H
 
 #include "enums.h"
 
@@ -30,4 +30,4 @@ class WildcardTreeNode
 		bool breakpoint;
 };
 
-#endif
+#endif // FS_WILDCARDTREE_H

--- a/src/xtea.h
+++ b/src/xtea.h
@@ -1,8 +1,8 @@
 // Copyright 2022 The Forgotten Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef TFS_XTEA_H
-#define TFS_XTEA_H
+#ifndef FS_XTEA_H
+#define FS_XTEA_H
 
 namespace xtea {
 
@@ -15,4 +15,4 @@ void decrypt(uint8_t* data, size_t length, const round_keys& k);
 
 } // namespace xtea
 
-#endif // TFS_XTEA_H
+#endif // FS_XTEA_H


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Let's have some standardization here. Prepended `FS_` to every guard to avoid name clashes on common names.

We could alternatively use `#pragma once` instead, the code style suggests it but it was never really used.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
