### PR TITLE
Trigger blockHit for healing

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -841,7 +841,7 @@ BlockType_t Creature::blockHit(Creature* attacker, CombatType_t combatType, int3
 	if (isImmune(combatType)) {
 		damage = 0;
 		blockType = BLOCK_IMMUNITY;
-	} else if (checkDefense || checkArmor) {
+	} else if (combatType != COMBAT_HEALING && (checkDefense || checkArmor)) {
 		bool hasDefense = false;
 
 		if (blockCount > 0) {
@@ -902,11 +902,15 @@ BlockType_t Creature::blockHit(Creature* attacker, CombatType_t combatType, int3
 			blockType = BLOCK_ARMOR;
 		}
 
-		attacker->onAttackedCreature(this);
-		attacker->onAttackedCreatureBlockHit(blockType);
+		if (combatType != COMBAT_HEALING) {
+			attacker->onAttackedCreature(this);
+			attacker->onAttackedCreatureBlockHit(blockType);
+		}
 	}
 
-	onAttacked();
+	if (combatType != COMBAT_HEALING) {
+		onAttacked();
+	}
 	return blockType;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3990,10 +3990,6 @@ bool Game::combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* ta
 		return true;
 	}
 
-	if (damage.primary.value > 0) {
-		return false;
-	}
-
 	static const auto sendBlockEffect = [this](BlockType_t blockType, CombatType_t combatType,
 	                                           const Position& targetPos) {
 		if (blockType == BLOCK_DEFENSE) {
@@ -4033,21 +4029,28 @@ bool Game::combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* ta
 
 	BlockType_t primaryBlockType, secondaryBlockType;
 	if (damage.primary.type != COMBAT_NONE) {
-		damage.primary.value = -damage.primary.value;
+		damage.primary.value = std::abs(damage.primary.value);
 		primaryBlockType = target->blockHit(attacker, damage.primary.type, damage.primary.value, checkDefense,
 		                                    checkArmor, field, ignoreResistances);
 
-		damage.primary.value = -damage.primary.value;
+		if (damage.primary.type != COMBAT_HEALING) {
+			damage.primary.value = -damage.primary.value;
+		}
+
 		sendBlockEffect(primaryBlockType, damage.primary.type, target->getPosition());
 	} else {
 		primaryBlockType = BLOCK_NONE;
 	}
 
 	if (damage.secondary.type != COMBAT_NONE) {
-		damage.secondary.value = -damage.secondary.value;
+		damage.secondary.value = std::abs(damage.secondary.value);
 		secondaryBlockType = target->blockHit(attacker, damage.secondary.type, damage.secondary.value, false, false,
 		                                      field, ignoreResistances);
-		damage.secondary.value = -damage.secondary.value;
+
+		if (damage.secondary.type != COMBAT_HEALING) {
+			damage.secondary.value = -damage.primary.value;
+		}
+
 		sendBlockEffect(secondaryBlockType, damage.secondary.type, target->getPosition());
 	} else {
 		secondaryBlockType = BLOCK_NONE;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4048,7 +4048,7 @@ bool Game::combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* ta
 		                                      field, ignoreResistances);
 
 		if (damage.secondary.type != COMBAT_HEALING) {
-			damage.secondary.value = -damage.primary.value;
+			damage.secondary.value = -damage.secondary.value;
 		}
 
 		sendBlockEffect(secondaryBlockType, damage.secondary.type, target->getPosition());


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Trigger blockhit for healing, this will fix boostpercent attribute boosting health "damage"

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Fix #4122
Additionaly basic absorbs should also now work with COMBAT_HEALING, you need to add parsing it to items.xml though.

<!-- You can safely ignore the links below:  -->

Confirmed to work.
https://otland.net/threads/boostpercenthealing-attribute-by-nekiro.282422/#post-2712660

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
