### PR TITLE
fix console warning for boost/reflect

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -616,6 +616,7 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 
 				getAttributes()->reflect[combatType] = reflect;
 			}
+			break;
 		}
 
 		case ATTR_BOOST: {
@@ -634,6 +635,7 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 
 				getAttributes()->boostPercent[combatType] = percent;
 			}
+			break;
 		}
 
 		//these should be handled through derived classes


### PR DESCRIPTION

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

gets rid of "serialization error" message when a player who logs in has an item with custom boost/reflect

**Issues addressed:** #2807 (merged PR)
### Steps to reproduce
1. execute lua script
```
item = player:addItem("knight armor", 1)
item:setReflect(COMBAT_FIREDAMAGE, {chance = 10, percent = 10})
```
2. log out
3. log in
4. look at console

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
