### PR TITLE
Fix: not being able to login with latest client due to incorrect max client version

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -9,7 +9,7 @@ static constexpr auto STATUS_SERVER_VERSION = "1.5";
 static constexpr auto STATUS_SERVER_DEVELOPERS = "The Forgotten Server Team";
 
 static constexpr auto CLIENT_VERSION_MIN = 1280;
-static constexpr auto CLIENT_VERSION_MAX = 1287;
+static constexpr auto CLIENT_VERSION_MAX = 1288;
 static constexpr auto CLIENT_VERSION_STR = "12.87";
 
 static constexpr auto AUTHENTICATOR_DIGITS = 6U;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Players were unable to connect with client version **12.87.12128** because despite the "visual" version being 12.87, it was is internally **12.88**, so I've changed it and tested this time. Now its possible to login and play with any client from 12.80 to 12.87 version range.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
not being able to login with latest client (12.87.12128 as of this date)

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
