### PR TITLE
Fix pathfinding behavior when trying to hang on the wall

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1028,7 +1028,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 			}
 
 			std::vector<Direction> listDir;
-			if (player->getPathTo(walkPos, listDir, 0, 0, true, true)) {
+			if (player->getPathTo(mapToPos, listDir, 0, 1, true, true)) {
 				g_dispatcher.addTask([=, playerID = player->getID(), listDir = std::move(listDir)]() {
 					playerAutoWalk(playerID, listDir);
 				});

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1001,23 +1001,15 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 		}
 
 		if (!Position::areInRange<1, 1, 0>(playerPos, mapToPos)) {
-			Position walkPos = mapToPos;
-			if (vertical) {
-				walkPos.x++;
-			} else {
-				walkPos.y++;
-			}
-
 			Position itemPos = fromPos;
 			uint8_t itemStackPos = fromStackPos;
 
-			if (fromPos.x != 0xFFFF && Position::areInRange<1, 1>(mapFromPos, playerPos) &&
-			    !Position::areInRange<1, 1, 0>(mapFromPos, walkPos)) {
+			if (fromPos.x != 0xFFFF && Position::areInRange<1, 1>(mapFromPos, playerPos)) {
 				// need to pickup the item first
 				Item* moveItem = nullptr;
 
 				ReturnValue ret = internalMoveItem(fromCylinder, player, INDEX_WHEREEVER, item, count, &moveItem, 0,
-				                                   player, nullptr, &fromPos, &toPos);
+					                                player, nullptr, &fromPos, &toPos);
 				if (ret != RETURNVALUE_NOERROR) {
 					player->sendCancelMessage(ret);
 					return;
@@ -1025,7 +1017,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 
 				// changing the position since its now in the inventory of the player
 				internalGetPosition(moveItem, itemPos, itemStackPos);
-			}
+		}
 
 			std::vector<Direction> listDir;
 			if (player->getPathTo(mapToPos, listDir, 0, 1, true, true)) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1009,7 +1009,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 				Item* moveItem = nullptr;
 
 				ReturnValue ret = internalMoveItem(fromCylinder, player, INDEX_WHEREEVER, item, count, &moveItem, 0,
-					                                player, nullptr, &fromPos, &toPos);
+				                                   player, nullptr, &fromPos, &toPos);
 				if (ret != RETURNVALUE_NOERROR) {
 					player->sendCancelMessage(ret);
 					return;
@@ -1017,7 +1017,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 
 				// changing the position since its now in the inventory of the player
 				internalGetPosition(moveItem, itemPos, itemStackPos);
-		}
+			}
 
 			std::vector<Direction> listDir;
 			if (player->getPathTo(mapToPos, listDir, 0, 1, true, true)) {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

The increment on the XY axis is a problem for pathfind when this path is "not walkable".

Problem:

https://user-images.githubusercontent.com/53269692/200188508-a6914911-7254-455f-aea4-2948c980cc96.mp4

Fix:

https://user-images.githubusercontent.com/53269692/200188560-14763e18-05b0-4ce5-8ed8-2f912f81d255.mp4



Found another problem: (no solution)

https://user-images.githubusercontent.com/53269692/200188590-4d3eb409-a908-4aa1-a265-cea73d4d73c7.mp4


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
