### PR TITLE
Bestiary monsters

### DIFF
--- a/data/monster/monsters/acid_blob.xml
+++ b/data/monster/monsters/acid_blob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Acid Blob" nameDescription="an acid blob" race="venom" experience="250" speed="180">
+<monster name="Acid Blob" nameDescription="an acid blob" race="venom" experience="250" speed="180" raceId="513">
 	<health now="250" max="250" />
 	<look type="314" corpse="9962" />
 	<targetchange interval="5000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Slime" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Acid Blob locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />
 		<attack name="earth" interval="2000" target="0" chance="30" radius="4" min="-10" max="-20">

--- a/data/monster/monsters/acid_blob.xml
+++ b/data/monster/monsters/acid_blob.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Slime" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Acid Blob locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Acid Blob locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />
 		<attack name="earth" interval="2000" target="0" chance="30" radius="4" min="-10" max="-20">

--- a/data/monster/monsters/acolyte_of_the_cult.xml
+++ b/data/monster/monsters/acolyte_of_the_cult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Acolyte of the Cult" nameDescription="an acolyte of the cult" race="blood" experience="300" speed="200">
+<monster name="Acolyte of the Cult" nameDescription="an acolyte of the cult" race="blood" experience="300" speed="200" raceId="253">
 	<health now="390" max="390" />
 	<look type="194" head="95" body="100" legs="100" feet="19" corpse="20319" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Acolyte of the Cult locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="2" />
 		<attack name="lifedrain" interval="2000" chance="20" range="7" radius="1" target="1" min="-60" max="-120">

--- a/data/monster/monsters/acolyte_of_the_cult.xml
+++ b/data/monster/monsters/acolyte_of_the_cult.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Acolyte of the Cult locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Acolyte of the Cult locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="2" />
 		<attack name="lifedrain" interval="2000" chance="20" range="7" radius="1" target="1" min="-60" max="-120">

--- a/data/monster/monsters/adept_of_the_cult.xml
+++ b/data/monster/monsters/adept_of_the_cult.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Adept of the Cult locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Adept of the Cult locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" poison="2" />
 		<attack name="lifedrain" interval="2000" chance="20" range="7" target="1" min="-70" max="-150">

--- a/data/monster/monsters/adept_of_the_cult.xml
+++ b/data/monster/monsters/adept_of_the_cult.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Adept of the Cult" nameDescription="an adept of the cult" race="blood" experience="400" speed="215">
+<monster name="Adept of the Cult" nameDescription="an adept of the cult" race="blood" experience="400" speed="215" raceId="253">
 	<health now="430" max="430" />
 	<look type="194" head="95" body="94" legs="94" feet="19" corpse="20311" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Adept of the Cult locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" poison="2" />
 		<attack name="lifedrain" interval="2000" chance="20" range="7" target="1" min="-70" max="-150">

--- a/data/monster/monsters/adult_goanna.xml
+++ b/data/monster/monsters/adult_goanna.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Adult Goanna" nameDescription="an adult goanna" race="blood" experience="6650" speed="420">
+<monster name="Adult Goanna" nameDescription="an adult goanna" race="blood" experience="6650" speed="420" raceId="1818">
 	<health now="8300" max="8300" />
 	<look type="1195" corpse="34061" />
 	<targetchange interval="2000" chance="5" />
@@ -20,6 +20,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Reptile" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Adult Goanna locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-350" poison="19" />
 		<attack name="wave t" interval="2000" chance="10" min="-250" max="-380" />

--- a/data/monster/monsters/adult_goanna.xml
+++ b/data/monster/monsters/adult_goanna.xml
@@ -21,7 +21,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Reptile" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Adult Goanna locations"/>
+		charmPoints="50" stars="4" occurrence="0" locations="Adult Goanna locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-350" poison="19" />
 		<attack name="wave t" interval="2000" chance="10" min="-250" max="-380" />

--- a/data/monster/monsters/adventurer.xml
+++ b/data/monster/monsters/adventurer.xml
@@ -20,5 +20,5 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Adventurer locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Adventurer locations" />
 </monster>

--- a/data/monster/monsters/adventurer.xml
+++ b/data/monster/monsters/adventurer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Adventurer" nameDescription="an adventurer" race="blood" experience="0" speed="106">
+<monster name="Adventurer" nameDescription="an adventurer" race="blood" experience="0" speed="106" raceId="922">
 	<health now="65" max="65" />
 	<look type="129" head="93" body="15" legs="72" feet="80" addons="0" corpse="20315" />
 	<targetchange interval="4000" chance="10" />
@@ -19,4 +19,6 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Adventurer locations"/>
 </monster>

--- a/data/monster/monsters/amazon.xml
+++ b/data/monster/monsters/amazon.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Amazon locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Amazon locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />
 		<attack name="physical" interval="2000" chance="15" range="7" min="0" max="-40">

--- a/data/monster/monsters/amazon.xml
+++ b/data/monster/monsters/amazon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Amazon" nameDescription="an amazon" race="blood" experience="60" speed="172" manacost="390">
+<monster name="Amazon" nameDescription="an amazon" race="blood" experience="60" speed="172" manacost="390" raceId="77">
 	<health now="110" max="110" />
 	<look type="137" head="113" body="120" legs="95" feet="115" corpse="20323" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Amazon locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />
 		<attack name="physical" interval="2000" chance="15" range="7" min="0" max="-40">

--- a/data/monster/monsters/ancient_scarab.xml
+++ b/data/monster/monsters/ancient_scarab.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Vermin" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Ancient Scarab locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Ancient Scarab locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-210" poison="56" />
 		<attack name="earth" interval="2000" chance="20" range="7" min="-15" max="-145">

--- a/data/monster/monsters/ancient_scarab.xml
+++ b/data/monster/monsters/ancient_scarab.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Ancient Scarab" nameDescription="an ancient scarab" race="venom" experience="720" speed="218">
+<monster name="Ancient Scarab" nameDescription="an ancient scarab" race="venom" experience="720" speed="218" raceId="79">
 	<health now="1000" max="1000" />
 	<look type="79" corpse="6021" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Ancient Scarab locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-210" poison="56" />
 		<attack name="earth" interval="2000" chance="20" range="7" min="-15" max="-145">

--- a/data/monster/monsters/arctic_faun.xml
+++ b/data/monster/monsters/arctic_faun.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Arctic Faun" nameDescription="an arctic faun" race="blood" experience="300" speed="210">
+<monster name="Arctic Faun" nameDescription="an arctic faun" race="blood" experience="300" speed="210" raceId="1626">
 	<health now="300" max="300" />
 	<look type="980" head="85" body="0" legs="0" feet="85" addons="0" corpse="31467" />
 	<targetchange interval="2000" chance="5" />
@@ -14,6 +14,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Fey" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Arctic Faun locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="physical" interval="1000" chance="15" range="7" min="0" max="-180">

--- a/data/monster/monsters/arctic_faun.xml
+++ b/data/monster/monsters/arctic_faun.xml
@@ -15,7 +15,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Fey" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Arctic Faun locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Arctic Faun locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="physical" interval="1000" chance="15" range="7" min="0" max="-180">

--- a/data/monster/monsters/armadile.xml
+++ b/data/monster/monsters/armadile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Armadile" nameDescription="an armadile" race="undead" experience="2900" speed="440">
+<monster name="Armadile" nameDescription="an armadile" race="undead" experience="2900" speed="440" raceId="880">
 	<health now="3800" max="3800" />
 	<look type="487" corpse="18378" />
 	<targetchange interval="4000" chance="10" />
@@ -14,6 +14,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="1" locations="Armadile locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />
 		<attack name="drunk" interval="2000" chance="15" radius="4" target="1" duration="5000">

--- a/data/monster/monsters/armadile.xml
+++ b/data/monster/monsters/armadile.xml
@@ -15,7 +15,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="1" locations="Armadile locations"/>
+		charmPoints="50" stars="4" occurrence="1" locations="Armadile locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />
 		<attack name="drunk" interval="2000" chance="15" radius="4" target="1" duration="5000">

--- a/data/monster/monsters/askarak_demon.xml
+++ b/data/monster/monsters/askarak_demon.xml
@@ -18,7 +18,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Demon" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Askarak Demon locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Askarak Demon locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-143" />
 		<attack name="earth" interval="2000" chance="20" range="7" radius="6" target="0" min="-20" max="-60">

--- a/data/monster/monsters/askarak_demon.xml
+++ b/data/monster/monsters/askarak_demon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Askarak Demon" nameDescription="an askarak demon" race="venom" experience="900" speed="220">
+<monster name="Askarak Demon" nameDescription="an askarak demon" race="venom" experience="900" speed="220" raceId="727">
 	<health now="1500" max="1500" />
 	<look type="420" corpse="13815" />
 	<targetchange interval="4000" chance="10" />
@@ -17,6 +17,8 @@
 		<flag runonhealth="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Demon" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Askarak Demon locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-143" />
 		<attack name="earth" interval="2000" chance="20" range="7" radius="6" target="0" min="-20" max="-60">

--- a/data/monster/monsters/askarak_lord.xml
+++ b/data/monster/monsters/askarak_lord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Askarak Lord" nameDescription="an askarak lord" race="venom" experience="1200" speed="230">
+<monster name="Askarak Lord" nameDescription="an askarak lord" race="venom" experience="1200" speed="230" raceId="728">
 	<health now="2100" max="2100" />
 	<look type="410" corpse="13956" />
 	<targetchange interval="4000" chance="10" />
@@ -16,6 +16,8 @@
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
 	</flags>
+	<bestiary class="Demon" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Askarak Lord locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-186" />
 		<attack name="earth" interval="2000" chance="20" range="7" radius="6" target="0" min="-40" max="-80">

--- a/data/monster/monsters/askarak_lord.xml
+++ b/data/monster/monsters/askarak_lord.xml
@@ -17,7 +17,7 @@
 		<flag runonhealth="0" />
 	</flags>
 	<bestiary class="Demon" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Askarak Lord locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Askarak Lord locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-186" />
 		<attack name="earth" interval="2000" chance="20" range="7" radius="6" target="0" min="-40" max="-80">

--- a/data/monster/monsters/askarak_prince.xml
+++ b/data/monster/monsters/askarak_prince.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Askarak Prince" nameDescription="an askarak prince" race="venom" experience="1700" speed="240">
+<monster name="Askarak Prince" nameDescription="an askarak prince" race="venom" experience="1700" speed="240" raceId="729">
 	<health now="2600" max="2600" />
 	<look type="419" corpse="13957" />
 	<targetchange interval="4000" chance="10" />
@@ -16,6 +16,8 @@
 		<flag staticattack="80" />
 		<flag runonhealth="0" />
 	</flags>
+	<bestiary class="Demon" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="2" locations="Acid Prince locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-353" />
 		<attack name="earth" interval="2000" chance="20" range="7" radius="6" target="0" min="-70" max="-250">

--- a/data/monster/monsters/askarak_prince.xml
+++ b/data/monster/monsters/askarak_prince.xml
@@ -17,7 +17,7 @@
 		<flag runonhealth="0" />
 	</flags>
 	<bestiary class="Demon" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="2" locations="Acid Prince locations"/>
+		charmPoints="25" stars="3" occurrence="2" locations="Acid Prince locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-353" />
 		<attack name="earth" interval="2000" chance="20" range="7" radius="6" target="0" min="-70" max="-250">

--- a/data/monster/monsters/assassin.xml
+++ b/data/monster/monsters/assassin.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Assassin locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Assassin locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" />
 		<attack name="physical" interval="2000" chance="15" range="7" min="0" max="-40">

--- a/data/monster/monsters/assassin.xml
+++ b/data/monster/monsters/assassin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Assassin" nameDescription="an assassin" race="blood" experience="105" speed="224" manacost="450">
+<monster name="Assassin" nameDescription="an assassin" race="blood" experience="105" speed="224" manacost="450" raceId="224">
 	<health now="175" max="175" />
 	<look type="152" head="95" body="95" legs="95" feet="95" addons="3" corpse="20327" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Assassin locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-120" />
 		<attack name="physical" interval="2000" chance="15" range="7" min="0" max="-40">

--- a/data/monster/monsters/azure_frog.xml
+++ b/data/monster/monsters/azure_frog.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Amphibic" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Azure Frog locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Azure Frog locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />
 	</attacks>

--- a/data/monster/monsters/azure_frog.xml
+++ b/data/monster/monsters/azure_frog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Azure Frog" nameDescription="an azure frog" race="blood" experience="20" speed="200" manacost="305">
+<monster name="Azure Frog" nameDescription="an azure frog" race="blood" experience="20" speed="200" manacost="305" raceId="268">
 	<health now="60" max="60" />
 	<look type="226" head="87" body="85" legs="85" feet="87" corpse="6079" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Amphibic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Azure Frog locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />
 	</attacks>

--- a/data/monster/monsters/badger.xml
+++ b/data/monster/monsters/badger.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Badger" namedescription="a badger" race="blood" experience="5" speed="140" manacost="200">
+<monster name="Badger" namedescription="a badger" race="blood" experience="5" speed="140" manacost="200" raceId="105">
 	<health now="23" max="23" />
 	<look type="105" corpse="6034" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="1" occurrence="0" locations="Badger locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-12" />
 	</attacks>

--- a/data/monster/monsters/badger.xml
+++ b/data/monster/monsters/badger.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Mammal" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="1" occurrence="0" locations="Badger locations"/>
+		charmPoints="15" stars="1" occurrence="0" locations="Badger locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-12" />
 	</attacks>

--- a/data/monster/monsters/bandit.xml
+++ b/data/monster/monsters/bandit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bandit" nameDescription="a bandit" race="blood" experience="65" speed="180" manacost="450">
+<monster name="Bandit" nameDescription="a bandit" race="blood" experience="65" speed="180" manacost="450" raceId="223">
 	<health now="245" max="245" />
 	<look type="129" head="58" body="40" legs="24" feet="95" corpse="20331" />
 	<targetchange interval="5000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Bandit locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />
 	</attacks>

--- a/data/monster/monsters/bandit.xml
+++ b/data/monster/monsters/bandit.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Bandit locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Bandit locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />
 	</attacks>

--- a/data/monster/monsters/bane_bringer.xml
+++ b/data/monster/monsters/bane_bringer.xml
@@ -17,7 +17,7 @@
 		<flag runonhealth="0" />
 	</flags>
 	<bestiary class="Plant" prowess="2" expertise="3" mastery="5"
-		charmPoints="50" stars="3" occurrence="3" locations="Bane Bringer locations"/>
+		charmPoints="50" stars="3" occurrence="3" locations="Bane Bringer locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />
 	</attacks>

--- a/data/monster/monsters/bane_bringer.xml
+++ b/data/monster/monsters/bane_bringer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bane Bringer" nameDescription="a bane bringer" experience="400" speed="260" race="undead">
+<monster name="Bane Bringer" nameDescription="a bane bringer" experience="400" speed="260" race="undead" raceId="679">
 	<health now="2500" max="2500" />
 	<look type="310" corpse="9867" />
 	<targetchange speed="0" chance="8" />
@@ -16,6 +16,8 @@
 		<flag staticattack="90" />
 		<flag runonhealth="0" />
 	</flags>
+	<bestiary class="Plant" prowess="2" expertise="3" mastery="5"
+		charmPoints="50" stars="3" occurrence="3" locations="Bane Bringer locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />
 	</attacks>

--- a/data/monster/monsters/banshee.xml
+++ b/data/monster/monsters/banshee.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Banshee" nameDescription="a banshee" race="undead" experience="900" speed="220">
+<monster name="Banshee" nameDescription="a banshee" race="undead" experience="900" speed="220" raceId="78">
 	<health now="1000" max="1000" />
 	<look type="78" corpse="6019" />
 	<targetchange interval="4000" chance="10" />
@@ -17,6 +17,8 @@
 		<flag runonhealth="599" />
 		<flag canwalkonenergy="0" />
 	</flags>
+	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Banshee locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="3" />
 		<attack name="lifedrain" interval="2000" chance="15" radius="4" target="0" min="-100" max="-200">

--- a/data/monster/monsters/banshee.xml
+++ b/data/monster/monsters/banshee.xml
@@ -18,7 +18,7 @@
 		<flag canwalkonenergy="0" />
 	</flags>
 	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Banshee locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Banshee locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="3" />
 		<attack name="lifedrain" interval="2000" chance="15" radius="4" target="0" min="-100" max="-200">

--- a/data/monster/monsters/barbarian_bloodwalker.xml
+++ b/data/monster/monsters/barbarian_bloodwalker.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Barbarian Bloodwalker locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Barbarian Bloodwalker locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" />
 	</attacks>

--- a/data/monster/monsters/barbarian_bloodwalker.xml
+++ b/data/monster/monsters/barbarian_bloodwalker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Barbarian Bloodwalker" nameDescription="a barbarian bloodwalker" race="blood" experience="195" speed="236" manacost="590">
+<monster name="Barbarian Bloodwalker" nameDescription="a barbarian bloodwalker" race="blood" experience="195" speed="236" manacost="590" raceId="323">
 	<health now="305" max="305" />
 	<look type="255" head="114" body="113" legs="132" feet="94" corpse="20335" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Barbarian Bloodwalker locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-240" />
 	</attacks>

--- a/data/monster/monsters/barbarian_brutetamer.xml
+++ b/data/monster/monsters/barbarian_brutetamer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Barbarian Brutetamer" nameDescription="a barbarian brutetamer" race="blood" experience="90" speed="190">
+<monster name="Barbarian Brutetamer" nameDescription="a barbarian brutetamer" race="blood" experience="90" speed="190" raceId="332">
 	<health now="145" max="145" />
 	<look type="264" head="78" body="97" legs="95" feet="121" corpse="20339" />
 	<targetchange interval="60000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Brutetamer locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />
 		<attack name="physical" interval="2000" chance="20" range="7" radius="1" target="1" min="0" max="-34">

--- a/data/monster/monsters/barbarian_brutetamer.xml
+++ b/data/monster/monsters/barbarian_brutetamer.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Brutetamer locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Brutetamer locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />
 		<attack name="physical" interval="2000" chance="20" range="7" radius="1" target="1" min="0" max="-34">

--- a/data/monster/monsters/barbarian_headsplitter.xml
+++ b/data/monster/monsters/barbarian_headsplitter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Barbarian Headsplitter" nameDescription="a barbarian headsplitter" race="blood" experience="85" speed="168" manacost="450">
+<monster name="Barbarian Headsplitter" nameDescription="a barbarian headsplitter" race="blood" experience="85" speed="168" manacost="450" raceId="333">
 	<health now="100" max="100" />
 	<look type="253" head="115" body="86" legs="119" feet="113" corpse="20343" />
 	<targetchange interval="60000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Headsplitter locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />
 		<attack name="physical" interval="2000" chance="15" range="7" radius="1" target="1" min="0" max="-60">

--- a/data/monster/monsters/barbarian_headsplitter.xml
+++ b/data/monster/monsters/barbarian_headsplitter.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Headsplitter locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Headsplitter locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />
 		<attack name="physical" interval="2000" chance="15" range="7" radius="1" target="1" min="0" max="-60">

--- a/data/monster/monsters/barbarian_skullhunter.xml
+++ b/data/monster/monsters/barbarian_skullhunter.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Skullhunter locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Skullhunter locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-65" />
 	</attacks>

--- a/data/monster/monsters/barbarian_skullhunter.xml
+++ b/data/monster/monsters/barbarian_skullhunter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Barbarian Skullhunter" nameDescription="a barbarian skullhunter" race="blood" experience="85" speed="168" manacost="450">
+<monster name="Barbarian Skullhunter" nameDescription="a barbarian skullhunter" race="blood" experience="85" speed="168" manacost="450" raceId="322">
 	<health now="135" max="135" />
 	<look type="254" head="0" body="77" legs="96" feet="114" corpse="20347" />
 	<targetchange interval="60000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Barbarian Skullhunter locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-65" />
 	</attacks>

--- a/data/monster/monsters/barkless_fanatic.xml
+++ b/data/monster/monsters/barkless_fanatic.xml
@@ -14,7 +14,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Humanoid" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Barkless Fanatic locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Barkless Fanatic locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-230" />
 		<attack name="earth" interval="2000" chance="20" range="7" target="1" radius="4" min="-220" max="-450">

--- a/data/monster/monsters/barkless_fanatic.xml
+++ b/data/monster/monsters/barkless_fanatic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Barkless Fanatic" nameDescription="a barkless fanatic" race="blood" experience="2500" speed="300">
+<monster name="Barkless Fanatic" nameDescription="a barkless fanatic" race="blood" experience="2500" speed="300" raceId="1488">
 	<health now="3200" max="3200" />
 	<look type="990" corpse="6012" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Barkless Fanatic locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-230" />
 		<attack name="earth" interval="2000" chance="20" range="7" target="1" radius="4" min="-220" max="-450">

--- a/data/monster/monsters/bat.xml
+++ b/data/monster/monsters/bat.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
-		charmPoints="5" stars="1" occurrence="0" locations="Bat locations"/>
+		charmPoints="5" stars="1" occurrence="0" locations="Bat locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-8" />
 	</attacks>

--- a/data/monster/monsters/bat.xml
+++ b/data/monster/monsters/bat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bat" namedescription="a bat" race="blood" experience="10" speed="200" manacost="250">
+<monster name="Bat" namedescription="a bat" race="blood" experience="10" speed="200" manacost="250" raceId="122">
 	<health now="30" max="30" />
 	<look type="122" corpse="6053" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Bat locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-8" />
 	</attacks>

--- a/data/monster/monsters/bear.xml
+++ b/data/monster/monsters/bear.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Mammal" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Bear locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Bear locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />
 	</attacks>

--- a/data/monster/monsters/bear.xml
+++ b/data/monster/monsters/bear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bear" nameDescription="a bear" race="blood" experience="23" speed="156" manacost="300">
+<monster name="Bear" nameDescription="a bear" race="blood" experience="23" speed="156" manacost="300" raceId="16">
 	<health now="80" max="80" />
 	<look type="16" corpse="5975" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Bear locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />
 	</attacks>

--- a/data/monster/monsters/behemoth.xml
+++ b/data/monster/monsters/behemoth.xml
@@ -18,7 +18,7 @@
 		<flag canwalkonenergy="0" />
 	</flags>
 	<bestiary class="Giant" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Behemoth locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Behemoth locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-455" />
 		<attack name="physical" interval="2000" chance="15" range="7" min="0" max="-200">

--- a/data/monster/monsters/behemoth.xml
+++ b/data/monster/monsters/behemoth.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Behemoth" nameDescription="a behemoth" race="blood" experience="2500" speed="340">
+<monster name="Behemoth" nameDescription="a behemoth" race="blood" experience="2500" speed="340" raceId="55">
 	<health now="4000" max="4000" />
 	<look type="55" corpse="5999" />
 	<targetchange interval="4000" chance="10" />
@@ -17,6 +17,8 @@
 		<flag runonhealth="0" />
 		<flag canwalkonenergy="0" />
 	</flags>
+	<bestiary class="Giant" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Behemoth locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-455" />
 		<attack name="physical" interval="2000" chance="15" range="7" min="0" max="-200">

--- a/data/monster/monsters/berserker_chicken.xml
+++ b/data/monster/monsters/berserker_chicken.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Berserker Chicken" namedescription="a berserker chicken" race="blood" experience="220" speed="300" manacost="220">
+<monster name="Berserker Chicken" namedescription="a berserker chicken" race="blood" experience="220" speed="300" manacost="220" raceId="561">
 	<health now="465" max="465" />
 	<look type="111" corpse="6042" />
 	<targetchange interval="5000" chance="8" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Bird" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="1" locations="Berserker Chicken locations"/>
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-200" />
 		<attack name="physical" interval="2000" chance="30" range="1" min="0" max="-100" />

--- a/data/monster/monsters/berserker_chicken.xml
+++ b/data/monster/monsters/berserker_chicken.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Bird" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="1" locations="Berserker Chicken locations"/>
+		charmPoints="25" stars="3" occurrence="1" locations="Berserker Chicken locations" />
 	<attacks>
 		<attack name="melee" interval="1200" min="0" max="-200" />
 		<attack name="physical" interval="2000" chance="30" range="1" min="0" max="-100" />

--- a/data/monster/monsters/betrayed_wraith.xml
+++ b/data/monster/monsters/betrayed_wraith.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Betrayed Wraith" nameDescription="a betrayed wraith" race="undead" experience="3500" speed="346">
+<monster name="Betrayed Wraith" nameDescription="a betrayed wraith" race="undead" experience="3500" speed="346" raceId="284">
 	<health now="4200" max="4200" />
 	<look type="233" corpse="6316" />
 	<targetchange interval="4000" chance="15" />
@@ -16,6 +16,8 @@
 		<flag staticattack="90" />
 		<flag runonhealth="300" />
 	</flags>
+	<bestiary class="Undead" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Betrayed Wraith locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />
 		<attack name="betrayed wraith skill reducer" chance="10" />

--- a/data/monster/monsters/betrayed_wraith.xml
+++ b/data/monster/monsters/betrayed_wraith.xml
@@ -17,7 +17,7 @@
 		<flag runonhealth="300" />
 	</flags>
 	<bestiary class="Undead" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Betrayed Wraith locations"/>
+		charmPoints="50" stars="4" occurrence="0" locations="Betrayed Wraith locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />
 		<attack name="betrayed wraith skill reducer" chance="10" />

--- a/data/monster/monsters/biting_book.xml
+++ b/data/monster/monsters/biting_book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Biting Book" nameDescription="a biting book" race="ink" experience="9350" speed="480">
+<monster name="Biting Book" nameDescription="a biting book" race="ink" experience="9350" speed="480" raceId="1656">
 	<health now="6500" max="6500" />
 	<look type="1066" corpse="31265" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Construct" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Biting Book locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1055" />
 		<attack name="physical" interval="2000" chance="15" min="0" max="-1210" range="3" radius="1" target="1">

--- a/data/monster/monsters/biting_book.xml
+++ b/data/monster/monsters/biting_book.xml
@@ -14,7 +14,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Construct" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Biting Book locations"/>
+		charmPoints="50" stars="4" occurrence="0" locations="Biting Book locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-1055" />
 		<attack name="physical" interval="2000" chance="15" min="0" max="-1210" range="3" radius="1" target="1">

--- a/data/monster/monsters/black_sheep.xml
+++ b/data/monster/monsters/black_sheep.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
-		charmPoints="5" stars="1" occurrence="0" locations="Black Sheep locations"/>
+		charmPoints="5" stars="1" occurrence="0" locations="Black Sheep locations" />
 	<defenses armor="1" defense="1" />
 	<elements>
 		<element firePercent="-5" />

--- a/data/monster/monsters/black_sheep.xml
+++ b/data/monster/monsters/black_sheep.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Black Sheep" namedescription="a black sheep" race="blood" experience="0" speed="116" manacost="250">
+<monster name="Black Sheep" namedescription="a black sheep" race="blood" experience="0" speed="116" manacost="250" raceId="13">
 	<health now="20" max="20" />
 	<look type="13" corpse="5994" />
 	<targetchange interval="4000" chance="20" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Black Sheep locations"/>
 	<defenses armor="1" defense="1" />
 	<elements>
 		<element firePercent="-5" />

--- a/data/monster/monsters/black_sphinx_acolyte.xml
+++ b/data/monster/monsters/black_sphinx_acolyte.xml
@@ -21,7 +21,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Black Sphinx Acolyte locations"/>	
+		charmPoints="50" stars="4" occurrence="0" locations="Black Sphinx Acolyte locations" />	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />
 		<attack name="earth" interval="2000" chance="10" radius="3" min="-300" max="-400">

--- a/data/monster/monsters/black_sphinx_acolyte.xml
+++ b/data/monster/monsters/black_sphinx_acolyte.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Black Sphinx Acolyte" nameDescription="a black sphinx acolyte" race="blood" experience="7200" speed="310">
+<monster name="Black Sphinx Acolyte" nameDescription="a black sphinx acolyte" race="blood" experience="7200" speed="310" raceId="1800">
 	<health now="8100" max="8100" />
 	<look type="1200" head="95" body="95" legs="94" feet="95" corpse="34079" />
 	<targetchange interval="2000" chance="5" />
@@ -20,6 +20,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Black Sphinx Acolyte locations"/>	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />
 		<attack name="earth" interval="2000" chance="10" radius="3" min="-300" max="-400">

--- a/data/monster/monsters/blightwalker.xml
+++ b/data/monster/monsters/blightwalker.xml
@@ -18,7 +18,7 @@
 		<flag canwalkonenergy="0" />
 	</flags>
 	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Blightwalker locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Blightwalker locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-490" />
 		<attack name="earth" interval="2000" chance="20" range="7" target="1" radius="1" min="-220" max="-405">

--- a/data/monster/monsters/blightwalker.xml
+++ b/data/monster/monsters/blightwalker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Blightwalker" nameDescription="a blightwalker" race="undead" experience="5850" speed="250">
+<monster name="Blightwalker" nameDescription="a blightwalker" race="undead" experience="5850" speed="250" raceId="298">
 	<health now="8900" max="8900" />
 	<look type="246" corpse="6354" />
 	<targetchange interval="4000" chance="10" />
@@ -17,6 +17,8 @@
 		<flag runonhealth="800" />
 		<flag canwalkonenergy="0" />
 	</flags>
+	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Blightwalker locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-490" />
 		<attack name="earth" interval="2000" chance="20" range="7" target="1" radius="1" min="-220" max="-405">

--- a/data/monster/monsters/blood_beast.xml
+++ b/data/monster/monsters/blood_beast.xml
@@ -17,7 +17,7 @@
 		<flag runonhealth="0" />
 	</flags>
 	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Blood Beast locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Blood Beast locations" />
 	<attacks>
 		<attack name="melee" interval="2000" skill="82" attack="50" poison="260" />
 		<attack name="poison" interval="2000" chance="13" range="5" min="-65" max="-105" target="1">

--- a/data/monster/monsters/blood_beast.xml
+++ b/data/monster/monsters/blood_beast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Blood Beast" nameDescription="a blood beast" race="venom" experience="1000" speed="220">
+<monster name="Blood Beast" nameDescription="a blood beast" race="venom" experience="1000" speed="220" raceId="1040">
 	<health now="1600" max="1600" />
 	<look type="602" corpse="23351" />
 	<targetchange interval="2000" chance="4" />
@@ -16,6 +16,8 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
 	</flags>
+	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Blood Beast locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" skill="82" attack="50" poison="260" />
 		<attack name="poison" interval="2000" chance="13" range="5" min="-65" max="-105" target="1">

--- a/data/monster/monsters/blood_crab.xml
+++ b/data/monster/monsters/blood_crab.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Blood Crab locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Blood Crab locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />
 	</attacks>

--- a/data/monster/monsters/blood_crab.xml
+++ b/data/monster/monsters/blood_crab.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Blood Crab" nameDescription="a blood crab" race="blood" experience="160" speed="160" manacost="505">
+<monster name="Blood Crab" nameDescription="a blood crab" race="blood" experience="160" speed="160" manacost="505" raceId="261">
 	<health now="290" max="290" />
 	<look type="200" corpse="6075" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Blood Crab locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />
 	</attacks>

--- a/data/monster/monsters/blood_hand.xml
+++ b/data/monster/monsters/blood_hand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Blood Hand" nameDescription="a blood hand" race="blood" experience="750" speed="220">
+<monster name="Blood Hand" nameDescription="a blood hand" race="blood" experience="750" speed="220" raceId="974">
 	<health now="700" max="700" />
 	<look type="552" corpse="21257" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Blood Hand locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-158" poison="80" />
 		<attack name="lifedrain" interval="2000" chance="20" target="0" radius="4" min="-50" max="-100">

--- a/data/monster/monsters/blood_hand.xml
+++ b/data/monster/monsters/blood_hand.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Blood Hand locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Blood Hand locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-158" poison="80" />
 		<attack name="lifedrain" interval="2000" chance="20" target="0" radius="4" min="-50" max="-100">

--- a/data/monster/monsters/blood_priest.xml
+++ b/data/monster/monsters/blood_priest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Blood Priest" nameDescription="a blood priest" race="blood" experience="900" speed="210">
+<monster name="Blood Priest" nameDescription="a blood priest" race="blood" experience="900" speed="210" raceId="961">
 	<health now="820" max="820" />
 	<look type="553" corpse="21262" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Blood Priest locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" poison="100" />
 		<attack name="death" interval="2000" chance="20" range="7" target="1" min="-60" max="-100">

--- a/data/monster/monsters/blood_priest.xml
+++ b/data/monster/monsters/blood_priest.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Blood Priest locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Blood Priest locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" poison="100" />
 		<attack name="death" interval="2000" chance="20" range="7" target="1" min="-60" max="-100">

--- a/data/monster/monsters/blue_djinn.xml
+++ b/data/monster/monsters/blue_djinn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Blue Djinn" nameDescription="a blue djinn" race="blood" experience="215" speed="220">
+<monster name="Blue Djinn" nameDescription="a blue djinn" race="blood" experience="215" speed="220" raceId="80">
 	<health now="330" max="330" />
 	<look type="80" corpse="6020" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Magical" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Blue Djinn locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />
 		<attack name="fire" interval="2000" chance="15" range="7" min="-45" max="-80">

--- a/data/monster/monsters/blue_djinn.xml
+++ b/data/monster/monsters/blue_djinn.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Magical" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Blue Djinn locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Blue Djinn locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />
 		<attack name="fire" interval="2000" chance="15" range="7" min="-45" max="-80">

--- a/data/monster/monsters/boar.xml
+++ b/data/monster/monsters/boar.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Mammal" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Boar locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Boar locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />
 	</attacks>

--- a/data/monster/monsters/boar.xml
+++ b/data/monster/monsters/boar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Boar" nameDescription="a boar" race="blood" experience="60" speed="410" manacost="465">
+<monster name="Boar" nameDescription="a boar" race="blood" experience="60" speed="410" manacost="465" raceId="693">
 	<health now="198" max="198" />
 	<look type="380" corpse="13308" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Boar locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-50" />
 	</attacks>

--- a/data/monster/monsters/bog_frog.xml
+++ b/data/monster/monsters/bog_frog.xml
@@ -17,5 +17,5 @@
 		<flag runonhealth="25" />
 	</flags>
 	<bestiary class="Amphibic" prowess="10" expertise="100" mastery="250"
-		charmPoints="5" stars="1" occurrence="0" locations="Bog Frog locations"/>
+		charmPoints="5" stars="1" occurrence="0" locations="Bog Frog locations" />
 </monster>

--- a/data/monster/monsters/bog_frog.xml
+++ b/data/monster/monsters/bog_frog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bog Frog" namedescription="a bog frog" race="blood" experience="0" speed="200" manacost="305">
+<monster name="Bog Frog" namedescription="a bog frog" race="blood" experience="0" speed="200" manacost="305" raceId="738">
 	<health now="25" max="25" />
 	<look type="412" corpse="6079" />
 	<targetchange interval="4000" chance="0" />
@@ -16,4 +16,6 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="25" />
 	</flags>
+	<bestiary class="Amphibic" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Bog Frog locations"/>
 </monster>

--- a/data/monster/monsters/bog_raider.xml
+++ b/data/monster/monsters/bog_raider.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Magical" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Bog Raider locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Bog Raider locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" poison="80" />
 		<attack name="lifedrain" interval="2000" chance="10" min="-90" max="-140" range="7" target="1">

--- a/data/monster/monsters/bog_raider.xml
+++ b/data/monster/monsters/bog_raider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bog Raider" nameDescription="a bog raider" race="venom" experience="800" speed="250">
+<monster name="Bog Raider" nameDescription="a bog raider" race="venom" experience="800" speed="250" raceId="460">
 	<health now="1300" max="1300" />
 	<look type="299" corpse="8951" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Magical" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Bog Raider locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-180" poison="80" />
 		<attack name="lifedrain" interval="2000" chance="10" min="-90" max="-140" range="7" target="1">

--- a/data/monster/monsters/bonebeast.xml
+++ b/data/monster/monsters/bonebeast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bonebeast" nameDescription="a bonebeast" race="undead" experience="580" speed="218">
+<monster name="Bonebeast" nameDescription="a bonebeast" race="undead" experience="580" speed="218" raceId="101">
 	<health now="515" max="515" />
 	<look type="101" corpse="6030" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Bonebeast locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="100" />
 		<attack name="earth" interval="2000" chance="15" range="7" min="-50" max="-90">

--- a/data/monster/monsters/bonebeast.xml
+++ b/data/monster/monsters/bonebeast.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Bonebeast locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Bonebeast locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" poison="100" />
 		<attack name="earth" interval="2000" chance="15" range="7" min="-50" max="-90">

--- a/data/monster/monsters/bonelord.xml
+++ b/data/monster/monsters/bonelord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bonelord" nameDescription="a bonelord" race="venom" experience="170" speed="150">
+<monster name="Bonelord" nameDescription="a bonelord" race="venom" experience="170" speed="150" raceId="17">
 	<health now="260" max="260" />
 	<look type="17" corpse="5992" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Magical" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Bonelord locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />
 		<attack name="energy" interval="2000" chance="5" range="7" min="-15" max="-45">

--- a/data/monster/monsters/bonelord.xml
+++ b/data/monster/monsters/bonelord.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Magical" prowess="25" expertise="250" mastery="500"
-		charmPoints="15" stars="2" occurrence="0" locations="Bonelord locations"/>
+		charmPoints="15" stars="2" occurrence="0" locations="Bonelord locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />
 		<attack name="energy" interval="2000" chance="5" range="7" min="-15" max="-45">

--- a/data/monster/monsters/boogy.xml
+++ b/data/monster/monsters/boogy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Boogy" nameDescription="a boogy" race="blood" experience="950" speed="210">
+<monster name="Boogy" nameDescription="a boogy" race="blood" experience="950" speed="210" raceId="1439">
 	<health now="1300" max="1300" />
 	<look type="981" corpse="28475" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Fey" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Boogy locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />
 		<attack name="physical" interval="3000" chance="11" radius="6" target="1" min="-100" max="-300">

--- a/data/monster/monsters/boogy.xml
+++ b/data/monster/monsters/boogy.xml
@@ -14,7 +14,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Fey" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Boogy locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Boogy locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />
 		<attack name="physical" interval="3000" chance="11" radius="6" target="1" min="-100" max="-300">

--- a/data/monster/monsters/brain_squid.xml
+++ b/data/monster/monsters/brain_squid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Brain Squid" nameDescription="a brain squid" race="ink" experience="17672" speed="430">
+<monster name="Brain Squid" nameDescription="a brain squid" race="ink" experience="17672" speed="430" raceId="1653">
 	<health now="18000" max="18000" />
 	<look type="1059" head="17" body="41" legs="77" feet="57" addons="0" corpse="31238" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Brain Squid locations"/>	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="energy" interval="2000" chance="15" range="7" min="-200" max="-470">

--- a/data/monster/monsters/brain_squid.xml
+++ b/data/monster/monsters/brain_squid.xml
@@ -14,7 +14,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Brain Squid locations"/>	
+		charmPoints="50" stars="4" occurrence="0" locations="Brain Squid locations" />	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="energy" interval="2000" chance="15" range="7" min="-200" max="-470">

--- a/data/monster/monsters/braindeath.xml
+++ b/data/monster/monsters/braindeath.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Braindeath locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Braindeath locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />
 		<attack name="energy" interval="2000" chance="10" range="7" min="-93" max="-170">

--- a/data/monster/monsters/braindeath.xml
+++ b/data/monster/monsters/braindeath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Braindeath" nameDescription="a braindeath" race="venom" experience="985" speed="218">
+<monster name="Braindeath" nameDescription="a braindeath" race="venom" experience="985" speed="218" raceId="321">
 	<health now="1225" max="1225" />
 	<look type="256" corpse="7256" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Undead" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Braindeath locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />
 		<attack name="energy" interval="2000" chance="10" range="7" min="-93" max="-170">

--- a/data/monster/monsters/brimstone_bug.xml
+++ b/data/monster/monsters/brimstone_bug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Brimstone Bug" namedescription="a brimstone bug" race="venom" experience="900" speed="200">
+<monster name="Brimstone Bug" namedescription="a brimstone bug" race="venom" experience="900" speed="200" raceId="674">
 	<health now="1300" max="1300" />
 	<look type="352" corpse="12527" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Brimstone Bug locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-213" poison="400" />
 		<attack name="speed" interval="2000" chance="20" range="7" speedchange="-600" duration="10000">

--- a/data/monster/monsters/brimstone_bug.xml
+++ b/data/monster/monsters/brimstone_bug.xml
@@ -19,7 +19,7 @@
 		<flag canwalkonfire="0" />
 	</flags>
 	<bestiary class="Vermin" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Brimstone Bug locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Brimstone Bug locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-213" poison="400" />
 		<attack name="speed" interval="2000" chance="20" range="7" speedchange="-600" duration="10000">

--- a/data/monster/monsters/broken_shaper.xml
+++ b/data/monster/monsters/broken_shaper.xml
@@ -21,7 +21,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Humanoid" prowess="50" expertise="500" mastery="1000"
-		charmPoints="25" stars="3" occurrence="0" locations="Broken Shaper locations"/>
+		charmPoints="25" stars="3" occurrence="0" locations="Broken Shaper locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="physical" interval="2000" chance="35" range="7" target="1" min="0" max="-150">

--- a/data/monster/monsters/broken_shaper.xml
+++ b/data/monster/monsters/broken_shaper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Broken Shaper" nameDescription="a broken shaper" race="blood" experience="1600" speed="310">
+<monster name="Broken Shaper" nameDescription="a broken shaper" race="blood" experience="1600" speed="310" raceId="1321">
 	<health now="2200" max="2200" />
 	<look type="932" head="94" body="76" legs="0" feet="82" corpse="27724" />
 	<targetchange interval="2000" chance="5" />
@@ -20,6 +20,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Broken Shaper locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="physical" interval="2000" chance="35" range="7" target="1" min="0" max="-150">

--- a/data/monster/monsters/brown_horse.xml
+++ b/data/monster/monsters/brown_horse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190">
+<monster name="Horse" nameDescription="a horse" race="blood" experience="0" speed="190" raceId="750">
 	<health now="75" max="75" />
 	<look type="436" corpse="0" />
 	<targetchange interval="4000" chance="20" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="1" locations="Horse locations"/>
 	<voices interval="5000" chance="10">
 		<voice sentence="Weeeeheeeeeee" />
 		<voice sentence="*snort*" />

--- a/data/monster/monsters/brown_horse.xml
+++ b/data/monster/monsters/brown_horse.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
-		charmPoints="5" stars="1" occurrence="1" locations="Horse locations"/>
+		charmPoints="5" stars="1" occurrence="1" locations="Horse locations" />
 	<voices interval="5000" chance="10">
 		<voice sentence="Weeeeheeeeeee" />
 		<voice sentence="*snort*" />

--- a/data/monster/monsters/bug.xml
+++ b/data/monster/monsters/bug.xml
@@ -20,7 +20,7 @@
 		<flag canwalkonpoison="0" />
 	</flags>
 	<bestiary class="Vermin" prowess="10" expertise="100" mastery="250"
-		charmPoints="5" stars="1" occurrence="0" locations="Bug locations"/>
+		charmPoints="5" stars="1" occurrence="0" locations="Bug locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-23" />
 	</attacks>

--- a/data/monster/monsters/bug.xml
+++ b/data/monster/monsters/bug.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Bug" namedescription="a bug" race="venom" experience="18" speed="160" manacost="250">
+<monster name="Bug" namedescription="a bug" race="venom" experience="18" speed="160" manacost="250" raceId="45">
 	<health now="29" max="29" />
 	<look type="45" corpse="5990" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Bug locations"/>
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-23" />
 	</attacks>

--- a/data/monster/monsters/burning_book.xml
+++ b/data/monster/monsters/burning_book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Burning Book" nameDescription="a burning book" race="ink" experience="11934" speed="440">
+<monster name="Burning Book" nameDescription="a burning book" race="ink" experience="11934" speed="440" raceId="1663">
 	<health now="18000" max="18000" />
 	<look type="1061" head="79" body="113" legs="78" feet="112" addons="0" corpse="31410" />
 	<targetchange interval="2000" chance="5" />
@@ -13,13 +13,15 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Burning Book locations"/>
 	<immunities>
 		<immunity paralyze="1" />
 		<immunity invisible="1" />
 		<immunity drunk="1" />
 	</immunities>
 	<elements>
-		<element firePercent="100" />
+		<element firePercent="100" />1
 		<element icePercent="-10" />
 	</elements>
 	<attacks>

--- a/data/monster/monsters/burning_book.xml
+++ b/data/monster/monsters/burning_book.xml
@@ -14,7 +14,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Burning Book locations"/>
+		charmPoints="50" stars="4" occurrence="0" locations="Burning Book locations" />
 	<immunities>
 		<immunity paralyze="1" />
 		<immunity invisible="1" />

--- a/data/monster/monsters/burning_book.xml
+++ b/data/monster/monsters/burning_book.xml
@@ -21,7 +21,7 @@
 		<immunity drunk="1" />
 	</immunities>
 	<elements>
-		<element firePercent="100" />1
+		<element firePercent="100" />
 		<element icePercent="-10" />
 	</elements>
 	<attacks>

--- a/data/monster/monsters/burning_gladiator.xml
+++ b/data/monster/monsters/burning_gladiator.xml
@@ -21,7 +21,7 @@
 		<flag canwalkonpoison="1" />
 	</flags>
 	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
-		charmPoints="50" stars="4" occurrence="0" locations="Burning Gladiator locations"/>	
+		charmPoints="50" stars="4" occurrence="0" locations="Burning Gladiator locations" />	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-550" />
 		<attack name="fire" interval="2000" chance="10" ring="3" target="0" min="-300" max="-500">

--- a/data/monster/monsters/burning_gladiator.xml
+++ b/data/monster/monsters/burning_gladiator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Burning Gladiator" nameDescription="a burning gladiator" race="blood" experience="7350" speed="290">
+<monster name="Burning Gladiator" nameDescription="a burning gladiator" race="blood" experience="7350" speed="290" raceId="1798">
 	<health now="10000" max="10000" />
 	<look type="541" head="95" body="113" legs="3" feet="3" addons="1" corpse="34302" />
 	<targetchange interval="2000" chance="5" />
@@ -20,6 +20,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Burning Gladiator locations"/>	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-550" />
 		<attack name="fire" interval="2000" chance="10" ring="3" target="0" min="-300" max="-500">

--- a/data/monster/monsters/calamary.xml
+++ b/data/monster/monsters/calamary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Calamary" nameDescription="a calamary" race="undead" experience="0" speed="160">
+<monster name="Calamary" nameDescription="a calamary" race="undead" experience="0" speed="160" raceId="780">
 	<health now="75" max="75" />
 	<look type="451" corpse="15280" />
 	<targetchange interval="4000" chance="8" />
@@ -16,6 +16,8 @@
 		<flag runonhealth="75" />
 		<flag canwalkonenergy="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Calamary locations" />
 	<elements>
 		<element energyPercent="-5" />
 		<element physicalPercent="-5" />

--- a/data/monster/monsters/carniphila.xml
+++ b/data/monster/monsters/carniphila.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Carniphila" nameDescription="a carniphila" race="venom" experience="150" speed="110">
+<monster name="Carniphila" nameDescription="a carniphila" race="venom" experience="150" speed="110" raceId="120">
 	<health now="255" max="255" />
 	<look type="120" corpse="6047" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Plant" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Carniphila locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" poison="100" />
 		<attack name="earth" interval="2000" chance="15" range="7" min="-60" max="-95">

--- a/data/monster/monsters/carrion_worm.xml
+++ b/data/monster/monsters/carrion_worm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Carrion Worm" nameDescription="a carrion worm" race="blood" experience="70" speed="160" manacost="380">
+<monster name="Carrion Worm" nameDescription="a carrion worm" race="blood" experience="70" speed="160" manacost="380" raceId="251">
 	<health now="145" max="145" />
 	<look type="192" corpse="6069" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Carrion Worm locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" />
 	</attacks>

--- a/data/monster/monsters/cat.xml
+++ b/data/monster/monsters/cat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cat" nameDescription="a cat" race="blood" experience="0" speed="190" manacost="220">
+<monster name="Cat" nameDescription="a cat" race="blood" experience="0" speed="190" manacost="220" raceId="387">
 	<health now="20" max="20" />
 	<look type="276" corpse="7637" />
 	<targetchange interval="4000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="5" expertise="10" mastery="25"
+		charmPoints="1" stars="0" occurrence="0" locations="Cat locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="0" />
 	</attacks>

--- a/data/monster/monsters/cave_devourer.xml
+++ b/data/monster/monsters/cave_devourer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cave Devourer" nameDescription="a cave devourer" race="venom" experience="2380" speed="240">
+<monster name="Cave Devourer" nameDescription="a cave devourer" race="venom" experience="2380" speed="240" raceId="1544">
 	<health now="4500" max="4500" />
 	<look type="1036" corpse="30215" />
 	<targetchange interval="2000" chance="5" />
@@ -14,6 +14,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Cave Devourer locations" />	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-400" />
 		<attack name="death" interval="2000" chance="15" range="3" length="6" spread="3" min="-70" max="-160">

--- a/data/monster/monsters/cave_parrot.xml
+++ b/data/monster/monsters/cave_parrot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cave Parrot" nameDescription="a cave parrot" race="blood" experience="0" speed="320">
+<monster name="Cave Parrot" nameDescription="a cave parrot" race="blood" experience="0" speed="320" raceId="1307">
 	<health now="30" max="30" />
 	<look type="217" corpse="6056" />
 	<targetchange interval="2000" chance="5" />
@@ -20,6 +20,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Bird" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Cave Parrot locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-5" />
 	</attacks>

--- a/data/monster/monsters/cave_rat.xml
+++ b/data/monster/monsters/cave_rat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cave Rat" nameDescription="a cave rat" race="blood" experience="10" speed="150" manacost="250">
+<monster name="Cave Rat" nameDescription="a cave rat" race="blood" experience="10" speed="150" manacost="250" raceId="56">
 	<health now="30" max="30" />
 	<look type="56" corpse="5964" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Mammal" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Cave Rat locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-10" />
 	</attacks>

--- a/data/monster/monsters/centipede.xml
+++ b/data/monster/monsters/centipede.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Centipede" namedescription="a centipede" race="venom" experience="34" speed="166" manacost="335">
+<monster name="Centipede" namedescription="a centipede" race="venom" experience="34" speed="166" manacost="335" raceId="124">
 	<health now="70" max="70" />
 	<look type="124" corpse="6050" />
 	<targetchange interval="5000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Centipede locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-45" poison="20" />
 	</attacks>

--- a/data/monster/monsters/chakoya_toolshaper.xml
+++ b/data/monster/monsters/chakoya_toolshaper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Chakoya Toolshaper" nameDescription="a chakoya toolshaper" race="blood" experience="40" speed="136">
+<monster name="Chakoya Toolshaper" nameDescription="a chakoya toolshaper" race="blood" experience="40" speed="136" raceId="328">
 	<health now="80" max="80" />
 	<look type="259" corpse="7320" />
 	<targetchange interval="60000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Chakoya Toolshaper locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-35" />
 		<attack name="physical" interval="2000" chance="10" range="7" radius="3" target="1" min="0" max="-45">

--- a/data/monster/monsters/chakoya_tribewarden.xml
+++ b/data/monster/monsters/chakoya_tribewarden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Chakoya Tribewarden" nameDescription="a chakoya tribewarden" race="blood" experience="40" speed="200" manacost="305">
+<monster name="Chakoya Tribewarden" nameDescription="a chakoya tribewarden" race="blood" experience="40" speed="200" manacost="305" raceId="319">
 	<health now="68" max="68" />
 	<look type="259" corpse="7320" />
 	<targetchange interval="60000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Chakoya Tribewarden locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-30" />
 	</attacks>

--- a/data/monster/monsters/chakoya_windcaller.xml
+++ b/data/monster/monsters/chakoya_windcaller.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Chakoya Windcaller" nameDescription="a chakoya windcaller" race="blood" experience="48" speed="200" manacost="305">
+<monster name="Chakoya Windcaller" nameDescription="a chakoya windcaller" race="blood" experience="48" speed="200" manacost="305" raceId="329">
 	<health now="84" max="84" />
 	<look type="260" corpse="7320" />
 	<targetchange interval="60000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Chakoya Windcaller locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-22" />
 		<attack name="ice" interval="2000" chance="15" range="7" min="-16" max="-32">

--- a/data/monster/monsters/chasm_spawn.xml
+++ b/data/monster/monsters/chasm_spawn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Chasm Spawn" nameDescription="a chasm spawn" race="venom" experience="2700" speed="230">
+<monster name="Chasm Spawn" nameDescription="a chasm spawn" race="venom" experience="2700" speed="230" raceId="1546">
 	<health now="4500" max="4500" />
 	<look type="1037" corpse="30219" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Chasm Spawn locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" />
 		<attack name="earth" interval="2000" chance="15" range="7" target="1" min="-5" max="-16">

--- a/data/monster/monsters/chicken.xml
+++ b/data/monster/monsters/chicken.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Chicken" namedescription="a chicken" race="blood" experience="0" speed="128" manacost="220">
+<monster name="Chicken" namedescription="a chicken" race="blood" experience="0" speed="128" manacost="220" raceId="111">
 	<health now="15" max="15" />
 	<look type="111" corpse="6042" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Bird" prowess="10" expertise="100" mastery="250"
+		charmPoints="5" stars="1" occurrence="0" locations="Chicken locations" />
 	<defenses armor="1" defense="1" />
 	<voices interval="5000" chance="10">
 		<voice sentence="Gokgoooook" />

--- a/data/monster/monsters/choking_fear.xml
+++ b/data/monster/monsters/choking_fear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Choking Fear" nameDescription="a choking fear" race="undead" experience="4700" speed="260">
+<monster name="Choking Fear" nameDescription="a choking fear" race="undead" experience="4700" speed="260" raceId="1015">
 	<health now="5800" max="5800" />
 	<look type="586" corpse="22493" />
 	<targetchange interval="4000" chance="5" />
@@ -17,6 +17,8 @@
 		<flag runonhealth="0" />
 		<flag canwalkonenergy="0" />
 	</flags>
+	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Choking Fear locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-499" poison="600" />
 		<attack name="poisoncondition" interval="2000" chance="10" length="5" spread="3" target="0" min="-700" max="-900">

--- a/data/monster/monsters/clay_guardian.xml
+++ b/data/monster/monsters/clay_guardian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Clay Guardian" nameDescription="a clay guardian" race="undead" experience="400" speed="210">
+<monster name="Clay Guardian" nameDescription="a clay guardian" race="undead" experience="400" speed="210" raceId="706">
 	<health now="625" max="625" />
 	<look type="333" corpse="13972" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Construct" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Clay Guardian locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-125" />
 		<attack name="earth" interval="2000" chance="20" range="7" min="-30" max="-150">

--- a/data/monster/monsters/cliff_strider.xml
+++ b/data/monster/monsters/cliff_strider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cliff Strider" nameDescription="a cliff strider" race="undead" experience="5700" speed="246">
+<monster name="Cliff Strider" nameDescription="a cliff strider" race="undead" experience="5700" speed="246" raceId="889">
 	<health now="9400" max="9400" />
 	<look type="497" corpse="17420" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Elemental" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Cliff Strider locations" />	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-499" />
 		<attack name="physical" interval="2000" chance="20" radius="4" target="1" min="0" max="-800">

--- a/data/monster/monsters/clomp.xml
+++ b/data/monster/monsters/clomp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Clomp" nameDescription="a clomp" race="blood" experience="475" speed="430">
+<monster name="Clomp" nameDescription="a clomp" race="blood" experience="475" speed="430" raceId="1174">
 	<health now="900" max="900" />
 	<look type="860" corpse="25398" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Mammal" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Clomp locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-260" />
 	</attacks>

--- a/data/monster/monsters/cobra.xml
+++ b/data/monster/monsters/cobra.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra" namedescription="a cobra" race="blood" experience="30" speed="120" manacost="275">
+<monster name="Cobra" namedescription="a cobra" race="blood" experience="30" speed="120" manacost="275" raceId="81">
 	<health now="65" max="65" />
 	<look type="81" corpse="3007" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Reptile" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Cobra locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="0" poison="100" />
 		<attack name="poisoncondition" interval="2000" chance="15" range="7" min="-20" max="-40">

--- a/data/monster/monsters/cobra_assassin.xml
+++ b/data/monster/monsters/cobra_assassin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra Assassin" nameDescription="a cobra assassin" race="blood" experience="6980" speed="280">
+<monster name="Cobra Assassin" nameDescription="a cobra assassin" race="blood" experience="6980" speed="280" raceId="1775">
 	<health now="8200" max="8200" />
 	<look type="1217" head="2" body="2" legs="77" feet="19" addons="1" corpse="34203" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Cobra Assassin locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-450" />
 		<attack name="wave t" interval="2000" chance="10" min="-300" max="-380" />

--- a/data/monster/monsters/cobra_scout.xml
+++ b/data/monster/monsters/cobra_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra Scout" nameDescription="a cobra scout" race="blood" experience="7310" speed="300">
+<monster name="Cobra Scout" nameDescription="a cobra scout" race="blood" experience="7310" speed="300" raceId="1776">
 	<health now="8500" max="8500" />
 	<look type="1217" head="1" body="1" legs="102" feet="78" addons="2" corpse="34291" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Cobra Scout locations" />	
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />
 		<attack name="earth" interval="2000" chance="22" range="4" target="1" min="-350" max="-450">

--- a/data/monster/monsters/cobra_vizier.xml
+++ b/data/monster/monsters/cobra_vizier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra Vizier" nameDescription="a cobra vizier" race="blood" experience="7650" speed="320">
+<monster name="Cobra Vizier" nameDescription="a cobra vizier" race="blood" experience="7650" speed="320" raceId="1824">
 	<health now="8500" max="8500" />
 	<look type="1217" head="19" body="19" legs="67" feet="78" corpse="34295" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Human" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Cobra Vizier locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-480" />
 		<attack name="explosion wave" interval="2000" chance="15" min="-280" max="-400" />

--- a/data/monster/monsters/coral_frog.xml
+++ b/data/monster/monsters/coral_frog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Coral Frog" namedescription="a coral frog" race="blood" experience="20" speed="200" manacost="305">
+<monster name="Coral Frog" namedescription="a coral frog" race="blood" experience="20" speed="200" manacost="305" raceId="269">
 	<health now="60" max="60" />
 	<look type="226" head="114" body="79" legs="78" feet="114" corpse="6079" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Coral Frog locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />
 	</attacks>

--- a/data/monster/monsters/corym_charlatan.xml
+++ b/data/monster/monsters/corym_charlatan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Corym Charlatan" nameDescription="a corym charlatan" race="blood" experience="150" speed="180" manacost="490">
+<monster name="Corym Charlatan" nameDescription="a corym charlatan" race="blood" experience="150" speed="180" manacost="490" raceId="916">
 	<health now="250" max="250" />
 	<look type="532" head="0" body="78" legs="59" feet="0" corpse="19725" />
 	<targetchange interval="5000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Corym Charlatan locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-100" />
 	</attacks>

--- a/data/monster/monsters/corym_skirmisher.xml
+++ b/data/monster/monsters/corym_skirmisher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Corym Skirmisher" nameDescription="a corym skirmisher" race="blood" experience="260" speed="200" manacost="695">
+<monster name="Corym Skirmisher" nameDescription="a corym skirmisher" race="blood" experience="260" speed="200" manacost="695" raceId="917">
 	<health now="450" max="450" />
 	<look type="533" head="0" body="76" legs="83" feet="0" corpse="19726" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Corym Skirmisher locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-110" />
 		<attack name="physical" interval="2000" chance="20" range="7" min="0" max="-90">

--- a/data/monster/monsters/corym_vanguard.xml
+++ b/data/monster/monsters/corym_vanguard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Corym Vanguard" nameDescription="a corym vanguard" race="blood" experience="490" speed="210">
+<monster name="Corym Vanguard" nameDescription="a corym vanguard" race="blood" experience="490" speed="210" raceId="918">
 	<health now="700" max="700" />
 	<look type="534" head="0" body="19" legs="121" feet="0" corpse="19734" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Humanoid" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Corym Vanguard locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />
 		<attack name="earth" interval="2000" chance="10" target="0" length="5" spread="3" min="-50" max="-100">

--- a/data/monster/monsters/crab.xml
+++ b/data/monster/monsters/crab.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crab" namedescription="a crab" race="blood" experience="30" speed="144" manacost="305">
+<monster name="Crab" namedescription="a crab" race="blood" experience="30" speed="144" manacost="305" raceId="112">
 	<health now="55" max="55" />
 	<look type="112" corpse="6039" />
 	<targetchange interval="4000" chance="0" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Crab locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-20" />
 	</attacks>

--- a/data/monster/monsters/crawler.xml
+++ b/data/monster/monsters/crawler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crawler" nameDescription="a crawler" race="venom" experience="1000" speed="200">
+<monster name="Crawler" nameDescription="a crawler" race="venom" experience="1000" speed="200" raceId="786">
 	<health now="1450" max="1450" />
 	<look type="456" corpse="15292" />
 	<targetchange interval="4000" chance="10" />
@@ -17,6 +17,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Vermin" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Crawler locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-228" poison="80" />
 		<attack name="earth" interval="2000" chance="20" range="7" min="-100" max="-180">

--- a/data/monster/monsters/crazed_beggar.xml
+++ b/data/monster/monsters/crazed_beggar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crazed Beggar" nameDescription="a crazed beggar" race="blood" experience="35" speed="154" manacost="300">
+<monster name="Crazed Beggar" nameDescription="a crazed beggar" race="blood" experience="35" speed="154" manacost="300" raceId="525">
 	<health now="100" max="100" />
 	<look type="153" head="40" body="19" legs="21" feet="97" addons="3" corpse="20351" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Crazed Beggar locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-25" />
 	</attacks>

--- a/data/monster/monsters/crimson_frog.xml
+++ b/data/monster/monsters/crimson_frog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crimson Frog" nameDescription="a crimson frog" race="blood" experience="20" speed="200" manacost="305">
+<monster name="Crimson Frog" nameDescription="a crimson frog" race="blood" experience="20" speed="200" manacost="305" raceId="270">
 	<health now="60" max="60" />
 	<look type="226" head="94" body="78" legs="77" feet="112" corpse="6079" />
 	<targetchange interval="4000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Crimson Frog locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-24" />
 	</attacks>

--- a/data/monster/monsters/crocodile.xml
+++ b/data/monster/monsters/crocodile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crocodile" nameDescription="a crocodile" race="blood" experience="40" speed="156" manacost="350">
+<monster name="Crocodile" nameDescription="a crocodile" race="blood" experience="40" speed="156" manacost="350" raceId="119">
 	<health now="105" max="105" />
 	<look type="119" corpse="6046" />
 	<targetchange interval="5000" chance="0" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Crocodile locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-40" />
 	</attacks>

--- a/data/monster/monsters/crustacea_gigantica.xml
+++ b/data/monster/monsters/crustacea_gigantica.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crustacea Gigantica" nameDescription="a crustacea gigantica" race="blood" experience="1800" speed="290">
+<monster name="Crustacea Gigantica" nameDescription="a crustacea gigantica" race="blood" experience="1800" speed="290" raceId="697">
 	<health now="1600" max="1600" />
 	<look type="383" corpse="13331" />
 	<targetchange interval="5000" chance="8" />
@@ -16,6 +16,8 @@
 		<flag targetdistance="1" />
 		<flag runonhealth="0" />
 	</flags>
+	<bestiary class="Aquatic" prowess="2" expertise="3" mastery="5"
+		charmPoints="50" stars="2" occurrence="3" locations="Crustacea Gigantica locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-600" />
 	</attacks>

--- a/data/monster/monsters/crypt_defiler.xml
+++ b/data/monster/monsters/crypt_defiler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crypt Defiler" nameDescription="a crypt defiler" race="blood" experience="70" speed="205">
+<monster name="Crypt Defiler" nameDescription="a crypt defiler" race="blood" experience="70" speed="205" raceId="868">
 	<health now="180" max="180" />
 	<look type="146" head="62" body="132" legs="42" feet="75" addons="3" corpse="20359" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Crypt Defiler locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-90" />
 		<attack name="physical" interval="2000" chance="15" range="7" radius="1" target="1" min="0" max="-40">

--- a/data/monster/monsters/crypt_shambler.xml
+++ b/data/monster/monsters/crypt_shambler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crypt Shambler" nameDescription="a crypt shambler" race="undead" experience="195" speed="140" manacost="580">
+<monster name="Crypt Shambler" nameDescription="a crypt shambler" race="undead" experience="195" speed="140" manacost="580" raceId="100">
 	<health now="330" max="330" />
 	<look type="100" corpse="6029" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Undead" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Crypt Shambler locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-140" />
 		<attack name="lifedrain" interval="2000" chance="15" target="1" range="1" min="-28" max="-55" />

--- a/data/monster/monsters/crypt_warden.xml
+++ b/data/monster/monsters/crypt_warden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crypt Warden" nameDescription="a crypt warden" race="blood" experience="8400" speed="290">
+<monster name="Crypt Warden" nameDescription="a crypt warden" race="blood" experience="8400" speed="290" raceId="1805">
 	<health now="8300" max="8300" />
 	<look type="1190" head="41" body="38" legs="0" feet="0" corpse="34306" />
 	<targetchange interval="2000" chance="5" />
@@ -20,6 +20,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Crypt Warden locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-500" />
 		<attack name="earth" interval="2000" chance="8" ring="3" target="0" min="-250" max="-380">

--- a/data/monster/monsters/crystal_spider.xml
+++ b/data/monster/monsters/crystal_spider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crystal Spider" nameDescription="a crystal spider" race="undead" experience="900" speed="230">
+<monster name="Crystal Spider" nameDescription="a crystal spider" race="undead" experience="900" speed="230" raceId="330">
 	<health now="1250" max="1250" />
 	<look type="263" corpse="7344" />
 	<targetchange interval="4000" chance="15" />
@@ -16,6 +16,8 @@
 		<flag runonhealth="0" />
 		<flag canwalkonenergy="0" />
 	</flags>
+	<bestiary class="Magical" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Crystal Spider locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-250" poison="160" />
 		<attack name="speed" interval="2000" chance="15" range="7" radius="6" target="0" speedchange="-800" duration="15000">

--- a/data/monster/monsters/crystal_wolf.xml
+++ b/data/monster/monsters/crystal_wolf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crystal Wolf" nameDescription="a crystal wolf" race="undead" experience="275" speed="200">
+<monster name="Crystal Wolf" nameDescription="a crystal wolf" race="undead" experience="275" speed="200" raceId="740">
 	<health now="750" max="750" />
 	<look type="391" corpse="13584" />
 	<targetchange interval="4000" chance="10" />
@@ -19,6 +19,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Magical" prowess="2" expertise="3" mastery="5"
+		charmPoints="50" stars="3" occurrence="3" locations="Crystal Wolf locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-80" />
 		<attack name="earth" interval="2000" chance="15" length="3" spread="2" min="-60" max="-130">

--- a/data/monster/monsters/crystalcrusher.xml
+++ b/data/monster/monsters/crystalcrusher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Crystalcrusher" nameDescription="a crystalcrusher" race="venom" experience="500" speed="230">
+<monster name="Crystalcrusher" nameDescription="a crystalcrusher" race="venom" experience="500" speed="230" raceId="869">
 	<health now="570" max="570" />
 	<look type="511" corpse="18487" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonenergy="0" />
 		<flag canwalkonfire="0" />
 	</flags>
+	<bestiary class="Magical" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Crystalcrusher locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-167" />
 		<attack name="earth" interval="2000" chance="10" target="1" radius="3" min="-110" max="-260">

--- a/data/monster/monsters/cult_believer.xml
+++ b/data/monster/monsters/cult_believer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cult Believer" nameDescription="a cult believer" race="blood" experience="850" speed="260">
+<monster name="Cult Believer" nameDescription="a cult believer" race="blood" experience="850" speed="260" raceId="1512">
 	<health now="975" max="975" />
 	<look type="132" head="98" body="96" legs="39" feet="38" addons="1" corpse="24673" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Cult Believer locations" />
 	<immunities>
 		<immunity paralyze="1" />
 		<immunity invisible="1" />

--- a/data/monster/monsters/cult_enforcer.xml
+++ b/data/monster/monsters/cult_enforcer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cult Enforcer" nameDescription="a cult enforcer" race="blood" experience="1000" speed="260">
+<monster name="Cult Enforcer" nameDescription="a cult enforcer" race="blood" experience="1000" speed="260" raceId="1513">
 	<health now="1150" max="1150" />
 	<look type="134" head="95" body="19" legs="57" feet="76" addons="1" corpse="24673" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Cult Enforcer locations" />
 	<immunities>
 		<immunity paralyze="1" />
 		<immunity invisible="1" />

--- a/data/monster/monsters/cult_scholar.xml
+++ b/data/monster/monsters/cult_scholar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cult Scholar" nameDescription="a cult scholar" race="blood" experience="1100" speed="260">
+<monster name="Cult Scholar" nameDescription="a cult scholar" race="blood" experience="1100" speed="260" raceId="1514">
 	<health now="1650" max="1650" />
 	<look type="145" head="19" body="77" legs="3" feet="20" addons="1" corpse="24673" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Human" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Cult Scholar locations" />
 	<immunities>
 		<immunity paralyze="1" />
 		<immunity invisible="1" />

--- a/data/monster/monsters/cursed_book.xml
+++ b/data/monster/monsters/cursed_book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cursed Book" nameDescription="a cursed book" race="ink" experience="13345" speed="440">
+<monster name="Cursed Book" nameDescription="a cursed book" race="ink" experience="13345" speed="440" raceId="1655">
 	<health now="20000" max="20000" />
 	<look type="1061" head="79" body="81" legs="93" feet="0" addons="0" corpse="31470" />
 	<targetchange interval="2000" chance="5" />
@@ -13,6 +13,8 @@
 		<flag canwalkonfire="1" />
 		<flag canwalkonpoison="1" />
 	</flags>
+	<bestiary class="Magical" prowess="100" expertise="1000" mastery="2500"
+		charmPoints="50" stars="4" occurrence="0" locations="Cursed Book locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-200" />
 		<attack name="physical" interval="1000" chance="15" range="7" min="-400" max="-680">

--- a/data/monster/monsters/cyclops.xml
+++ b/data/monster/monsters/cyclops.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cyclops" nameDescription="a cyclops" race="blood" experience="150" speed="190" manacost="490">
+<monster name="Cyclops" nameDescription="a cyclops" race="blood" experience="150" speed="190" manacost="490" raceId="22">
 	<health now="260" max="260" />
 	<look type="22" corpse="5962" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Giant" prowess="25" expertise="250" mastery="500"
+		charmPoints="15" stars="2" occurrence="0" locations="Cyclops locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-105" />
 	</attacks>

--- a/data/monster/monsters/cyclops_drone.xml
+++ b/data/monster/monsters/cyclops_drone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cyclops Drone" nameDescription="a cyclops drone" race="blood" experience="200" speed="198" manacost="525">
+<monster name="Cyclops Drone" nameDescription="a cyclops drone" race="blood" experience="200" speed="198" manacost="525" raceId="391">
 	<health now="325" max="325" />
 	<look type="280" corpse="7847" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Giant" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Cyclops Drone locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-105" />
 		<attack name="physical" interval="2000" chance="35" range="7" min="0" max="-80">

--- a/data/monster/monsters/cyclops_smith.xml
+++ b/data/monster/monsters/cyclops_smith.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cyclops Smith" nameDescription="a cyclops smith" race="blood" experience="255" speed="204" manacost="695">
+<monster name="Cyclops Smith" nameDescription="a cyclops smith" race="blood" experience="255" speed="204" manacost="695" raceId="389">
 	<health now="435" max="435" />
 	<look type="277" corpse="7740" />
 	<targetchange interval="4000" chance="10" />
@@ -18,6 +18,8 @@
 		<flag canwalkonfire="0" />
 		<flag canwalkonpoison="0" />
 	</flags>
+	<bestiary class="Giant" prowess="50" expertise="500" mastery="1000"
+		charmPoints="25" stars="3" occurrence="0" locations="Cyclops Smith locations" />
 	<attacks>
 		<attack name="melee" interval="2000" min="0" max="-150" />
 		<attack name="physical" interval="2000" chance="10" range="7" min="0" max="-70">


### PR DESCRIPTION
Continuation of https://github.com/otland/forgottenserver/pull/4356

Some notes for current content: 
- locations - created based on monster name + " locations" (ex: "Burning Book locations")
- Affected monsters - currently from monsters starting with the letters A to C (file name)
- current affected files - 95 monsters
- highest raceId value - 1824 for Cobra Vizier (12.20 update), can affect bestiary storage range
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.