### PR TITLE
Move doAddContainerItem to compat, improve container:addItem

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -904,6 +904,15 @@ function doAddContainerItemEx(uid, virtualId)
 	return res
 end
 
+function doAddContainerItem(uid, itemid, count)
+	local container = Container(uid)
+	if not container then
+		return false
+	end
+
+	return container:addItem(itemid, count)
+end
+
 function doSendMagicEffect(pos, magicEffect, ...) return Position(pos):sendMagicEffect(magicEffect, ...) end
 function doSendDistanceShoot(fromPos, toPos, distanceEffect, ...) return Position(fromPos):sendDistanceEffect(toPos, distanceEffect, ...) end
 function isSightClear(fromPos, toPos, floorCheck) return Position(fromPos):isSightClear(toPos, floorCheck) end

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -428,9 +428,6 @@ private:
 	static int luaIsMoveable(lua_State* L);
 	static int luaIsValidUID(lua_State* L);
 
-	// container
-	static int luaDoAddContainerItem(lua_State* L);
-
 	//
 	static int luaCreateCombatArea(lua_State* L);
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Removes `doAddContainerItem` from the sources and moves it to Lua, using the already implemented `container:addItem`, but improving over it, allowing to add >100 stackable or >1 non-stackable items at once by creating several stacks. If more than 100 stackable or 1 non-stackable items are added, a table will be returned with info about all the stacks.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
