### PR TITLE
Update stamina regeneration according to update 12.31

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -164,7 +164,7 @@ monsterOverspawn = false
 -- Stamina
 staminaSystem = true
 timeToRegenMinuteStamina = 3 * 60
-timeToRegenMinutePremiumStamina = 10 * 60
+timeToRegenMinutePremiumStamina = 6 * 60
 
 -- Scripts
 warnUnsafeScripts = true

--- a/data/creaturescripts/scripts/regenerate_stamina.lua
+++ b/data/creaturescripts/scripts/regenerate_stamina.lua
@@ -12,14 +12,14 @@ function onLogin(player)
 	end
 
 	local staminaMinutes = player:getStamina()
-	local maxNormalStaminaRegen = math.floor((3600 / 6) * (100 / (100 + staminaMinutes)))
+	local maxNormalStaminaRegen = 2340 - math.min(2340, staminaMinutes)
 
-	local regainStaminaSeconds = offlineTime / configManager.getNumber(configKeys.STAMINA_REGEN_MINUTE) * 60
-	if regainStaminaSeconds > maxNormalStaminaRegen then
-		local happyHourStaminaRegen = (regainStaminaSeconds - maxNormalStaminaRegen) * configManager.getNumber(configKeys.STAMINA_REGEN_PREMIUM) / 180
-		staminaMinutes = math.min(2520, math.max(2340, staminaMinutes) + happyHourStaminaRegen / 60)
+	local regainStaminaMinutes = offlineTime / configManager.getNumber(configKeys.STAMINA_REGEN_MINUTE)
+	if regainStaminaMinutes > maxNormalStaminaRegen then
+		local happyHourStaminaRegen = (offlineTime - (maxNormalStaminaRegen * 180)) / configManager.getNumber(configKeys.STAMINA_REGEN_PREMIUM)
+		staminaMinutes = math.min(2520, math.max(2340, staminaMinutes) + happyHourStaminaRegen)
 	else
-		staminaMinutes = staminaMinutes + regainStaminaSeconds / 60
+		staminaMinutes = staminaMinutes + regainStaminaMinutes
 	end
 
 	player:setStamina(staminaMinutes)

--- a/data/creaturescripts/scripts/regenerate_stamina.lua
+++ b/data/creaturescripts/scripts/regenerate_stamina.lua
@@ -12,14 +12,14 @@ function onLogin(player)
 	end
 
 	local staminaMinutes = player:getStamina()
-	local maxNormalStaminaRegen = 2340 - math.min(2340, staminaMinutes)
+	local maxNormalStaminaRegen = math.floor((3600 / 6) * (100 / (100 + staminaMinutes)))
 
-	local regainStaminaMinutes = offlineTime / configManager.getNumber(configKeys.STAMINA_REGEN_MINUTE)
-	if regainStaminaMinutes > maxNormalStaminaRegen then
-		local happyHourStaminaRegen = (offlineTime - (maxNormalStaminaRegen * 180)) / configManager.getNumber(configKeys.STAMINA_REGEN_PREMIUM)
-		staminaMinutes = math.min(2520, math.max(2340, staminaMinutes) + happyHourStaminaRegen)
+	local regainStaminaSeconds = offlineTime / configManager.getNumber(configKeys.STAMINA_REGEN_MINUTE) * 60
+	if regainStaminaSeconds > maxNormalStaminaRegen then
+		local happyHourStaminaRegen = (regainStaminaSeconds - maxNormalStaminaRegen) * configManager.getNumber(configKeys.STAMINA_REGEN_PREMIUM) / 180
+		staminaMinutes = math.min(2520, math.max(2340, staminaMinutes) + happyHourStaminaRegen / 60)
 	else
-		staminaMinutes = staminaMinutes + regainStaminaMinutes
+		staminaMinutes = staminaMinutes + regainStaminaSeconds / 60
 	end
 
 	player:setStamina(staminaMinutes)

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -276,7 +276,7 @@ bool ConfigManager::load()
 	integer[QUEST_TRACKER_FREE_LIMIT] = getGlobalNumber(L, "questTrackerFreeLimit", 10);
 	integer[QUEST_TRACKER_PREMIUM_LIMIT] = getGlobalNumber(L, "questTrackerPremiumLimit", 15);
 	integer[STAMINA_REGEN_MINUTE] = getGlobalNumber(L, "timeToRegenMinuteStamina", 3 * 60);
-	integer[STAMINA_REGEN_PREMIUM] = getGlobalNumber(L, "timeToRegenMinutePremiumStamina", 10 * 60);
+	integer[STAMINA_REGEN_PREMIUM] = getGlobalNumber(L, "timeToRegenMinutePremiumStamina", 6 * 60);
 
 	expStages = loadXMLStages();
 	if (expStages.empty()) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
This commit updates the stamina regeneration code to reflect the changes introduced in update 12.31, which lowered the regeneration rate of green stamina to 6 seconds per 1 second of stamina.
An option to use seconds instead of minutes was also added to make the code more readable.

Note: Needs testing before being added.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#3871

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
