### PR TITLE
Fix wrong case for Bragrumol's xml in monsters.xml 

### DIFF
--- a/data/monster/monsters.xml
+++ b/data/monster/monsters.xml
@@ -103,7 +103,7 @@
 	<monster name="Boogy" file="monsters/boogy.xml" />
 	<monster name="Bound Astral Power" file="monsters/bound_astral_power.xml" />
 	<monster name="Bovinus" file="monsters/bovinus.xml" />
-	<monster name="Bragrumol" file="monsters/Bragrumol.xml" />
+	<monster name="Bragrumol" file="monsters/bragrumol.xml" />
 	<monster name="Brain Squid" file="monsters/brain_squid.xml" />
 	<monster name="Braindeath" file="monsters/braindeath.xml" />
 	<monster name="Brimstone Bug" file="monsters/brimstone_bug.xml" />


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes `[Error - Monsters::loadMonster] Failed to load data/monster/monsters/Bragrumol.xml: File was not found`, which happens on case-sensitive filesystems.

**Issues addressed:** n/a (I think) <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide