### PR TITLE
Allow gdb to call saveGameState()

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -157,6 +157,9 @@ void Game::setGameState(GameState_t newState)
 	}
 }
 
+#if !defined(_MSC_VER)
+__attribute__((used))
+#endif
 void Game::saveGameState()
 {
 	if (gameState == GAME_STATE_NORMAL) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This change ensures saveGameState() can be called by an external debugger, as is standard practice for 99% of production servers.
The ability to do this seems to have been lost somewhere in the 1.3 development cycle.
I consider being able to do this by default without any custom changes as essential as it has been a known 'feature' for a very long time, including being suggested as something you **should** use by Mark [back in 2013](https://github.com/otland/forgottenserver/issues/341#issuecomment-31402880).

**Issues addressed:** #4149 <!-- Write here the issue number, if any. -->
 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
