### PR TITLE
Fix addEvent scheduler values being passed by reference not value

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3931,7 +3931,7 @@ int LuaScriptInterface::luaAddEvent(lua_State* L)
 	eventDesc.scriptId = getScriptEnv()->getScriptId();
 
 	auto& lastTimerEventId = g_luaEnvironment.lastEventTimerId;
-	eventDesc.eventId = g_scheduler.addEvent(createSchedulerTask(delay, [&]() { g_luaEnvironment.executeTimerEvent(lastTimerEventId); }));
+	eventDesc.eventId = g_scheduler.addEvent(createSchedulerTask(delay, [=]() { g_luaEnvironment.executeTimerEvent(lastTimerEventId); }));
 
 	g_luaEnvironment.timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
 	lua_pushnumber(L, lastTimerEventId++);


### PR DESCRIPTION
Fixes #4031

Apparently (from what I read on the internet) std::bind copies values, #4017 introduces usage of lambdas and this was changed to ref [&] and broke npcs and probably a lot more, so the solution is to bring back passing by value.