### PR TITLE
fix: droptracker

### DIFF
--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -1,11 +1,11 @@
 function Monster:onDropLoot(corpse)
-	local player = Player(corpse:getCorpseOwner())
-	if player then
-		player:updateKillTracker(self, corpse)
-	end
 	local onDropLoot = EventCallback.onDropLoot
 	if onDropLoot then
 		onDropLoot(self, corpse)
+	end	
+	local player = Player(corpse:getCorpseOwner())
+	if player then
+		player:updateKillTracker(self, corpse)
 	end
 end
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Moved part of the code so that the loot is created before the `Player.updateKillTracker` function is called. This is so that the corpse has items and that the "**Drop Tracker**" works.

![image](https://user-images.githubusercontent.com/3027705/233882825-a8bb5971-0ca9-49ae-a47f-bdbe7ac020fc.png)


**Issues addressed:** <!-- Write here the issue number, if any. -->
none

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
