### PR TITLE
Fix issue where players with pz lock were able to bypass the white skull timer

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -938,7 +938,7 @@ void Player::sendPing()
 	}
 
 	if (noPongTime >= noPongKickTime) {
-		if (isConnecting || getTile() && getTile()->hasFlag(TILESTATE_NOLOGOUT) || pzLocked) {
+		if (isConnecting || (getTile() && getTile()->hasFlag(TILESTATE_NOLOGOUT)) || pzLocked) {
 			return;
 		}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -938,7 +938,7 @@ void Player::sendPing()
 	}
 
 	if (noPongTime >= noPongKickTime) {
-		if (isConnecting || getTile()->hasFlag(TILESTATE_NOLOGOUT) || pzLocked) {
+		if (isConnecting || getTile() && getTile()->hasFlag(TILESTATE_NOLOGOUT) || pzLocked) {
 			return;
 		}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -938,10 +938,6 @@ void Player::sendPing()
 	}
 
 	if (noPongTime >= noPongKickTime) {
-		if (isConnecting || getTile()->hasFlag(TILESTATE_NOLOGOUT)) {
-			return;
-		}
-
 		if (isConnecting || getTile()->hasFlag(TILESTATE_NOLOGOUT) || pzLocked) {
 			return;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -942,6 +942,10 @@ void Player::sendPing()
 			return;
 		}
 
+		if (isConnecting || getTile()->hasFlag(TILESTATE_NOLOGOUT) || pzLocked) {
+			return;
+		}
+
 		if (!g_creatureEvents->playerLogout(this)) {
 			return;
 		}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
Added code to prevent players with "pz lock" from logging out of the game before the determined time, as well as players who are connecting or in an area where logout is prohibited. Now, when trying to log out in any of these situations, the player will not be able to do so and will remain connected in the game. This code helps to avoid possible bug exploitation issues and ensures that players correctly comply with the waiting time required before leaving the game.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Close #3754

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
