### PR TITLE
fix io.write not writing to console after logging a command

### DIFF
--- a/data/talkactions/lib/talkactions.lua
+++ b/data/talkactions/lib/talkactions.lua
@@ -6,7 +6,6 @@ function logCommand(player, words, param)
 		return
 	end
 
-	io.output(file)
-	io.write(logFormat:format(os.date("%d/%m/%Y %H:%M"), words, param):trim() .. "\n")
-	io.close(file)
+	file:write(logFormat:format(os.date("%d/%m/%Y %H:%M"), words, param):trim() .. "\n")
+	file:close(file)
 end


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`io.output` is the function that changes default Lua output. Redirecting it to log file breaks io.write globally.
This PR changes `logCommand` to work intended way without breaking anything.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
