### PR TITLE
updated checkout actions to v3

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: >

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -65,9 +65,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+          fetch-depth: 0
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.
@@ -148,9 +146,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+          fetch-depth: 0
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -62,7 +62,7 @@ jobs:
             luajit: off
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -145,7 +145,7 @@ jobs:
               lua luajit libmariadb pugixml cryptopp fmt
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -19,7 +19,7 @@ jobs:
   check-format:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt update -q && sudo apt install -yq clang-format

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'otland/forgottenserver'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: >

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: docker build . --file Dockerfile --tag image

--- a/.github/workflows/lua-syntax.yml
+++ b/.github/workflows/lua-syntax.yml
@@ -14,7 +14,7 @@ jobs:
   luac:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: leafo/gh-actions-lua@v8.0.0
         with:

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -38,9 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+          fetch-depth: 0
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.
@@ -129,9 +127,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+          fetch-depth: 0
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -35,7 +35,7 @@ jobs:
               lua libmariadb pugixml cryptopp fmt
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -126,7 +126,7 @@ jobs:
               lua luajit libmariadb pugixml cryptopp fmt
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/xml-syntax.yml
+++ b/.github/workflows/xml-syntax.yml
@@ -14,7 +14,7 @@ jobs:
   xmllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes a warning at the clang workflow, as node12 is being deprecated and node16 will be required, and now it seems v3 is the default one now, so I changed on the other files as well.

https://github.com/actions/checkout

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
