### PR TITLE
New methods for storage map

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -304,6 +304,14 @@ function Player.addSkill(self, skillId, value, round)
 	return self:addSkillLevel(skillId, value)
 end
 
+function Player.hasStorageKey(self, key)
+	return self:getStorageValue(self, key, 1) ~= self:getStorageValue(self, key)
+end
+
+function Player.clearStorageValue(self, key)
+	return self:setStorageValue(key, nil)
+end
+
 function Player.getWeaponType(self)
 	local weapon = self:getSlotItem(CONST_SLOT_LEFT)
 	if weapon then

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -305,7 +305,7 @@ function Player.addSkill(self, skillId, value, round)
 end
 
 function Player.hasStorageKey(self, key)
-	return self:getStorageValue(self, key, 1) ~= self:getStorageValue(self, key)
+	return self:getStorageValue(self, key, nil) ~= nil
 end
 
 function Player.clearStorageValue(self, key)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2664,7 +2664,6 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("Player", "getStorageValue", LuaScriptInterface::luaPlayerGetStorageValue);
 	registerMethod("Player", "setStorageValue", LuaScriptInterface::luaPlayerSetStorageValue);
-	registerMethod("Player", "hasStorageKey", LuaScriptInterface::luaPlayerHasStorageKey);
 	registerMethod("Player", "clearStorageValues", LuaScriptInterface::luaPlayerClearStorageValues);
 
 	registerMethod("Player", "addItem", LuaScriptInterface::luaPlayerAddItem);
@@ -9741,7 +9740,7 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 	if (player->getStorageValue(key, value)) {
 		lua_pushnumber(L, value);
 	} else {
-		lua_pushnumber(L, getNumber<int32_t>(L, 3, -1));
+		lua_pushnumber(L, getNumber<int32_t>(L, 3, value));
 	}
 	return 1;
 }
@@ -9749,7 +9748,6 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 {
 	// player:setStorageValue(key, value)
-	int32_t value = getNumber<int32_t>(L, 3);
 	uint32_t key = getNumber<uint32_t>(L, 2);
 	Player* player = getUserdata<Player>(L, 1);
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
@@ -9759,21 +9757,9 @@ int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 	}
 
 	if (player) {
+		auto value = lua_isnil(L, 3) ? std::nullopt : std::make_optional(getNumber<int32_t>(L, 3));
 		player->addStorageValue(key, value);
 		pushBoolean(L, true);
-	} else {
-		lua_pushnil(L);
-	}
-	return 1;
-}
-
-int LuaScriptInterface::luaPlayerHasStorageKey(lua_State* L)
-{
-	// player:hasStorageKey(key)
-	uint32_t key = getNumber<uint32_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		pushBoolean(L, player->hasStorageKey(key));
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9728,7 +9728,7 @@ int LuaScriptInterface::luaPlayerSetBankBalance(lua_State* L)
 
 int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 {
-	// player:getStorageValue(key[, default = -1])
+	// player:getStorageValue(key[, defaultValue = -1])
 	Player* player = getUserdata<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
@@ -9739,7 +9739,7 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 	int32_t value;
 	if (player->getStorageValue(key, value)) {
 		lua_pushnumber(L, value);
-	} else if (lua_isnil(L, 3)) {
+	} else if (lua_gettop(L) >= 3 && lua_isnil(L, 3)) {
 		lua_pushnil(L);
 	} else {
 		lua_pushnumber(L, getNumber<int32_t>(L, 3, value));

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9739,6 +9739,8 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 	int32_t value;
 	if (player->getStorageValue(key, value)) {
 		lua_pushnumber(L, value);
+	} else if (lua_isnil(L, 3)) {
+		lua_pushnil(L);
 	} else {
 		lua_pushnumber(L, getNumber<int32_t>(L, 3, value));
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2664,6 +2664,8 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("Player", "getStorageValue", LuaScriptInterface::luaPlayerGetStorageValue);
 	registerMethod("Player", "setStorageValue", LuaScriptInterface::luaPlayerSetStorageValue);
+	registerMethod("Player", "hasStorageKey", LuaScriptInterface::luaPlayerHasStorageKey);
+	registerMethod("Player", "clearStorageValues", LuaScriptInterface::luaPlayerClearStorageValues);
 
 	registerMethod("Player", "addItem", LuaScriptInterface::luaPlayerAddItem);
 	registerMethod("Player", "addItemEx", LuaScriptInterface::luaPlayerAddItemEx);
@@ -9727,7 +9729,7 @@ int LuaScriptInterface::luaPlayerSetBankBalance(lua_State* L)
 
 int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 {
-	// player:getStorageValue(key)
+	// player:getStorageValue(key[, default = -1])
 	Player* player = getUserdata<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
@@ -9739,7 +9741,7 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 	if (player->getStorageValue(key, value)) {
 		lua_pushnumber(L, value);
 	} else {
-		lua_pushnumber(L, -1);
+		lua_pushnumber(L, getNumber<int32_t>(L, 3, -1));
 	}
 	return 1;
 }
@@ -9758,6 +9760,32 @@ int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 
 	if (player) {
 		player->addStorageValue(key, value);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerHasStorageKey(lua_State* L)
+{
+	// player:hasStorageKey(key)
+	uint32_t key = getNumber<uint32_t>(L, 2);
+	Player* player = getUserdata<Player>(L, 1);
+	if (player) {
+		pushBoolean(L, player->hasStorageKey(key));
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerClearStorageValues(lua_State* L)
+{
+	// player:clearStorageValues()
+	Player* player = getUserdata<Player>(L, 1);
+	if (player) {
+		player->clearStorageValues();
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -942,7 +942,6 @@ private:
 
 	static int luaPlayerGetStorageValue(lua_State* L);
 	static int luaPlayerSetStorageValue(lua_State* L);
-	static int luaPlayerHasStorageKey(lua_State* L);
 	static int luaPlayerClearStorageValues(lua_State* L);
 
 	static int luaPlayerAddItem(lua_State* L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -942,6 +942,8 @@ private:
 
 	static int luaPlayerGetStorageValue(lua_State* L);
 	static int luaPlayerSetStorageValue(lua_State* L);
+	static int luaPlayerHasStorageKey(lua_State* L);
+	static int luaPlayerClearStorageValues(lua_State* L);
 
 	static int luaPlayerAddItem(lua_State* L);
 	static int luaPlayerAddItemEx(lua_State* L);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -702,8 +702,9 @@ uint16_t Player::getLookCorpse() const
 	return ITEM_MALE_CORPSE;
 }
 
-void Player::addStorageValue(const uint32_t key, const int32_t value, const bool isLogin /* = false*/)
+void Player::addStorageValue(const uint32_t key, const std::optional<int32_t> data, const bool isLogin /* = false*/)
 {
+	int32_t value = data ? data.value() : -1;
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
 		if (IS_IN_KEYRANGE(key, OUTFITS_RANGE)) {
 			outfits.emplace_back(value >> 16, value & 0xFF);
@@ -719,7 +720,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 	int32_t oldValue;
 	getStorageValue(key, oldValue);
 
-	if (value != -1) {
+	if (data) {
 		storageMap[key] = value;
 	} else {
 		storageMap.erase(key);

--- a/src/player.h
+++ b/src/player.h
@@ -4,8 +4,6 @@
 #ifndef FS_PLAYER_H
 #define FS_PLAYER_H
 
-#include <optional>
-
 #include "creature.h"
 #include "cylinder.h"
 #include "depotlocker.h"
@@ -15,6 +13,8 @@
 #include "protocolgame.h"
 #include "town.h"
 #include "vocation.h"
+
+#include <optional>
 
 class DepotChest;
 class House;

--- a/src/player.h
+++ b/src/player.h
@@ -253,9 +253,8 @@ public:
 
 	bool canOpenCorpse(uint32_t ownerId) const;
 
-	void addStorageValue(const uint32_t key, const int32_t value, const bool isLogin = false);
+	void addStorageValue(const uint32_t key, const std::optional<int32_t> data, const bool isLogin = false);
 	bool getStorageValue(const uint32_t key, int32_t& value) const;
-	bool hasStorageKey(const uint32_t key) const { return storageMap.contains(key); }
 	void clearStorageValues() { storageMap.clear(); }
 	void genReservedStorageRange();
 

--- a/src/player.h
+++ b/src/player.h
@@ -4,6 +4,8 @@
 #ifndef FS_PLAYER_H
 #define FS_PLAYER_H
 
+#include <optional>
+
 #include "creature.h"
 #include "cylinder.h"
 #include "depotlocker.h"

--- a/src/player.h
+++ b/src/player.h
@@ -255,6 +255,8 @@ public:
 
 	void addStorageValue(const uint32_t key, const int32_t value, const bool isLogin = false);
 	bool getStorageValue(const uint32_t key, int32_t& value) const;
+	bool hasStorageKey(const uint32_t key) const { return storageMap.contains(key); }
+	void clearStorageValues() { storageMap.clear(); }
 	void genReservedStorageRange();
 
 	void setGroup(Group* newGroup) { group = newGroup; }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
There's already a [similar PR](https://github.com/otland/forgottenserver/issues/3982), although it was directed to branch 1.4 and it also seems inactive...

The list of new methods added:
```lua
player:clearStorageValue(key)
player:clearStorageValues()
player:hasStorageKey(key)
```

List of modified methods:
```lua
player:getStorageValue(key[, defaultValue = -1 or nil])
plyaer:setStorageValue(key, int or nil)
```

* It is now possible to have a custom default value.
* It is also possible to set a nil value to remove storage.
* We can remove all of a player's storages with a new clear method.
* We can know if a key exists with a new method.
* We can store in the database the integer -1

**Notes:** The integer -1 will continue to be the default value for excellence and compatibility, however there is a new way to save it in the database or delete it, with the new modifications.

Thanks to @ranisalt for the suggestion to use `std::optional` as a possible solution.

**Issues addressed:** closes #3982