### PR TITLE
prevent double call to equipFunction inside MoveEvent::fireEquip

### DIFF
--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -998,12 +998,8 @@ ReturnValue MoveEvent::fireEquip(Player* player, Item* item, slots_t slot, bool 
 	if (equipFunction) {
 		ret = equipFunction(this, player, item, slot, isCheck);
 	}
-	if (scripted) {
-		if (ret == RETURNVALUE_NOERROR) {
-			if (!executeEquip(player, item, slot, isCheck)) {
-				ret = RETURNVALUE_CANNOTBEDRESSED;
-			}
-		}
+	if (scripted && (ret == RETURNVALUE_NOERROR) && !executeEquip(player, item, slot, isCheck)) {
+		ret = RETURNVALUE_CANNOTBEDRESSED;
 	}
 	return ret;
 }

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -994,19 +994,18 @@ bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos)
 
 ReturnValue MoveEvent::fireEquip(Player* player, Item* item, slots_t slot, bool isCheck)
 {
+	ReturnValue ret = RETURNVALUE_NOERROR;
+	if (equipFunction) {
+		ret = equipFunction(this, player, item, slot, isCheck);
+	}
 	if (scripted) {
-		ReturnValue ret = RETURNVALUE_NOERROR;
-		if (equipFunction) {
-			ret = equipFunction(this, player, item, slot, isCheck);
-		}
 		if (ret == RETURNVALUE_NOERROR) {
 			if (!executeEquip(player, item, slot, isCheck)) {
-				ret =  RETURNVALUE_CANNOTBEDRESSED;
+				ret = RETURNVALUE_CANNOTBEDRESSED;
 			}
 		}
-		return ret;
 	}
-	return equipFunction(this, player, item, slot, isCheck);
+	return ret;
 }
 
 bool MoveEvent::executeEquip(Player* player, Item* item, slots_t slot, bool isCheck)

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -995,13 +995,16 @@ bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos)
 ReturnValue MoveEvent::fireEquip(Player* player, Item* item, slots_t slot, bool isCheck)
 {
 	if (scripted) {
-		if (!equipFunction || equipFunction(this, player, item, slot, isCheck) == RETURNVALUE_NOERROR) {
-			if (executeEquip(player, item, slot, isCheck)) {
-				return RETURNVALUE_NOERROR;
-			}
-			return RETURNVALUE_CANNOTBEDRESSED;
+		ReturnValue ret = RETURNVALUE_NOERROR;
+		if (equipFunction) {
+			ret = equipFunction(this, player, item, slot, isCheck);
 		}
-		return equipFunction(this, player, item, slot, isCheck);
+		if (ret == RETURNVALUE_NOERROR) {
+			if (!executeEquip(player, item, slot, isCheck)) {
+				ret =  RETURNVALUE_CANNOTBEDRESSED;
+			}
+		}
+		return ret;
 	}
 	return equipFunction(this, player, item, slot, isCheck);
 }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

prevent double call to the equipFunction when equipFunction does not return RETURNVALUE_NOERROR.

<!-- Describe the changes that this pull request makes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
