### PR TITLE
Update clang-format to reflect changes in recent version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,14 @@ Language:        Cpp
 BasedOnStyle:    Google
 AccessModifierOffset: -4
 AlignEscapedNewlines: DontAlign
-BreakBeforeBraces: Mozilla
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterStruct:     true
+  AfterUnion:      true
+  SplitEmptyFunction: false
 BreakConstructorInitializers: AfterColon
 BreakStringLiterals: false
 ColumnLimit:     120

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: >
-          sudo apt-get update &&
-          sudo apt-get install clang-format
+        run: sudo apt update -q && sudo apt install -yq clang-format
 
       - name: Check code style
         run: clang-format -n -style=file --Werror src/*.{cpp,h}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Recent versions of `clang-format` have changed the bracing configuration for `Mozilla`, resulting in constructors following this format:

```cpp
Class::Class():
{
}
```

Which doesn't really follow our standard anymore. This fixes the formatting while keeping source unchanged.

Alternatively, we could just adopt the new formatting rules.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
