### PR TITLE
Remove usages of Game.convertIpToString and mark as deprecated

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -580,12 +580,10 @@ function getPlayerLearnedInstantSpell(cid, name) local p = Player(cid) return p 
 function isPlayerGhost(cid) local p = Player(cid) return p and p:isInGhostMode() or false end
 function isPlayerPzLocked(cid) local p = Player(cid) return p and p:isPzLocked() or false end
 function isPremium(cid) local p = Player(cid) return p and p:isPremium() or false end
-function getPlayersByIPAddress(ip, mask)
-	if not mask then mask = 0xFFFFFFFF end
-	local masked = bit.band(ip, mask)
+function getPlayersByIPAddress(ip)
 	local result = {}
 	for _, player in ipairs(Game.getPlayers()) do
-		if bit.band(player:getIp(), mask) == masked then
+		if player:getIp() == masked then
 			result[#result + 1] = player:getId()
 		end
 	end
@@ -1290,6 +1288,23 @@ end
 
 function doExecuteRaid(raidName)
 	return Game.startRaid(raidName)
+end
+
+function Game.convertIpToString(ip)
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Game.convertIpToString is deprecated and will be removed in the future. Use the return value of player:getIp() instead.")
+
+	if type(ip) == "string" then
+		return ip
+	end
+
+	local band = bit.band
+	local rshift = bit.rshift
+	return string.format("%d.%d.%d.%d",
+		band(ip, 0xFF),
+		band(rshift(ip, 8), 0xFF),
+		band(rshift(ip, 16), 0xFF),
+		rshift(ip, 24)
+	)
 end
 
 numberToVariant = Variant

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -580,13 +580,31 @@ function getPlayerLearnedInstantSpell(cid, name) local p = Player(cid) return p 
 function isPlayerGhost(cid) local p = Player(cid) return p and p:isInGhostMode() or false end
 function isPlayerPzLocked(cid) local p = Player(cid) return p and p:isPzLocked() or false end
 function isPremium(cid) local p = Player(cid) return p and p:isPremium() or false end
-function getPlayersByIPAddress(ip)
+function getPlayersByIPAddress(ip, mask)
 	local result = {}
+
+	if type(ip) == "string" then
+		for _, player in ipairs(Game.getPlayers()) do
+			if player:getIp() == ip then
+				result[#result + 1] = player:getId()
+			end
+		end
+
+		return result
+	end
+
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking getPlayersByIPAddress with a numeric IP is deprecated and will be removed in the future. Please use the string representation of the IP.")
+
+	if not mask then mask = 0xFFFFFFFF end
+	local masked = bit.band(ip, mask)
+	local lshift = bit.lshift
 	for _, player in ipairs(Game.getPlayers()) do
-		if player:getIp() == masked then
-			result[#result + 1] = player:getId()
+		local a, b, c, d = player:getIp():match("(%d*)%.(%d*)%.(%d*)%.(%d*)")
+		if a and b and c and d and bit.band(lshift(a, 24) + lshift(b, 16) + lshift(c, 8) + d, mask) == masked then
+			players[#players + 1] = player:getId()
 		end
 	end
+
 	return result
 end
 getPlayersByIp = getPlayersByIPAddress

--- a/data/lib/core/game.lua
+++ b/data/lib/core/game.lua
@@ -8,17 +8,6 @@ function Game.broadcastMessage(message, messageType)
 	end
 end
 
-function Game.convertIpToString(ip)
-	local band = bit.band
-	local rshift = bit.rshift
-	return string.format("%d.%d.%d.%d",
-		band(ip, 0xFF),
-		band(rshift(ip, 8), 0xFF),
-		band(rshift(ip, 16), 0xFF),
-		rshift(ip, 24)
-	)
-end
-
 function Game.getReverseDirection(direction)
 	if direction == WEST then
 		return EAST

--- a/data/scripts/eventcallbacks/player/default_onLook.lua
+++ b/data/scripts/eventcallbacks/player/default_onLook.lua
@@ -47,7 +47,7 @@ ec.onLook = function(self, thing, position, distance, description)
 		if thing:isCreature() then
 			if thing:isPlayer() then
 				description = string.format("%s\nGUID: %s", description, thing:getGuid())
-				description = string.format("%s\nIP: %s.", description, Game.convertIpToString(thing:getIp()))
+				description = string.format("%s\nIP: %s.", description, thing:getIp())
 			end
 		end
 	end

--- a/data/scripts/eventcallbacks/player/default_onLookInBattleList.lua
+++ b/data/scripts/eventcallbacks/player/default_onLookInBattleList.lua
@@ -17,7 +17,7 @@ ec.onLookInBattleList = function(self, creature, distance)
 
 		if creature:isPlayer() then
 			description = string.format("%s\nGUID: %s", description, creature:getGuid())
-			description = string.format("%s\nIP: %s", description, Game.convertIpToString(creature:getIp()))
+			description = string.format("%s\nIP: %s", description, creature:getIp())
 		end
 	end
 	return description

--- a/data/talkactions/scripts/info.lua
+++ b/data/talkactions/scripts/info.lua
@@ -21,7 +21,7 @@ function onSay(player, words, param)
 	player:sendTextMessage(MESSAGE_INFO_DESCR, "Magic Level: " .. target:getMagicLevel())
 	player:sendTextMessage(MESSAGE_INFO_DESCR, "Speed: " .. target:getSpeed())
 	player:sendTextMessage(MESSAGE_INFO_DESCR, "Position: " .. string.format("(%0.5d / %0.5d / %0.3d)", target:getPosition().x, target:getPosition().y, target:getPosition().z))
-	player:sendTextMessage(MESSAGE_INFO_DESCR, "IP: " .. Game.convertIpToString(targetIp))
+	player:sendTextMessage(MESSAGE_INFO_DESCR, "IP: " .. targetIp)
 
 	local players = {}
 	for _, targetPlayer in ipairs(Game.getPlayers()) do

--- a/data/talkactions/scripts/mc_check.lua
+++ b/data/talkactions/scripts/mc_check.lua
@@ -28,7 +28,7 @@ function onSay(player, words, param)
 		local listLength = #list
 		if listLength > 1 then
 			local tmpPlayer = list[1]
-			local message = ("%s: %s [%d]"):format(Game.convertIpToString(ip), tmpPlayer:getName(), tmpPlayer:getLevel())
+			local message = ("%s: %s [%d]"):format(ip, tmpPlayer:getName(), tmpPlayer:getLevel())
 			for i = 2, listLength do
 				tmpPlayer = list[i]
 				message = ("%s, %s [%d]"):format(message, tmpPlayer:getName(), tmpPlayer:getLevel())


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Fixes a backwards-incompatibility introduced in #3952 where there are still some functions around that expect numeric IPs, which are not available anymore. Since most of the time the IP comes from `player:getIP()`, which returns string values, this function can be skipped, but if they come from somewhere else it will still try to convert the number.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#4274 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
