### PR TITLE
Fix closing door

### DIFF
--- a/data/scripts/movements/closing_door.lua
+++ b/data/scripts/movements/closing_door.lua
@@ -1,5 +1,4 @@
 local closingDoor = MoveEvent()
-closingDoor:type("stepout")
 
 function closingDoor.onStepOut(creature, item, position, fromPosition)
 	local tile = Tile(position)
@@ -8,11 +7,11 @@ function closingDoor.onStepOut(creature, item, position, fromPosition)
 	end
 
 	local newPosition = {x = position.x + 1, y = position.y, z = position.z}
-	local query = Tile(newPosition):queryAdd(creature)
+	local query = Tile(newPosition):queryAdd(creature, FLAG_IGNOREBLOCKCREATURE)
 	if query ~= RETURNVALUE_NOERROR or query == RETURNVALUE_NOTENOUGHROOM then
 		newPosition.x = newPosition.x - 1
 		newPosition.y = newPosition.y + 1
-		query = Tile(newPosition):queryAdd(creature)
+		query = Tile(newPosition):queryAdd(creature, FLAG_IGNOREBLOCKCREATURE)
 	end
 
 	if query == RETURNVALUE_NOERROR or query ~= RETURNVALUE_NOTENOUGHROOM then


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
I added the flag `FLAG_IGNOREBLOCKCREATURE`, This is because we are checking if the items can be moved to the next tile. Otherwise, they won't move because queryAdd returns `RETURNVALUE_NOTENOUGHROOM` since the player is already on the tile.

**Issues addressed:** #4467
