### PR TITLE
Fix fmt Warning C4275 | Format enum

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 5b1214315250939257ef5d62ecdcbca18cf4fb1c
+          vcpkgGitCommitId: 2f56fdad4bcf43c21ec6f952cf7b91c8c43c5c0d
 
       - name: Build with CMake
         uses: lukka/run-cmake@v10

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 5b1214315250939257ef5d62ecdcbca18cf4fb1c
+          vcpkgGitCommitId: 2f56fdad4bcf43c21ec6f952cf7b91c8c43c5c0d
 
       - name: Build with CMake
         uses: lukka/run-cmake@v10

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -47,6 +47,7 @@ static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 #pragma warning(disable : 4319) // '~': zero extending 'unsigned int' to 'lua_Number' of greater size
 #pragma warning(disable : 4351) // new behavior: elements of array will be default initialized
 #pragma warning(disable : 4458) // declaration hides class member
+#pragma warning(disable : 4275) // can be ignored in Visual C++ if you are deriving from a type in the C++ STL
 #endif
 
 #ifndef _WIN32_WINNT

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -44,10 +44,10 @@ static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 #pragma warning(disable : 4244) // 'argument' : conversion from 'type1' to 'type2', possible loss of data
 #pragma warning(disable : 4250) // 'class1' : inherits 'class2::member' via dominance
 #pragma warning(disable : 4267) // 'var' : conversion from 'size_t' to 'type', possible loss of data
+#pragma warning(disable : 4275) // can be ignored in Visual C++ if you are deriving from a type in the C++ STL
 #pragma warning(disable : 4319) // '~': zero extending 'unsigned int' to 'lua_Number' of greater size
 #pragma warning(disable : 4351) // new behavior: elements of array will be default initialized
 #pragma warning(disable : 4458) // declaration hides class member
-#pragma warning(disable : 4275) // can be ignored in Visual C++ if you are deriving from a type in the C++ STL
 #endif
 
 #ifndef _WIN32_WINNT

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -318,8 +318,8 @@ bool IOMapSerialize::saveHouseInfo()
 
 		std::string listText;
 		if (house->getAccessList(GUEST_LIST, listText) && !listText.empty()) {
-			if (!stmt.addRow(fmt::format("{:d}, {:d}, {:s}", house->getId(), static_cast<uint16_t>(GUEST_LIST),
-			                             db.escapeString(listText)))) {
+			if (!stmt.addRow(
+			        fmt::format("{:d}, {}, {:s}", house->getId(), format_as(GUEST_LIST), db.escapeString(listText)))) {
 				return false;
 			}
 
@@ -327,7 +327,7 @@ bool IOMapSerialize::saveHouseInfo()
 		}
 
 		if (house->getAccessList(SUBOWNER_LIST, listText) && !listText.empty()) {
-			if (!stmt.addRow(fmt::format("{:d}, {:d}, {:s}", house->getId(), static_cast<uint16_t>(SUBOWNER_LIST),
+			if (!stmt.addRow(fmt::format("{:d}, {}, {:s}", house->getId(), format_as(SUBOWNER_LIST),
 			                             db.escapeString(listText)))) {
 				return false;
 			}

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -318,7 +318,8 @@ bool IOMapSerialize::saveHouseInfo()
 
 		std::string listText;
 		if (house->getAccessList(GUEST_LIST, listText) && !listText.empty()) {
-			if (!stmt.addRow(fmt::format("{:d}, {}, {:s}", house->getId(), GUEST_LIST, db.escapeString(listText)))) {
+			if (!stmt.addRow(fmt::format("{:d}, {:d}, {:s}", house->getId(), static_cast<uint16_t>(GUEST_LIST),
+			                             db.escapeString(listText)))) {
 				return false;
 			}
 
@@ -326,7 +327,8 @@ bool IOMapSerialize::saveHouseInfo()
 		}
 
 		if (house->getAccessList(SUBOWNER_LIST, listText) && !listText.empty()) {
-			if (!stmt.addRow(fmt::format("{:d}, {}, {:s}", house->getId(), SUBOWNER_LIST, db.escapeString(listText)))) {
+			if (!stmt.addRow(fmt::format("{:d}, {:d}, {:s}", house->getId(), static_cast<uint16_t>(SUBOWNER_LIST),
+			                             db.escapeString(listText)))) {
 				return false;
 			}
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -72,4 +72,10 @@ int64_t OTSYS_TIME();
 
 SpellGroup_t stringToSpellGroup(const std::string& value);
 
+template <typename E>
+auto format_as(E e)
+{
+	return fmt::underlying(e);
+}
+
 #endif // FS_TOOLS_H


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The latest version of fmt 10.0.0 throw [Warning C4275](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170), I have added it to the list of ignored warnings.
Add `format_as` method to correctly format the value of any `enum` (suggested by: @nekiro)

Finally now we can compile TFS 🌺

**Issues addressed:** #4465