### PR TITLE
Refactor getHoldingPlayer method

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -336,17 +336,15 @@ uint16_t Item::getSubType() const
 	return count;
 }
 
-Player* Item::getHoldingPlayer() const
+const Player* Item::getHoldingPlayer() const
 {
-	Cylinder* p = getParent();
-	while (p) {
-		if (p->getCreature()) {
-			return p->getCreature()->getPlayer();
-		}
-
-		p = p->getParent();
+	const Cylinder* topParent = getTopParent();
+	if (!topParent) {
+		return nullptr;
 	}
-	return nullptr;
+
+	const Creature* topParentCreature = topParent->getCreature();
+	return topParentCreature ? topParentCreature->getPlayer() : nullptr;
 }
 
 void Item::setSubType(uint16_t n)

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -338,13 +338,7 @@ uint16_t Item::getSubType() const
 
 const Player* Item::getHoldingPlayer() const
 {
-	const Cylinder* topParent = getTopParent();
-	if (!topParent) {
-		return nullptr;
-	}
-
-	const Creature* topParentCreature = topParent->getCreature();
-	return topParentCreature ? topParentCreature->getPlayer() : nullptr;
+	return dynamic_cast<const Player*>(getTopParent());
 }
 
 void Item::setSubType(uint16_t n)

--- a/src/item.h
+++ b/src/item.h
@@ -839,7 +839,7 @@ class Item : virtual public Thing
 		void setID(uint16_t newid);
 
 		// Returns the player that is holding this item in his inventory
-		Player* getHoldingPlayer() const;
+		const Player* getHoldingPlayer() const;
 
 		WeaponType_t getWeaponType() const {
 			return items[id].weaponType;


### PR DESCRIPTION
If player is holding an item then top parent of that item is always player, which means, we don't need to check every single parent going up the hierarchy.