### PR TITLE
A* Pathfinding fixes

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1644,7 +1644,7 @@ bool Creature::isInvisible() const
 
 bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const FindPathParams& fpp) const
 {
-	return g_game.map.getPathMatching(*this, dirList, FrozenPathingConditionCall(targetPos), fpp);
+	return g_game.map.getPathMatching(*this, targetPos, dirList, FrozenPathingConditionCall(targetPos), fpp);
 }
 
 bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirList, int32_t minTargetDist,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -505,16 +505,16 @@ bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= fal
 		return false;
 	}
 
-	if (isPathFinding) {
+	if (isPathfinding) {
 		const Creature* creature = tile->getTopCreature();
 		if (creature && tile->getTopVisibleCreature(creature) || tile->hasProperty(CONST_PROP_BLOCKPATH) ||
-                    tile->hasProperty(CONST_PROP_BLOCKSOLID)) {
+		    tile->hasProperty(CONST_PROP_BLOCKSOLID)) {
 			return false;
 		}
 	}
 
 	return !tile->hasProperty(CONST_PROP_BLOCKPROJECTILE);
-}
+};
 
 namespace {
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -550,7 +550,7 @@ bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t
 
 } // namespace
 
-bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
+bool Map::checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
 					 bool isPathfinding /*= false*/)
 {
 	if (x0 == x1 && y0 == y1) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -493,7 +493,8 @@ bool Map::canThrowObjectTo(const Position& fromPos, const Position& toPos, bool 
 	return !checkLineOfSight || isSightClear(fromPos, toPos, sameFloor);
 }
 
-bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= false*/, bool isPathfinding /*= false*/) const
+bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= false*/,
+					  bool isPathfinding /*= false*/) const
 {
 	const Tile* tile = getTile(x, y, z);
 	if (!tile) {
@@ -549,7 +550,8 @@ bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t
 
 } // namespace
 
-bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding /*= false*/) const
+bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
+					 bool isPathfinding /*= false*/)
 {
 	if (x0 == x1 && y0 == y1) {
 		return true;
@@ -782,7 +784,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			// The cost to walk to this neighbor
 			const int_fast32_t walkCost = AStarNodes::getMapWalkCost(n, pos);
 			const int_fast32_t speedCost = AStarNodes::getTileWalkCost(creature, tile);
-			const int_fast32_t distEnd = (Position::getDistanceX(pos, targetPos) + Position::getDistanceY(pos, targetPos));
+			const int_fast32_t distEnd = Position::getDistanceX(pos, targetPos) + Position::getDistanceY(pos, targetPos);
 			const int_fast32_t f = distEnd + (walkCost + speedCost);
 
 			if (neighborNode) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -750,7 +750,9 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			}
 
 			if (fpp.keepDistance && !pathCondition.isInRange(startPos, pos, fpp)) {
-				continue;
+				if (distX < fpp.maxTargetDist && distY < fpp.maxTargetDist) {
+					continue;
+				}
 			}
 
 			// Sight is clear. We shouldn't have to move backwards.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -806,14 +806,12 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 					// The node on the closed/open list is cheaper than this one
 					continue;
 				}
-
-				// g_game.addMagicEffect(pos, CONST_ME_TELEPORT);
+				
 				neighborNode->f = newf;
 				neighborNode->parent = n;
 				nodes.openNode(neighborNode);
 			} else {
 				// Does not exist in the open/closed list, create a new node
-				g_game.addMagicEffect(pos, CONST_ME_POFF);
 				neighborNode = nodes.createOpenNode(n, pos.x, pos.y, newf);
 				if (!neighborNode) {
 					if (found) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -667,8 +667,14 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	const Position startPos = pos;
 
 	// Don't update path if the target is too far away
-	if (Position::getDistanceX(startPos, targetPos) > fpp.maxSearchDist ||
-	    Position::getDistanceY(startPos, targetPos) > fpp.maxSearchDist) {
+	const int_fast32_t distX = Position::getDistanceX(startPos, targetPos);
+	const int_fast32_t distY = Position::getDistanceY(startPos, targetPos);
+	if (distX > fpp.maxSearchDist || distY > fpp.maxSearchDist) {
+		return false;
+	}
+
+	// We are at the target and don't need to walk away. No need to update path.
+	if (!fpp.keepDistance && fpp.minTargetDist <= 1 && distX < 2 && distY < 2) {
 		return false;
 	}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -754,7 +754,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			}
 
 			// Sight is clear. We shouldn't have to move backwards.
-			if (sightClear) {
+			if (sightClear && !fpp.keepDistance) {
 				if (startPos.x == targetPos.x) {
 					// Don't check nodes if start and end pos X are the same and node X is different.
 					if (pos.x != targetPos.x) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -514,7 +514,7 @@ bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= fal
 
 namespace {
 
-bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding /*= false*/)
+bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding)
 {
 	float dx = x1 - x0;
 	float slope = (dx == 0) ? 1 : (y1 - y0) / dx;
@@ -531,7 +531,7 @@ bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t 
 	return true;
 }
 
-bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding /*= false*/)
+bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding)
 {
 	float dx = x1 - x0;
 	float slope = (dx == 0) ? 1 : (y1 - y0) / dx;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -807,7 +807,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 					// The node on the closed/open list is cheaper than this one
 					continue;
 				}
-				
+
 				neighborNode->f = newf;
 				neighborNode->parent = n;
 				nodes.openNode(neighborNode);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -550,8 +550,8 @@ bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t
 
 } // namespace
 
-bool Map::checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
-					 bool isPathfinding /*= false*/)
+bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
+					 bool isPathfinding /*= false*/) const
 {
 	if (x0 == x1 && y0 == y1) {
 		return true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -586,7 +586,8 @@ bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uin
 	return checkSlightLine(x0, y0, x1, y1, z, isPathFinding);
 }
 
-bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor /*= false*/, bool pathFinding /*= false*/) const
+bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor /*= false*/,
+                       bool pathFinding = false) const
 {
 	// target is on the same floor
 	if (fromPos.z == toPos.z) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -662,6 +662,11 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	Position endPos;
 	const Position startPos = pos;
 
+	// Don't update path if the target is too far away
+	if (Position::getDistanceX(startPos, targetPos) > fpp.maxSearchDist || Position::getDistanceY(startPos, targetPos) > fpp.maxSearchDist) {
+		return false;
+	}
+
 	int32_t bestMatch = 0;
 
 	AStarNodes nodes(pos.x, pos.y);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -514,7 +514,7 @@ bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= fal
 	}
 
 	return !tile->hasProperty(CONST_PROP_BLOCKPROJECTILE);
-};
+}
 
 namespace {
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -587,7 +587,7 @@ bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uin
 }
 
 bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor /*= false*/,
-                       bool pathFinding = false) const
+                       bool pathFinding /*= false*/) const
 {
 	// target is on the same floor
 	if (fromPos.z == toPos.z) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -791,7 +791,8 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			const int_fast32_t walkCost = AStarNodes::getMapWalkCost(n, pos);
 			const int_fast32_t speedCost = AStarNodes::getTileWalkCost(creature, tile);
 			const int_fast32_t distEnd = Position::getDistanceX(pos, targetPos) + Position::getDistanceY(pos, targetPos);
-			const int_fast32_t f = distEnd + (walkCost + speedCost);
+			const int_fast32_t distStart = Position::getDistanceX(pos, startPos) + Position::getDistanceY(pos, startPos);
+			const int_fast32_t f = distEnd + distStart + (walkCost + speedCost);
 
 			if (neighborNode) {
 				if (neighborNode->f <= f) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -505,8 +505,12 @@ bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= fal
 		return false;
 	}
 
-	if (isPathfinding && tile->hasProperty(CONST_PROP_BLOCKPATH) || tile->hasProperty(CONST_PROP_BLOCKSOLID)) {
-		return false;
+	if (isPathFinding) {
+		const Creature* creature = tile->getTopCreature();
+		if (creature && tile->getTopVisibleCreature(creature) || tile->hasProperty(CONST_PROP_BLOCKPATH) ||
+                    tile->hasProperty(CONST_PROP_BLOCKSOLID)) {
+			return false;
+		}
 	}
 
 	return !tile->hasProperty(CONST_PROP_BLOCKPROJECTILE);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -494,7 +494,7 @@ bool Map::canThrowObjectTo(const Position& fromPos, const Position& toPos, bool 
 }
 
 bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= false*/,
-					  bool isPathfinding /*= false*/) const
+                      bool isPathfinding /*= false*/) const
 {
 	const Tile* tile = getTile(x, y, z);
 	if (!tile) {
@@ -551,7 +551,7 @@ bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t
 } // namespace
 
 bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
-					 bool isPathfinding /*= false*/) const
+                         bool isPathfinding /*= false*/) const
 {
 	if (x0 == x1 && y0 == y1) {
 		return true;
@@ -663,7 +663,8 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	const Position startPos = pos;
 
 	// Don't update path if the target is too far away
-	if (Position::getDistanceX(startPos, targetPos) > fpp.maxSearchDist || Position::getDistanceY(startPos, targetPos) > fpp.maxSearchDist) {
+	if (Position::getDistanceX(startPos, targetPos) > fpp.maxSearchDist ||
+	    Position::getDistanceY(startPos, targetPos) > fpp.maxSearchDist) {
 		return false;
 	}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -797,23 +797,23 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			}
 
 			// The cost to walk to this neighbor
-			const int_fast32_t G = AStarNodes::getMapWalkCost(n, pos);
-			const int_fast32_t E = AStarNodes::getTileWalkCost(creature, tile);
-			const int_fast32_t H = (Position::getDistanceX(pos, targetPos) + Position::getDistanceY(pos, targetPos));
-			const int_fast32_t newf = H + (G + E);
+			const int_fast32_t walkCost = AStarNodes::getMapWalkCost(n, pos);
+			const int_fast32_t speedCost = AStarNodes::getTileWalkCost(creature, tile);
+			const int_fast32_t distEnd = (Position::getDistanceX(pos, targetPos) + Position::getDistanceY(pos, targetPos));
+			const int_fast32_t f = distEnd + (walkCost + speedCost);
 
 			if (neighborNode) {
-				if (neighborNode->f <= newf) {
+				if (neighborNode->f <= f) {
 					// The node on the closed/open list is cheaper than this one
 					continue;
 				}
 
-				neighborNode->f = newf;
+				neighborNode->f = f;
 				neighborNode->parent = n;
 				nodes.openNode(neighborNode);
 			} else {
 				// Does not exist in the open/closed list, create a new node
-				neighborNode = nodes.createOpenNode(n, pos.x, pos.y, newf);
+				neighborNode = nodes.createOpenNode(n, pos.x, pos.y, f);
 				if (!neighborNode) {
 					if (found) {
 						break;

--- a/src/map.h
+++ b/src/map.h
@@ -27,18 +27,11 @@ static constexpr int32_t MAP_NORMALWALKCOST = 10;
 static constexpr int32_t MAP_DIAGONALWALKCOST = 25;
 
 static int_fast32_t dirNeighbors[8][5][2] = {
-		{{-1, 0}, {0, 1}, {1, 0}, {1, 1}, {-1, 1}},
-		{{-1, 0}, {0, 1}, {0, -1}, {-1, -1}, {-1, 1}},
-		{{-1, 0}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}},
-		{{0, 1}, {1, 0}, {0, -1}, {1, -1}, {1, 1}},
-		{{1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}},
-		{{-1, 0}, {0, -1}, {-1, -1}, {1, -1}, {-1, 1}},
-		{{0, 1}, {1, 0}, {1, -1}, {1, 1}, {-1, 1}},
-		{{-1, 0}, {0, 1}, {-1, -1}, {1, 1}, {-1, 1}}
-};
-static int_fast32_t allNeighbors[8][2] = {
-	{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}
-};
+    {{-1, 0}, {0, 1}, {1, 0}, {1, 1}, {-1, 1}},    {{-1, 0}, {0, 1}, {0, -1}, {-1, -1}, {-1, 1}},
+    {{-1, 0}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}}, {{0, 1}, {1, 0}, {0, -1}, {1, -1}, {1, 1}},
+    {{1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}},  {{-1, 0}, {0, -1}, {-1, -1}, {1, -1}, {-1, 1}},
+    {{0, 1}, {1, 0}, {1, -1}, {1, 1}, {-1, 1}},    {{-1, 0}, {0, 1}, {-1, -1}, {1, 1}, {-1, 1}}};
+static int_fast32_t allNeighbors[8][2] = {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}};
 
 class AStarNodes
 {
@@ -250,7 +243,8 @@ public:
 	 *Destination point \param sameFloor checks if the destination is on same
 	 *floor \returns The result if there is no obstacles
 	 */
-	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false, bool pathFinding = false) const;
+	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false,
+	                  bool pathFinding = false) const;
 	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathFinding = false) const;
 
 	const Tile* canWalkTo(const Creature& creature, const Position& pos) const;

--- a/src/map.h
+++ b/src/map.h
@@ -234,7 +234,7 @@ public:
 	 *	\param blockFloor counts the ground tile as an obstacle
 	 *	\returns The result if there is an obstacle or not
 	 */
-	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false, bool pathFinding = false) const;
+	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false, bool isPathfinding = false) const;
 
 	/**
 	 * Checks if path is clear from fromPos to toPos
@@ -244,8 +244,8 @@ public:
 	 *floor \returns The result if there is no obstacles
 	 */
 	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false,
-	                  bool pathFinding = false) const;
-	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathFinding = false) const;
+	                  bool isPathfinding = false) const;
+	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding = false) const;
 
 	const Tile* canWalkTo(const Creature& creature, const Position& pos) const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -245,7 +245,8 @@ public:
 	 */
 	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false,
 	                  bool isPathfinding = false) const;
-	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool isPathfinding = false) const;
+	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
+						bool isPathfinding = false) const;
 
 	const Tile* canWalkTo(const Creature& creature, const Position& pos) const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -26,6 +26,20 @@ static constexpr int32_t MAX_NODES = 512;
 static constexpr int32_t MAP_NORMALWALKCOST = 10;
 static constexpr int32_t MAP_DIAGONALWALKCOST = 25;
 
+static int_fast32_t dirNeighbors[8][5][2] = {
+		{{-1, 0}, {0, 1}, {1, 0}, {1, 1}, {-1, 1}},
+		{{-1, 0}, {0, 1}, {0, -1}, {-1, -1}, {-1, 1}},
+		{{-1, 0}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}},
+		{{0, 1}, {1, 0}, {0, -1}, {1, -1}, {1, 1}},
+		{{1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}},
+		{{-1, 0}, {0, -1}, {-1, -1}, {1, -1}, {-1, 1}},
+		{{0, 1}, {1, 0}, {1, -1}, {1, 1}, {-1, 1}},
+		{{-1, 0}, {0, 1}, {-1, -1}, {1, 1}, {-1, 1}}
+};
+static int_fast32_t allNeighbors[8][2] = {
+	{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}
+};
+
 class AStarNodes
 {
 public:
@@ -227,7 +241,7 @@ public:
 	 *	\param blockFloor counts the ground tile as an obstacle
 	 *	\returns The result if there is an obstacle or not
 	 */
-	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false) const;
+	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false, bool pathFinding = false) const;
 
 	/**
 	 * Checks if path is clear from fromPos to toPos
@@ -236,12 +250,12 @@ public:
 	 *Destination point \param sameFloor checks if the destination is on same
 	 *floor \returns The result if there is no obstacles
 	 */
-	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false) const;
-	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z) const;
+	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false, bool pathFinding = false) const;
+	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathFinding = false) const;
 
 	const Tile* canWalkTo(const Creature& creature, const Position& pos) const;
 
-	bool getPathMatching(const Creature& creature, std::vector<Direction>& dirList,
+	bool getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,
 	                     const FrozenPathingConditionCall& pathCondition, const FindPathParams& fpp) const;
 
 	std::map<std::string, Position> waypoints;

--- a/src/map.h
+++ b/src/map.h
@@ -246,7 +246,7 @@ public:
 	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false,
 	                  bool isPathfinding = false) const;
 	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
-						bool isPathfinding = false) const;
+	                    bool isPathfinding = false) const;
 
 	const Tile* canWalkTo(const Creature& creature, const Position& pos) const;
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2026,6 +2026,7 @@ void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp)
 	if (isSummon()) {
 		if (getMaster() == creature) {
 			fpp.maxTargetDist = 2;
+			fpp.keepDistance = true;
 			fpp.fullPathSearch = true;
 		} else if (mType->info.targetDistance <= 1) {
 			fpp.fullPathSearch = true;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
The current A* pathfinding system does not work correctly. This pull request is to fix what is missing and even includes some additional speed to the default A* algorithm.

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
1) Add targetPos to Creature::getPathTo
2) Fix the f algorithm in Map::getPathMatching
3) Add a sightline check to see if there are obstacles
4) Improve default A* Algorithm based on sightline check

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3569 -- Possibly
#2464

Video of Pathfinding
https://youtu.be/TYV4qFLHr-Q

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
