### PR TITLE
Add check for missing ignoreEndValue attribute

### DIFF
--- a/data/scripts/quests/#load_quests_xml.lua
+++ b/data/scripts/quests/#load_quests_xml.lua
@@ -20,9 +20,13 @@ function globalEvent.onStartup()
 				storageId = tonumber(missionNode:attribute("storageid")),
 				startValue = tonumber(missionNode:attribute("startvalue")),
 				endValue = tonumber(missionNode:attribute("endvalue")),
-				ignoreEndValue = table.contains({'1', 'y', 't'}, tostring(missionNode:attribute("ignoreendvalue"):sub(1, 1):lower())),
 				description = missionNode:attribute("description")
 			}
+
+			local ignoreEndValueAttr = missionNode:attribute("ignoreendvalue")
+			if ignoreEndValueAttr ~= nil then
+				mission.ignoreEndValue = table.contains({'1', 'y', 't'}, tostring(ignoreEndValueAttr:sub(1, 1):lower()))
+			end
 
 			if not mission.description then
 				local missionState = missionNode:firstChild()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
Add check for missing ignoreEndValue attribute.

This pull request adds a check in the quest loading script to handle cases where the "ignoreEndValue" attribute is missing from missions in the quests.xml file. Previously, the script would encounter an error when trying to access the attribute, causing the quest loading process to fail. With this change, if the attribute is not present, the script will continue execution without any errors, ensuring that quests without the "ignoreEndValue" attribute can still be loaded successfully.

**Issues addressed:** <!-- Write here the issue number, if any. -->
I found the problem when using [orts](https://github.com/EPuncker/orts2)

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
