### PR TITLE
Avoid user timing attack

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -97,6 +97,8 @@ bool IOLoginData::loginserverAuthentication(const std::string& name, const std::
 uint32_t IOLoginData::gameworldAuthentication(const std::string& accountName, const std::string& password,
                                               std::string& characterName, std::string& token, uint32_t tokenTime)
 {
+	std::string passwordHash = transformToSHA1(password);
+
 	Database& db = Database::getInstance();
 	DBResult_ptr result = db.storeQuery(
 	    fmt::format("SELECT `id`, `password`, `secret` FROM `accounts` WHERE `name` = {:s} OR `email` = {:s}",
@@ -122,7 +124,7 @@ uint32_t IOLoginData::gameworldAuthentication(const std::string& accountName, co
 		}
 	}
 
-	if (transformToSHA1(password) != result->getString("password")) {
+	if (passwordHash != result->getString("password")) {
 		return 0;
 	}
 

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -63,6 +63,8 @@ std::string decodeSecret(const std::string& secret)
 
 bool IOLoginData::loginserverAuthentication(const std::string& name, const std::string& password, Account& account)
 {
+	std::string passwordHash = transformToSHA1(password);
+
 	Database& db = Database::getInstance();
 
 	DBResult_ptr result = db.storeQuery(fmt::format(
@@ -72,7 +74,7 @@ bool IOLoginData::loginserverAuthentication(const std::string& name, const std::
 		return false;
 	}
 
-	if (transformToSHA1(password) != result->getString("password")) {
+	if (passwordHash != result->getString("password")) {
 		return false;
 	}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Optional - Changes Proposes
- SHA1 it's as fast as rocket, which makes this PR optional.

### For curious ?
- Auth response time varies depending on query and hash-gen.
- If you consult the bank, returning without not gen the password-hash, the time is different if the user exists.
Ex: if user not exists: return select time, if exists: return select time + password hash gen. With this, you can see if user exists in database.

### Future is Argon2 ?
- If the password hash is changed, test verification response time.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
