### PR TITLE
Limits to spell range to prevent invalid configurations

### DIFF
--- a/data/monster/monsters/dragon_wrath.xml
+++ b/data/monster/monsters/dragon_wrath.xml
@@ -30,7 +30,7 @@
 			<attribute key="shootEffect" value="death" />
 			<attribute key="areaEffect" value="smallclouds" />
 		</attack>
-		<attack name="speed" interval="2000" chance="20" range="9" target="1" speedchange="-800" duration="20000">
+		<attack name="speed" interval="2000" chance="20" target="1" speedchange="-800" duration="20000">
 			<attribute key="areaEffect" value="smallclouds" />
 		</attack>
 		<attack name="lifedrain" interval="2000" chance="20" range="7" target="1" min="-90" max="-250">

--- a/data/monster/monsters/drasilla.xml
+++ b/data/monster/monsters/drasilla.xml
@@ -20,7 +20,7 @@
 		<attack name="fire" interval="6000" chance="60" min="-100" max="-180" length="8" spread="3">
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
-		<attack name="fire" interval="3000" range="10" radius="5" target="1" chance="50" min="-70" max="-115">
+		<attack name="fire" interval="3000" radius="5" target="1" chance="50" min="-70" max="-115">
 			<attribute key="areaEffect" value="firearea" />
 		</attack>
 	</attacks>

--- a/data/monster/monsters/fallen_mooh'tah_master_ghar.xml
+++ b/data/monster/monsters/fallen_mooh'tah_master_ghar.xml
@@ -27,7 +27,7 @@
 			<attribute key="shootEffect" value="death" />
 			<attribute key="areaEffect" value="mortarea" />
 		</attack>
-		<attack name="poisoncondition" interval="4500" chance="40" min="-10" max="-200" range="10">
+		<attack name="poisoncondition" interval="4500" chance="40" min="-10" max="-200">
 			<attribute key="shootEffect" value="poison" />
 		</attack>
 		<attack name="earth" interval="5000" chance="30" length="8" spread="3" min="-60" max="-300">

--- a/data/monster/monsters/ghazbaran.xml
+++ b/data/monster/monsters/ghazbaran.xml
@@ -29,7 +29,7 @@
 		<attack name="energy" interval="4000" chance="30" length="8" spread="0" min="-100" max="-800">
 			<attribute key="areaEffect" value="mortarea" />
 		</attack>
-		<attack name="physical" interval="3000" chance="20" range="14" radius="5" target="0" min="-200" max="-480">
+		<attack name="physical" interval="3000" chance="20" radius="5" target="0" min="-200" max="-480">
 			<attribute key="areaEffect" value="poff" />
 		</attack>
 		<attack name="physical" interval="4000" chance="15" range="7" radius="13" target="0" min="-100" max="-650">

--- a/data/monster/monsters/pythius_the_rotten.xml
+++ b/data/monster/monsters/pythius_the_rotten.xml
@@ -38,7 +38,7 @@
 		<attack name="death" interval="2000" chance="18" length="7" spread="0" min="-165" max="-200">
 			<attribute key="areaEffect" value="redspark" />
 		</attack>
-		<attack name="manadrain" interval="2500" chance="22" range="8" min="-85" max="-110">
+		<attack name="manadrain" interval="2500" chance="22" min="-85" max="-110">
 			<attribute key="shootEffect" value="ice" />
 		</attack>
 		<attack name="drowncondition" interval="1000" chance="45" length="8" spread="3">

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -97,7 +97,7 @@ const std::string& Monster::getNameDescription() const
 
 bool Monster::canSee(const Position& pos) const
 {
-	return Creature::canSee(getPosition(), pos, Map::maxClientViewportX + 1, Map::maxClientViewportX + 1);
+	return Creature::canSee(getPosition(), pos, Map::maxClientViewportX + 1, Map::maxClientViewportY + 1);
 }
 
 bool Monster::canWalkOnFieldType(CombatType_t combatType) const
@@ -846,7 +846,7 @@ bool Monster::canUseAttack(const Position& pos, const Creature* target) const
 		uint32_t distance =
 		    std::max<uint32_t>(Position::getDistanceX(pos, targetPos), Position::getDistanceY(pos, targetPos));
 		for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
-			if (spellBlock.range != 0 && distance <= spellBlock.range) {
+			if (distance <= spellBlock.range) {
 				return g_game.isSightClear(pos, targetPos, true);
 			}
 		}
@@ -876,8 +876,7 @@ bool Monster::canUseSpell(const Position& pos, const Position& targetPos, const 
 		}
 	}
 
-	if (sb.range != 0 &&
-	    std::max<uint32_t>(Position::getDistanceX(pos, targetPos), Position::getDistanceY(pos, targetPos)) > sb.range) {
+	if (std::max<uint32_t>(Position::getDistanceX(pos, targetPos), Position::getDistanceY(pos, targetPos)) > sb.range) {
 		inRange = false;
 		return false;
 	}

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -124,10 +124,13 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 		          << " - Missing chance value on non-melee spell: " << name << std::endl;
 	}
 
+	sb.range = std::max<uint32_t>(Map::maxClientViewportX + 1, Map::maxClientViewportY + 1);
 	if ((attr = node.attribute("range"))) {
 		uint32_t range = pugi::cast<uint32_t>(attr.value());
-		if (range > (Map::maxViewportX * 2)) {
-			range = Map::maxViewportX * 2;
+		if (range > std::max<uint32_t>(Map::maxClientViewportX + 1, Map::maxClientViewportY + 1)) {
+			range = std::max<uint32_t>(Map::maxClientViewportX + 1, Map::maxClientViewportY + 1);
+			std::cout << "[Warning - Monsters::deserializeSpell] - " << description
+			          << " - spell range exceeds limit of " << range << std::endl;
 		}
 		sb.range = range;
 	}
@@ -560,8 +563,10 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 		sb.chance = spell->chance;
 	}
 
-	if (spell->range > (Map::maxViewportX * 2)) {
-		spell->range = Map::maxViewportX * 2;
+	if (spell->range > std::max<uint8_t>(Map::maxClientViewportX + 1, Map::maxClientViewportY + 1)) {
+		spell->range = std::max<uint8_t>(Map::maxClientViewportX + 1, Map::maxClientViewportY + 1);
+		std::cout << "[Warning - Monsters::deserializeSpell] - " << description << " - spell range exceeds limit of "
+		          << spell->range << std::endl;
 	}
 	sb.range = spell->range;
 

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -6,6 +6,7 @@
 
 #include "const.h"
 #include "enums.h"
+#include "map.h"
 
 class ConditionDamage;
 class LuaScriptInterface;
@@ -188,7 +189,7 @@ public:
 	std::string scriptName = "";
 
 	uint8_t chance = 100;
-	uint8_t range = 0;
+	uint8_t range = std::max(Map::maxClientViewportX + 1, Map::maxClientViewportY + 1);
 	uint8_t drunkenness = 0;
 
 	uint16_t interval = 2000;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #4161

- Fix monster canSee Range
- Limit spell range to ViewPort
- Add warning to spells which exceed range
- Allow spells to execute with range of 0
- Fixes to attacks with spell range >= 8

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
