### PR TITLE
Fix issue with item decay

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4624,8 +4624,7 @@ void Game::internalDecayItem(Item* item)
 {
 	const int32_t decayTo = item->getDecayTo();
 	if (decayTo > 0) {
-		Item* newItem = transformItem(item, decayTo);
-		startDecay(newItem);
+		startDecay(transformItem(item, decayTo));
 	} else {
 		ReturnValue ret = internalRemoveItem(item);
 		if (ret != RETURNVALUE_NOERROR) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4622,9 +4622,9 @@ void Game::startDecay(Item* item)
 
 void Game::internalDecayItem(Item* item)
 {
-	const ItemType& it = Item::items[item->getID()];
-	if (it.decayTo != 0) {
-		Item* newItem = transformItem(item, item->getDecayTo());
+	const int32_t decayTo = item->getDecayTo();
+	if (decayTo > 0) {
+		Item* newItem = transformItem(item, decayTo);
 		startDecay(newItem);
 	} else {
 		ReturnValue ret = internalRemoveItem(item);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2073,13 +2073,7 @@ bool Item::canDecay() const
 		return false;
 	}
 
-	uint32_t decayTime = getDuration();
-	if (decayTime == 0) {
-		const ItemType& it = Item::items[id];
-		decayTime = it.decayTime;
-	}
-
-	if (getDecayTo() < 0 || decayTime == 0) {
+	if (getDecayTo() < 0 || getDecayTime() == 0) {
 		return false;
 	}
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2073,8 +2073,13 @@ bool Item::canDecay() const
 		return false;
 	}
 
-	const ItemType& it = Item::items[id];
-	if (getDecayTo() < 0 || it.decayTime == 0) {
+	uint32_t decayTime = getDuration();
+	if (decayTime == 0) {
+		const ItemType& it = Item::items[id];
+		decayTime = it.decayTime;
+	}
+
+	if (getDecayTo() < 0 || decayTime == 0) {
 		return false;
 	}
 

--- a/src/item.h
+++ b/src/item.h
@@ -799,6 +799,13 @@ class Item : virtual public Thing
 			return static_cast<ItemDecayState_t>(getIntAttr(ITEM_ATTRIBUTE_DECAYSTATE));
 		}
 
+		int32_t getDecayTime() const {
+			if (hasAttribute(ITEM_ATTRIBUTE_DURATION)) {
+				return getIntAttr(ITEM_ATTRIBUTE_DURATION);
+			}
+			return items[id].decayTime;
+		}
+
 		void setDecayTo(int32_t decayTo) {
 			setIntAttr(ITEM_ATTRIBUTE_DECAYTO, decayTo);
 		}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2067,6 +2067,10 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(MONSTERS_EVENT_MOVE)
 	registerEnum(MONSTERS_EVENT_SAY)
 
+	registerEnum(DECAYING_FALSE)
+	registerEnum(DECAYING_TRUE)
+	registerEnum(DECAYING_PENDING)
+
 	// _G
 	registerGlobalVariable("INDEX_WHEREEVER", INDEX_WHEREEVER);
 	registerGlobalBoolean("VIRTUAL_PARENT", true);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
with these changes you can configure any item for decaying
example:
```lua
local talkAction = TalkAction("!test")

function talkAction.onSay(player, words, param, type)
    local armor = Game.createItem(2467, 1, player:getPosition())
    armor:setAttribute(ITEM_ATTRIBUTE_DURATION, 1000)
    armor:setAttribute(ITEM_ATTRIBUTE_DECAYTO, 2173)
    armor:setAttribute(ITEM_ATTRIBUTE_DECAYSTATE, 0) -- or armor:setAttribute(ITEM_ATTRIBUTE_DECAYSTATE, DECAYING_FALSE)
    armor:decay()
    return false
end

talkAction:register()
```

or

```lua
local talkAction = TalkAction("!test")

function talkAction.onSay(player, words, param, type)
    local armor = Game.createItem(2467, 1, player:getPosition())
    armor:setAttribute(ITEM_ATTRIBUTE_DURATION, 1000)
    armor:decay(2173)
    return false
end

talkAction:register()
```

The problem is that `canDecay` is checking the time of the `itemType` only, instead of taking into account the time defined directly to the `item`

**Issues addressed:** Nothing!