### PR TITLE
Fixed exp stages ignoring last stage

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -90,9 +90,10 @@ ExperienceStages loadLuaStages(lua_State* L)
 	lua_pushnil(L);
 	while (lua_next(L, -2) != 0) {
 		const auto tableIndex = lua_gettop(L);
-		auto minLevel = LuaScriptInterface::getField<uint32_t>(L, tableIndex, "minlevel");
-		auto maxLevel = LuaScriptInterface::getField<uint32_t>(L, tableIndex, "maxlevel");
-		auto multiplier = LuaScriptInterface::getField<float>(L, tableIndex, "multiplier");
+		auto minLevel = LuaScriptInterface::getField<uint32_t>(L, tableIndex, "minlevel", 1);
+		auto maxLevel =
+		    LuaScriptInterface::getField<uint32_t>(L, tableIndex, "maxlevel", std::numeric_limits<uint32_t>::max());
+		auto multiplier = LuaScriptInterface::getField<float>(L, tableIndex, "multiplier", 1);
 		stages.emplace_back(minLevel, maxLevel, multiplier);
 		lua_pop(L, 4);
 	}
@@ -118,12 +119,10 @@ ExperienceStages loadXMLStages()
 				return {};
 			}
 		} else {
-			uint32_t minLevel, maxLevel, multiplier;
+			uint32_t minLevel = 1, maxLevel = std::numeric_limits<uint32_t>::max(), multiplier = 1;
 
 			if (auto minLevelAttribute = stageNode.attribute("minlevel")) {
 				minLevel = pugi::cast<uint32_t>(minLevelAttribute.value());
-			} else {
-				minLevel = 1;
 			}
 
 			if (auto maxLevelAttribute = stageNode.attribute("maxlevel")) {
@@ -132,8 +131,6 @@ ExperienceStages loadXMLStages()
 
 			if (auto multiplierAttribute = stageNode.attribute("multiplier")) {
 				multiplier = pugi::cast<uint32_t>(multiplierAttribute.value());
-			} else {
-				multiplier = 1;
 			}
 
 			stages.emplace_back(minLevel, maxLevel, multiplier);
@@ -328,9 +325,9 @@ bool ConfigManager::getBoolean(boolean_config_t what) const
 
 float ConfigManager::getExperienceStage(uint32_t level) const
 {
-	auto it = std::find_if(expStages.begin(), expStages.end(), [level](ExperienceStages::value_type stage) {
-		auto maxLevel = std::get<1>(stage);
-		return level >= std::get<0>(stage) && (level <= maxLevel || maxLevel == 0);
+	auto it = std::find_if(expStages.begin(), expStages.end(), [level](auto&& stage) {
+		auto&& [minLevel, maxLevel, _] = stage;
+		return level >= minLevel && level <= maxLevel;
 	});
 
 	if (it == expStages.end()) {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -329,7 +329,8 @@ bool ConfigManager::getBoolean(boolean_config_t what) const
 float ConfigManager::getExperienceStage(uint32_t level) const
 {
 	auto it = std::find_if(expStages.begin(), expStages.end(), [level](ExperienceStages::value_type stage) {
-		return level >= std::get<0>(stage) && level <= std::get<1>(stage);
+		auto maxLevel = std::get<1>(stage);
+		return level >= std::get<0>(stage) && (level <= maxLevel || maxLevel == 0);
 	});
 
 	if (it == expStages.end()) {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -329,11 +329,8 @@ bool ConfigManager::getBoolean(boolean_config_t what) const
 float ConfigManager::getExperienceStage(uint32_t level) const
 {
 	auto it = std::find_if(expStages.begin(), expStages.end(), [level](ExperienceStages::value_type stage) {
-		if (auto maxLevelAttribute = stageNode.attribute("maxlevel")) {
-			maxLevel = pugi::cast<uint32_t>(maxLevelAttribute.value());
-		} else {
-			maxLevel = std::numeric_limits<uint32_t>::max();
-		}
+		auto maxLevel = std::get<1>(stage);
+		return level >= std::get<0>(stage) && (level <= maxLevel || maxLevel == 0);
 	});
 
 	if (it == expStages.end()) {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -329,8 +329,11 @@ bool ConfigManager::getBoolean(boolean_config_t what) const
 float ConfigManager::getExperienceStage(uint32_t level) const
 {
 	auto it = std::find_if(expStages.begin(), expStages.end(), [level](ExperienceStages::value_type stage) {
-		auto maxLevel = std::get<1>(stage);
-		return level >= std::get<0>(stage) && (level <= maxLevel || maxLevel == 0);
+		if (auto maxLevelAttribute = stageNode.attribute("maxlevel")) {
+			maxLevel = pugi::cast<uint32_t>(maxLevelAttribute.value());
+		} else {
+			maxLevel = std::numeric_limits<uint32_t>::max();
+		}
 	});
 
 	if (it == expStages.end()) {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -329,6 +329,13 @@ public:
 		return getNumber<T>(L, -1);
 	}
 
+	template <typename T, typename... Args>
+	static T getField(lua_State* L, int32_t arg, const std::string& key, T&& defaultValue)
+	{
+		lua_getfield(L, arg, key.c_str());
+		return getNumber<T>(L, -1, std::forward<T>(defaultValue));
+	}
+
 	static std::string getFieldString(lua_State* L, int32_t arg, const std::string& key);
 
 	static LuaDataType getUserdataType(lua_State* L, int32_t arg);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixed exp stages ignoring last stage

### Context

> if you have x5 in config
> (not staged rate)
> last stage will be ignored and use that value instead
> because it checks min < level < max
> and max is 0
> in last stage
> so it never satisfies
> and defaults to RATE_EXP

<!-- Describe the changes that this pull request makes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
