### PR TITLE
Add talkaction to grant all mounts and outfits to a player

### DIFF
--- a/data/scripts/talkactions/add_all_mounts.lua
+++ b/data/scripts/talkactions/add_all_mounts.lua
@@ -1,0 +1,21 @@
+local talk = TalkAction("/addallmounts")
+
+function talk.onSay(player, words, param)
+	if not player:getGroup():getAccess() then
+        return true
+    end
+
+    local targetPlayer = Player(param)
+    if not targetPlayer then
+        player:sendCancelMessage("Player not found.")
+        return false
+    end
+
+    targetPlayer:addAllMounts()
+    player:sendTextMessage(MESSAGE_INFO_DESCR, "All mounts have been delivered to " .. targetPlayer:getName() .. ".")
+    targetPlayer:sendTextMessage(MESSAGE_INFO_DESCR, "You have received all mounts from " .. player:getName() .. ".")
+    return false
+end
+
+talk:separator(" ")
+talk:register()

--- a/data/scripts/talkactions/add_all_outifts.lua
+++ b/data/scripts/talkactions/add_all_outifts.lua
@@ -1,0 +1,21 @@
+local talk = TalkAction("/addalloutifts")
+
+function talk.onSay(player, words, param)
+	if not player:getGroup():getAccess() then
+        return true
+    end
+
+    local targetPlayer = Player(param)
+    if not targetPlayer then
+        player:sendCancelMessage("Player not found.")
+        return false
+    end
+
+    targetPlayer:addAddonToAllOutfits()
+    player:sendTextMessage(MESSAGE_INFO_DESCR, "All outfits have been delivered to " .. targetPlayer:getName() .. ".")
+    targetPlayer:sendTextMessage(MESSAGE_INFO_DESCR, "You have received all outfits from " .. player:getName() .. ".")
+    return false
+end
+
+talk:separator(" ")
+talk:register()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
This pull request adds a new talkaction command `/addallmounts<playername>` and  `/addalloutifts<playername>` that allows administrators to grant all mounts and all addons to a target player. The talkaction function iterates through all available mounts and outfits and adds them to the player's mount and outfit lists. The function also sends a message to both the administrator and the target player to confirm that the command has been executed.

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
