### PR TITLE
No need to use pugi::cast let's just use as_string

### DIFF
--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -143,7 +143,7 @@ bool TalkAction::configureEvent(const pugi::xml_node& node)
 
 	pugi::xml_attribute separatorAttribute = node.attribute("separator");
 	if (separatorAttribute) {
-		separator = pugi::cast<char>(separatorAttribute.value());
+		separator = separatorAttribute.as_string();
 	}
 
 	for (auto word : explodeString(wordsAttribute.as_string(), ";")) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This PR fixes the problem with the talkactions separator, since when #3997 was merged this attribute was no longer parsed properly with `pugi::cast<char>`

**Issues addressed:** Nothing!