### PR TITLE
Addition of option to preview items for sale

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3343,7 +3343,7 @@ bool Player::hasShopItemForSale(uint32_t itemId, uint8_t subType) const
 {
 	const ItemType& itemType = Item::items[itemId];
 	return std::any_of(shopItemList.begin(), shopItemList.end(), [&](const ShopInfo& shopInfo) {
-		return shopInfo.itemId == itemId && shopInfo.buyPrice != 0 &&
+		return shopInfo.itemId == itemId && (shopInfo.buyPrice != 0 || shopInfo.sellPrice != 0) &&
 		       (!itemType.isFluidContainer() || shopInfo.subType == subType);
 	});
 }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
Added support for the option to preview items for sale for players. Now, players can check the items that are for sale before purchasing them, allowing for a more informed purchasing experience.

![image](https://user-images.githubusercontent.com/26801045/229989035-58e15e2d-25c8-4282-b782-11d94b335be9.png)

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
