### PR TITLE
Fix for Correct Functioning of Mount in Outfit Window

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3116,7 +3116,12 @@ void ProtocolGame::sendOutfitWindow()
 		currentOutfit.lookMount = currentMount->clientId;
 	}
 
-	bool mounted = currentOutfit.lookMount != 0;
+	bool mounted;
+	if (player->wasMounted) {
+		mounted = currentOutfit.lookMount != 0;
+	} else {
+		mounted = player->isMounted();
+	}
 
 	AddOutfit(msg, currentOutfit);
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This small change fixes an incorrect behavior of the outfit window, related to mounts.
Currently once you have a mount available, it will always be checked in the window, now it will only be checked if you are actually mounted according to the case.

**Issues addressed:** Nothing!