### PR TITLE
Add XML parsing bindings for Lua

### DIFF
--- a/data/scripts/lib/xml.lua
+++ b/data/scripts/lib/xml.lua
@@ -1,0 +1,18 @@
+local boolTrue = {"1", "y", "Y", "t", "T"}
+
+function tobool(str)
+    return str and table.contains(boolTrue, str[0])
+end
+
+function XMLNode.children(self)
+    local node = self:firstChild()
+    return function()
+        if not node then
+            return nil
+        end
+
+        local prevNode = node
+        node = node:nextSibling()
+        return prevNode
+    end
+end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3284,6 +3284,22 @@ void LuaScriptInterface::registerFunctions()
 
 	// exclusively for wands & distance weapons
 	registerMethod("Weapon", "shootType", LuaScriptInterface::luaWeaponShootType);
+
+	// XML
+	registerClass("XMLDocument", "", LuaScriptInterface::luaCreateXmlDocument);
+	registerMetaMethod("XMLDocument", "__gc", LuaScriptInterface::luaDeleteXmlDocument);
+	registerMethod("XMLDocument", "delete", LuaScriptInterface::luaDeleteXmlDocument);
+
+	registerMethod("XMLDocument", "child", LuaScriptInterface::luaXmlDocumentChild);
+
+	registerClass("XMLNode", "");
+	registerMetaMethod("XMLNode", "__gc", LuaScriptInterface::luaDeleteXmlNode);
+	registerMethod("XMLNode", "delete", LuaScriptInterface::luaDeleteXmlNode);
+
+	registerMethod("XMLNode", "attribute", LuaScriptInterface::luaXmlNodeAttribute);
+	registerMethod("XMLNode", "name", LuaScriptInterface::luaXmlNodeName);
+	registerMethod("XMLNode", "firstChild", LuaScriptInterface::luaXmlNodeFirstChild);
+	registerMethod("XMLNode", "nextSibling", LuaScriptInterface::luaXmlNodeNextSibling);
 }
 
 #undef registerEnum
@@ -17842,6 +17858,149 @@ int LuaScriptInterface::luaWeaponExtraElement(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+// XML
+int LuaScriptInterface::luaCreateXmlDocument(lua_State* L)
+{
+	// XMLDocument(filename)
+	std::string filename = getString(L, 2);
+	if (filename.empty()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto doc = std::make_unique<pugi::xml_document>();
+	if (auto result = doc->load_file(filename.c_str())) {
+		pushUserdata<pugi::xml_document>(L, doc.release());
+		setMetatable(L, -1, "XMLDocument");
+	} else {
+		printXMLError("Error - LuaScriptInterface::luaCreateXmlDocument", filename, result);
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaDeleteXmlDocument(lua_State* L)
+{
+	// doc:delete() or doc:__gc()
+	pugi::xml_document** document = getRawUserdata<pugi::xml_document>(L, 1);
+	if (document && *document) {
+		delete *document;
+		*document = nullptr;
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaXmlDocumentChild(lua_State* L)
+{
+	// doc:child(name)
+	pugi::xml_document* document = getUserdata<pugi::xml_document>(L, 1);
+	if (!document) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	std::string name = getString(L, 2);
+	if (name.empty()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto node = std::make_unique<pugi::xml_node>(document->child(name.c_str()));
+	pushUserdata<pugi::xml_node>(L, node.release());
+	setMetatable(L, -1, "XMLNode");
+	return 1;
+}
+
+int LuaScriptInterface::luaDeleteXmlNode(lua_State* L)
+{
+	// node:delete() or node:__gc()
+	pugi::xml_node** node = getRawUserdata<pugi::xml_node>(L, 1);
+	if (node && *node) {
+		delete *node;
+		*node = nullptr;
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaXmlNodeAttribute(lua_State* L)
+{
+	// node:attribute(name)
+	pugi::xml_node* node = getUserdata<pugi::xml_node>(L, 1);
+	if (!node) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	std::string name = getString(L, 2);
+	if (name.empty()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	pugi::xml_attribute attribute = node->attribute(name.c_str());
+	if (attribute) {
+		pushString(L, attribute.value());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaXmlNodeName(lua_State* L)
+{
+	// node:name()
+	pugi::xml_node* node = getUserdata<pugi::xml_node>(L, 1);
+	if (!node) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	pushString(L, node->name());
+	return 1;
+}
+
+int LuaScriptInterface::luaXmlNodeFirstChild(lua_State* L)
+{
+	// node:firstChild()
+	pugi::xml_node* node = getUserdata<pugi::xml_node>(L, 1);
+	if (!node) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto firstChild = node->first_child();
+	if (!firstChild) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto newNode = std::make_unique<pugi::xml_node>(std::move(firstChild));
+	pushUserdata<pugi::xml_node>(L, newNode.release());
+	setMetatable(L, -1, "XMLNode");
+	return 1;
+}
+
+int LuaScriptInterface::luaXmlNodeNextSibling(lua_State* L)
+{
+	// node:nextSibling()
+	pugi::xml_node* node = getUserdata<pugi::xml_node>(L, 1);
+	if (!node) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto nextSibling = node->next_sibling();
+	if (!nextSibling) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto newNode = std::make_unique<pugi::xml_node>(std::move(nextSibling));
+	pushUserdata<pugi::xml_node>(L, newNode.release());
+	setMetatable(L, -1, "XMLNode");
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1554,6 +1554,17 @@ private:
 	// exclusively for wands & distance weapons
 	static int luaWeaponShootType(lua_State* L);
 
+	// XML
+	static int luaCreateXmlDocument(lua_State* L);
+	static int luaDeleteXmlDocument(lua_State* L);
+	static int luaXmlDocumentChild(lua_State* L);
+
+	static int luaDeleteXmlNode(lua_State* L);
+	static int luaXmlNodeAttribute(lua_State* L);
+	static int luaXmlNodeName(lua_State* L);
+	static int luaXmlNodeFirstChild(lua_State* L);
+	static int luaXmlNodeNextSibling(lua_State* L);
+
 	//
 	std::string lastLuaError;
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Adds XML parsing functions to Lua script interface, allowing us to navigate XML files without having to have that functionality inside the engine. I have implemented the smallest subset of features that was enough to parse any of the XML files we currently use for configuration. The intent is to have a migration path from XML without dropping any functionality immediately, and still benefitting from the cleaner engine.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
