### PR TITLE
Fix bugs in mount system

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3509,8 +3509,12 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool randomize
 
 		changeSpeed(player, speedChange);
 		player->setCurrentMount(mount->id);
-	} else if (player->isMounted()) {
-		player->dismount();
+	} else {
+		if (player->isMounted()) {
+			player->dismount();
+		}
+
+		player->wasMounted = false;
 	}
 
 	if (player->canWear(outfit.lookType, outfit.lookAddons)) {
@@ -3526,6 +3530,10 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool randomize
 		}
 
 		internalCreatureChangeOutfit(player, outfit);
+	}
+
+	if (player->isMounted()) {
+		player->onChangeZone(player->getZone());
 	}
 }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3207,7 +3207,6 @@ void ProtocolGame::sendOutfitWindow()
 	msg.addByte(0xC8);
 
 	Outfit_t currentOutfit = player->getDefaultOutfit();
-	bool mounted = currentOutfit.lookMount != 0;
 
 	if (currentOutfit.lookType == 0) {
 		Outfit_t newOutfit;
@@ -3219,6 +3218,8 @@ void ProtocolGame::sendOutfitWindow()
 	if (currentMount) {
 		currentOutfit.lookMount = currentMount->clientId;
 	}
+
+	bool mounted = currentOutfit.lookMount != 0;
 
 	AddOutfit(msg, currentOutfit);
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x` inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Fix 1: enabling mount in pz through set outfit dialog was allowing to ride a mount in pz
Fix 2: players who opened "set outfit" in pz had mount checkbox disabled despite preferring to have a mount

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
