### PR TITLE
fix invalid argument in spell:group

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -15794,7 +15794,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 			}
 		} else {
 			SpellGroup_t primaryGroup = getNumber<SpellGroup_t>(L, 2);
-			SpellGroup_t secondaryGroup = getNumber<SpellGroup_t>(L, 2);
+			SpellGroup_t secondaryGroup = getNumber<SpellGroup_t>(L, 3);
 			if (primaryGroup && secondaryGroup) {
 				spell->setGroup(primaryGroup);
 				spell->setSecondaryGroup(secondaryGroup);


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Steps to reproduce
1. set two groups to Lua spell, for example `spell:group(1, 2)`
2. set two cooldowns like `spell:groupCooldown(2000, 22000)`
3. observe cooldowns bar

expected: two groups have cooldowns
observed: secondary group is ignored despite the function arguments suggesting otherwise



<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
