### PR TITLE
ModalWindow default buttons issue fixed.

### DIFF
--- a/data/scripts/creaturescripts/modal_window_helper.lua
+++ b/data/scripts/creaturescripts/modal_window_helper.lua
@@ -193,9 +193,9 @@ function ModalWindow:create()
 		local name = self.buttons[id].name
 		modalWindow:addButton(id, name)
 		if id == self.defaultEnterButton or name == self.defaultEnterButton then
-			modalWindow:setDefaultEnterButton(id)
+			modalWindow:setDefaultEnterButton(id - 1)
 		elseif id == self.defaultEscapeButton or name == self.defaultEscapeButton then
-			modalWindow:setDefaultEscapeButton(id)
+			modalWindow:setDefaultEscapeButton(id - 1)
 		end
 	end
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -50,8 +50,8 @@ extern Scripts* g_scripts;
 
 Game::Game()
 {
-	offlineTrainingWindow.defaultEnterButton = 1;
-	offlineTrainingWindow.defaultEscapeButton = 0;
+	offlineTrainingWindow.defaultEnterButton = 0;
+	offlineTrainingWindow.defaultEscapeButton = 1;
 	offlineTrainingWindow.choices.emplace_back("Sword Fighting and Shielding", SKILL_SWORD);
 	offlineTrainingWindow.choices.emplace_back("Axe Fighting and Shielding", SKILL_AXE);
 	offlineTrainingWindow.choices.emplace_back("Club Fighting and Shielding", SKILL_CLUB);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3547,8 +3547,8 @@ void ProtocolGame::sendModalWindow(const ModalWindow& modalWindow)
 		msg.addByte(it.second);
 	}
 
-	msg.addByte(modalWindow.defaultEnterButton);
 	msg.addByte(modalWindow.defaultEscapeButton);
+	msg.addByte(modalWindow.defaultEnterButton);
 	msg.addByte(modalWindow.priority ? 0x01 : 0x00);
 
 	writeToOutputBuffer(msg);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
These small changes fix the default buttons issue.

**For you information:**

The following examples only apply to those who do not use [ModalWindow Helper](https://github.com/otland/forgottenserver/pull/4223), as this system handles this automatically.
<details>

<summary> Simple Examples </summary>

Let's assume we have a list of buttons like this:
![image](https://user-images.githubusercontent.com/28090948/230802125-991b8e02-7eac-4c9f-a33b-f7341e5d991e.png)
**Yes**, buttons can have any ID, even duplicates.

Now it is normal to think that you can bind the default button by its ID, but that is not true.
If you wanted to bind the default button you need to get its index in the list and use this index, for example if I want to select the button:
![image](https://user-images.githubusercontent.com/28090948/230802214-35031d34-be5c-49d6-85b3-5b20df809e45.png)
I must use index 1, since the client counts from 0.
`modalWindow:setDefaultEscapeButton(1)`

If I want to select the button:
![image](https://user-images.githubusercontent.com/28090948/230802258-6cedb0cc-9ba9-41a9-9292-51125af7db52.png)
You must use index 0, I think at this point you already understood.
`modalWindow:setDefaultEnterButton(0)`

for the button:
![image](https://user-images.githubusercontent.com/28090948/230802337-09c4d3e8-64a0-4f03-b5b2-ddd82aca95e5.png)
You must use index 4
`modalWindow:setDefaultEnterButton(4)`

</details>

**Issues addressed:** #4370