### PR TITLE
Fixed rare crash on clean map

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -511,6 +511,7 @@ public:
 	std::forward_list<Item*> toDecayItems;
 
 	std::unordered_set<Tile*> getTilesToClean() const { return tilesToClean; }
+	bool isTileInCleanList(Tile* tile) { return tilesToClean.find(tile) != tilesToClean.end(); }
 	void addTileToClean(Tile* tile) { tilesToClean.emplace(tile); }
 	void removeTileToClean(Tile* tile) { tilesToClean.erase(tile); }
 	void clearTilesToClean() { tilesToClean.clear(); }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -5223,6 +5223,10 @@ int LuaScriptInterface::luaTileRemove(lua_State* L)
 		return 1;
 	}
 
+	if (g_game.isTileInCleanList(tile)) {
+		g_game.removeTileToClean(tile);
+	}
+
 	g_game.map.removeTile(tile->getPosition());
 	pushBoolean(L, true);
 	return 1;


### PR DESCRIPTION
Co-Authored-By: Mario <3682541+EvilHero90@users.noreply.github.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Issue addressed
> it's related to map cleaning and calling the lua method `tile:remove()` before a clean is performed and that tile is on the clean list
<!-- Describe the changes that this pull request makes. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
