### PR TITLE
Move all system headers to PCH

### DIFF
--- a/src/combat.h
+++ b/src/combat.h
@@ -8,9 +8,6 @@
 #include "condition.h"
 #include "item.h"
 
-#include <utility>
-#include <valarray>
-
 class Creature;
 class Player;
 struct Position;

--- a/src/condition.h
+++ b/src/condition.h
@@ -6,8 +6,6 @@
 
 #include "enums.h"
 
-#include <limits>
-
 class Creature;
 class Player;
 class PropStream;

--- a/src/database.h
+++ b/src/database.h
@@ -6,8 +6,6 @@
 
 #include "pugicast.h"
 
-#include <mysql/mysql.h>
-
 class DBResult;
 using DBResult_ptr = std::shared_ptr<DBResult>;
 

--- a/src/databasetasks.h
+++ b/src/databasetasks.h
@@ -7,8 +7,6 @@
 #include "database.h"
 #include "thread_holder_base.h"
 
-#include <condition_variable>
-
 struct DatabaseTask {
 	DatabaseTask(std::string&& query, std::function<void(DBResult_ptr, bool)>&& callback, bool store) :
 		query(std::move(query)), callback(std::move(callback)), store(store) {}

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -27,8 +27,6 @@ static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 #define _USE_MATH_DEFINES
 #endif
 
-#include <cmath>
-
 #ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -4,9 +4,6 @@
 #ifndef FS_FILELOADER_H
 #define FS_FILELOADER_H
 
-#include <boost/iostreams/device/mapped_file.hpp>
-#include <limits>
-
 class PropStream;
 
 namespace OTB {

--- a/src/item.h
+++ b/src/item.h
@@ -10,9 +10,6 @@
 #include "thing.h"
 #include "tools.h"
 
-#include <boost/variant.hpp>
-#include <deque>
-
 class BedItem;
 class Container;
 class Door;

--- a/src/lockfree.h
+++ b/src/lockfree.h
@@ -8,8 +8,6 @@
 #define _ENABLE_ATOMIC_ALIGNMENT_FIX
 #endif
 
-#include <boost/lockfree/stack.hpp>
-
 /*
  * we use this to avoid instantiating multiple free lists for objects of the
  * same size and it can be replaced by a variable template in C++14

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -8,14 +8,6 @@
 #include "enums.h"
 #include "position.h"
 
-#include <cassert>
-
-#if __has_include("luajit/lua.hpp")
-#include <luajit/lua.hpp>
-#else
-#include <lua.hpp>
-#endif
-
 #if LUA_VERSION_NUM >= 502
 #ifndef LUA_COMPAT_ALL
 #ifndef LUA_COMPAT_MODULE

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -1,8 +1,6 @@
 #ifndef FS_LUAVARIANT_H
 #define FS_LUAVARIANT_H
 
-#include <variant>
-
 enum LuaVariantType_t {
 	VARIANT_NUMBER = 0,
 	VARIANT_POSITION = 1,

--- a/src/mounts.cpp
+++ b/src/mounts.cpp
@@ -5,7 +5,6 @@
 
 #include "mounts.h"
 
-#include "definitions.h"
 #include "pugicast.h"
 #include "tools.h"
 

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -7,24 +7,49 @@
 // Definitions should be global.
 #include "definitions.h"
 
+// System headers required in headers should be included here.
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <bitset>
 #include <boost/asio.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/lockfree/stack.hpp>
+#include <boost/variant.hpp>
+#include <cassert>
+#include <condition_variable>
+#include <cryptopp/rsa.h>
 #include <cstdint>
+#include <cstdlib>
+#include <deque>
 #include <fmt/color.h>
 #include <forward_list>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <mysql/mysql.h>
 #include <pugixml.hpp>
+#include <random>
 #include <set>
 #include <sstream>
+#include <string_view>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <valarray>
+#include <variant>
 #include <vector>
+
+#if __has_include("luajit/lua.hpp")
+#include <luajit/lua.hpp>
+#else
+#include <lua.hpp>
+#endif
 
 #endif // FS_OTPCH_H

--- a/src/player.h
+++ b/src/player.h
@@ -14,8 +14,6 @@
 #include "town.h"
 #include "vocation.h"
 
-#include <bitset>
-
 class DepotChest;
 class House;
 class NetworkMessage;

--- a/src/podium.h
+++ b/src/podium.h
@@ -6,8 +6,6 @@
 
 #include "item.h"
 
-#include <bitset>
-
 class Podium final : public Item
 {
 	public:

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -6,7 +6,6 @@
 
 #include "chat.h"
 #include "creature.h"
-#include "definitions.h"
 #include "protocol.h"
 #include "tasks.h"
 

--- a/src/pugicast.h
+++ b/src/pugicast.h
@@ -4,8 +4,6 @@
 #ifndef FS_PUGICAST_H
 #define FS_PUGICAST_H
 
-#include <cstdlib>
-
 namespace pugi {
 
 template<class T> T cast(const char* str);

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -4,8 +4,6 @@
 #ifndef FS_RSA_H
 #define FS_RSA_H
 
-#include <cryptopp/rsa.h>
-
 class RSA
 {
 	public:

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -6,8 +6,6 @@
 
 #include "position.h"
 
-#include <utility>
-
 class Monster;
 class MonsterType;
 class Npc;

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -6,8 +6,6 @@
 
 #include "thread_holder_base.h"
 
-#include <condition_variable>
-
 using TaskFunc = std::function<void(void)>;
 const int DISPATCHER_TASK_EXPIRATION = 2000;
 const auto SYSTEM_TIME_ZERO = std::chrono::system_clock::time_point(std::chrono::milliseconds(0));

--- a/src/thread_holder_base.h
+++ b/src/thread_holder_base.h
@@ -6,8 +6,6 @@
 
 #include "enums.h"
 
-#include <atomic>
-
 template <typename Derived>
 class ThreadHolder
 {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -6,7 +6,6 @@
 #include "tools.h"
 
 #include "configmanager.h"
-#include "definitions.h"
 
 #include <chrono>
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -8,9 +8,6 @@
 #include "enums.h"
 #include "position.h"
 
-#include <random>
-#include <string_view>
-
 void printXMLError(const std::string& where, const std::string& fileName, const pugi::xml_parse_result& result);
 
 std::string transformToSHA1(const std::string& input);

--- a/src/xtea.h
+++ b/src/xtea.h
@@ -4,8 +4,6 @@
 #ifndef FS_XTEA_H
 #define FS_XTEA_H
 
-#include <array>
-
 namespace xtea {
 
 using key = std::array<uint32_t, 4>;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Further improves #4019 by adding all system headers to the precompiled header. According to [this and several other sources](https://stackoverflow.com/questions/23904353/what-to-add-to-precompiled-headers), every included header that is not expected to change often - that is, usually all system headers - are good candidates.

There is a notable improvement from ~2:40 to less than 2 minutes build in my machine.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
