### PR TITLE
Replace slower boost::lexical_cast with stdlib conversions

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -4,7 +4,7 @@
 #ifndef FS_DATABASE_H
 #define FS_DATABASE_H
 
-#include <boost/lexical_cast.hpp>
+#include "pugicast.h"
 
 #include <mysql/mysql.h>
 
@@ -136,20 +136,14 @@ class DBResult
 			auto it = listNames.find(s);
 			if (it == listNames.end()) {
 				std::cout << "[Error - DBResult::getNumber] Column '" << s << "' doesn't exist in the result set" << std::endl;
-				return static_cast<T>(0);
+				return {};
 			}
 
 			if (!row[it->second]) {
-				return static_cast<T>(0);
+				return {};
 			}
 
-			T data;
-			try {
-				data = boost::lexical_cast<T>(row[it->second]);
-			} catch (boost::bad_lexical_cast&) {
-				data = 0;
-			}
-			return data;
+			return pugi::cast<T>(row[it->second]);
 		}
 
 		std::string getString(const std::string& s) const;

--- a/src/pugicast.h
+++ b/src/pugicast.h
@@ -4,20 +4,25 @@
 #ifndef FS_PUGICAST_H
 #define FS_PUGICAST_H
 
-#include <boost/lexical_cast.hpp>
-
 namespace pugi {
-	template<typename T>
-	T cast(const pugi::char_t* str)
-	{
-		T value;
-		try {
-			value = boost::lexical_cast<T>(str);
-		} catch (boost::bad_lexical_cast&) {
-			value = T();
-		}
-		return value;
-	}
+
+template<class T> T cast(const char* str);
+
+template<> inline float cast(const char* str) { return std::strtof(str, nullptr); }
+template<> inline double cast(const char* str) { return std::strtod(str, nullptr); }
+template<> inline long cast(const char* str) { return std::strtol(str, nullptr, 0); }
+template<> inline long long cast(const char* str) { return std::strtoll(str, nullptr, 0); }
+template<> inline unsigned long cast(const char* str) { return std::strtoul(str, nullptr, 0); }
+template<> inline unsigned long long cast(const char* str) { return std::strtoull(str, nullptr, 0); }
+
+template<> inline char cast(const char* str) { return static_cast<char>(cast<long>(str)); }
+template<> inline signed char cast(const char* str) { return static_cast<signed char>(cast<long>(str)); }
+template<> inline short cast(const char* str) { return static_cast<short>(cast<long>(str)); }
+template<> inline int cast(const char* str) { return static_cast<int>(cast<long>(str)); }
+template<> inline unsigned char cast(const char* str) { return static_cast<unsigned char>(cast<unsigned long>(str)); }
+template<> inline unsigned short cast(const char* str) { return static_cast<unsigned short>(cast<unsigned long>(str)); }
+template<> inline unsigned int cast(const char* str) { return static_cast<unsigned int>(cast<unsigned long>(str)); }
+
 }
 
 #endif // FS_PUGICAST_H


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Replaces the slow `boost::lexical_cast` calls with standard library functions for a... boost in performance! [Results vary from type to type](https://godbolt.org/z/9hxdcGcYv), on my machine it is at least 2x faster across the board for integers, and 150x faster for bytes (signed and unsigned char), and 8x faster for floats. The difference is slightly smaller on godbolt as you can see.

Yes, it is necessary to specify both `char` and `signed char` because they *might* not map to the same type (on my machine, `int8_t` maps to `signed char` and the `char`-only version does not apply). Same goes for `int` and `long`.

This is not on a critical path and the improvement might not be significant. Notably, it may speed up XML parsing (which is fast anyway) and loading data from the database.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
