### PR TITLE
Fix Player initialization order

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -33,7 +33,7 @@ uint32_t Player::playerAutoID = 0x10000000;
 uint32_t Player::playerIDLimit = 0x20000000;
 
 Player::Player(ProtocolGame_ptr p) :
-	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), inbox(new Inbox(ITEM_INBOX)), storeInbox(new StoreInbox(ITEM_STORE_INBOX)), client(std::move(p))
+	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), client(std::move(p)), inbox(new Inbox(ITEM_INBOX)), storeInbox(new StoreInbox(ITEM_STORE_INBOX))
 {
 	inbox->incrementReferenceCounter();
 

--- a/src/player.h
+++ b/src/player.h
@@ -1272,6 +1272,7 @@ class Player final : public Creature, public Cylinder
 		int64_t lastPong;
 		int64_t nextAction = 0;
 
+		ProtocolGame_ptr client;
 		BedItem* bedItem = nullptr;
 		Guild* guild = nullptr;
 		GuildRank_ptr guildRank = nullptr;
@@ -1284,7 +1285,6 @@ class Player final : public Creature, public Cylinder
 		Npc* shopOwner = nullptr;
 		Party* party = nullptr;
 		Player* tradePartner = nullptr;
-		ProtocolGame_ptr client;
 		SchedulerTask* walkTask = nullptr;
 		Town* town = nullptr;
 		Vocation* vocation = nullptr;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes the following issue:
```
[51/70] Compiling C++ object tfs.p/src_player.cpp.o
In file included from ../src/player.cpp:6:
../src/player.h: In constructor ‘Player::Player(ProtocolGame_ptr)’:
../src/player.h:1281:29: warning: ‘Player::storeInbox’ will be initialized after [-Wreorder]
 1281 |                 StoreInbox* storeInbox = nullptr;
      |                             ^~~~~~~~~~
../src/player.h:1277:34: warning:   ‘ProtocolGame_ptr Player::client’ [-Wreorder]
 1277 |                 ProtocolGame_ptr client;
      |                                  ^~~~~~
../src/player.cpp:42:1: warning:   when initialized here [-Wreorder]
   42 | Player::Player(ProtocolGame_ptr p) :
      | ^~~~~~
```

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
