### PR TITLE
Possibility of tracking the text window

### DIFF
--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -451,9 +451,9 @@ void CreatureEvent::executeModalWindow(Player* player, uint32_t modalWindowId, u
 	scriptInterface->callVoidFunction(4);
 }
 
-bool CreatureEvent::executeTextEdit(Player* player, Item* item, const std::string& text)
+bool CreatureEvent::executeTextEdit(Player* player, Item* item, std::string_view text, const uint32_t windowTextId)
 {
-	// onTextEdit(player, item, text)
+	// onTextEdit(player, item, text, windowTextId)
 	if (!scriptInterface->reserveScriptEnv()) {
 		std::cout << "[Error - CreatureEvent::executeTextEdit] Call stack overflow" << std::endl;
 		return false;
@@ -471,7 +471,9 @@ bool CreatureEvent::executeTextEdit(Player* player, Item* item, const std::strin
 	LuaScriptInterface::pushThing(L, item);
 	LuaScriptInterface::pushString(L, text);
 
-	return scriptInterface->callFunction(3);
+	lua_pushinteger(L, windowTextId);
+
+	return scriptInterface->callFunction(4);
 }
 
 void CreatureEvent::executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage)

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -55,7 +55,7 @@ public:
 	void executeOnKill(Creature* creature, Creature* target);
 	bool executeAdvance(Player* player, skills_t, uint32_t, uint32_t);
 	void executeModalWindow(Player* player, uint32_t modalWindowId, uint8_t buttonId, uint8_t choiceId);
-	bool executeTextEdit(Player* player, Item* item, const std::string& text);
+	bool executeTextEdit(Player* player, Item* item, std::string_view text, uint32_t windowTextId);
 	void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 	void executeManaChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 	void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -55,7 +55,7 @@ public:
 	void executeOnKill(Creature* creature, Creature* target);
 	bool executeAdvance(Player* player, skills_t, uint32_t, uint32_t);
 	void executeModalWindow(Player* player, uint32_t modalWindowId, uint8_t buttonId, uint8_t choiceId);
-	bool executeTextEdit(Player* player, Item* item, std::string_view text, uint32_t windowTextId);
+	bool executeTextEdit(Player* player, Item* item, std::string_view text, const uint32_t windowTextId);
 	void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 	void executeManaChange(Creature* creature, Creature* attacker, CombatDamage& damage);
 	void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2449,7 +2449,7 @@ void Game::playerRotateItem(uint32_t playerId, const Position& pos, uint8_t stac
 	}
 }
 
-void Game::playerWriteItem(uint32_t playerId, uint32_t windowTextId, const std::string& text)
+void Game::playerWriteItem(uint32_t playerId, uint32_t windowTextId, std::string_view text)
 {
 	Player* player = getPlayerByID(playerId);
 	if (!player) {
@@ -2483,7 +2483,7 @@ void Game::playerWriteItem(uint32_t playerId, uint32_t windowTextId, const std::
 	}
 
 	for (auto creatureEvent : player->getCreatureEvents(CREATURE_EVENT_TEXTEDIT)) {
-		if (!creatureEvent->executeTextEdit(player, writeItem, text)) {
+		if (!creatureEvent->executeTextEdit(player, writeItem, text, windowTextId)) {
 			player->setWriteItem(nullptr);
 			return;
 		}

--- a/src/game.h
+++ b/src/game.h
@@ -352,7 +352,7 @@ public:
 	void playerMoveUpContainer(uint32_t playerId, uint8_t cid);
 	void playerUpdateContainer(uint32_t playerId, uint8_t cid);
 	void playerRotateItem(uint32_t playerId, const Position& pos, uint8_t stackPos, const uint16_t spriteId);
-	void playerWriteItem(uint32_t playerId, uint32_t windowTextId, const std::string& text);
+	void playerWriteItem(uint32_t playerId, uint32_t windowTextId, std::string_view text);
 	void playerBrowseField(uint32_t playerId, const Position& pos);
 	void playerSeekInContainer(uint32_t playerId, uint8_t containerId, uint16_t index);
 	void playerUpdateHouseWindow(uint32_t playerId, uint8_t listId, uint32_t windowTextId, const std::string& text);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9976,7 +9976,7 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 	player->writeItem = item;
 	player->maxWriteLen = length;
 	player->sendTextWindow(item, length, canWrite);
-	pushBoolean(L, true);
+	lua_pushinteger(L, player->windowTextId);
 	return 1;
 }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1335,7 +1335,7 @@ void ProtocolGame::parseTextWindow(NetworkMessage& msg)
 {
 	uint32_t windowTextID = msg.get<uint32_t>();
 	auto newText = msg.getString();
-	g_dispatcher.addTask([playerID = player->getID(), windowTextID, newText = std::string{newText}]() {
+	g_dispatcher.addTask([playerID = player->getID(), windowTextID, newText]() {
 		g_game.playerWriteItem(playerID, windowTextID, newText);
 	});
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This adds the possibility of tracking the text window, using the ID, so we can avoid some problems that were previously impossible to avoid.

<details>

<summary> example </summary>

```lua
textEditRequests[player:getId()] = player:showTextDialog(...
```

```lua
function creatureEvent.onTextEdit(player, item, text, windowTextId)
	local playerId = player:getId()
	local lastWindowTextId = textEditRequests[playerId]
	textEditRequests[playerId] = nil
	if lastWindowTextId ~= windowTextId then
               -- Incorrect Window
		return true
	end
```

</details>

If this tracking is not done, one can open a text window and then use the cancel button, then use another item that will open another text window and then press the accept button, then your script will trigger and possibly give it an unwanted behavior.

**This is backward compatible.**

**Issues addressed:** Nothing!