### PR TITLE
[New Methods] get/set exhaustion

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -393,3 +393,15 @@ function Player.isPromoted(self)
 	local fromVocId = vocation:getDemotion():getId()
 	return vocation:getId() ~= fromVocId
 end
+
+function Player.setExhaustion(self, value, time)
+	return self:setStorageValue(value, time + os.time())
+end
+
+function Player.getExhaustion(self, value)
+	local storage = self:getStorageValue(value)
+	if storage <= 0 then
+		return 0
+	end
+	return storage - os.time()
+end

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -394,14 +394,10 @@ function Player.isPromoted(self)
 	return vocation:getId() ~= fromVocId
 end
 
-function Player.setExhaustion(self, value, time)
-	return self:setStorageValue(value, time + os.time())
+function Player.setExhaustion(self, key, seconds)
+	return self:setStorageValue(key, os.time() + seconds)
 end
 
-function Player.getExhaustion(self, value)
-	local storage = self:getStorageValue(value)
-	if storage <= 0 then
-		return 0
-	end
-	return storage - os.time()
+function Player.getExhaustion(self, key)
+	return math.max(self:getStorageValue(key) - os.time(), 0)
 end


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
This pull request adds two new functions to the Player class: setExhaustion and getExhaustion. These functions allow for easy management of player exhaustion values, which can be useful for limiting the frequency of certain actions or events in a game. The setExhaustion function takes two arguments: the value to set and the duration of the exhaustion in seconds. The getExhaustion function takes one argument, the value to retrieve, and returns the remaining duration of the exhaustion in seconds.

**Example usage:**
Set a 10 second exhaustion for the player
```lua
player:setExhaustion(1234, 10)
```

Check if the player is still exhausted for value 1234
```lua
if player:getExhaustion(1234) > 0 then
    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You are still exhausted.")
end
```

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
