### PR TITLE
Add has & clear storage methods, default return for get

### DIFF
--- a/data/talkactions/scripts/storage.lua
+++ b/data/talkactions/scripts/storage.lua
@@ -1,0 +1,38 @@
+function onSay(player, words, param)
+	if not player:getGroup():getAccess() then
+		return true
+	end
+
+	if player:getAccountType() < ACCOUNT_TYPE_GOD then
+		return false
+	end
+
+	local split = param:splitTrimmed(",")
+	local target = Player(split[1])
+
+	if not target then
+		player:sendCancelMessage("Player not found.")
+		return false
+	end
+
+	local key = tonumber(split[2])
+	if not key or key < 0 then
+		player:sendCancelMessage("Key must be a positive integer.")
+		return false
+	end
+
+	if not split[3] then
+		player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, ("%s: %d = %d"):format(target:getName(), key, target:getStorageValue(key)))
+		return false
+	end
+
+	local value = tonumber(split[3])
+	if not value then
+		player:sendCancelMessage("Value must be an integer.")
+		return false
+	end
+
+	target:setStorageValue(key, value)
+	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, ("%s: %d = %d"):format(target:getName(), key, value))
+	return false
+end

--- a/data/talkactions/talkactions.xml
+++ b/data/talkactions/talkactions.xml
@@ -34,6 +34,7 @@
 	<talkaction words="/hide" script="hide.lua" />
 	<talkaction words="/reload" separator=" " script="reload.lua" />
 	<talkaction words="/raid" separator=" " script="force_raid.lua" />
+	<talkaction words="/storage" separator=" " script="storage.lua" />
 
 	<!-- player talkactions -->
 	<talkaction words="!buypremium" script="buyprem.lua" />

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9171,7 +9171,7 @@ int LuaScriptInterface::luaPlayerHasStorage(lua_State* L)
 		return 1;
 	}
 
-	lua_pushboolean(L, player->storageMap.find(getNumber<uint32_t>(L, 2)) != player->storageMap.end());
+	pushBoolean(L, player->storageMap.find(getNumber<uint32_t>(L, 2)) != player->storageMap.end());
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -959,6 +959,9 @@ class LuaScriptInterface
 		static int luaPlayerGetBankBalance(lua_State* L);
 		static int luaPlayerSetBankBalance(lua_State* L);
 
+		static int luaPlayerHasStorage(lua_State* L);
+		static int luaPlayerClearStorage(lua_State* L);
+
 		static int luaPlayerGetStorageValue(lua_State* L);
 		static int luaPlayerSetStorageValue(lua_State* L);
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

New lua methods:
* player:hasStorage(key): bool - returns if player has storage value set
* player:clearStorage(key): true - currently just a fancier way of calling setStorageValue(key, -1)

Modified lua methods:
* player:getStorageValue(key): int -> player:getStorageValue(key, [default = -1]): int - returns `default` if the storage is not set 

Talkaction:
* `/storage player-name, key[, value]`
  * if `value` param is omitted, displays the current value of storage
  * if `value` param is specified, sets the storage to that value

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #3982 (Partially)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
