### PR TITLE
Trigger onInventoryUpdate/onEquip on login

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -489,6 +489,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 			if (pid >= CONST_SLOT_FIRST && pid <= CONST_SLOT_LAST) {
 				player->internalAddThing(pid, item);
+				player->postAddNotification(item, nullptr, pid);
 			} else {
 				ItemMap::const_iterator it2 = itemMap.find(pid);
 				if (it2 == itemMap.end()) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This change adds the ability to trigger onInventoryUpdate and onEquip respectively, thus providing the opportunity to not rely on an extra onLogin event in the Revscripts.

No one seemed to care about this because usually when we equip an item, we give the player a condition, and that's it. So when the player logs out, these conditions are saved in the database, and when the player logs in, these conditions are loaded and added to the player, so it's not necessary to trigger these events.

So if we want to have a different type of logic other than just adding a simple condition, we need these events to be triggered, in order to have complete control and ensure that the behavior of these events is consistent.

**Issues addressed:** Nothing!