### PR TITLE
Quarter-hourly update to client clock

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4694,6 +4694,13 @@ void Game::updateWorldTime()
 	time_t osTime = time(nullptr);
 	tm* timeInfo = localtime(&osTime);
 	worldTime = (timeInfo->tm_sec + (timeInfo->tm_min * 60)) / 2.5f;
+
+	// quarter-hourly update to client clock near the minimap
+	if (worldTime % 15 == 0) {
+		for (const auto& it : players) {
+			it.second->sendWorldTime();
+		}
+	}
 }
 
 void Game::shutdown()

--- a/src/player.h
+++ b/src/player.h
@@ -1060,6 +1060,11 @@ class Player final : public Creature, public Cylinder
 				client->sendWorldLight(lightInfo);
 			}
 		}
+		void sendWorldTime() {
+			if (client) {
+				client->sendWorldTime();
+			}
+		}
 		void sendChannelsDialog() {
 			if (client) {
 				client->sendChannelsDialog();


### PR DESCRIPTION
Co-Authored-By: Łukasz Zbiżek <Zbizu@users.noreply.github.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
quarter-hourly update to client clock near the minimap
now this works:
![2022-04-04 14_02_19-Tibia - Perflex](https://user-images.githubusercontent.com/4684880/161594882-cb471e87-c3af-4b87-9d02-ffe818aea6a8.png)

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
