### PR TITLE
add onUseItem event

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -35,6 +35,7 @@
 	<event class="Player" method="onGainSkillTries" enabled="1" />
 	<event class="Player" method="onWrapItem" enabled="1" />
 	<event class="Player" method="onInventoryUpdate" enabled="1" />
+	<event class="Player" method="onUseItem" enabled="0" />
 
 	<!-- Monster methods -->
 	<event class="Monster" method="onDropLoot" enabled="1" />

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -315,3 +315,7 @@ function Player:onInventoryUpdate(item, slot, equip)
 		EventCallback.onInventoryUpdate(self, item, slot, equip)
 	end
 end
+
+function Player:onUseItem(item)
+	return true
+end

--- a/src/events.h
+++ b/src/events.h
@@ -56,6 +56,7 @@ class Events
 		int32_t playerOnGainSkillTries = -1;
 		int32_t playerOnWrapItem = -1;
 		int32_t playerOnInventoryUpdate = -1;
+		int32_t playerOnUseItem = -1;
 
 		// Monster
 		int32_t monsterOnDropLoot = -1;
@@ -109,6 +110,7 @@ public:
 	void eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_t& tries);
 	void eventPlayerOnWrapItem(Player* player, Item* item);
 	void eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
+	bool eventPlayerOnUseItem(Player* player, Item* item);
 
 	// Monster
 	void eventMonsterOnDropLoot(Monster* monster, Container* corpse);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2164,6 +2164,10 @@ void Game::playerUseItemEx(uint32_t playerId, const Position& fromPos, uint8_t f
 	player->resetIdleTime();
 	player->setNextActionTask(nullptr);
 
+	if (!g_events->eventPlayerOnUseItem(player, item)) {
+		return;
+	}
+
 	g_actions->useItemEx(player, fromPos, toPos, toStackPos, item, isHotkey);
 }
 
@@ -2222,6 +2226,10 @@ void Game::playerUseItem(uint32_t playerId, const Position& pos, uint8_t stackPo
 
 	player->resetIdleTime();
 	player->setNextActionTask(nullptr);
+
+	if (!g_events->eventPlayerOnUseItem(player, item)) {
+		return;
+	}
 
 	g_actions->useItem(player, pos, index, item, isHotkey);
 }
@@ -2322,6 +2330,10 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position& fromPos, uin
 
 	player->resetIdleTime();
 	player->setNextActionTask(nullptr);
+
+	if (!g_events->eventPlayerOnUseItem(player, item)) {
+		return;
+	}
 
 	g_actions->useItemEx(player, fromPos, creature->getPosition(), creature->getParent()->getThingIndex(creature), item,
 	                     isHotkey, creature);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add `onUseItem` event functionality. It allows to obtain item usage statistics or to block an item from being used under certain conditions.

```lua
function Player:onUseItem(item)
    if player:hasFlag(FLAG_CANT_USE_ITEMS) then
        return false
    end
    print("Player " .. self:getName() .. " used item with ID " .. item:getId())
    return true
end
```

**Issues addressed:**  #4076 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
