### PR TITLE
Fix item equipping after decay

### DIFF
--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -849,6 +849,8 @@ ReturnValue MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, slots
 		g_game.startDecay(item);
 	}
 
+	player->setItemAbility(slot, false);
+
 	if (!it.abilities) {
 		return RETURNVALUE_NOERROR;
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A pretty ghetto fix for this issue, I'd like to hear other people's opinions on how this could be addressed properly.
The underlying issue is how the movement system works, `postRemoveNotification` & `postAddNotification` are calling the equip functions again due to the `transformItem` call. In my opinion, a rework for the movement system should be included in [2.0 milestones](https://github.com/otland/forgottenserver/projects/3).

### If we remove the first instance of `player->setItemAbility(slot, false);` before the transform is called, and leave only the 2nd instance after the transform, we will end up with a stack overflow.
[223151992H.webm](https://user-images.githubusercontent.com/9944017/209206662-77aa558e-f51e-405a-88f2-6825fb1c4153.webm)


### If we don't have the second instance of the `player->setItemAbility(slot, false);` call, which is currently the case, we will have the issue that is shown in the video.
[22312h737x.webm](https://user-images.githubusercontent.com/9944017/209206405-63f72378-0354-471e-bdbf-573410a21248.webm)


### If we have both instances of the call present, we achieve expected behaviour.
[22314q388r.webm](https://user-images.githubusercontent.com/9944017/209206646-9ce9da87-2776-487f-b6c2-4c7d99ee8232.webm)


<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** After an item decays, you would need to equip the next item twice in order for it to transform & apply it's effects


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
