### PR TITLE
bugfix: text color in Windows cmd/powershell

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -136,6 +136,13 @@ void mainLoader(int, char*[], ServiceManager* services)
 	srand(static_cast<unsigned int>(OTSYS_TIME()));
 #ifdef _WIN32
 	SetConsoleTitle(STATUS_SERVER_NAME);
+	
+	// fixes a problem with escape characters not being processed in Windows consoles
+	HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD dwMode = 0;
+	GetConsoleMode(hOut, &dwMode);
+	dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+	SetConsoleMode(hOut, dwMode);
 #endif
 
 	printServerVersion();


### PR DESCRIPTION

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Steps to reproduce
(Windows 10)
1. add a line like this one somewhere:
https://github.com/otland/forgottenserver/blob/474b959f8bae491afe10d2e7fa4919722e594ce3/src/otserv.cpp#L61
2. compile
3. start by double clicking the server executable

observed and expected results can be seen on screenshots below

### Changes Proposed
#3940 has introduced a colored message
colored messages sometimes fail to process in command prompt/powershell
this code fixes that issue (screenshots below)

**NOTE:** THESE SCREENSHOTS COME FROM MY FORK, THE LINE WHICH IS USED BY OFFICIAL TFS IS MENTIONED IN "STEPS TO REPRODUCE" SECTION

before:
**NOTE:** while this works properly in Visual Studio debugger, it breaks when you start the server normally
![obraz](https://user-images.githubusercontent.com/5205079/160255157-4b3346bf-73d0-484d-b635-33fa1acd7c4a.png)

after:
![obraz](https://user-images.githubusercontent.com/5205079/160255205-0da46390-8dc5-4055-911e-24e1cac2d408.png)


<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #3940 (merged PR)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
