### PR TITLE
item.custom property fancy access

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -102,6 +102,17 @@ do
 end
 
 do
+	local function customAttributeProxy(item)
+		return setmetatable({}, {
+			__index = function (self, key)
+				return item:getCustomAttribute(key)
+			end,
+			__newindex = function (self, key, value)
+				item:setCustomAttribute(key, value)
+			end
+		})
+	end
+
 	local function ItemIndex(self, key)
 		local methods = getmetatable(self)
 		if key == "itemid" then
@@ -112,6 +123,8 @@ do
 			return methods.getUniqueId(self)
 		elseif key == "type" then
 			return methods.getSubType(self)
+		elseif key == "custom" then
+			return customAttributeProxy(self)
 		end
 		return methods[key]
 	end


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These changes add the ability to get or set a custom attribute using the `__index` and `__newindex` metamethods just like with `player.storage` and `player.accountStorage`

`data/scripts/any.lua`
```lua
print(item.custom[1])
item.custom[1] = 100
print(item.custom.useCount)
item.custom.useCount = 2
item.custom["useCount"] = "uwu"
...
```

**Issues addressed:** Nothing!
