### PR TITLE
Perform gameworld authentication using character ID

### DIFF
--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -20,17 +20,17 @@ public:
 	static Account loadAccount(uint32_t accno);
 
 	static bool loginserverAuthentication(const std::string& name, const std::string& password, Account& account);
-	static std::pair<uint32_t, std::string_view> gameworldAuthentication(std::string_view accountName,
-	                                                                     std::string_view password,
-	                                                                     std::string_view characterName,
-	                                                                     std::string_view token, uint32_t tokenTime);
+	static std::pair<uint32_t, uint32_t> gameworldAuthentication(std::string_view accountName,
+	                                                             std::string_view password,
+	                                                             std::string_view characterName, std::string_view token,
+	                                                             uint32_t tokenTime);
 	static uint32_t getAccountIdByPlayerName(const std::string& playerName);
 	static uint32_t getAccountIdByPlayerId(uint32_t playerId);
 
 	static AccountType_t getAccountType(uint32_t accountId);
 	static void setAccountType(uint32_t accountId, AccountType_t accountType);
 	static void updateOnlineStatus(uint32_t guid, bool login);
-	static bool preloadPlayer(Player* player, const std::string& name);
+	static bool preloadPlayer(Player* player);
 
 	static bool loadPlayerById(Player* player, uint32_t id);
 	static bool loadPlayerByName(Player* player, const std::string& name);

--- a/src/player.h
+++ b/src/player.h
@@ -113,7 +113,7 @@ public:
 	static MuteCountMap muteCountMap;
 
 	const std::string& getName() const override { return name; }
-	void setName(const std::string& name) { this->name = name; }
+	void setName(std::string_view name) { this->name = name; }
 	const std::string& getNameDescription() const override { return name; }
 	std::string getDescription(int32_t lookDistance) const override;
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -151,18 +151,18 @@ void ProtocolGame::release()
 	Protocol::release();
 }
 
-void ProtocolGame::login(const std::string& name, uint32_t accountId, OperatingSystem_t operatingSystem)
+void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSystem_t operatingSystem)
 {
 	// dispatcher thread
-	Player* foundPlayer = g_game.getPlayerByName(name);
+	Player* foundPlayer = g_game.getPlayerByGUID(characterId);
 	if (!foundPlayer || g_config.getBoolean(ConfigManager::ALLOW_CLONES)) {
 		player = new Player(getThis());
-		player->setName(name);
 
 		player->incrementReferenceCounter();
 		player->setID();
+		player->setGUID(characterId);
 
-		if (!IOLoginData::preloadPlayer(player, name)) {
+		if (!IOLoginData::preloadPlayer(player)) {
 			disconnectClient("Your character could not be loaded.");
 			return;
 		}
@@ -468,17 +468,14 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	uint32_t accountId;
-	std::tie(accountId, characterName) =
+	auto [accountId, characterId] =
 	    IOLoginData::gameworldAuthentication(accountName, password, characterName, token, tokenTime);
 	if (accountId == 0) {
 		disconnectClient("Account name or password is not correct.");
 		return;
 	}
 
-	g_dispatcher.addTask([=, thisPtr = getThis(), characterName = std::string{characterName}]() {
-		thisPtr->login(characterName, accountId, operatingSystem);
-	});
+	g_dispatcher.addTask([=, thisPtr = getThis()]() { thisPtr->login(characterId, accountId, operatingSystem); });
 }
 
 void ProtocolGame::onConnect()

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -66,7 +66,7 @@ public:
 
 	explicit ProtocolGame(Connection_ptr connection) : Protocol(connection) {}
 
-	void login(const std::string& name, uint32_t accountId, OperatingSystem_t operatingSystem);
+	void login(uint32_t characterId, uint32_t accountId, OperatingSystem_t operatingSystem);
 	void logout(bool displayEffect, bool forced);
 
 	uint16_t getVersion() const { return version; }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Instead of performing gameworld authentication and login using the character name, instead read the character ID as early as possible and use that instead. This reduces the need to pass strings around.

**Issues addressed:**
Fixes #4359 
Closes #4360

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
