### PR TITLE
Use combat_ptr in combat:getParameter

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13236,8 +13236,9 @@ int LuaScriptInterface::luaCombatSetParameter(lua_State* L)
 int LuaScriptInterface::luaCombatGetParameter(lua_State* L)
 {
 	// combat:getParameter(key)
-	Combat* combat = getUserdata<Combat>(L, 1);
+	const Combat_ptr& combat = getSharedPtr<Combat>(L, 1);
 	if (!combat) {
+		reportErrorFunc(L, getErrorDesc(LUA_ERROR_COMBAT_NOT_FOUND));
 		lua_pushnil(L);
 		return 1;
 	}


### PR DESCRIPTION
This method was added later and the code wasn't updated to shared_ptr combat code.