### PR TITLE
A better check for getNumber/getBoolean with defaultRet

### DIFF
--- a/src/luascript.h
+++ b/src/luascript.h
@@ -276,8 +276,7 @@ public:
 	template <typename T>
 	static T getNumber(lua_State* L, int32_t arg, T defaultValue)
 	{
-		const auto parameters = lua_gettop(L);
-		if (parameters == 0 || arg > parameters) {
+		if (lua_isnumber(L, arg) == 0) {
 			return defaultValue;
 		}
 		return getNumber<T>(L, arg);
@@ -305,8 +304,7 @@ public:
 	static bool getBoolean(lua_State* L, int32_t arg) { return lua_toboolean(L, arg) != 0; }
 	static bool getBoolean(lua_State* L, int32_t arg, bool defaultValue)
 	{
-		const auto parameters = lua_gettop(L);
-		if (parameters == 0 || arg > parameters) {
+		if (lua_isboolean(L, arg) == 0) {
 			return defaultValue;
 		}
 		return lua_toboolean(L, arg) != 0;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Currently the check evaluates if `arg` is greater than the stack size or if the stack is empty, which is wrong in many cases, this is used so rarely that I didn't even realize it, but it makes particularly sense. when dealing with `defaultRet`

**Issues addressed:** #4199