### PR TITLE
Support charges and bulk item creation by talkaction

### DIFF
--- a/data/talkactions/scripts/create_item.lua
+++ b/data/talkactions/scripts/create_item.lua
@@ -29,7 +29,7 @@ function onSay(player, words, param)
 	local count = tonumber(split[2])
 	local subType = 1
 	if not itemType:isStackable() and split[3] then
-		subType = math.max(1, split[3] and tonumber(split[3]) or 1)
+		subType = math.max(1, tonumber(split[3]) or 1)
 	end
 
 	if count then

--- a/data/talkactions/scripts/create_item.lua
+++ b/data/talkactions/scripts/create_item.lua
@@ -27,23 +27,32 @@ function onSay(player, words, param)
 	end
 
 	local count = tonumber(split[2])
+	local subType = 1
+	if not itemType:isStackable() and split[3] then
+		subType = math.max(1, split[3] and tonumber(split[3]) or 1)
+	end
+
 	if count then
-		if itemType:isStackable() then
-			count = math.min(10000, math.max(1, count))
-		elseif not itemType:isFluidContainer() then
-			count = math.min(100, math.max(1, count))
+		if itemType:isFluidContainer() then
+			count = math.max(0, math.min(count, 99))
 		else
-			count = math.max(0, count)
+			count = math.min(10000, math.max(1, count))
 		end
 	else
 		if not itemType:isFluidContainer() then
-			count = 1
+			count = math.max(1, itemType:getCharges())
 		else
 			count = 0
 		end
 	end
 
-	local result = player:addItem(itemType:getId(), count)
+	local result = nil
+	if itemType:isStackable() then
+		result = player:addItem(itemType:getId(), count, true, subType)
+	else
+		result = player:addItem(itemType:getId(), subType, true, count)
+	end
+
 	if result then
 		if not itemType:isStackable() then
 			if type(result) == "table" then


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

* Better charges support:
  * Related issue: #4156
  * Not limited to 100
  * Creates with default charges specified in items.xml if not provided (`/i strange talisman` = talisman with 200 charges)
  * `/i strange talisman, 250, 2` = 2 talismans with 250 charges each
* Allow to create all items in bulk
  * For example, creating 10 vials of mana fluid would be: `/i 2006, 7, 10`

**Issues addressed:** #4156


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
