### PR TITLE
Remove house from database if not exist on the map

### DIFF
--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -265,11 +265,14 @@ bool IOMapSerialize::loadHouseInfo()
 	}
 
 	do {
-		House* house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("id"));
+		uint32_t houseId = result->getNumber<uint32_t>("id");
+		House* house = g_game.map.houses.getHouse(houseId);
 		if (house) {
 			house->setOwner(result->getNumber<uint32_t>("owner"), false);
 			house->setPaidUntil(result->getNumber<time_t>("paid"));
 			house->setPayRentWarnings(result->getNumber<uint32_t>("warnings"));
+		} else {
+			db.executeQuery(fmt::format("DELETE FROM `houses` WHERE `id` = {:d}", houseId));
 		}
 	} while (result->next());
 


### PR DESCRIPTION
### Pull Request Prelude

When house ID will change in XML (or house will be deleted at all during map edition) it is ignored during map loads, but remain in database. I don't see a reason why, so I'm proposing following change. Only one `DELETE` query is required, as `tile_store` and `house_lists` tables are connected if parent would be deleted.

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
