### PR TITLE
Use string views to avoid copying strings

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -44,8 +44,6 @@ void Actions::clear(bool fromLua)
 
 LuaScriptInterface& Actions::getScriptInterface() { return scriptInterface; }
 
-std::string Actions::getScriptBaseName() const { return "actions"; }
-
 Event_ptr Actions::getEvent(const std::string& nodeName)
 {
 	if (!caseInsensitiveEqual(nodeName, "action")) {
@@ -539,8 +537,6 @@ bool Action::loadFunction(const pugi::xml_attribute& attr, bool isScripted)
 	}
 	return true;
 }
-
-std::string Action::getScriptEventName() const { return "onUse"; }
 
 ReturnValue Action::canExecuteAction(const Player* player, const Position& toPos)
 {

--- a/src/actions.h
+++ b/src/actions.h
@@ -54,7 +54,7 @@ public:
 	ActionFunction function;
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override { return "onUse"; }
 
 	bool allowFarUse = false;
 	bool checkFloor = true;
@@ -89,7 +89,7 @@ private:
 	ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
 
 	LuaScriptInterface& getScriptInterface() override;
-	std::string getScriptBaseName() const override;
+	std::string_view getScriptBaseName() const override { return "actions"; }
 	Event_ptr getEvent(const std::string& nodeName) override;
 	bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
 

--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -17,7 +17,7 @@ bool BaseEvents::loadFromXml()
 		return false;
 	}
 
-	std::string scriptsName = getScriptBaseName();
+	std::string scriptsName{getScriptBaseName()};
 	std::string basePath = "data/" + scriptsName + "/";
 	if (getScriptInterface().loadFile(basePath + "lib/" + scriptsName + ".lua") == -1) {
 		std::cout << "[Warning - BaseEvents::loadFromXml] Can not load " << scriptsName << " lib/" << scriptsName

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -30,7 +30,7 @@ public:
 	int32_t getScriptId() { return scriptId; }
 
 protected:
-	virtual std::string getScriptEventName() const = 0;
+	virtual std::string_view getScriptEventName() const = 0;
 
 	int32_t scriptId = 0;
 	LuaScriptInterface* scriptInterface = nullptr;
@@ -49,7 +49,7 @@ public:
 
 private:
 	virtual LuaScriptInterface& getScriptInterface() = 0;
-	virtual std::string getScriptBaseName() const = 0;
+	virtual std::string_view getScriptBaseName() const = 0;
 	virtual Event_ptr getEvent(const std::string& nodeName) = 0;
 	virtual bool registerEvent(Event_ptr event, const pugi::xml_node& node) = 0;
 	virtual void clear(bool) = 0;

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -338,7 +338,7 @@ float ConfigManager::getExperienceStage(uint32_t level) const
 	return std::get<2>(*it);
 }
 
-bool ConfigManager::setString(string_config_t what, const std::string& value)
+bool ConfigManager::setString(string_config_t what, std::string_view value)
 {
 	if (what >= LAST_STRING_CONFIG) {
 		std::cout << "[Warning - ConfigManager::setString] Accessing invalid index: " << what << std::endl;

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -136,7 +136,7 @@ public:
 	bool getBoolean(boolean_config_t what) const;
 	float getExperienceStage(uint32_t level) const;
 
-	bool setString(string_config_t what, const std::string& value);
+	bool setString(string_config_t what, std::string_view value);
 	bool setNumber(integer_config_t what, int32_t value);
 	bool setBoolean(boolean_config_t what, bool value);
 

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -32,8 +32,6 @@ void CreatureEvents::removeInvalidEvents()
 
 LuaScriptInterface& CreatureEvents::getScriptInterface() { return scriptInterface; }
 
-std::string CreatureEvents::getScriptBaseName() const { return "creaturescripts"; }
-
 Event_ptr CreatureEvents::getEvent(const std::string& nodeName)
 {
 	if (!caseInsensitiveEqual(nodeName, "event")) {
@@ -196,7 +194,7 @@ bool CreatureEvent::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-std::string CreatureEvent::getScriptEventName() const
+std::string_view CreatureEvent::getScriptEventName() const
 {
 	// Depending on the type script event name is different
 	switch (type) {
@@ -238,7 +236,7 @@ std::string CreatureEvent::getScriptEventName() const
 
 		case CREATURE_EVENT_NONE:
 		default:
-			return std::string();
+			return "";
 	}
 }
 

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -62,7 +62,7 @@ public:
 	//
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override;
 
 	std::string eventName;
 	CreatureEventType_t type;
@@ -92,7 +92,7 @@ public:
 
 private:
 	LuaScriptInterface& getScriptInterface() override;
-	std::string getScriptBaseName() const override;
+	std::string_view getScriptBaseName() const override { return "creaturescripts"; }
 	Event_ptr getEvent(const std::string& nodeName) override;
 	bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -192,7 +192,8 @@ std::string_view DBResult::getString(std::string_view column) const
 {
 	auto it = listNames.find(column);
 	if (it == listNames.end()) {
-		std::cout << "[Error - DBResult::getString] Column '" << column << "' does not exist in result set." << std::endl;
+		std::cout << "[Error - DBResult::getString] Column '" << column << "' does not exist in result set."
+		          << std::endl;
 		return {};
 	}
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -204,24 +204,6 @@ std::string_view DBResult::getString(std::string_view column) const
 	return {row[it->second], size};
 }
 
-const char* DBResult::getStream(std::string_view column, unsigned long& size) const
-{
-	auto it = listNames.find(column);
-	if (it == listNames.end()) {
-		std::cout << "[Error - DBResult::getStream] Column '" << column << "' doesn't exist in the result set" << std::endl;
-		size = 0;
-		return nullptr;
-	}
-
-	if (!row[it->second]) {
-		size = 0;
-		return nullptr;
-	}
-
-	size = mysql_fetch_lengths(handle)[it->second];
-	return row[it->second];
-}
-
 bool DBResult::hasNext() const { return row; }
 
 bool DBResult::next()

--- a/src/database.h
+++ b/src/database.h
@@ -65,7 +65,7 @@ public:
 	 * @param s string to be escaped
 	 * @return quoted string
 	 */
-	std::string escapeString(const std::string& s) const;
+	std::string escapeString(std::string_view s) const { return escapeBlob(s.data(), s.length()); }
 
 	/**
 	 * Escapes binary stream for query.
@@ -126,11 +126,11 @@ public:
 	DBResult& operator=(const DBResult&) = delete;
 
 	template <typename T>
-	T getNumber(const std::string& s) const
+	T getNumber(std::string_view column) const
 	{
-		auto it = listNames.find(s);
+		auto it = listNames.find(column);
 		if (it == listNames.end()) {
-			std::cout << "[Error - DBResult::getNumber] Column '" << s << "' doesn't exist in the result set"
+			std::cout << "[Error - DBResult::getNumber] Column '" << column << "' doesn't exist in the result set"
 			          << std::endl;
 			return {};
 		}
@@ -142,8 +142,8 @@ public:
 		return pugi::cast<T>(row[it->second]);
 	}
 
-	std::string getString(const std::string& s) const;
-	const char* getStream(const std::string& s, unsigned long& size) const;
+	std::string_view getString(std::string_view column) const;
+	const char* getStream(std::string_view column, unsigned long& size) const;
 
 	bool hasNext() const;
 	bool next();
@@ -152,7 +152,7 @@ private:
 	MYSQL_RES* handle;
 	MYSQL_ROW row;
 
-	std::map<std::string, size_t> listNames;
+	std::map<std::string_view, size_t> listNames;
 
 	friend class Database;
 };

--- a/src/database.h
+++ b/src/database.h
@@ -143,7 +143,6 @@ public:
 	}
 
 	std::string_view getString(std::string_view column) const;
-	const char* getStream(std::string_view column, unsigned long& size) const;
 
 	bool hasNext() const;
 	bool next();

--- a/src/databasemanager.cpp
+++ b/src/databasemanager.cpp
@@ -22,7 +22,7 @@ bool DatabaseManager::optimizeTables()
 	}
 
 	do {
-		std::string tableName = result->getString("TABLE_NAME");
+		const auto tableName = result->getString("TABLE_NAME");
 		std::cout << "> Optimizing table " << tableName << "..." << std::flush;
 
 		if (db.executeQuery(fmt::format("OPTIMIZE TABLE `{:s}`", tableName))) {

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -74,20 +74,20 @@ public:
 		return true;
 	}
 
-	bool readString(std::string& ret)
+	std::pair<std::string_view, bool> readString()
 	{
 		uint16_t strLen;
 		if (!read<uint16_t>(strLen)) {
-			return false;
+			return {"", false};
 		}
 
 		if (size() < strLen) {
-			return false;
+			return {"", false};
 		}
 
-		ret.assign(p, strLen);
+		std::string_view ret{p, strLen};
 		p += strLen;
-		return true;
+		return {ret, true};
 	}
 
 	bool skip(size_t n)
@@ -114,11 +114,7 @@ public:
 	PropWriteStream(const PropWriteStream&) = delete;
 	PropWriteStream& operator=(const PropWriteStream&) = delete;
 
-	const char* getStream(size_t& size) const
-	{
-		size = buffer.size();
-		return buffer.data();
-	}
+	std::string_view getStream() const { return {buffer.data(), buffer.size()}; }
 
 	void clear() { buffer.clear(); }
 

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -305,7 +305,7 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-std::string GlobalEvent::getScriptEventName() const
+std::string_view GlobalEvent::getScriptEventName() const
 {
 	switch (eventType) {
 		case GLOBALEVENT_STARTUP:

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -44,7 +44,7 @@ public:
 	void clear(bool fromLua) override final;
 
 private:
-	std::string getScriptBaseName() const override { return "globalevents"; }
+	std::string_view getScriptBaseName() const override { return "globalevents"; }
 
 	Event_ptr getEvent(const std::string& nodeName) override;
 	bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
@@ -81,7 +81,7 @@ public:
 private:
 	GlobalEvent_t eventType = GLOBALEVENT_NONE;
 
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override;
 
 	std::string name;
 	int64_t nextExecution = 0;

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -51,7 +51,7 @@ GuildRank_ptr Guild::getRankByLevel(uint8_t level) const
 	return nullptr;
 }
 
-void Guild::addRank(uint32_t rankId, const std::string& rankName, uint8_t level)
+void Guild::addRank(uint32_t rankId, std::string_view rankName, uint8_t level)
 {
 	ranks.emplace_back(std::make_shared<GuildRank>(rankId, rankName, level));
 }

--- a/src/guild.h
+++ b/src/guild.h
@@ -12,7 +12,7 @@ struct GuildRank
 	std::string name;
 	uint8_t level;
 
-	GuildRank(uint32_t id, std::string name, uint8_t level) : id(id), name(std::move(name)), level(level) {}
+	GuildRank(uint32_t id, std::string_view name, uint8_t level) : id{id}, name{name}, level{level} {}
 };
 
 using GuildRank_ptr = std::shared_ptr<GuildRank>;
@@ -20,7 +20,7 @@ using GuildRank_ptr = std::shared_ptr<GuildRank>;
 class Guild
 {
 public:
-	Guild(uint32_t id, std::string name) : name(std::move(name)), id(id) {}
+	Guild(uint32_t id, std::string_view name) : name{name}, id{id} {}
 
 	void addMember(Player* player);
 	void removeMember(Player* player);
@@ -35,7 +35,7 @@ public:
 	GuildRank_ptr getRankById(uint32_t rankId);
 	GuildRank_ptr getRankByName(const std::string& name) const;
 	GuildRank_ptr getRankByLevel(uint8_t level) const;
-	void addRank(uint32_t rankId, const std::string& rankName, uint8_t level);
+	void addRank(uint32_t rankId, std::string_view rankName, uint8_t level);
 
 	const std::string& getMotd() const { return motd; }
 	void setMotd(const std::string& motd) { this->motd = motd; }

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -156,7 +156,7 @@ bool House::kickPlayer(Player* player, Player* target)
 	return true;
 }
 
-void House::setAccessList(uint32_t listId, const std::string& textlist)
+void House::setAccessList(uint32_t listId, std::string_view textlist)
 {
 	if (listId == GUEST_LIST) {
 		guestList.parseList(textlist);
@@ -373,7 +373,7 @@ bool House::executeTransfer(HouseTransferItem* item, Player* newOwner)
 	return true;
 }
 
-void AccessList::parseList(const std::string& list)
+void AccessList::parseList(std::string_view list)
 {
 	playerList.clear();
 	guildRankList.clear();
@@ -383,7 +383,7 @@ void AccessList::parseList(const std::string& list)
 		return;
 	}
 
-	std::istringstream listStream(list);
+	std::istringstream listStream{this->list};
 	std::string line;
 
 	uint16_t lineNo = 1;
@@ -530,7 +530,7 @@ bool Door::canUse(const Player* player)
 	return accessList->isInList(player);
 }
 
-void Door::setAccessList(const std::string& textlist)
+void Door::setAccessList(std::string_view textlist)
 {
 	if (!accessList) {
 		accessList.reset(new AccessList());

--- a/src/house.h
+++ b/src/house.h
@@ -17,7 +17,7 @@ class Player;
 class AccessList
 {
 public:
-	void parseList(const std::string& list);
+	void parseList(std::string_view list);
 	void addPlayer(const std::string& name);
 	void addGuild(const std::string& name);
 	void addGuildRank(const std::string& name, const std::string& rankName);
@@ -56,7 +56,7 @@ public:
 
 	bool canUse(const Player* player);
 
-	void setAccessList(const std::string& textlist);
+	void setAccessList(std::string_view textlist);
 	bool getAccessList(std::string& list) const;
 
 	void onRemoved() override;
@@ -111,7 +111,7 @@ public:
 	// listId special values:
 	// GUEST_LIST	 guest list
 	// SUBOWNER_LIST subowner list
-	void setAccessList(uint32_t listId, const std::string& textlist);
+	void setAccessList(uint32_t listId, std::string_view textlist);
 	bool getAccessList(uint32_t listId, std::string& list) const;
 
 	bool isInvited(const Player* player) const;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -667,12 +667,9 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 		propWriteStream.clear();
 		item->serializeAttr(propWriteStream);
 
-		size_t attributesSize;
-		const char* attributes = propWriteStream.getStream(attributesSize);
-
 		if (!query_insert.addRow(fmt::format("{:d}, {:d}, {:d}, {:d}, {:d}, {:s}", player->getGUID(), pid, runningId,
 		                                     item->getID(), item->getSubType(),
-		                                     db.escapeBlob(attributes, attributesSize)))) {
+		                                     db.escapeString(propWriteStream.getStream())))) {
 			return false;
 		}
 	}
@@ -709,12 +706,9 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 			propWriteStream.clear();
 			item->serializeAttr(propWriteStream);
 
-			size_t attributesSize;
-			const char* attributes = propWriteStream.getStream(attributesSize);
-
 			if (!query_insert.addRow(fmt::format("{:d}, {:d}, {:d}, {:d}, {:d}, {:s}", player->getGUID(), parentId,
 			                                     runningId, item->getID(), item->getSubType(),
-			                                     db.escapeBlob(attributes, attributesSize)))) {
+			                                     db.escapeString(propWriteStream.getStream())))) {
 				return false;
 			}
 		}
@@ -750,9 +744,6 @@ bool IOLoginData::savePlayer(Player* player)
 			propWriteStream.write<uint8_t>(CONDITIONATTR_END);
 		}
 	}
-
-	size_t conditionsSize;
-	const char* conditions = propWriteStream.getStream(conditionsSize);
 
 	// First, an UPDATE query to write the player itself
 	std::ostringstream query;
@@ -798,7 +789,7 @@ bool IOLoginData::savePlayer(Player* player)
 		query << "`lastip` = INET6_ATON('" << player->lastIP.to_string() << "'),";
 	}
 
-	query << "`conditions` = " << db.escapeBlob(conditions, conditionsSize) << ',';
+	query << "`conditions` = " << db.escapeString(propWriteStream.getStream()) << ',';
 
 	if (g_game.getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
 		int64_t skullTime = 0;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -32,7 +32,7 @@ Account IOLoginData::loadAccount(uint32_t accno)
 	return account;
 }
 
-std::string decodeSecret(const std::string& secret)
+std::string decodeSecret(std::string_view secret)
 {
 	// simple base32 decoding
 	std::string key;
@@ -86,7 +86,7 @@ bool IOLoginData::loginserverAuthentication(const std::string& name, const std::
 	    "SELECT `name` FROM `players` WHERE `account_id` = {:d} AND `deletion` = 0 ORDER BY `name` ASC", account.id));
 	if (result) {
 		do {
-			account.characters.push_back(result->getString("name"));
+			account.characters.emplace_back(result->getString("name"));
 		} while (result->next());
 	}
 	return true;
@@ -970,9 +970,11 @@ std::string IOLoginData::getNameByGuid(uint32_t guid)
 	DBResult_ptr result =
 	    Database::getInstance().storeQuery(fmt::format("SELECT `name` FROM `players` WHERE `id` = {:d}", guid));
 	if (!result) {
-		return std::string();
+		return {};
 	}
-	return result->getString("name");
+
+	auto name = result->getString("name");
+	return {name.data(), name.size()};
 }
 
 uint32_t IOLoginData::getGuidByName(const std::string& name)

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -308,10 +308,9 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	player->capacity = result->getNumber<uint32_t>("cap") * 100;
 	player->blessings = result->getNumber<uint16_t>("blessings");
 
-	unsigned long conditionsSize;
-	const char* conditions = result->getStream("conditions", conditionsSize);
+	auto conditions = result->getString("conditions");
 	PropStream propStream;
-	propStream.init(conditions, conditionsSize);
+	propStream.init(conditions.data(), conditions.size());
 
 	Condition* condition = Condition::createCondition(propStream);
 	while (condition) {
@@ -1036,11 +1035,9 @@ void IOLoginData::loadItems(ItemMap& itemMap, DBResult_ptr result)
 		uint16_t type = result->getNumber<uint16_t>("itemtype");
 		uint16_t count = result->getNumber<uint16_t>("count");
 
-		unsigned long attrSize;
-		const char* attr = result->getStream("attributes", attrSize);
-
+		auto attr = result->getString("attributes");
 		PropStream propStream;
-		propStream.init(attr, attrSize);
+		propStream.init(attr.data(), attr.size());
 
 		Item* item = Item::CreateItem(type, count);
 		if (item) {

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -20,8 +20,10 @@ public:
 	static Account loadAccount(uint32_t accno);
 
 	static bool loginserverAuthentication(const std::string& name, const std::string& password, Account& account);
-	static uint32_t gameworldAuthentication(const std::string& accountName, const std::string& password,
-	                                        std::string& characterName, std::string& token, uint32_t tokenTime);
+	static std::pair<uint32_t, std::string_view> gameworldAuthentication(std::string_view accountName,
+	                                                                     std::string_view password,
+	                                                                     std::string_view characterName,
+	                                                                     std::string_view token, uint32_t tokenTime);
 	static uint32_t getAccountIdByPlayerName(const std::string& playerName);
 	static uint32_t getAccountIdByPlayerId(uint32_t playerId);
 

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -50,7 +50,7 @@ Tile* IOMap::createTile(Item*& ground, Item* item, uint16_t x, uint16_t y, uint8
 	return tile;
 }
 
-bool IOMap::loadMap(Map* map, const std::string& fileName)
+bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName)
 {
 	int64_t start = OTSYS_TIME();
 	try {
@@ -146,7 +146,8 @@ bool IOMap::loadMap(Map* map, const std::string& fileName)
 	return true;
 }
 
-bool IOMap::parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map, const std::string& fileName)
+bool IOMap::parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map,
+                                   const std::filesystem::path& fileName)
 {
 	PropStream propStream;
 	if (!loader.getProps(mapNode, propStream)) {
@@ -154,38 +155,39 @@ bool IOMap::parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode
 		return false;
 	}
 
-	std::string mapDescription;
-	std::string tmp;
-
 	uint8_t attribute;
 	while (propStream.read<uint8_t>(attribute)) {
 		switch (attribute) {
-			case OTBM_ATTR_DESCRIPTION:
-				if (!propStream.readString(mapDescription)) {
+			case OTBM_ATTR_DESCRIPTION: {
+				auto [mapDescription, ok] = propStream.readString();
+				if (!ok) {
 					setLastErrorString("Invalid description tag.");
 					return false;
 				}
 				break;
+			}
 
-			case OTBM_ATTR_EXT_SPAWN_FILE:
-				if (!propStream.readString(tmp)) {
+			case OTBM_ATTR_EXT_SPAWN_FILE: {
+				auto [spawnFile, ok] = propStream.readString();
+				if (!ok) {
 					setLastErrorString("Invalid spawn tag.");
 					return false;
 				}
 
-				map.spawnfile = fileName.substr(0, fileName.rfind('/') + 1);
-				map.spawnfile += tmp;
+				map.spawnfile = fileName.parent_path() / spawnFile;
 				break;
+			}
 
-			case OTBM_ATTR_EXT_HOUSE_FILE:
-				if (!propStream.readString(tmp)) {
+			case OTBM_ATTR_EXT_HOUSE_FILE: {
+				auto [houseFile, ok] = propStream.readString();
+				if (!ok) {
 					setLastErrorString("Invalid house tag.");
 					return false;
 				}
 
-				map.housefile = fileName.substr(0, fileName.rfind('/') + 1);
-				map.housefile += tmp;
+				map.housefile = fileName.parent_path() / houseFile;
 				break;
+			}
 
 			default:
 				setLastErrorString("Unknown header node.");
@@ -411,8 +413,8 @@ bool IOMap::parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map
 			map.towns.addTown(townId, town);
 		}
 
-		std::string townName;
-		if (!propStream.readString(townName)) {
+		auto [townName, ok] = propStream.readString();
+		if (!ok) {
 			setLastErrorString("Could not read town name.");
 			return false;
 		}
@@ -444,8 +446,8 @@ bool IOMap::parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, 
 			return false;
 		}
 
-		std::string name;
-		if (!propStream.readString(name)) {
+		auto [name, ok] = propStream.readString();
+		if (!ok) {
 			setLastErrorString("Could not read waypoint name.");
 			return false;
 		}
@@ -456,7 +458,7 @@ bool IOMap::parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, 
 			return false;
 		}
 
-		map.waypoints[name] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
+		map.waypoints[std::string(name)] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
 	}
 	return true;
 }

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -458,7 +458,7 @@ bool IOMap::parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, 
 			return false;
 		}
 
-		map.waypoints[std::string(name)] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
+		map.waypoints[std::string{name}] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
 	}
 	return true;
 }

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -96,7 +96,7 @@ class IOMap
 	static Tile* createTile(Item*& ground, Item* item, uint16_t x, uint16_t y, uint8_t z);
 
 public:
-	bool loadMap(Map* map, const std::string& fileName);
+	bool loadMap(Map* map, const std::filesystem::path& fileName);
 
 	/* Load the spawns
 	 * \param map pointer to the Map class
@@ -133,7 +133,8 @@ public:
 	void setLastErrorString(std::string error) { errorString = error; }
 
 private:
-	bool parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map, const std::string& fileName);
+	bool parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map,
+	                            const std::filesystem::path& fileName);
 	bool parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map);
 	bool parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map);
 	bool parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Map& map);

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -74,8 +74,7 @@ bool IOMapSerialize::saveHouseItems()
 			saveTile(stream, tile);
 
 			if (auto attributes = stream.getStream(); !attributes.empty()) {
-				if (!stmt.addRow(
-				        fmt::format("{:d}, {:s}", house->getId(), db.escapeString(attributes)))) {
+				if (!stmt.addRow(fmt::format("{:d}, {:s}", house->getId(), db.escapeString(attributes)))) {
 					return false;
 				}
 				stream.clear();

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -21,11 +21,9 @@ void IOMapSerialize::loadHouseItems(Map* map)
 	}
 
 	do {
-		unsigned long attrSize;
-		const char* attr = result->getStream("data", attrSize);
-
+		auto attr = result->getString("data");
 		PropStream propStream;
-		propStream.init(attr, attrSize);
+		propStream.init(attr.data(), attr.size());
 
 		uint16_t x, y;
 		uint8_t z;

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -73,11 +73,9 @@ bool IOMapSerialize::saveHouseItems()
 		for (HouseTile* tile : house->getTiles()) {
 			saveTile(stream, tile);
 
-			size_t attributesSize;
-			const char* attributes = stream.getStream(attributesSize);
-			if (attributesSize > 0) {
+			if (auto attributes = stream.getStream(); !attributes.empty()) {
 				if (!stmt.addRow(
-				        fmt::format("{:d}, {:s}", house->getId(), db.escapeBlob(attributes, attributesSize)))) {
+				        fmt::format("{:d}, {:s}", house->getId(), db.escapeString(attributes)))) {
 					return false;
 				}
 				stream.clear();
@@ -378,10 +376,8 @@ bool IOMapSerialize::saveHouse(House* house)
 	for (HouseTile* tile : house->getTiles()) {
 		saveTile(stream, tile);
 
-		size_t attributesSize;
-		const char* attributes = stream.getStream(attributesSize);
-		if (attributesSize > 0) {
-			if (!stmt.addRow(fmt::format("{:d}, {:s}", houseId, db.escapeBlob(attributes, attributesSize)))) {
+		if (auto attributes = stream.getStream(); attributes.size() > 0) {
+			if (!stmt.addRow(fmt::format("{:d}, {:s}", houseId, db.escapeString(attributes)))) {
 				return false;
 			}
 			stream.clear();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -375,8 +375,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 		}
 
 		case ATTR_TEXT: {
-			std::string text;
-			if (!propStream.readString(text)) {
+			auto [text, ok] = propStream.readString();
+			if (!ok) {
 				return ATTR_READ_ERROR;
 			}
 
@@ -395,8 +395,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 		}
 
 		case ATTR_WRITTENBY: {
-			std::string writer;
-			if (!propStream.readString(writer)) {
+			auto [writer, ok] = propStream.readString();
+			if (!ok) {
 				return ATTR_READ_ERROR;
 			}
 
@@ -405,8 +405,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 		}
 
 		case ATTR_DESC: {
-			std::string text;
-			if (!propStream.readString(text)) {
+			auto [text, ok] = propStream.readString();
+			if (!ok) {
 				return ATTR_READ_ERROR;
 			}
 
@@ -447,8 +447,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 		}
 
 		case ATTR_NAME: {
-			std::string name;
-			if (!propStream.readString(name)) {
+			auto [name, ok] = propStream.readString();
+			if (!ok) {
 				return ATTR_READ_ERROR;
 			}
 
@@ -457,8 +457,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 		}
 
 		case ATTR_ARTICLE: {
-			std::string article;
-			if (!propStream.readString(article)) {
+			auto [article, ok] = propStream.readString();
+			if (!ok) {
 				return ATTR_READ_ERROR;
 			}
 
@@ -467,8 +467,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 		}
 
 		case ATTR_PLURALNAME: {
-			std::string pluralName;
-			if (!propStream.readString(pluralName)) {
+			auto [pluralName, ok] = propStream.readString();
+			if (!ok) {
 				return ATTR_READ_ERROR;
 			}
 
@@ -698,8 +698,8 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream& propStream)
 
 			for (uint64_t i = 0; i < size; i++) {
 				// Unserialize key type and value
-				std::string key;
-				if (!propStream.readString(key)) {
+				auto [key, ok] = propStream.readString();
+				if (!ok) {
 					return ATTR_READ_ERROR;
 				};
 
@@ -1126,7 +1126,7 @@ const std::string& ItemAttributes::getStrAttr(itemAttrTypes type) const
 	return *attr->value.string;
 }
 
-void ItemAttributes::setStrAttr(itemAttrTypes type, const std::string& value)
+void ItemAttributes::setStrAttr(itemAttrTypes type, std::string_view value)
 {
 	if (!isStrAttrType(type)) {
 		return;

--- a/src/item.h
+++ b/src/item.h
@@ -232,7 +232,7 @@ public:
 					if (!ok) {
 						return false;
 					}
-					value = std::string(str);
+					value = std::string{str};
 					break;
 				}
 
@@ -408,7 +408,7 @@ private:
 		} else {
 			getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = new CustomAttributeMap();
 		}
-		auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+		auto lowercaseKey = boost::algorithm::to_lower_copy(std::string{key});
 		getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom->emplace(lowercaseKey, value);
 	}
 
@@ -419,7 +419,7 @@ private:
 		} else {
 			getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = new CustomAttributeMap();
 		}
-		auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+		auto lowercaseKey = boost::algorithm::to_lower_copy(std::string{key});
 		getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom->emplace(lowercaseKey, value);
 	}
 
@@ -432,7 +432,7 @@ private:
 	const CustomAttribute* getCustomAttribute(std::string_view key)
 	{
 		if (const CustomAttributeMap* customAttrMap = getCustomAttributeMap()) {
-			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string{key});
 			if (auto it = customAttrMap->find(lowercaseKey); it != customAttrMap->end()) {
 				return &(it->second);
 			}
@@ -449,7 +449,7 @@ private:
 	bool removeCustomAttribute(std::string_view key)
 	{
 		if (CustomAttributeMap* customAttrMap = getCustomAttributeMap()) {
-			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string{key});
 			if (auto it = customAttrMap->find(lowercaseKey); it != customAttrMap->end()) {
 				customAttrMap->erase(it);
 				return true;

--- a/src/item.h
+++ b/src/item.h
@@ -228,11 +228,11 @@ public:
 
 			switch (pos) {
 				case 1: { // std::string
-					std::string tmp;
-					if (!propStream.readString(tmp)) {
+					auto [str, ok] = propStream.readString();
+					if (!ok) {
 						return false;
 					}
-					value = tmp;
+					value = std::string(str);
 					break;
 				}
 
@@ -369,7 +369,7 @@ private:
 	}
 
 	const std::string& getStrAttr(itemAttrTypes type) const;
-	void setStrAttr(itemAttrTypes type, const std::string& value);
+	void setStrAttr(itemAttrTypes type, std::string_view value);
 
 	int64_t getIntAttr(itemAttrTypes type) const;
 	void setIntAttr(itemAttrTypes type, int64_t value);
@@ -401,26 +401,26 @@ private:
 	}
 
 	template <typename R>
-	void setCustomAttribute(std::string& key, R value)
+	void setCustomAttribute(std::string_view key, R value)
 	{
-		boost::algorithm::to_lower(key);
 		if (hasAttribute(ITEM_ATTRIBUTE_CUSTOM)) {
 			removeCustomAttribute(key);
 		} else {
 			getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = new CustomAttributeMap();
 		}
-		getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom->emplace(key, value);
+		auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+		getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom->emplace(lowercaseKey, value);
 	}
 
-	void setCustomAttribute(std::string& key, CustomAttribute& value)
+	void setCustomAttribute(std::string_view key, const CustomAttribute& value)
 	{
-		boost::algorithm::to_lower(key);
 		if (hasAttribute(ITEM_ATTRIBUTE_CUSTOM)) {
 			removeCustomAttribute(key);
 		} else {
 			getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = new CustomAttributeMap();
 		}
-		getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom->insert(std::make_pair(std::move(key), std::move(value)));
+		auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+		getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom->emplace(lowercaseKey, value);
 	}
 
 	const CustomAttribute* getCustomAttribute(int64_t key)
@@ -429,11 +429,11 @@ private:
 		return getCustomAttribute(tmp);
 	}
 
-	const CustomAttribute* getCustomAttribute(const std::string& key)
+	const CustomAttribute* getCustomAttribute(std::string_view key)
 	{
 		if (const CustomAttributeMap* customAttrMap = getCustomAttributeMap()) {
-			auto it = customAttrMap->find(boost::algorithm::to_lower_copy(key));
-			if (it != customAttrMap->end()) {
+			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+			if (auto it = customAttrMap->find(lowercaseKey); it != customAttrMap->end()) {
 				return &(it->second);
 			}
 		}
@@ -446,11 +446,11 @@ private:
 		return removeCustomAttribute(tmp);
 	}
 
-	bool removeCustomAttribute(const std::string& key)
+	bool removeCustomAttribute(std::string_view key)
 	{
 		if (CustomAttributeMap* customAttrMap = getCustomAttributeMap()) {
-			auto it = customAttrMap->find(boost::algorithm::to_lower_copy(key));
-			if (it != customAttrMap->end()) {
+			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string(key));
+			if (auto it = customAttrMap->find(lowercaseKey); it != customAttrMap->end()) {
 				customAttrMap->erase(it);
 				return true;
 			}
@@ -524,7 +524,7 @@ public:
 		}
 		return attributes->getStrAttr(type);
 	}
-	void setStrAttr(itemAttrTypes type, const std::string& value) { getAttributes()->setStrAttr(type, value); }
+	void setStrAttr(itemAttrTypes type, std::string_view value) { getAttributes()->setStrAttr(type, value); }
 
 	int64_t getIntAttr(itemAttrTypes type) const
 	{
@@ -551,12 +551,12 @@ public:
 	}
 
 	template <typename R>
-	void setCustomAttribute(std::string& key, R value)
+	void setCustomAttribute(std::string_view key, R value)
 	{
 		getAttributes()->setCustomAttribute(key, value);
 	}
 
-	void setCustomAttribute(std::string& key, ItemAttributes::CustomAttribute& value)
+	void setCustomAttribute(std::string_view key, ItemAttributes::CustomAttribute& value)
 	{
 		getAttributes()->setCustomAttribute(key, value);
 	}
@@ -585,7 +585,7 @@ public:
 		return getAttributes()->removeCustomAttribute(key);
 	}
 
-	bool removeCustomAttribute(const std::string& key)
+	bool removeCustomAttribute(std::string_view key)
 	{
 		if (!attributes) {
 			return false;
@@ -593,10 +593,10 @@ public:
 		return getAttributes()->removeCustomAttribute(key);
 	}
 
-	void setSpecialDescription(const std::string& desc) { setStrAttr(ITEM_ATTRIBUTE_DESCRIPTION, desc); }
+	void setSpecialDescription(std::string_view desc) { setStrAttr(ITEM_ATTRIBUTE_DESCRIPTION, desc); }
 	const std::string& getSpecialDescription() const { return getStrAttr(ITEM_ATTRIBUTE_DESCRIPTION); }
 
-	void setText(const std::string& text) { setStrAttr(ITEM_ATTRIBUTE_TEXT, text); }
+	void setText(std::string_view text) { setStrAttr(ITEM_ATTRIBUTE_TEXT, text); }
 	void resetText() { removeAttribute(ITEM_ATTRIBUTE_TEXT); }
 	const std::string& getText() const { return getStrAttr(ITEM_ATTRIBUTE_TEXT); }
 
@@ -604,7 +604,7 @@ public:
 	void resetDate() { removeAttribute(ITEM_ATTRIBUTE_DATE); }
 	time_t getDate() const { return static_cast<time_t>(getIntAttr(ITEM_ATTRIBUTE_DATE)); }
 
-	void setWriter(const std::string& writer) { setStrAttr(ITEM_ATTRIBUTE_WRITER, writer); }
+	void setWriter(std::string_view writer) { setStrAttr(ITEM_ATTRIBUTE_WRITER, writer); }
 	void resetWriter() { removeAttribute(ITEM_ATTRIBUTE_WRITER); }
 	const std::string& getWriter() const { return getStrAttr(ITEM_ATTRIBUTE_WRITER); }
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4273,10 +4273,9 @@ int LuaScriptInterface::luaResultGetStream(lua_State* L)
 		return 1;
 	}
 
-	unsigned long length;
-	const char* stream = res->getStream(getString(L, 2), length);
-	lua_pushlstring(L, stream, length);
-	lua_pushnumber(L, length);
+	auto stream = res->getString(getString(L, 2));
+	lua_pushlstring(L, stream.data(), stream.size());
+	lua_pushnumber(L, stream.size());
 	return 2;
 }
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16124,7 +16124,7 @@ int LuaScriptInterface::luaSpellVocation(lua_State* L)
 	} else {
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		for (int i = 0; i < parameters; ++i) {
-			std::vector<std::string> vocList = explodeString(getString(L, 2 + i), ";");
+			auto vocList = explodeString(getString(L, 2 + i), ";");
 			spell->addVocationSpellMap(vocList[0], vocList.size() > 1 ? booleanString(vocList[1]) : false);
 		}
 		pushBoolean(L, true);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -340,7 +340,7 @@ int32_t LuaScriptInterface::loadFile(const std::string& file, Npc* npc /* = null
 	return 0;
 }
 
-int32_t LuaScriptInterface::getEvent(const std::string& eventName)
+int32_t LuaScriptInterface::getEvent(std::string_view eventName)
 {
 	// get our events table
 	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
@@ -350,7 +350,7 @@ int32_t LuaScriptInterface::getEvent(const std::string& eventName)
 	}
 
 	// get current event function pointer
-	lua_getglobal(luaState, eventName.c_str());
+	lua_getglobal(luaState, eventName.data());
 	if (!isFunction(luaState, -1)) {
 		lua_pop(luaState, 2);
 		return -1;
@@ -363,9 +363,9 @@ int32_t LuaScriptInterface::getEvent(const std::string& eventName)
 
 	// reset global value of this event
 	lua_pushnil(luaState);
-	lua_setglobal(luaState, eventName.c_str());
+	lua_setglobal(luaState, eventName.data());
 
-	cacheFiles[runningEventId] = loadingFile + ":" + eventName;
+	cacheFiles[runningEventId] = fmt::format("{:s}:{:s}", loadingFile, eventName);
 	return runningEventId++;
 }
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -626,9 +626,9 @@ void LuaScriptInterface::pushCylinder(lua_State* L, Cylinder* cylinder)
 	}
 }
 
-void LuaScriptInterface::pushString(lua_State* L, const std::string& value)
+void LuaScriptInterface::pushString(lua_State* L, std::string_view value)
 {
-	lua_pushlstring(L, value.c_str(), value.length());
+	lua_pushlstring(L, value.data(), value.length());
 }
 
 void LuaScriptInterface::pushCallback(lua_State* L, int32_t callback) { lua_rawgeti(L, LUA_REGISTRYINDEX, callback); }

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -208,7 +208,7 @@ public:
 	// push/pop common structures
 	static void pushThing(lua_State* L, Thing* thing);
 	static void pushVariant(lua_State* L, const LuaVariant& var);
-	static void pushString(lua_State* L, const std::string& value);
+	static void pushString(lua_State* L, std::string_view value);
 	static void pushCallback(lua_State* L, int32_t callback);
 	static void pushCylinder(lua_State* L, Cylinder* cylinder);
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -173,7 +173,7 @@ public:
 	int32_t loadFile(const std::string& file, Npc* npc = nullptr);
 
 	const std::string& getFileById(int32_t scriptId);
-	int32_t getEvent(const std::string& eventName);
+	int32_t getEvent(std::string_view eventName);
 	int32_t getEvent();
 	int32_t getMetaEvent(const std::string& globalName, const std::string& eventName);
 

--- a/src/map.h
+++ b/src/map.h
@@ -261,8 +261,8 @@ private:
 
 	QTreeNode root;
 
-	std::string spawnfile;
-	std::string housefile;
+	std::filesystem::path spawnfile;
+	std::filesystem::path housefile;
 
 	uint32_t width = 0;
 	uint32_t height = 0;

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -166,7 +166,8 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 		}
 
 		std::unique_ptr<CombatSpell> combatSpellPtr(new CombatSpell(nullptr, needTarget, needDirection));
-		if (!combatSpellPtr->loadScript("data/" + g_spells->getScriptBaseName() + "/scripts/" + scriptName)) {
+		if (!combatSpellPtr->loadScript("data/" + std::string{g_spells->getScriptBaseName()} + "/scripts/" +
+		                                scriptName)) {
 			return false;
 		}
 
@@ -582,7 +583,8 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 
 	if (spell->isScripted) {
 		std::unique_ptr<CombatSpell> combatSpellPtr(new CombatSpell(nullptr, spell->needTarget, spell->needDirection));
-		if (!combatSpellPtr->loadScript("data/" + g_spells->getScriptBaseName() + "/scripts/" + spell->scriptName)) {
+		if (!combatSpellPtr->loadScript("data/" + std::string{g_spells->getScriptBaseName()} + "/scripts/" +
+		                                spell->scriptName)) {
 			std::cout << "cannot find file" << std::endl;
 			return false;
 		}

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -60,8 +60,6 @@ void MoveEvents::clear(bool fromLua)
 
 LuaScriptInterface& MoveEvents::getScriptInterface() { return scriptInterface; }
 
-std::string MoveEvents::getScriptBaseName() const { return "movements"; }
-
 Event_ptr MoveEvents::getEvent(const std::string& nodeName)
 {
 	if (!caseInsensitiveEqual(nodeName, "movevent")) {
@@ -526,7 +524,7 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 
 MoveEvent::MoveEvent(LuaScriptInterface* interface) : Event(interface) {}
 
-std::string MoveEvent::getScriptEventName() const
+std::string_view MoveEvent::getScriptEventName() const
 {
 	switch (eventType) {
 		case MOVE_EVENT_STEP_IN:
@@ -543,7 +541,7 @@ std::string MoveEvent::getScriptEventName() const
 			return "onRemoveItem";
 		default:
 			std::cout << "[Error - MoveEvent::getScriptEventName] Invalid event type" << std::endl;
-			return std::string();
+			return "";
 	}
 }
 

--- a/src/movement.h
+++ b/src/movement.h
@@ -63,7 +63,7 @@ private:
 	void clearPosMap(MovePosListMap& map, bool fromLua);
 
 	LuaScriptInterface& getScriptInterface() override;
-	std::string getScriptBaseName() const override;
+	std::string_view getScriptBaseName() const override { return "movements"; }
 	Event_ptr getEvent(const std::string& nodeName) override;
 	bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
 
@@ -168,7 +168,7 @@ public:
 	EquipFunction equipFunction;
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override;
 
 	uint32_t slot = SLOTP_WHEREEVER;
 

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -8,19 +8,19 @@
 #include "container.h"
 #include "podium.h"
 
-std::string NetworkMessage::getString(uint16_t stringLen /* = 0*/)
+std::string_view NetworkMessage::getString(uint16_t stringLen /* = 0*/)
 {
 	if (stringLen == 0) {
 		stringLen = get<uint16_t>();
 	}
 
 	if (!canRead(stringLen)) {
-		return std::string();
+		return {};
 	}
 
 	char* v = reinterpret_cast<char*>(buffer) + info.position; // does not break strict aliasing
 	info.position += stringLen;
-	return std::string(v, stringLen);
+	return {v, stringLen};
 }
 
 Position NetworkMessage::getPosition()
@@ -32,15 +32,15 @@ Position NetworkMessage::getPosition()
 	return pos;
 }
 
-void NetworkMessage::addString(const std::string& value)
+void NetworkMessage::addString(std::string_view value)
 {
-	size_t stringLen = value.length();
+	size_t stringLen = value.size();
 	if (!canAdd(stringLen + 2) || stringLen > 8192) {
 		return;
 	}
 
 	add<uint16_t>(stringLen);
-	memcpy(buffer + info.position, value.c_str(), stringLen);
+	memcpy(buffer + info.position, value.data(), stringLen);
 	info.position += stringLen;
 	info.length += stringLen;
 }

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -68,7 +68,7 @@ public:
 		return v;
 	}
 
-	std::string getString(uint16_t stringLen = 0);
+	std::string_view getString(uint16_t stringLen = 0);
 	Position getPosition();
 
 	// skips count unknown/unused bytes in an incoming message
@@ -100,7 +100,7 @@ public:
 	void addBytes(const char* bytes, size_t size);
 	void addPaddingBytes(size_t n);
 
-	void addString(const std::string& value);
+	void addString(std::string_view value);
 
 	void addDouble(double value, uint8_t precision = 2);
 

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <deque>
+#include <filesystem>
 #include <fmt/color.h>
 #include <forward_list>
 #include <functional>

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -392,16 +392,16 @@ bool argumentsHandler(const StringVector& args)
 			return false;
 		}
 
-		StringVector tmp = explodeString(arg, "=");
+		auto tmp = explodeString(arg, "=");
 
 		if (tmp[0] == "--config")
 			g_config.setString(ConfigManager::CONFIG_FILE, tmp[1]);
 		else if (tmp[0] == "--ip")
 			g_config.setString(ConfigManager::IP, tmp[1]);
 		else if (tmp[0] == "--login-port")
-			g_config.setNumber(ConfigManager::LOGIN_PORT, std::stoi(tmp[1]));
+			g_config.setNumber(ConfigManager::LOGIN_PORT, std::stoi(tmp[1].data()));
 		else if (tmp[0] == "--game-port")
-			g_config.setNumber(ConfigManager::GAME_PORT, std::stoi(tmp[1]));
+			g_config.setNumber(ConfigManager::GAME_PORT, std::stoi(tmp[1].data()));
 	}
 
 	return true;

--- a/src/player.h
+++ b/src/player.h
@@ -54,8 +54,8 @@ enum tradestate_t : uint8_t
 
 struct VIPEntry
 {
-	VIPEntry(uint32_t guid, std::string name, std::string description, uint32_t icon, bool notify) :
-	    guid(guid), name(std::move(name)), description(std::move(description)), icon(icon), notify(notify)
+	VIPEntry(uint32_t guid, std::string_view name, std::string_view description, uint32_t icon, bool notify) :
+	    guid{guid}, name{name}, description{description}, icon{icon}, notify{notify}
 	{}
 
 	uint32_t guid;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -395,9 +395,9 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 
 	msg.skipBytes(1); // Gamemaster flag
 
-	std::string sessionKey = msg.getString();
-	auto sessionArgs = explodeString(sessionKey, "\n",
-	                                 4); // acc name or email, password, token, timestamp divided by 30
+	const auto sessionKey = msg.getString();
+	// acc name or email, password, token, timestamp divided by 30
+	auto sessionArgs = explodeString(sessionKey, "\n", 4);
 	if (sessionArgs.size() < 2) {
 		disconnectClient("Malformed session key.");
 		return;
@@ -408,14 +408,14 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		msg.getString(); // OS version (?)
 	}
 
-	std::string& accountName = sessionArgs[0];
-	std::string& password = sessionArgs[1];
+	const auto accountName = sessionArgs[0];
+	const auto password = sessionArgs[1];
 	if (accountName.empty()) {
 		disconnectClient("You must enter your account name.");
 		return;
 	}
 
-	std::string token;
+	std::string_view token;
 	uint32_t tokenTime = 0;
 
 	// two-factor auth
@@ -428,7 +428,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		token = sessionArgs[2];
 
 		try {
-			tokenTime = std::stoul(sessionArgs[3]);
+			tokenTime = std::stoul(sessionArgs[3].data());
 		} catch (const std::invalid_argument&) {
 			disconnectClient("Malformed token packet.");
 			return;
@@ -440,7 +440,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		tokenTime = std::floor(challengeTimestamp / 30);
 	}
 
-	std::string characterName = msg.getString();
+	auto characterName = msg.getString();
 	uint32_t timeStamp = msg.get<uint32_t>();
 	uint8_t randNumber = msg.getByte();
 	if (challengeTimestamp != timeStamp || challengeRandom != randNumber) {
@@ -469,13 +469,15 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	uint32_t accountId = IOLoginData::gameworldAuthentication(accountName, password, characterName, token, tokenTime);
+	uint32_t accountId;
+	std::tie(accountId, characterName) =
+	    IOLoginData::gameworldAuthentication(accountName, password, characterName, token, tokenTime);
 	if (accountId == 0) {
 		disconnectClient("Account name or password is not correct.");
 		return;
 	}
 
-	g_dispatcher.addTask([=, thisPtr = getThis(), characterName = std::move(characterName)]() {
+	g_dispatcher.addTask([=, thisPtr = getThis(), characterName = std::string{characterName}]() {
 		thisPtr->login(characterName, accountId, operatingSystem);
 	});
 }
@@ -1037,16 +1039,16 @@ bool ProtocolGame::canSee(int32_t x, int32_t y, int32_t z) const
 // Parse methods
 void ProtocolGame::parseChannelInvite(NetworkMessage& msg)
 {
-	std::string name = msg.getString();
+	auto name = msg.getString();
 	g_dispatcher.addTask(
-	    [playerID = player->getID(), name = std::move(name)]() { g_game.playerChannelInvite(playerID, name); });
+	    [playerID = player->getID(), name = std::string{name}]() { g_game.playerChannelInvite(playerID, name); });
 }
 
 void ProtocolGame::parseChannelExclude(NetworkMessage& msg)
 {
-	std::string name = msg.getString();
+	auto name = msg.getString();
 	g_dispatcher.addTask(
-	    [=, playerID = player->getID(), name = std::move(name)]() { g_game.playerChannelExclude(playerID, name); });
+	    [=, playerID = player->getID(), name = std::string{name}]() { g_game.playerChannelExclude(playerID, name); });
 }
 
 void ProtocolGame::parseOpenChannel(NetworkMessage& msg)
@@ -1063,8 +1065,8 @@ void ProtocolGame::parseCloseChannel(NetworkMessage& msg)
 
 void ProtocolGame::parseOpenPrivateChannel(NetworkMessage& msg)
 {
-	std::string receiver = msg.getString();
-	g_dispatcher.addTask([playerID = player->getID(), receiver = std::move(receiver)]() {
+	auto receiver = msg.getString();
+	g_dispatcher.addTask([playerID = player->getID(), receiver = std::string{receiver}]() {
 		g_game.playerOpenPrivateChannel(playerID, receiver);
 	});
 }
@@ -1289,7 +1291,7 @@ void ProtocolGame::parseLookInBattleList(NetworkMessage& msg)
 
 void ProtocolGame::parseSay(NetworkMessage& msg)
 {
-	std::string receiver;
+	std::string_view receiver;
 	uint16_t channelId;
 
 	SpeakClasses type = static_cast<SpeakClasses>(msg.getByte());
@@ -1310,12 +1312,12 @@ void ProtocolGame::parseSay(NetworkMessage& msg)
 			break;
 	}
 
-	std::string text = msg.getString();
+	const auto text = msg.getString();
 	if (text.length() > 255) {
 		return;
 	}
 
-	g_dispatcher.addTask([=, playerID = player->getID(), receiver = std::move(receiver), text = std::move(text)]() {
+	g_dispatcher.addTask([=, playerID = player->getID(), receiver = std::string{receiver}, text = std::string{text}]() {
 		g_game.playerSay(playerID, channelId, type, receiver, text);
 	});
 }
@@ -1368,8 +1370,8 @@ void ProtocolGame::parseEquipObject(NetworkMessage& msg)
 void ProtocolGame::parseTextWindow(NetworkMessage& msg)
 {
 	uint32_t windowTextID = msg.get<uint32_t>();
-	std::string newText = msg.getString();
-	g_dispatcher.addTask([playerID = player->getID(), windowTextID, newText = std::move(newText)]() {
+	auto newText = msg.getString();
+	g_dispatcher.addTask([playerID = player->getID(), windowTextID, newText = std::string{newText}]() {
 		g_game.playerWriteItem(playerID, windowTextID, newText);
 	});
 }
@@ -1378,9 +1380,10 @@ void ProtocolGame::parseHouseWindow(NetworkMessage& msg)
 {
 	uint8_t doorId = msg.getByte();
 	uint32_t id = msg.get<uint32_t>();
-	const std::string text = msg.getString();
-	g_dispatcher.addTask(
-	    [=, playerID = player->getID()]() { g_game.playerUpdateHouseWindow(playerID, doorId, id, text); });
+	auto text = msg.getString();
+	g_dispatcher.addTask([=, playerID = player->getID(), text = std::string{text}]() {
+		g_game.playerUpdateHouseWindow(playerID, doorId, id, text);
+	});
 }
 
 void ProtocolGame::parseWrapItem(NetworkMessage& msg)
@@ -1445,9 +1448,9 @@ void ProtocolGame::parseLookInTrade(NetworkMessage& msg)
 
 void ProtocolGame::parseAddVip(NetworkMessage& msg)
 {
-	std::string name = msg.getString();
+	auto name = msg.getString();
 	g_dispatcher.addTask(
-	    [playerID = player->getID(), name = std::move(name)]() { g_game.playerRequestAddVip(playerID, name); });
+	    [playerID = player->getID(), name = std::string{name}]() { g_game.playerRequestAddVip(playerID, name); });
 }
 
 void ProtocolGame::parseRemoveVip(NetworkMessage& msg)
@@ -1459,10 +1462,10 @@ void ProtocolGame::parseRemoveVip(NetworkMessage& msg)
 void ProtocolGame::parseEditVip(NetworkMessage& msg)
 {
 	uint32_t guid = msg.get<uint32_t>();
-	std::string description = msg.getString();
+	const auto description = msg.getString();
 	uint32_t icon = std::min<uint32_t>(10, msg.get<uint32_t>()); // 10 is max icon in 9.63
 	bool notify = msg.getByte() != 0;
-	g_dispatcher.addTask([=, playerID = player->getID(), description = std::move(description)]() {
+	g_dispatcher.addTask([=, playerID = player->getID(), description = std::string{description}]() {
 		g_game.playerRequestEditVip(playerID, guid, description, icon, notify);
 	});
 }
@@ -1481,9 +1484,9 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 {
 	uint8_t reportType = msg.getByte();
 	uint8_t reportReason = msg.getByte();
-	std::string targetName = msg.getString();
-	std::string comment = msg.getString();
-	std::string translation;
+	const auto targetName = msg.getString();
+	const auto comment = msg.getString();
+	std::string_view translation;
 	if (reportType == REPORT_TYPE_NAME) {
 		translation = msg.getString();
 	} else if (reportType == REPORT_TYPE_STATEMENT) {
@@ -1491,8 +1494,8 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 		msg.get<uint32_t>(); // statement id, used to get whatever player have said, we don't log that.
 	}
 
-	g_dispatcher.addTask([=, playerID = player->getID(), targetName = std::move(targetName),
-	                      comment = std::move(comment), translation = std::move(translation)]() {
+	g_dispatcher.addTask([=, playerID = player->getID(), targetName = std::string{targetName},
+	                      comment = std::string{comment}, translation = std::string{translation}]() {
 		g_game.playerReportRuleViolation(playerID, targetName, reportType, reportReason, comment, translation);
 	});
 }
@@ -1500,14 +1503,14 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 void ProtocolGame::parseBugReport(NetworkMessage& msg)
 {
 	uint8_t category = msg.getByte();
-	std::string message = msg.getString();
+	const auto message = msg.getString();
 
 	Position position;
 	if (category == BUG_CATEGORY_MAP) {
 		position = msg.getPosition();
 	}
 
-	g_dispatcher.addTask([=, playerID = player->getID(), message = std::move(message)]() {
+	g_dispatcher.addTask([=, playerID = player->getID(), message = std::string{message}]() {
 		g_game.playerReportBug(playerID, message, position, category);
 	});
 }
@@ -1520,12 +1523,12 @@ void ProtocolGame::parseDebugAssert(NetworkMessage& msg)
 
 	debugAssertSent = true;
 
-	std::string assertLine = msg.getString();
-	std::string date = msg.getString();
-	std::string description = msg.getString();
-	std::string comment = msg.getString();
-	g_dispatcher.addTask([playerID = player->getID(), assertLine = std::move(assertLine), date = std::move(date),
-	                      description = std::move(description), comment = std::move(comment)]() {
+	auto assertLine = msg.getString();
+	auto date = msg.getString();
+	auto description = msg.getString();
+	auto comment = msg.getString();
+	g_dispatcher.addTask([playerID = player->getID(), assertLine = std::string{assertLine}, date = std::string{date},
+	                      description = std::string{description}, comment = std::string{comment}]() {
 		g_game.playerDebugAssert(playerID, assertLine, date, description, comment);
 	});
 }
@@ -3933,10 +3936,10 @@ void ProtocolGame::AddShopItem(NetworkMessage& msg, const ShopInfo& item)
 void ProtocolGame::parseExtendedOpcode(NetworkMessage& msg)
 {
 	uint8_t opcode = msg.getByte();
-	std::string buffer = msg.getString();
+	const auto buffer = msg.getString();
 
 	// process additional opcodes via lua script event
-	g_dispatcher.addTask([=, playerID = player->getID(), buffer = std::move(buffer)]() {
+	g_dispatcher.addTask([=, playerID = player->getID(), buffer = std::string{buffer}]() {
 		g_game.parsePlayerExtendedOpcode(playerID, opcode, buffer);
 	});
 }

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -395,9 +395,8 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 
 	msg.skipBytes(1); // Gamemaster flag
 
-	const auto sessionKey = msg.getString();
 	// acc name or email, password, token, timestamp divided by 30
-	auto sessionArgs = explodeString(sessionKey, "\n", 4);
+	auto sessionArgs = explodeString(msg.getString(), "\n", 4);
 	if (sessionArgs.size() < 2) {
 		disconnectClient("Malformed session key.");
 		return;
@@ -408,8 +407,8 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		msg.getString(); // OS version (?)
 	}
 
-	const auto accountName = sessionArgs[0];
-	const auto password = sessionArgs[1];
+	auto accountName = sessionArgs[0];
+	auto password = sessionArgs[1];
 	if (accountName.empty()) {
 		disconnectClient("You must enter your account name.");
 		return;
@@ -1312,7 +1311,7 @@ void ProtocolGame::parseSay(NetworkMessage& msg)
 			break;
 	}
 
-	const auto text = msg.getString();
+	auto text = msg.getString();
 	if (text.length() > 255) {
 		return;
 	}
@@ -1462,7 +1461,7 @@ void ProtocolGame::parseRemoveVip(NetworkMessage& msg)
 void ProtocolGame::parseEditVip(NetworkMessage& msg)
 {
 	uint32_t guid = msg.get<uint32_t>();
-	const auto description = msg.getString();
+	auto description = msg.getString();
 	uint32_t icon = std::min<uint32_t>(10, msg.get<uint32_t>()); // 10 is max icon in 9.63
 	bool notify = msg.getByte() != 0;
 	g_dispatcher.addTask([=, playerID = player->getID(), description = std::string{description}]() {
@@ -1484,8 +1483,8 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 {
 	uint8_t reportType = msg.getByte();
 	uint8_t reportReason = msg.getByte();
-	const auto targetName = msg.getString();
-	const auto comment = msg.getString();
+	auto targetName = msg.getString();
+	auto comment = msg.getString();
 	std::string_view translation;
 	if (reportType == REPORT_TYPE_NAME) {
 		translation = msg.getString();
@@ -1503,7 +1502,7 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 void ProtocolGame::parseBugReport(NetworkMessage& msg)
 {
 	uint8_t category = msg.getByte();
-	const auto message = msg.getString();
+	auto message = msg.getString();
 
 	Position position;
 	if (category == BUG_CATEGORY_MAP) {
@@ -3934,7 +3933,7 @@ void ProtocolGame::AddShopItem(NetworkMessage& msg, const ShopInfo& item)
 void ProtocolGame::parseExtendedOpcode(NetworkMessage& msg)
 {
 	uint8_t opcode = msg.getByte();
-	const auto buffer = msg.getString();
+	auto buffer = msg.getString();
 
 	// process additional opcodes via lua script event
 	g_dispatcher.addTask([=, playerID = player->getID(), buffer = std::string{buffer}]() {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3259,8 +3259,7 @@ void ProtocolGame::sendOutfitWindow()
 
 	std::vector<ProtocolOutfit> protocolOutfits;
 	if (player->isAccessPlayer()) {
-		static const std::string gamemasterOutfitName = "Gamemaster";
-		protocolOutfits.emplace_back(gamemasterOutfitName, 75, 0);
+		protocolOutfits.emplace_back("Gamemaster", 75, 0);
 	}
 
 	protocolOutfits.reserve(outfits.size());
@@ -3360,8 +3359,7 @@ void ProtocolGame::sendPodiumWindow(const Item* item)
 	// add GM outfit for staff members
 	std::vector<ProtocolOutfit> protocolOutfits;
 	if (player->isAccessPlayer()) {
-		static const std::string gamemasterOutfitName = "Gamemaster";
-		protocolOutfits.emplace_back(gamemasterOutfitName, 75, 0);
+		protocolOutfits.emplace_back("Gamemaster", 75, 0);
 	}
 
 	// fetch player addons info

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -183,13 +183,13 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	std::string accountName = msg.getString();
+	auto accountName = msg.getString();
 	if (accountName.empty()) {
 		disconnectClient("Invalid account name.", version);
 		return;
 	}
 
-	std::string password = msg.getString();
+	auto password = msg.getString();
 	if (password.empty()) {
 		disconnectClient("Invalid password.", version);
 		return;
@@ -202,10 +202,11 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	std::string authToken = msg.getString();
+	auto authToken = msg.getString();
 
-	g_dispatcher.addTask(
-	    [=, thisPtr = std::static_pointer_cast<ProtocolLogin>(shared_from_this()), accountName = std::move(accountName),
-	     password = std::move(password),
-	     authToken = std::move(authToken)]() { thisPtr->getCharacterList(accountName, password, authToken, version); });
+	g_dispatcher.addTask([=, thisPtr = std::static_pointer_cast<ProtocolLogin>(shared_from_this()),
+	                      accountName = std::string{accountName}, password = std::string{password},
+	                      authToken = std::string{authToken}]() {
+		thisPtr->getCharacterList(accountName, password, authToken, version);
+	});
 }

--- a/src/raids.cpp
+++ b/src/raids.cpp
@@ -555,8 +555,6 @@ bool ScriptEvent::configureRaidEvent(const pugi::xml_node& eventNode)
 	return true;
 }
 
-std::string ScriptEvent::getScriptEventName() const { return "onRaid"; }
-
 bool ScriptEvent::executeEvent()
 {
 	// onRaid()

--- a/src/raids.h
+++ b/src/raids.h
@@ -182,7 +182,7 @@ public:
 	bool executeEvent() override;
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override { return "onRaid"; }
 };
 
 #endif // FS_RAIDS_H

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -7,8 +7,6 @@
 
 #include "configmanager.h"
 
-#include <filesystem>
-
 extern LuaEnvironment g_luaEnvironment;
 extern ConfigManager g_config;
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -104,8 +104,6 @@ void Spells::clear(bool fromLua)
 
 LuaScriptInterface& Spells::getScriptInterface() { return scriptInterface; }
 
-std::string Spells::getScriptBaseName() const { return "spells"; }
-
 Event_ptr Spells::getEvent(const std::string& nodeName)
 {
 	if (caseInsensitiveEqual(nodeName, "rune")) {
@@ -791,8 +789,6 @@ uint32_t Spell::getManaCost(const Player* player) const
 	return 0;
 }
 
-std::string InstantSpell::getScriptEventName() const { return "onCastSpell"; }
-
 bool InstantSpell::configureEvent(const pugi::xml_node& node)
 {
 	if (!Spell::configureSpell(node)) {
@@ -1062,8 +1058,6 @@ bool InstantSpell::canCast(const Player* player) const
 
 	return false;
 }
-
-std::string RuneSpell::getScriptEventName() const { return "onCastSpell"; }
 
 bool RuneSpell::configureEvent(const pugi::xml_node& node)
 {

--- a/src/spells.h
+++ b/src/spells.h
@@ -40,7 +40,7 @@ public:
 	TalkActionResult_t playerSaySpell(Player* player, std::string& words);
 
 	static Position getCasterPosition(Creature* creature, Direction dir);
-	std::string getScriptBaseName() const override;
+	std::string_view getScriptBaseName() const override { return "spells"; }
 
 	const std::map<std::string, InstantSpell>& getInstantSpells() const { return instants; };
 
@@ -91,7 +91,7 @@ public:
 	Combat_ptr getCombat() { return combat; }
 
 private:
-	std::string getScriptEventName() const override { return "onCastSpell"; }
+	std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
 	Combat_ptr combat;
 
@@ -249,7 +249,7 @@ public:
 	bool canThrowSpell(const Creature* creature, const Creature* target) const;
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
 	bool internalCastSpell(Creature* creature, const LuaVariant& var);
 
@@ -296,7 +296,7 @@ public:
 	}
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
 	bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -134,7 +134,7 @@ public:
 	void setLearnable(bool l) { learnable = l; }
 
 	const auto& getVocationSpellMap() const { return vocationSpellMap; }
-	void addVocationSpellMap(const std::string& vocationName, bool showInDescription)
+	void addVocationSpellMap(std::string_view vocationName, bool showInDescription)
 	{
 		int32_t vocationId = g_vocations.getVocationId(vocationName);
 		if (vocationId != -1) {

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -26,8 +26,6 @@ void TalkActions::clear(bool fromLua)
 
 LuaScriptInterface& TalkActions::getScriptInterface() { return scriptInterface; }
 
-std::string TalkActions::getScriptBaseName() const { return "talkactions"; }
-
 Event_ptr TalkActions::getEvent(const std::string& nodeName)
 {
 	if (!caseInsensitiveEqual(nodeName, "talkaction")) {
@@ -136,8 +134,6 @@ bool TalkAction::configureEvent(const pugi::xml_node& node)
 	}
 	return true;
 }
-
-std::string TalkAction::getScriptEventName() const { return "onSay"; }
 
 bool TalkAction::executeSay(Player* player, const std::string& words, const std::string& param, SpeakClasses type) const
 {

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -47,7 +47,7 @@ public:
 	void setNeedAccess(bool b) { needAccess = b; }
 
 private:
-	std::string getScriptEventName() const override;
+	std::string_view getScriptEventName() const override { return "onSay"; }
 
 	std::string words;
 	std::vector<std::string> wordsMap;
@@ -73,7 +73,7 @@ public:
 
 private:
 	LuaScriptInterface& getScriptInterface() override;
-	std::string getScriptBaseName() const override;
+	std::string_view getScriptBaseName() const override { return "talkactions"; }
 	Event_ptr getEvent(const std::string& nodeName) override;
 	bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
 

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -27,10 +27,10 @@ public:
 
 	const std::string& getWords() const { return words; }
 	const std::vector<std::string>& getWordsMap() const { return wordsMap; }
-	void setWords(std::string word)
+	void setWords(std::string_view word)
 	{
 		words = word;
-		wordsMap.push_back(word);
+		wordsMap.emplace_back(word);
 	}
 	std::string getSeparator() const { return separator; }
 	void setSeparator(std::string sep) { separator = sep; }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -121,7 +121,7 @@ static void processSHA1MessageBlock(const uint8_t* messageBlock, uint32_t* H)
 	H[4] += E;
 }
 
-std::string transformToSHA1(const std::string& input)
+std::string transformToSHA1(std::string_view input)
 {
 	uint32_t H[] = {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
 
@@ -240,12 +240,13 @@ bool caseInsensitiveStartsWith(std::string_view str, std::string_view prefix)
 	                                                 [](char a, char b) { return tolower(a) == tolower(b); });
 }
 
-StringVector explodeString(const std::string& inString, const std::string& separator, int32_t limit /* = -1*/)
+std::vector<std::string_view> explodeString(std::string_view inString, const std::string& separator,
+                                            int32_t limit /* = -1*/)
 {
-	StringVector returnVector;
-	std::string::size_type start = 0, end = 0;
+	std::vector<std::string_view> returnVector;
+	std::string_view::size_type start = 0, end = 0;
 
-	while (--limit != -1 && (end = inString.find(separator, start)) != std::string::npos) {
+	while (--limit != -1 && (end = inString.find(separator, start)) != std::string_view::npos) {
 		returnVector.push_back(inString.substr(start, end - start));
 		start = end + separator.size();
 	}
@@ -254,11 +255,11 @@ StringVector explodeString(const std::string& inString, const std::string& separ
 	return returnVector;
 }
 
-IntegerVector vectorAtoi(const StringVector& stringVector)
+IntegerVector vectorAtoi(const std::vector<std::string_view>& stringVector)
 {
 	IntegerVector returnVector;
 	for (const auto& string : stringVector) {
-		returnVector.push_back(std::stoi(string));
+		returnVector.push_back(std::stoi(string.data()));
 	}
 	return returnVector;
 }
@@ -876,7 +877,7 @@ std::string ucwords(std::string str)
 	return str;
 }
 
-bool booleanString(const std::string& str)
+bool booleanString(std::string_view str)
 {
 	if (str.empty()) {
 		return false;

--- a/src/tools.h
+++ b/src/tools.h
@@ -10,7 +10,7 @@
 
 void printXMLError(const std::string& where, const std::string& fileName, const pugi::xml_parse_result& result);
 
-std::string transformToSHA1(const std::string& input);
+std::string transformToSHA1(std::string_view input);
 std::string generateToken(const std::string& key, uint32_t ticks);
 
 // checks that str1 is equivalent to str2 ignoring letter case
@@ -22,8 +22,9 @@ bool caseInsensitiveStartsWith(std::string_view str, std::string_view prefix);
 using StringVector = std::vector<std::string>;
 using IntegerVector = std::vector<int32_t>;
 
-StringVector explodeString(const std::string& inString, const std::string& separator, int32_t limit = -1);
-IntegerVector vectorAtoi(const StringVector& stringVector);
+std::vector<std::string_view> explodeString(std::string_view inString, const std::string& separator,
+                                            int32_t limit = -1);
+IntegerVector vectorAtoi(const std::vector<std::string_view>& stringVector);
 constexpr bool hasBitSet(uint32_t flag, uint32_t flags) { return (flags & flag) != 0; }
 
 std::mt19937& getRandomGenerator();
@@ -55,7 +56,7 @@ uint32_t adlerChecksum(const uint8_t* data, size_t length);
 
 std::string ucfirst(std::string str);
 std::string ucwords(std::string str);
-bool booleanString(const std::string& str);
+bool booleanString(std::string_view str);
 
 size_t combatTypeToIndex(CombatType_t combatType);
 CombatType_t indexToCombatType(size_t v);

--- a/src/town.h
+++ b/src/town.h
@@ -15,7 +15,7 @@ public:
 	const std::string& getName() const { return name; }
 
 	void setTemplePos(Position pos) { templePosition = pos; }
-	void setName(std::string_view name) { this->name = std::string(name); }
+	void setName(std::string_view name) { this->name = name; }
 	uint32_t getID() const { return id; }
 
 private:

--- a/src/town.h
+++ b/src/town.h
@@ -15,7 +15,7 @@ public:
 	const std::string& getName() const { return name; }
 
 	void setTemplePos(Position pos) { templePosition = pos; }
-	void setName(std::string name) { this->name = std::move(name); }
+	void setName(std::string_view name) { this->name = std::string(name); }
 	uint32_t getID() const { return id; }
 
 private:

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -122,11 +122,8 @@ Vocation* Vocations::getVocation(uint16_t id)
 
 int32_t Vocations::getVocationId(std::string_view name) const
 {
-	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [=](auto it) {
-		return name.size() == it.second.name.size() &&
-		       std::equal(name.begin(), name.end(), it.second.name.begin(),
-		                  [](char a, char b) { return std::tolower(a) == std::tolower(b); });
-	});
+	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(),
+	                       [=](auto it) { return caseInsensitiveEqual(name, it.second.name); });
 	return it != vocationsMap.end() ? it->first : -1;
 }
 

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -120,9 +120,9 @@ Vocation* Vocations::getVocation(uint16_t id)
 	return &it->second;
 }
 
-int32_t Vocations::getVocationId(const std::string& name) const
+int32_t Vocations::getVocationId(std::string_view name) const
 {
-	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [&name](auto it) {
+	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(), [=](auto it) {
 		return name.size() == it.second.name.size() &&
 		       std::equal(name.begin(), name.end(), it.second.name.begin(),
 		                  [](char a, char b) { return std::tolower(a) == std::tolower(b); });

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -82,7 +82,7 @@ public:
 	bool loadFromXml();
 
 	Vocation* getVocation(uint16_t id);
-	int32_t getVocationId(const std::string& name) const;
+	int32_t getVocationId(std::string_view name) const;
 	uint16_t getPromotedVocation(uint16_t vocationId) const;
 
 private:

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -48,8 +48,6 @@ void Weapons::clear(bool fromLua)
 
 LuaScriptInterface& Weapons::getScriptInterface() { return scriptInterface; }
 
-std::string Weapons::getScriptBaseName() const { return "weapons"; }
-
 void Weapons::loadDefaults()
 {
 	for (size_t i = 100, size = Item::items.size(); i < size; ++i) {
@@ -246,8 +244,6 @@ bool Weapon::configureEvent(const pugi::xml_node& node)
 }
 
 void Weapon::configureWeapon(const ItemType& it) { id = it.id; }
-
-std::string Weapon::getScriptEventName() const { return "onUseWeapon"; }
 
 int32_t Weapon::playerWeaponCheck(Player* player, Creature* target, uint8_t shootRange) const
 {

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -37,7 +37,7 @@ public:
 
 private:
 	LuaScriptInterface& getScriptInterface() override;
-	std::string getScriptBaseName() const override;
+	std::string_view getScriptBaseName() const override { return "weapons"; }
 	Event_ptr getEvent(const std::string& nodeName) override;
 	bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
 
@@ -152,7 +152,7 @@ private:
 	bool wieldUnproperly = false;
 	std::string vocationString = "";
 
-	std::string getScriptEventName() const override final;
+	std::string_view getScriptEventName() const override final { return "onUseWeapon"; }
 
 	bool executeUseWeapon(Player* player, const LuaVariant& var) const;
 	void onUsedWeapon(Player* player, Item* item, Tile* destTile) const;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Avoids some string copies by using `string_view` to wrap existing strings instead of copying to a new string instance. Most notably, avoids copying strings from database column names and query results, and avoids copying strings when reading prop streams.

Additionally, throws in a bit of code modernization by replacing output parameters with returning pairs and destructuring assignments.

**Issues addressed:**
Closes #4064 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
