### PR TITLE
Prevent map loading crash

### DIFF
--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -27,14 +27,35 @@ struct Node
 	};
 };
 
-struct LoadError : std::exception
+enum OTBMExceptionType : uint8_t
 {
-	const char* what() const noexcept override = 0;
+	INVALID_FILE_FORMAT,
+	OPEN_FAILED
 };
 
-struct InvalidOTBFormat final : LoadError
+struct OTBMException final : std::exception
 {
-	const char* what() const noexcept override { return "Invalid OTBM file format"; }
+	OTBMException(OTBMExceptionType t) {
+		switch (t) {
+			case INVALID_FILE_FORMAT: {
+				w = "Invalid OTBM file format";
+				break;
+			}
+			case OPEN_FAILED: {
+				w = "Failed to open OTBM file";
+				break;
+			}
+			default: {
+				w = "OTBM Exception";
+				break;
+			}
+		}
+	}
+
+	const char* what() const noexcept override { return w; }
+
+private:
+	const char* w;
 };
 
 class Loader

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -35,7 +35,8 @@ enum OTBMExceptionType : uint8_t
 
 struct OTBMException final : std::exception
 {
-	OTBMException(OTBMExceptionType t) {
+	OTBMException(OTBMExceptionType t)
+	{
 		switch (t) {
 			case INVALID_FILE_FORMAT: {
 				w = "Invalid OTBM file format";

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -137,7 +137,7 @@ bool IOMap::loadMap(Map* map, const std::string& fileName)
 				return false;
 			}
 		}
-	} catch (const OTB::InvalidOTBFormat& err) {
+	} catch (const OTB::OTBMException& err) {
 		setLastErrorString(err.what());
 		return false;
 	}

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -43,6 +43,7 @@ std::unique_lock<std::mutex> g_loaderUniqueLock(g_loaderLock);
 void startupErrorMessage(const std::string& errorStr)
 {
 	fmt::print(fg(fmt::color::crimson) | fmt::emphasis::bold, "> ERROR: {:s}\n", errorStr);
+	getchar();
 	g_loaderSignal.notify_all();
 }
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Prevent crash when loading map and it does not exists, may happen if you misstyped the map name in config.lua


**Issues addressed:**
If the map does not exists, server just crash without telling you why.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
