### PR TITLE
Update lua-syntax action to latest version

### DIFF
--- a/.github/workflows/lua-syntax.yml
+++ b/.github/workflows/lua-syntax.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: leafo/gh-actions-lua@v8.0.0
+      - uses: leafo/gh-actions-lua@v10.0.0
         with:
-           luaVersion: "5.3.5"
+           luaVersion: "5.4"
 
       - name: Test Lua syntax
         run: find data/ -name '*.lua' -print0 | xargs -0 -n1 luac -p

--- a/.github/workflows/lua-syntax.yml
+++ b/.github/workflows/lua-syntax.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: leafo/gh-actions-lua@v10.0.0
+      - uses: leafo/gh-actions-lua@v10
         with:
            luaVersion: "5.4"
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Update lua-syntax action to latest version, Action now runs on node16 as node 12 actions are marked as deprecated:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

also bumped Lua version from 5.3.5 to 5.4 (it will default to latest 5.4.* version)

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
> [luac](https://github.com/otland/forgottenserver/actions/runs/4848872310/jobs/8640352902)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: leafo/gh-actions-lua@v8.0.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
