### PR TITLE
Refresh speed on vocation change.

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -101,6 +101,9 @@ bool Player::setVocation(uint16_t vocId)
 	vocation = voc;
 
 	updateRegeneration();
+	setBaseSpeed(voc->getBaseSpeed()); 
+	updateBaseSpeed();
+	g_game.changeSpeed(this, 0);
 	return true;
 }
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ X] I have followed [proper The Forgotten Server code styling][code].
- [ X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

By default, after changing vocation tfs will refresh baseSpeed only after login/leveling up/losing a level. It shouldn't work like that, it should refresh baseSpeed directly on changing vocation to an another one.

Example:
vocation 1 has baseSpeed = 250
vocation 2 has baseSpeed = 300

Then you have code: **player:setVocation(2)**
You will still have 250 baseSpeed until you do one of the following:
- Level up
- Level down
- Logout->Login

Adding those 3 lines that I suggested to add will make it refresh baseSpeed instantly.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
