### PR TITLE
Fix login into field issue

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -576,9 +576,10 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 				}
 			}
 
-			MagicField* field = getFieldItem();
-			if (!hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags) && field && field->getDamage() != 0) {
-				return RETURNVALUE_NOTPOSSIBLE;
+			if (MagicField* field = getFieldItem()) {
+				if (field->getDamage() != 0 && hasBitSet(FLAG_PATHFINDING, flags) && !hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
+					return RETURNVALUE_NOTPOSSIBLE;
+				}
 			}
 
 			if (!player->getParent() && hasFlag(TILESTATE_NOLOGOUT)) {

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -577,7 +577,8 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 			}
 
 			if (MagicField* field = getFieldItem()) {
-				if (field->getDamage() != 0 && hasBitSet(FLAG_PATHFINDING, flags) && !hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
+				if (field->getDamage() != 0 && hasBitSet(FLAG_PATHFINDING, flags) &&
+				    !hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
 					return RETURNVALUE_NOTPOSSIBLE;
 				}
 			}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Check is pathfinding flag to properly differentiate between how the queryAdd is called.


<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#4229 introduced a bug, when you login into energy bomb (the center of it) so you are blocked on every side by energy fields, server fails to place you into map and it results in teleporting to temple position.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
