### PR TITLE
Move toggle mount to Lua

### DIFF
--- a/data/scripts/network/toggle_mount.lua
+++ b/data/scripts/network/toggle_mount.lua
@@ -1,0 +1,8 @@
+local handler = PacketHandler(0xD4)
+
+function handler.onReceive(player, msg)
+    local mount = msg.getByte() ~= 0
+    player:toggleMount(mount)
+end
+
+handler:register()

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2661,6 +2661,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Player", "addMount", LuaScriptInterface::luaPlayerAddMount);
 	registerMethod("Player", "removeMount", LuaScriptInterface::luaPlayerRemoveMount);
 	registerMethod("Player", "hasMount", LuaScriptInterface::luaPlayerHasMount);
+	registerMethod("Player", "toggleMount", LuaScriptInterface::luaPlayerToggleMount);
 
 	registerMethod("Player", "getPremiumEndsAt", LuaScriptInterface::luaPlayerGetPremiumEndsAt);
 	registerMethod("Player", "setPremiumEndsAt", LuaScriptInterface::luaPlayerSetPremiumEndsAt);
@@ -10287,6 +10288,20 @@ int LuaScriptInterface::luaPlayerHasMount(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerToggleMount(lua_State* L)
+{
+	// player:toggleMount(mount)
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	bool mount = getBoolean(L, 2);
+	pushBoolean(L, player->toggleMount(mount));
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -966,6 +966,7 @@ private:
 	static int luaPlayerAddMount(lua_State* L);
 	static int luaPlayerRemoveMount(lua_State* L);
 	static int luaPlayerHasMount(lua_State* L);
+	static int luaPlayerToggleMount(lua_State* L);
 
 	static int luaPlayerGetPremiumEndsAt(lua_State* L);
 	static int luaPlayerSetPremiumEndsAt(lua_State* L);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -767,9 +767,6 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 		case 0xD3:
 			parseSetOutfit(msg);
 			break;
-		case 0xD4:
-			parseToggleMount(msg);
-			break;
 		// case 0xD5: break; // apply imbuement
 		// case 0xD6: break; // clear imbuement
 		// case 0xD7: break; // close imbuing window
@@ -1189,12 +1186,6 @@ void ProtocolGame::parseEditPodiumRequest(NetworkMessage& msg)
 	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
 		g_game.playerRequestEditPodium(playerID, pos, stackpos, spriteId);
 	});
-}
-
-void ProtocolGame::parseToggleMount(NetworkMessage& msg)
-{
-	bool mount = msg.getByte() != 0;
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerToggleMount(playerID, mount); });
 }
 
 void ProtocolGame::parseUseItem(NetworkMessage& msg)

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -130,8 +130,6 @@ private:
 	void parsePassPartyLeadership(NetworkMessage& msg);
 	void parseEnableSharedPartyExperience(NetworkMessage& msg);
 
-	void parseToggleMount(NetworkMessage& msg);
-
 	void parseModalWindowAnswer(NetworkMessage& msg);
 
 	void parseBrowseField(NetworkMessage& msg);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Moves player toggle mount handler to Lua. Additionally, adds `Player.toggleMount(bool)` to Lua, with the same parameters as `Player::toggleMount(bool)`

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
