### PR TITLE
Fix to Party:onLeave()

### DIFF
--- a/src/party.cpp
+++ b/src/party.cpp
@@ -65,11 +65,10 @@ bool Party::leaveParty(Player* player, bool forceRemove /* = false */)
 	if (player->getParty() != this && leader != player) {
 		return false;
 	}
-
-	if (forceRemove) {
-		g_events->eventPartyOnLeave(this, player);
-	} else if (!g_events->eventPartyOnLeave(this, player)) {
-		return false;
+	
+	bool canRemove = g_events->eventPartyOnLeave(this, player);
+	if (!forceRemove && !canRemove) {
+	    return false;
 	}
 
 	bool missingLeader = false;

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -56,7 +56,7 @@ void Party::disband()
 	delete this;
 }
 
-bool Party::leaveParty(Player* player)
+bool Party::leaveParty(Player* player, bool forceRemove /* = false */)
 {
 	if (!player) {
 		return false;
@@ -66,7 +66,9 @@ bool Party::leaveParty(Player* player)
 		return false;
 	}
 
-	if (!g_events->eventPartyOnLeave(this, player)) {
+	if (forceRemove) {
+		g_events->eventPartyOnLeave(this, player);
+	} else if (!g_events->eventPartyOnLeave(this, player)) {
 		return false;
 	}
 

--- a/src/party.h
+++ b/src/party.h
@@ -39,7 +39,7 @@ public:
 	bool joinParty(Player& player);
 	void revokeInvitation(Player& player);
 	bool passPartyLeadership(Player* player);
-	bool leaveParty(Player* player);
+	bool leaveParty(Player* player, bool forceRemove = false);
 
 	bool removeInvite(Player& player, bool removeFromPlayer = true);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1317,7 +1317,7 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 		clearPartyInvitations();
 
 		if (party) {
-			party->leaveParty(this);
+			party->leaveParty(this, true);
 		}
 
 		g_chat->removeUserFromAllChannels(*this);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

If Party:onLeave() is used and returns false whenever player is dying or logged out (removed) the player is not properly removed from the party, therefore making possible to cause server crash when the party gets updated.
This commit fix the issue by passing a bool forceRemove to Party::leaveParty when its called by Player::onRemoveCreature to ignore the return false in Party::leaveParty



<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
