### PR TITLE
remove pagezero_size deprecation warning on macos version >=13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,7 @@ else ()
 endif ()
 option(USE_LUAJIT "Use LuaJIT" ${FORCE_LUAJIT})
 
-if (FORCE_LUAJIT)
-    if (APPLE)
-        set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
-    endif ()
-else ()
+if (NOT FORCE_LUAJIT)
     find_package(Lua REQUIRED)
 endif ()
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Remove `-pagezero_size 10000 -image_base 100000000` linker flags, as they are deprecated as of macOS 13.0. Indeed, binaries built with these flags are killed upon startup. Plus, the compilation Wiki for macOS should be updated, too. `mysql-connector-c` has been deprecated in favour of `mysql-client`.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
