### PR TITLE
Fix reload global

### DIFF
--- a/data/talkactions/scripts/reload.lua
+++ b/data/talkactions/scripts/reload.lua
@@ -79,6 +79,11 @@ function onSay(player, words, param)
 	end
 
 	Game.reload(reloadType)
+	if reloadType == RELOAD_TYPE_GLOBAL then
+		-- we need to reload the scripts as well
+		Game.reload(RELOAD_TYPE_SCRIPTS)
+	end
+
 	player:sendTextMessage(MESSAGE_INFO_DESCR, string.format("Reloaded %s.", param:lower()))
 	return false
 end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4924,9 +4924,11 @@ int LuaScriptInterface::luaGameReload(lua_State* L)
 	if (reloadType == RELOAD_TYPE_GLOBAL) {
 		pushBoolean(L, g_luaEnvironment.loadFile("data/global.lua") == 0);
 		pushBoolean(L, g_scripts->loadScripts("scripts/lib", true, true));
-	} else {
-		pushBoolean(L, g_game.reload(reloadType));
+		lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+		return 2;
 	}
+
+	pushBoolean(L, g_game.reload(reloadType));
 	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
 	return 1;
 }


### PR DESCRIPTION

### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Because the global reload in [luascript.cpp](https://github.com/otland/forgottenserver/blob/dccc3bcc4be7e712dbcd6daf12c14553da604589/src/luascript.cpp#L4926) reloads the internal libraries of the revscript environment, [the tables where the eventcallbacks are stored are cleaned up](https://github.com/otland/forgottenserver/blob/master/data/scripts/lib/event_callbacks.lua), so we must reload the scripts after the global reload.

I also modified the code of the `Game.relaod` method a bit so that it would return 1 or 2 values ​​as the case may be, since previously a boolean was being pushed to the stack that was not even returned, [because only 1 value was being returned](https://github.com/otland/forgottenserver/blob/dccc3bcc4be7e712dbcd6daf12c14553da604589/src/luascript.cpp#L4931).

**Issues addressed:** #4304

According to the Issue lookAt fails, and yes, it's true, but so did all the related events, so it's a big problem if someone uses reloaded global 😩