### PR TITLE
correcting misspelled comment for weapon:wieldUnproperly

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17332,7 +17332,7 @@ int LuaScriptInterface::luaWeaponOnUseWeapon(lua_State* L)
 
 int LuaScriptInterface::luaWeaponUnproperly(lua_State* L)
 {
-	// weapon:wieldedUnproperly(bool)
+	// weapon:wieldUnproperly(bool)
 	Weapon* weapon = getUserdata<Weapon>(L, 1);
 	if (weapon) {
 		weapon->setWieldUnproperly(getBoolean(L, 2));


### PR DESCRIPTION
the method name is scripted as `weapon:wieldUnproperly`, but has incorrect comment