### PR TITLE
fix(npc): #4110 - remove useless params in some methods

### DIFF
--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -425,7 +425,7 @@ if not NpcHandler then
 		local cid = creature:getId()
 		local callback = self:getCallback(CALLBACK_PLAYER_ENDTRADE)
 		if not callback or callback(cid) then
-			if self:processModuleCallback(CALLBACK_PLAYER_ENDTRADE, cid, msgtype, msg) then
+			if self:processModuleCallback(CALLBACK_PLAYER_ENDTRADE, cid) then
 				if self:isFocused(cid) then
 					local player = Player(cid)
 					local playerName = player and player:getName() or -1
@@ -442,7 +442,7 @@ if not NpcHandler then
 		local cid = creature:getId()
 		local callback = self:getCallback(CALLBACK_PLAYER_CLOSECHANNEL)
 		if not callback or callback(cid) then
-			if self:processModuleCallback(CALLBACK_PLAYER_CLOSECHANNEL, cid, msgtype, msg) then
+			if self:processModuleCallback(CALLBACK_PLAYER_CLOSECHANNEL, cid) then
 				if self:isFocused(cid) then
 					self:unGreet(cid)
 				end


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Remove msgtype and message params from onPlayerEndTrade and onPlayerCloseChannel.


**Issues addressed:** closes #4110 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
