### PR TITLE
Fix monster load with forceLoad

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -824,6 +824,7 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 
 	if (!mType) {
 		mType = &monsters[boost::algorithm::to_lower_copy(monsterName)];
+		mType->info = {};
 	}
 
 	mType->name = attr.as_string();


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This change adds a reset of the monster `info`, in case the `forceLoad = true`. Otherwise, some containers will at best maintain duplications, such as `loots` and `voices`.

Before [this option](https://github.com/otland/forgottenserver/blob/a03b30f2c8bcd04a6a96f2d25541ae03e1b06f24/src/monsters.cpp#L61) did not exist in configManager, so this was not necessary `info = {};`, it is assumed that this line was the first time that a monster was created on the map.

Thanks @joseluis2g for repoting this problem.

**Issues addressed:** Nothing!