### PR TITLE
Allow to get monster storages in the onDeath event

### DIFF
--- a/data/scripts/monsters/monster_storages.lua
+++ b/data/scripts/monsters/monster_storages.lua
@@ -17,7 +17,9 @@ end
 local creatureEvent = CreatureEvent("MonsterStorages")
 
 function creatureEvent.onDeath(self)
-    MonsterStorages[self:getId()] = nil
+    addTask(function (id)
+        MonsterStorages[id] = nil
+    end, self:getId())
     return true
 end
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Important: This change is only mergeable if #3700 is merged.
This allows us to use monster storages in the onDeath event.

### What happens?
what happens is that the event [`onDeath` to remove monster storages](https://github.com/otland/forgottenserver/blob/cf28d1cfa1f56813ab35f7e6b7f11dc040fa7214/data/scripts/monsters/monster_storages.lua#L20) it is activated when the monster dies but not always this event is activated at the end, so if we try to get the storage in another onDeath event there is a possibility of getting an error because the storage was already removed earlier.

By using the `addTask` function we make sure that deleting the monster's storage happens after the interpreter finishes executing all onDeath events.

**Issues addressed:** Nothing!