### PR TITLE
Exp tracker

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -145,6 +145,8 @@ rateLoot = 2
 rateMagic = 3
 rateSpawn = 1
 
+analyserSendTrueRawExp = false
+
 -- Monster Despawn Config
 -- despawnRange is the amount of floors a monster can be from its spawn position
 -- despawnRadius is how many tiles away it can be from its spawn position

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -98,6 +98,7 @@ forceMonsterTypesOnLoad = true
 cleanProtectionZones = false
 luaItemDesc = false
 showPlayerLogInConsole = true
+analyserSendTrueRawExp = false
 
 -- VIP and Depot limits
 -- NOTE: you can set custom limits per group in data/XML/groups.xml
@@ -144,8 +145,6 @@ rateSkill = 3
 rateLoot = 2
 rateMagic = 3
 rateSpawn = 1
-
-analyserSendTrueRawExp = false
 
 -- Monster Despawn Config
 -- despawnRange is the amount of floors a monster can be from its spawn position

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -233,7 +233,7 @@ bool ConfigManager::load()
 	boolean[REMOVE_ON_DESPAWN] = getGlobalBoolean(L, "removeOnDespawn", true);
 	boolean[PLAYER_CONSOLE_LOGS] = getGlobalBoolean(L, "showPlayerLogInConsole", true);
 	boolean[TWO_FACTOR_AUTH] = getGlobalBoolean(L, "enableTwoFactorAuth", true);
-	boolean[EXP_ANALYSER_SEND_TRUE_RAW_EXP] = getGlobalBoolean(L, "AnalyserSendTrueRawExp", false);
+	boolean[EXP_ANALYSER_SEND_TRUE_RAW_EXP] = getGlobalBoolean(L, "analyserSendTrueRawExp", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -233,6 +233,7 @@ bool ConfigManager::load()
 	boolean[REMOVE_ON_DESPAWN] = getGlobalBoolean(L, "removeOnDespawn", true);
 	boolean[PLAYER_CONSOLE_LOGS] = getGlobalBoolean(L, "showPlayerLogInConsole", true);
 	boolean[TWO_FACTOR_AUTH] = getGlobalBoolean(L, "enableTwoFactorAuth", true);
+	boolean[EXP_ANALYSER_SEND_TRUE_RAW_EXP] = getGlobalBoolean(L, "analyserSendTrueRawExp", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -233,7 +233,6 @@ bool ConfigManager::load()
 	boolean[REMOVE_ON_DESPAWN] = getGlobalBoolean(L, "removeOnDespawn", true);
 	boolean[PLAYER_CONSOLE_LOGS] = getGlobalBoolean(L, "showPlayerLogInConsole", true);
 	boolean[TWO_FACTOR_AUTH] = getGlobalBoolean(L, "enableTwoFactorAuth", true);
-	boolean[EXP_ANALYSER_SEND_TRUE_RAW_EXP] = getGlobalBoolean(L, "analyserSendTrueRawExp", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -233,6 +233,7 @@ bool ConfigManager::load()
 	boolean[REMOVE_ON_DESPAWN] = getGlobalBoolean(L, "removeOnDespawn", true);
 	boolean[PLAYER_CONSOLE_LOGS] = getGlobalBoolean(L, "showPlayerLogInConsole", true);
 	boolean[TWO_FACTOR_AUTH] = getGlobalBoolean(L, "enableTwoFactorAuth", true);
+	boolean[EXP_ANALYSER_SEND_TRUE_RAW_EXP] = getGlobalBoolean(L, "AnalyserSendTrueRawExp", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -54,7 +54,6 @@ class ConfigManager
 			REMOVE_ON_DESPAWN,
 			PLAYER_CONSOLE_LOGS,
 			TWO_FACTOR_AUTH,
-			EXP_ANALYSER_SEND_TRUE_RAW_EXP,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -54,6 +54,7 @@ class ConfigManager
 			REMOVE_ON_DESPAWN,
 			PLAYER_CONSOLE_LOGS,
 			TWO_FACTOR_AUTH,
+			EXP_ANALYSER_SEND_TRUE_RAW_EXP,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2158,6 +2158,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::MAX_PACKETS_PER_SECOND)
 	registerEnumIn("configKeys", ConfigManager::PLAYER_CONSOLE_LOGS)
 	registerEnumIn("configKeys", ConfigManager::TWO_FACTOR_AUTH)
+	registerEnumIn("configKeys", ConfigManager::EXP_ANALYSER_SEND_TRUE_RAW_EXP)
 
 	// os
 	registerMethod("os", "mtime", LuaScriptInterface::luaSystemTime);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1825,6 +1825,11 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		levelPercent = 0;
 	}
 	sendStats();
+	if (g_config.getBoolean(ConfigManager::EXP_ANALYSER_SEND_TRUE_RAW_EXP)) {
+		sendExperienceTracker(rawExp, exp);
+	} else {
+		sendExperienceTracker(rawExp * g_config.getExperienceStage(getLevel()), exp);
+	}
 }
 
 void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
@@ -1904,6 +1909,8 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		levelPercent = 0;
 	}
 	sendStats();
+
+	sendExperienceTracker(0, -static_cast<int64_t>(exp));
 }
 
 uint8_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1825,11 +1825,6 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		levelPercent = 0;
 	}
 	sendStats();
-	if (g_config.getBoolean(ConfigManager::EXP_ANALYSER_SEND_TRUE_RAW_EXP)) {
-		sendExperienceTracker(rawExp, exp);
-	} else {
-		sendExperienceTracker(rawExp * g_config.getExperienceStage(getLevel()), exp);
-	}
 }
 
 void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
@@ -1909,8 +1904,6 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		levelPercent = 0;
 	}
 	sendStats();
-
-	sendExperienceTracker(0, -static_cast<int64_t>(exp));
 }
 
 uint8_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)

--- a/src/player.h
+++ b/src/player.h
@@ -954,13 +954,6 @@ class Player final : public Creature, public Cylinder
 			}
 		}
 		void sendStats();
-
-		void sendExperienceTracker(int64_t rawExp, int64_t finalExp) const {
-			if (client) {
-				client->sendExperienceTracker(rawExp, finalExp);
-			}
-		}
-
 		void sendBasicData() const {
 			if (client) {
 				client->sendBasicData();

--- a/src/player.h
+++ b/src/player.h
@@ -954,6 +954,13 @@ class Player final : public Creature, public Cylinder
 			}
 		}
 		void sendStats();
+
+		void sendExperienceTracker(int64_t rawExp, int64_t finalExp) const {
+			if (client) {
+				client->sendExperienceTracker(rawExp, finalExp);
+			}
+		}
+
 		void sendBasicData() const {
 			if (client) {
 				client->sendBasicData();

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1530,6 +1530,15 @@ void ProtocolGame::sendStats()
 	writeToOutputBuffer(msg);
 }
 
+void ProtocolGame::sendExperienceTracker(int64_t rawExp, int64_t finalExp)
+{
+	NetworkMessage msg;
+	msg.addByte(0xAF);
+	msg.add<int64_t>(rawExp);
+	msg.add<int64_t>(finalExp);
+	writeToOutputBuffer(msg);
+}
+
 void ProtocolGame::sendClientFeatures()
 {
 	NetworkMessage msg;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1530,15 +1530,6 @@ void ProtocolGame::sendStats()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendExperienceTracker(int64_t rawExp, int64_t finalExp)
-{
-	NetworkMessage msg;
-	msg.addByte(0xAF);
-	msg.add<int64_t>(rawExp);
-	msg.add<int64_t>(finalExp);
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendClientFeatures()
 {
 	NetworkMessage msg;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -190,7 +190,6 @@ class ProtocolGame final : public Protocol
 		void sendCancelTarget();
 		void sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit);
 		void sendStats();
-		void sendExperienceTracker(int64_t rawExp, int64_t finalExp);
 		void sendClientFeatures();
 		void sendBasicData();
 		void sendTextMessage(const TextMessage& message);

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -190,6 +190,7 @@ class ProtocolGame final : public Protocol
 		void sendCancelTarget();
 		void sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit);
 		void sendStats();
+		void sendExperienceTracker(int64_t rawExp, int64_t finalExp);
 		void sendClientFeatures();
 		void sendBasicData();
 		void sendTextMessage(const TextMessage& message);


### PR DESCRIPTION
Exp tracker feature
 config:
 analyserSendTrueRawExp - default false, give ability to send raw exp without multiplication by expStage
 
 analyserSendTrueRawExp false
![image](https://user-images.githubusercontent.com/17506599/157688059-362bc9c5-4c12-4a3a-a1c3-fd0a0a4c4aa4.png)

analyserSendTrueRawExp true
![image](https://user-images.githubusercontent.com/17506599/157688216-ee44edee-e296-42b7-8943-d46d0df83459.png)


