### PR TITLE
Remove custom boost/reflect items from market search

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1223,6 +1223,19 @@ bool Item::hasMarketAttributes() const
 		return true;
 	}
 
+	// disregard items with custom boost and reflect
+	for (uint16_t i = 0; i < COMBAT_COUNT; ++i) {
+		if (getBoostPercent(indexToCombatType(i), false) > 0) {
+			return false;
+		}
+
+		Reflect tmpReflect = getReflect(indexToCombatType(i), false);
+		if (tmpReflect.chance != 0 || tmpReflect.percent != 0) {
+			return false;
+		}
+	}
+
+	// disregard items with other modified attributes
 	for (const auto& attr : attributes->getList()) {
 		if (attr.type == ITEM_ATTRIBUTE_CHARGES) {
 			uint16_t charges = static_cast<uint16_t>(attr.value.integer);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1223,7 +1223,7 @@ bool Item::hasMarketAttributes() const
 		return true;
 	}
 
-	// disregard items with custom boost and reflect
+	// discard items with custom boost and reflect
 	for (uint16_t i = 0; i < COMBAT_COUNT; ++i) {
 		if (getBoostPercent(indexToCombatType(i), false) > 0) {
 			return false;
@@ -1235,7 +1235,7 @@ bool Item::hasMarketAttributes() const
 		}
 	}
 
-	// disregard items with other modified attributes
+	// discard items with other modified attributes
 	for (const auto& attr : attributes->getList()) {
 		if (attr.type == ITEM_ATTRIBUTE_CHARGES) {
 			uint16_t charges = static_cast<uint16_t>(attr.value.integer);


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Items modified with setBoostPercent/setReflect shouldn't be marketable

**Issues addressed:** #2807 (merged PR)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
