### PR TITLE
Merge loops over spectators in Game::placeCreature

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -537,9 +537,6 @@ bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedP
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendCreatureAppear(creature, creature->getPosition(), magicEffect);
 		}
-	}
-
-	for (Creature* spectator : spectators) {
 		spectator->onCreatureAppear(creature, true);
 	}
 


### PR DESCRIPTION


<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Game::placeCreature method has two different loops in sequence over the
same collection.

Merge them into a single one.

I was reading part of the code for the last 2 or 3 days and saw this code chunk, so I though about opening this PR. 
This code is kinda ancient, and I'm thinking if there is a reason for these two loops to be separate? The two reasons I could think about are 1. sendCreatureAppear has a side effect that we need to call it for everyone in this case before using onCreatureAppear; or 2. It's better to sendCreatureAppear to everyone as soon as possible for some network performance reason.
Is my change valid or there is a reason to be kept like it is today?

Thanks for your time

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
