### PR TITLE
Update pathfinding call

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -218,11 +218,6 @@ void Creature::onWalk()
 		eventWalk = 0;
 		addEventWalk();
 	}
-
-	if (!hasFollowPath && !followCreature && !attackedCreature || attackedCreature != followCreature) {
-		goToFollowCreature();
-		return;
-	}
 }
 
 void Creature::onWalk(Direction& dir)

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -137,10 +137,7 @@ void Creature::onThink(uint32_t interval)
 		blockTicks = 0;
 	}
 
-	if (forceUpdatePath) {
-		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
-		forceUpdatePath = false;
-	} else {
+	if (!forceUpdatePath) {
 		forceUpdatePath = true;
 	}
 
@@ -213,7 +210,7 @@ void Creature::onWalk()
 
 	if (attackedCreature) {
 		const Position& targetPos = attackedCreature->getPosition();
-		if (followPosition != targetPos) {
+		if (followPosition != targetPos || forceUpdatePath) {
 
 			FindPathParams fpp;
 			getPathSearchParams(attackedCreature, fpp);

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -137,6 +137,13 @@ void Creature::onThink(uint32_t interval)
 		blockTicks = 0;
 	}
 
+	if (forceUpdatePath) {
+		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
+		forceUpdatePath = false;
+	} else {
+		forceUpdatePath = true;
+	}
+
 	// scripting event - onThink
 	const CreatureEventList& thinkEvents = getCreatureEvents(CREATURE_EVENT_THINK);
 	for (CreatureEvent* thinkEvent : thinkEvents) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -199,7 +199,7 @@ void Creature::onWalk()
 		addEventWalk();
 	}
 
-	if (followCreature) {
+	if (followCreature && !attackedCreature || attackedCreature != followCreature) {
 		listWalkDir.clear();
 		goToFollowCreature();
 		return;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -153,6 +153,7 @@ void Creature::onThink(uint32_t interval)
 void Creature::checkPath()
 {
 	if (followCreature && !attackedCreature && followPosition != followCreature->getPosition()) {
+		followPosition = followCreature->getPosition();
 		goToFollowCreature();
 		return;
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -216,7 +216,8 @@ void Creature::onWalk()
 			FindPathParams fpp;
 			getPathSearchParams(attackedCreature, fpp);
 			const Position& pos = getPosition();
-			if (Position::getDistanceX(pos, targetPos) > fpp.maxSearchDist || Position::getDistanceY(pos, targetPos) > fpp.maxSearchDist) {
+			if (Position::getDistanceX(pos, targetPos) > fpp.maxSearchDist ||
+	                    Position::getDistanceY(pos, targetPos) > fpp.maxSearchDist) {
 				// Attacked Creature has gone too far. Stop trying to get a path.
 				listWalkDir.clear();
 				return;
@@ -926,12 +927,13 @@ bool Creature::setAttackedCreature(Creature* creature)
 			attackedCreature = nullptr;
 			return false;
 		}
-		
+
 		// Target is too far to get a path too. We shouldn't add him as a target.
 		FindPathParams fpp;
 		getPathSearchParams(creature, fpp);
 		const Position& pos = getPosition();
-		if (Position::getDistanceX(pos, creaturePos) > fpp.maxSearchDist || Position::getDistanceY(pos, creaturePos) > fpp.maxSearchDist) {
+		if (Position::getDistanceX(pos, creaturePos) > fpp.maxSearchDist ||
+                    Position::getDistanceY(pos, creaturePos) > fpp.maxSearchDist) {
 			attackedCreature = nullptr;
 			return false;
 		}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -924,16 +924,6 @@ bool Creature::setAttackedCreature(Creature* creature)
 			return false;
 		}
 
-		// Target is too far to get a path too. We shouldn't add him as a target.
-		FindPathParams fpp;
-		getPathSearchParams(creature, fpp);
-		const Position& pos = getPosition();
-		if (Position::getDistanceX(pos, creaturePos) > fpp.maxSearchDist ||
-		    Position::getDistanceY(pos, creaturePos) > fpp.maxSearchDist) {
-			attackedCreature = nullptr;
-			return false;
-		}
-
 		attackedCreature = creature;
 		followPosition = creaturePos;
 		onAttackedCreature(attackedCreature);

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -217,7 +217,7 @@ void Creature::onWalk()
 			getPathSearchParams(attackedCreature, fpp);
 			const Position& pos = getPosition();
 			if (Position::getDistanceX(pos, targetPos) > fpp.maxSearchDist ||
-	                    Position::getDistanceY(pos, targetPos) > fpp.maxSearchDist) {
+			    Position::getDistanceY(pos, targetPos) > fpp.maxSearchDist) {
 				// Attacked Creature has gone too far. Stop trying to get a path.
 				listWalkDir.clear();
 				return;
@@ -933,7 +933,7 @@ bool Creature::setAttackedCreature(Creature* creature)
 		getPathSearchParams(creature, fpp);
 		const Position& pos = getPosition();
 		if (Position::getDistanceX(pos, creaturePos) > fpp.maxSearchDist ||
-                    Position::getDistanceY(pos, creaturePos) > fpp.maxSearchDist) {
+		    Position::getDistanceY(pos, creaturePos) > fpp.maxSearchDist) {
 			attackedCreature = nullptr;
 			return false;
 		}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -136,6 +136,10 @@ void Creature::onThink(uint32_t interval)
 		blockCount = std::min<uint32_t>(blockCount + 1, 2);
 		blockTicks = 0;
 	}
+	
+	if (!forceUpdateFollowPath) {
+		forceUpdateFollowPath = true;
+	}
 
 	// scripting event - onThink
 	const CreatureEventList& thinkEvents = getCreatureEvents(CREATURE_EVENT_THINK);
@@ -148,7 +152,9 @@ void Creature::checkPath()
 {
 	if (attackedCreature) {
 		const Position& targetPos = attackedCreature->getPosition();
-		if (followPosition != targetPos) {
+		if (followPosition != targetPos || forceUpdateFollowPath) {
+			forceUpdateFollowPath = false;
+
 			FindPathParams fpp;
 			getPathSearchParams(attackedCreature, fpp);
 			const Position& pos = getPosition();

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -211,6 +211,7 @@ void Creature::onWalk()
 	if (attackedCreature) {
 		const Position& targetPos = attackedCreature->getPosition();
 		if (followPosition != targetPos || forceUpdatePath) {
+			forceUpdatePath = false;
 
 			FindPathParams fpp;
 			getPathSearchParams(attackedCreature, fpp);

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -198,7 +198,13 @@ void Creature::onWalk()
 		eventWalk = 0;
 		addEventWalk();
 	}
-	
+
+	if (followCreature) {
+		listWalkDir.clear();
+		goToFollowCreature();
+		return;
+	}
+
 	if (attackedCreature) {
 		const Position& targetPos = attackedCreature->getPosition();
 		if (followPosition != targetPos) {
@@ -209,11 +215,6 @@ void Creature::onWalk()
 			if (Position::getDistanceX(pos, targetPos) > fpp.maxSearchDist || Position::getDistanceY(pos, targetPos) > fpp.maxSearchDist) {
 				// Attacked Creature has gone too far. Stop trying to get a path.
 				listWalkDir.clear();
-				return;
-			}
-
-			if (followCreature) {
-				goToFollowCreature();
 				return;
 			}
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -137,9 +137,7 @@ void Creature::onThink(uint32_t interval)
 		blockTicks = 0;
 	}
 	
-	if (!forceUpdateFollowPath) {
-		forceUpdateFollowPath = true;
-	}
+	forceUpdateFollowPath = true;
 
 	// scripting event - onThink
 	const CreatureEventList& thinkEvents = getCreatureEvents(CREATURE_EVENT_THINK);

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -220,7 +220,7 @@ void Creature::onWalk()
 
 			followPosition = attackedCreature->getPosition();
 			listWalkDir.clear();
-			g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
+			g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 		}
 	}
 }
@@ -936,7 +936,7 @@ bool Creature::setAttackedCreature(Creature* creature)
 		attackedCreature = creature;
 		followPosition = creaturePos;
 		listWalkDir.clear();
-		g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
+		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 		onAttackedCreature(attackedCreature);
 		attackedCreature->onAttacked();
 	} else {
@@ -1026,7 +1026,7 @@ bool Creature::setFollowCreature(Creature* creature)
 		hasFollowPath = false;
 		followCreature = creature;
 		listWalkDir.clear();
-		g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
+		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 	} else {
 		followCreature = nullptr;
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -212,12 +212,14 @@ void Creature::onWalk()
 				return;
 			}
 
+			if (followCreature) {
+				goToFollowCreature();
+				return;
+			}
+
 			followPosition = attackedCreature->getPosition();
 			listWalkDir.clear();
 			g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
-			if (followCreature) {
-				goToFollowCreature();
-			}
 		}
 	}
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -136,7 +136,7 @@ void Creature::onThink(uint32_t interval)
 		blockCount = std::min<uint32_t>(blockCount + 1, 2);
 		blockTicks = 0;
 	}
-	
+
 	if (followCreature) {
 		goToFollowCreature();
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -215,6 +215,9 @@ void Creature::onWalk()
 			followPosition = attackedCreature->getPosition();
 			listWalkDir.clear();
 			g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
+			if (followCreature) {
+				goToFollowCreature();
+			}
 		}
 	}
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -137,6 +137,10 @@ void Creature::onThink(uint32_t interval)
 		blockTicks = 0;
 	}
 	
+	if (followCreature) {
+		goToFollowCreature();
+	}
+
 	forceUpdateFollowPath = true;
 
 	// scripting event - onThink

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -199,8 +199,7 @@ void Creature::onWalk()
 		addEventWalk();
 	}
 
-	if (followCreature && !attackedCreature || attackedCreature != followCreature) {
-		listWalkDir.clear();
+	if (!hasFollowPath && !followCreature && !attackedCreature || attackedCreature != followCreature) {
 		goToFollowCreature();
 		return;
 	}
@@ -219,7 +218,6 @@ void Creature::onWalk()
 			}
 
 			followPosition = attackedCreature->getPosition();
-			listWalkDir.clear();
 			g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 		}
 	}
@@ -935,7 +933,6 @@ bool Creature::setAttackedCreature(Creature* creature)
 
 		attackedCreature = creature;
 		followPosition = creaturePos;
-		listWalkDir.clear();
 		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 		onAttackedCreature(attackedCreature);
 		attackedCreature->onAttacked();
@@ -1025,7 +1022,6 @@ bool Creature::setFollowCreature(Creature* creature)
 
 		hasFollowPath = false;
 		followCreature = creature;
-		listWalkDir.clear();
 		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 	} else {
 		followCreature = nullptr;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -935,6 +935,8 @@ bool Creature::setAttackedCreature(Creature* creature)
 
 		attackedCreature = creature;
 		followPosition = creaturePos;
+		listWalkDir.clear();
+		g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
 		onAttackedCreature(attackedCreature);
 		attackedCreature->onAttacked();
 	} else {
@@ -1023,6 +1025,8 @@ bool Creature::setFollowCreature(Creature* creature)
 
 		hasFollowPath = false;
 		followCreature = creature;
+		listWalkDir.clear();
+		g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
 	} else {
 		followCreature = nullptr;
 	}

--- a/src/creature.h
+++ b/src/creature.h
@@ -409,6 +409,7 @@ protected:
 	bool skillLoss = true;
 	bool lootDrop = true;
 	bool cancelNextWalk = false;
+	bool forceUpdateFollowPath = false;
 	bool hasFollowPath = false;
 	bool hiddenHealth = false;
 	bool canUseDefense = true;

--- a/src/creature.h
+++ b/src/creature.h
@@ -370,6 +370,7 @@ protected:
 
 	Tile* tile = nullptr;
 	Creature* attackedCreature = nullptr;
+	Position followPosition;
 	Creature* master = nullptr;
 	Creature* followCreature = nullptr;
 
@@ -401,14 +402,12 @@ protected:
 	bool localMapCache[mapWalkHeight][mapWalkWidth] = {{false}};
 	bool isInternalRemoved = false;
 	bool isMapLoaded = false;
-	bool isUpdatingPath = false;
 	bool creatureCheck = false;
 	bool inCheckCreaturesVector = false;
 	bool skillLoss = true;
 	bool lootDrop = true;
 	bool cancelNextWalk = false;
 	bool hasFollowPath = false;
-	bool forceUpdateFollowPath = false;
 	bool hiddenHealth = false;
 	bool canUseDefense = true;
 	bool movementBlocked = false;

--- a/src/creature.h
+++ b/src/creature.h
@@ -53,6 +53,7 @@ struct FindPathParams
 
 static constexpr int32_t EVENT_CREATURECOUNT = 10;
 static constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 1000;
+static constexpr int32_t EVENT_CREATURE_PATH_INTERVAL = 20;
 static constexpr int32_t EVENT_CHECK_CREATURE_INTERVAL = (EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT);
 static constexpr uint32_t CREATURE_ID_MIN = 0x10000000;
 static constexpr uint32_t CREATURE_ID_MAX = std::numeric_limits<uint32_t>::max();
@@ -277,6 +278,7 @@ public:
 	void setCreatureLight(LightInfo lightInfo);
 
 	virtual void onThink(uint32_t interval);
+	virtual void checkPath();
 	void onAttacking(uint32_t interval);
 	virtual void onWalk();
 	virtual bool getNextStep(Direction& dir, uint32_t& flags);
@@ -413,7 +415,6 @@ protected:
 	bool skillLoss = true;
 	bool lootDrop = true;
 	bool cancelNextWalk = false;
-	bool forceUpdatePath = false;
 	bool hasFollowPath = false;
 	bool hiddenHealth = false;
 	bool canUseDefense = true;

--- a/src/creature.h
+++ b/src/creature.h
@@ -407,6 +407,7 @@ protected:
 	bool skillLoss = true;
 	bool lootDrop = true;
 	bool cancelNextWalk = false;
+	bool forceUpdatePath = false;
 	bool hasFollowPath = false;
 	bool hiddenHealth = false;
 	bool canUseDefense = true;

--- a/src/creature.h
+++ b/src/creature.h
@@ -118,7 +118,12 @@ public:
 	virtual Skulls_t getSkullClient(const Creature* creature) const { return creature->getSkull(); }
 	void setSkull(Skulls_t newSkull);
 	Direction getDirection() const { return direction; }
-	void setDirection(Direction dir) { direction = dir; }
+	void setDirection(Direction dir) {
+		direction = dir;
+		if (attackedCreature) {
+			goToFollowCreature();
+		}
+	}
 
 	bool isHealthHidden() const { return hiddenHealth; }
 	void setHiddenHealth(bool b) { hiddenHealth = b; }

--- a/src/creature.h
+++ b/src/creature.h
@@ -118,7 +118,8 @@ public:
 	virtual Skulls_t getSkullClient(const Creature* creature) const { return creature->getSkull(); }
 	void setSkull(Skulls_t newSkull);
 	Direction getDirection() const { return direction; }
-	void setDirection(Direction dir) {
+	void setDirection(Direction dir)
+	{
 		direction = dir;
 		if (attackedCreature) {
 			goToFollowCreature();

--- a/src/creature.h
+++ b/src/creature.h
@@ -119,13 +119,7 @@ public:
 	virtual Skulls_t getSkullClient(const Creature* creature) const { return creature->getSkull(); }
 	void setSkull(Skulls_t newSkull);
 	Direction getDirection() const { return direction; }
-	void setDirection(Direction dir)
-	{
-		direction = dir;
-		if (attackedCreature) {
-			goToFollowCreature();
-		}
-	}
+	void setDirection(Direction dir) { direction = dir; }
 
 	bool isHealthHidden() const { return hiddenHealth; }
 	void setHiddenHealth(bool b) { hiddenHealth = b; }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3919,14 +3919,10 @@ void Game::checkCreaturesPath(size_t index)
 	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL,
 	                                         [=]() { checkCreaturesPath((index + 1) % EVENT_CREATURECOUNT); }));
 
-	auto& checkCreatureList = checkCreatureLists[index];
-	auto it = checkCreatureList.begin(), end = checkCreatureList.end();
-	while (it != end) {
-		Creature* creature = *it;
+	for (Creature* creature : checkCreatureLists[index]) {
 		if (creature->getHealth() > 0) {
 			creature->checkPath();
 		}
-		++it;
 	}
 
 	cleanup();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -78,7 +78,7 @@ void Game::start(ServiceManager* manager)
 		g_scheduler.addEvent(createSchedulerTask(EVENT_LIGHTINTERVAL, [this]() { checkLight(); }));
 	}
 	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_THINK_INTERVAL, [this]() { checkCreatures(0); }));
-	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL, std::bind(&Game::checkCreaturesPath, this, 0)));
+	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL, [this]() { checkCreaturesPath(0); }));
 	g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() { checkDecay(); }));
 }
 
@@ -3916,7 +3916,8 @@ void Game::checkCreatures(size_t index)
 
 void Game::checkCreaturesPath(size_t index)
 {
-	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL, std::bind(&Game::checkCreaturesPath, this, (index + 1) % EVENT_CREATURECOUNT)));
+	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL,
+	                                         [=]() { checkCreaturesPath((index + 1) % EVENT_CREATURECOUNT); }));
 
 	auto& checkCreatureList = checkCreatureLists[index];
 	auto it = checkCreatureList.begin(), end = checkCreatureList.end();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -78,6 +78,7 @@ void Game::start(ServiceManager* manager)
 		g_scheduler.addEvent(createSchedulerTask(EVENT_LIGHTINTERVAL, [this]() { checkLight(); }));
 	}
 	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_THINK_INTERVAL, [this]() { checkCreatures(0); }));
+	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL, std::bind(&Game::checkCreaturesPath, this, 0)));
 	g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() { checkDecay(); }));
 }
 
@@ -3908,6 +3909,23 @@ void Game::checkCreatures(size_t index)
 			it = checkCreatureList.erase(it);
 			ReleaseCreature(creature);
 		}
+	}
+
+	cleanup();
+}
+
+void Game::checkCreaturesPath(size_t index)
+{
+	g_scheduler.addEvent(createSchedulerTask(EVENT_CREATURE_PATH_INTERVAL, std::bind(&Game::checkCreaturesPath, this, (index + 1) % EVENT_CREATURECOUNT)));
+
+	auto& checkCreatureList = checkCreatureLists[index];
+	auto it = checkCreatureList.begin(), end = checkCreatureList.end();
+	while (it != end) {
+		Creature* creature = *it;
+		if (creature->getHealth() > 0) {
+			creature->checkPath();
+		}
+		++it;
 	}
 
 	cleanup();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -713,7 +713,7 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 	if (!Position::areInRange<1, 1, 0>(movingCreatureOrigPos, player->getPosition())) {
 		// need to walk to the creature first before moving it
 		std::vector<Direction> listDir;
-		if (player->getPathTo(movingCreatureOrigPos, listDir, 0, 1, true, true)) {
+		if (player->getPathTo(movingCreatureOrigPos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 			g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 				playerAutoWalk(playerID, listDir);
 			}));
@@ -970,7 +970,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 	if (!Position::areInRange<1, 1>(playerPos, mapFromPos)) {
 		// need to walk to the item first before using it
 		std::vector<Direction> listDir;
-		if (player->getPathTo(item->getPosition(), listDir, 0, 1, true, true)) {
+		if (player->getPathTo(item->getPosition(), listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 			g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 				playerAutoWalk(playerID, listDir);
 			}));
@@ -1031,7 +1031,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 			}
 
 			std::vector<Direction> listDir;
-			if (player->getPathTo(walkPos, listDir, 0, 0, true, true)) {
+			if (player->getPathTo(walkPos, listDir, 0, 0, true, true, PLAYER_SEARCHDIST)) {
 				g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 					playerAutoWalk(playerID, listDir);
 				}));
@@ -2135,7 +2135,7 @@ void Game::playerUseItemEx(uint32_t playerId, const Position& fromPos, uint8_t f
 			}
 
 			std::vector<Direction> listDir;
-			if (player->getPathTo(walkToPos, listDir, 0, 1, true, true)) {
+			if (player->getPathTo(walkToPos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 				g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 					playerAutoWalk(playerID, listDir);
 				}));
@@ -2196,7 +2196,7 @@ void Game::playerUseItem(uint32_t playerId, const Position& pos, uint8_t stackPo
 	if (ret != RETURNVALUE_NOERROR) {
 		if (ret == RETURNVALUE_TOOFARAWAY) {
 			std::vector<Direction> listDir;
-			if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
+			if (player->getPathTo(pos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 				g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 					playerAutoWalk(playerID, listDir);
 				}));
@@ -2295,7 +2295,7 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position& fromPos, uin
 			}
 
 			std::vector<Direction> listDir;
-			if (player->getPathTo(walkToPos, listDir, 0, 1, true, true)) {
+			if (player->getPathTo(walkToPos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 				g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 					playerAutoWalk(playerID, listDir);
 				}));
@@ -2414,7 +2414,7 @@ void Game::playerRotateItem(uint32_t playerId, const Position& pos, uint8_t stac
 
 	if (pos.x != 0xFFFF && !Position::areInRange<1, 1, 0>(pos, player->getPosition())) {
 		std::vector<Direction> listDir;
-		if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
+		if (player->getPathTo(pos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 			g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 				playerAutoWalk(playerID, listDir);
 			}));
@@ -2513,7 +2513,7 @@ void Game::playerBrowseField(uint32_t playerId, const Position& pos)
 
 	if (!Position::areInRange<1, 1>(playerPos, pos)) {
 		std::vector<Direction> listDir;
-		if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
+		if (player->getPathTo(pos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 			g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 				playerAutoWalk(playerID, listDir);
 			}));
@@ -2619,7 +2619,7 @@ void Game::playerWrapItem(uint32_t playerId, const Position& position, uint8_t s
 
 	if (position.x != 0xFFFF && !Position::areInRange<1, 1, 0>(position, player->getPosition())) {
 		std::vector<Direction> listDir;
-		if (player->getPathTo(position, listDir, 0, 1, true, true)) {
+		if (player->getPathTo(position, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 			g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 				playerAutoWalk(playerID, listDir);
 			}));
@@ -2691,7 +2691,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 
 	if (!Position::areInRange<1, 1>(tradeItemPosition, playerPosition)) {
 		std::vector<Direction> listDir;
-		if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
+		if (player->getPathTo(pos, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 			g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 				playerAutoWalk(playerID, listDir);
 			}));
@@ -3413,7 +3413,7 @@ void Game::playerRequestEditPodium(uint32_t playerId, const Position& position, 
 	if (!player->isAccessPlayer()) {
 		if (position.x != 0xFFFF && !Position::areInRange<1, 1, 0>(position, player->getPosition())) {
 			std::vector<Direction> listDir;
-			if (player->getPathTo(position, listDir, 0, 1, true, true)) {
+			if (player->getPathTo(position, listDir, 0, 1, true, true, PLAYER_SEARCHDIST)) {
 				g_dispatcher.addTask(createTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 					playerAutoWalk(playerID, listDir);
 				}));

--- a/src/game.h
+++ b/src/game.h
@@ -438,6 +438,7 @@ public:
 	void updateCreatureWalk(uint32_t creatureId);
 	void checkCreatureAttack(uint32_t creatureId);
 	void checkCreatures(size_t index);
+	void checkCreaturesPath(size_t index);
 	void checkLight();
 
 	bool combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* target, bool checkDefense, bool checkArmor,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1389,7 +1389,6 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
 	if (hasFollowPath && (creature == followCreature || (creature == this && followCreature))) {
-		isUpdatingPath = false;
 		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 	}
 

--- a/src/player.h
+++ b/src/player.h
@@ -93,6 +93,8 @@ using MuteCountMap = std::map<uint32_t, uint32_t>;
 static constexpr int32_t PLAYER_MAX_SPEED = 1500;
 static constexpr int32_t PLAYER_MIN_SPEED = 10;
 
+static constexpr int32_t PLAYER_SEARCHDIST = 9;
+
 static constexpr int32_t NOTIFY_DEPOT_BOX_RANGE = 1;
 
 class Player final : public Creature, public Cylinder


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
Monsters update follow path only when onThink() occurs. This causes a lag that makes monsters easy to get away from.
This pull will make them update their path whenever the path they need to get to changes.

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Remove path update onThink()
Add a check to when the creature walks to see if it needs to update its path.
If the position it needs to get to hasn't changed it will not update its path.

Watch path update behavior here:
https://youtu.be/TYV4qFLHr-Q

Creature Keep Distance:
https://youtu.be/2FkE23HkhS0

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
