### PR TITLE
Add storage values to creatures

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -5,6 +5,7 @@
 	<event class="Creature" method="onAreaCombat" enabled="0" />
 	<event class="Creature" method="onTargetCombat" enabled="0" />
 	<event class="Creature" method="onHear" enabled="0" />
+	<event class="Creature" method="onUpdateStorage" enabled="1" />
 
 	<!-- Party methods -->
 	<event class="Party" method="onJoin" enabled="0" />
@@ -39,7 +40,6 @@
 	<event class="Player" method="onWrapItem" enabled="1" />
 	<event class="Player" method="onInventoryUpdate" enabled="1" />
 	<event class="Player" method="onNetworkMessage" enabled="1" />
-	<event class="Player" method="onUpdateStorage" enabled="1" />
 
 	<!-- Monster methods -->
 	<event class="Monster" method="onDropLoot" enabled="1" />

--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -34,3 +34,10 @@ function Creature:onHear(speaker, words, type)
 		onHear(self, speaker, words, type)
 	end
 end
+
+function Creature:onUpdateStorage(key, value, oldValue, isSpawn)
+	local onUpdateStorage = EventCallback.onUpdateStorage
+	if onUpdateStorage then
+		onUpdateStorage(self, key, value, oldValue, isSpawn)
+	end
+end

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -357,10 +357,3 @@ function Player:onNetworkMessage(recvByte, msg)
 
 	handler(self, msg)
 end
-
-function Player:onUpdateStorage(key, value, oldValue, isLogin)
-	local onUpdateStorage = EventCallback.onUpdateStorage
-	if onUpdateStorage then
-		onUpdateStorage(self, key, value, oldValue, isLogin)
-	end
-end

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -580,6 +580,25 @@ function getPlayerLearnedInstantSpell(cid, name) local p = Player(cid) return p 
 function isPlayerGhost(cid) local p = Player(cid) return p and p:isInGhostMode() or false end
 function isPlayerPzLocked(cid) local p = Player(cid) return p and p:isPzLocked() or false end
 function isPremium(cid) local p = Player(cid) return p and p:isPremium() or false end
+
+STORAGEVALUE_EMPTY = -1
+function Player:getStorageValue(key)
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking Creature:getStorageValue will return nil to indicate absence in the future. Please update your scripts accordingly.")
+
+	local v = Creature.getStorageValue(self, key)
+	return v or STORAGEVALUE_EMPTY
+end
+
+function Player:setStorageValue(key, value)
+
+	if value == STORAGEVALUE_EMPTY then
+		print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking Creature:setStorageValue with a value of -1 to remove it is deprecated. Please use Creature:removeStorageValue(key) instead.")
+		Creature.removeStorageValue(self, key)
+	else
+		Creature.setStorageValue(self, key, value)
+	end
+end
+
 function getPlayersByIPAddress(ip, mask)
 	local result = {}
 

--- a/data/lib/core/achievements.lua
+++ b/data/lib/core/achievements.lua
@@ -729,7 +729,7 @@ function Player.removeAchievement(self, ach)
 	end
 
 	if self:hasAchievement(achievement.id) then
-		self:setStorageValue(PlayerStorageKeys.achievementsBase + achievement.id, -1)
+		self:setStorageValue(PlayerStorageKeys.achievementsBase + achievement.id, nil)
 		if achievement.points > 0 then
 			local value = self:getStorageValue(PlayerStorageKeys.achievementsTotal)
 			self:setStorageValue(PlayerStorageKeys.achievementsTotal, value - achievement.points)

--- a/data/scripts/eventcallbacks/player/default_onUpdateStorage.lua
+++ b/data/scripts/eventcallbacks/player/default_onUpdateStorage.lua
@@ -2,8 +2,13 @@ local lastQuestUpdate = {}
 
 local ec = EventCallback
 
-ec.onUpdateStorage = function(player, key, value, oldValue, isLogin)
-	if isLogin then
+ec.onUpdateStorage = function(creature, key, value, oldValue, isSpawn)
+	if isSpawn then
+		return
+	end
+
+	local player = Player(creature)
+	if not player then
 		return
 	end
 

--- a/data/scripts/monsters/cobra_flask.lua
+++ b/data/scripts/monsters/cobra_flask.lua
@@ -10,7 +10,7 @@ function ev.onSpawn(monster, position, startup, artificial)
 				monster:setHealth(monster:getMaxHealth() * 0.75)
 				monster:getPosition():sendMagicEffect(CONST_ME_GREEN_RINGS)
 			else
-				Game.setStorageValue(GlobalStorageKeys.cobraBastionFlask, -1)
+				Game.setStorageValue(GlobalStorageKeys.cobraBastionFlask, nil)
 			end
 		end
 	end

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -7,6 +7,7 @@
 
 #include "combat.h"
 #include "configmanager.h"
+#include "events.h"
 #include "game.h"
 #include "monster.h"
 #include "party.h"
@@ -20,6 +21,7 @@ double Creature::speedC = -4795.01;
 extern Game g_game;
 extern ConfigManager g_config;
 extern CreatureEvents* g_creatureEvents;
+extern Events* g_events;
 
 Creature::Creature() { onIdleStatus(); }
 
@@ -1663,4 +1665,24 @@ bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirL
 	fpp.minTargetDist = minTargetDist;
 	fpp.maxTargetDist = maxTargetDist;
 	return getPathTo(targetPos, dirList, fpp);
+}
+
+void Creature::setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn)
+{
+	auto oldValue = getStorageValue(key);
+	if (value) {
+		storageMap.insert_or_assign(key, value.value());
+	} else {
+		storageMap.erase(key);
+	}
+	g_events->eventCreatureOnUpdateStorage(this, key, oldValue, value, isSpawn);
+}
+
+std::optional<int32_t> Creature::getStorageValue(uint32_t key) const
+{
+	auto it = storageMap.find(key);
+	if (it == storageMap.end()) {
+		return std::nullopt;
+	}
+	return std::make_optional(it->second);
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -344,6 +344,10 @@ public:
 		}
 	}
 
+	virtual void setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn = false);
+	virtual std::optional<int32_t> getStorageValue(uint32_t key) const;
+	decltype(auto) getStorageMap() const { return storageMap; }
+
 protected:
 	virtual bool useCacheMap() const { return false; }
 
@@ -440,6 +444,9 @@ protected:
 	friend class Game;
 	friend class Map;
 	friend class LuaScriptInterface;
+
+private:
+	std::map<uint32_t, int32_t> storageMap;
 };
 
 #endif // FS_CREATURE_H

--- a/src/events.h
+++ b/src/events.h
@@ -27,6 +27,7 @@ class Events
 		int32_t creatureOnAreaCombat = -1;
 		int32_t creatureOnTargetCombat = -1;
 		int32_t creatureOnHear = -1;
+		int32_t creatureOnUpdateStorage = -1;
 
 		// Party
 		int32_t partyOnJoin = -1;
@@ -61,7 +62,6 @@ class Events
 		int32_t playerOnWrapItem = -1;
 		int32_t playerOnInventoryUpdate = -1;
 		int32_t playerOnNetworkMessage = -1;
-		int32_t playerOnUpdateStorage = -1;
 
 		// Monster
 		int32_t monsterOnDropLoot = -1;
@@ -78,6 +78,8 @@ public:
 	ReturnValue eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bool aggressive);
 	ReturnValue eventCreatureOnTargetCombat(Creature* creature, Creature* target);
 	void eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
+	void eventCreatureOnUpdateStorage(Creature* creature, uint32_t key, std::optional<int32_t> value,
+	                                  std::optional<int32_t> oldValue, bool isSpawn);
 
 	// Party
 	bool eventPartyOnJoin(Party* party, Player* player);
@@ -119,8 +121,6 @@ public:
 	void eventPlayerOnWrapItem(Player* player, Item* item);
 	void eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
 	void eventPlayerOnNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage* msg);
-	void eventPlayerOnUpdateStorage(Player* player, const uint32_t key, const int32_t value, const int32_t oldValue,
-	                                bool isLogin);
 
 	// Monster
 	void eventMonsterOnDropLoot(Monster* monster, Container* corpse);

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -605,7 +605,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	if ((result = db.storeQuery(
 	         fmt::format("SELECT `key`, `value` FROM `player_storage` WHERE `player_id` = {:d}", player->getGUID())))) {
 		do {
-			player->addStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int32_t>("value"), true);
+			player->setStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int32_t>("value"), true);
 		} while (result->next());
 	}
 
@@ -937,8 +937,8 @@ bool IOLoginData::savePlayer(Player* player)
 	DBInsert storageQuery("INSERT INTO `player_storage` (`player_id`, `key`, `value`) VALUES ");
 	player->genReservedStorageRange();
 
-	for (const auto& it : player->storageMap) {
-		if (!storageQuery.addRow(fmt::format("{:d}, {:d}, {:d}", player->getGUID(), it.first, it.second))) {
+	for (const auto& [key, value] : player->getStorageMap()) {
+		if (!storageQuery.addRow(fmt::format("{:d}, {:d}, {:d}", player->getGUID(), key, value))) {
 			return false;
 		}
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2560,6 +2560,9 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("Creature", "getZone", LuaScriptInterface::luaCreatureGetZone);
 
+	registerMethod("Creature", "getStorageValue", LuaScriptInterface::luaCreatureGetStorageValue);
+	registerMethod("Creature", "setStorageValue", LuaScriptInterface::luaCreatureSetStorageValue);
+
 	// Player
 	registerClass("Player", "Creature", LuaScriptInterface::luaPlayerCreate);
 	registerMetaMethod("Player", "__eq", LuaScriptInterface::luaUserdataCompare);
@@ -2657,9 +2660,6 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("Player", "getBankBalance", LuaScriptInterface::luaPlayerGetBankBalance);
 	registerMethod("Player", "setBankBalance", LuaScriptInterface::luaPlayerSetBankBalance);
-
-	registerMethod("Player", "getStorageValue", LuaScriptInterface::luaPlayerGetStorageValue);
-	registerMethod("Player", "setStorageValue", LuaScriptInterface::luaPlayerSetStorageValue);
 
 	registerMethod("Player", "addItem", LuaScriptInterface::luaPlayerAddItem);
 	registerMethod("Player", "addItemEx", LuaScriptInterface::luaPlayerAddItemEx);
@@ -8642,6 +8642,46 @@ int LuaScriptInterface::luaCreatureGetZone(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaCreatureGetStorageValue(lua_State* L)
+{
+	// creature:getStorageValue(key)
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	uint32_t key = getNumber<uint32_t>(L, 2);
+	if (auto storage = creature->getStorageValue(key)) {
+		lua_pushnumber(L, storage.value());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureSetStorageValue(lua_State* L)
+{
+	// creature:setStorageValue(key, value)
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	uint32_t key = getNumber<uint32_t>(L, 2);
+	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
+		reportErrorFunc(L, fmt::format("Accessing reserved range: {:d}", key));
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	int32_t value = getNumber<int32_t>(L, 3);
+	creature->setStorageValue(key, value);
+	pushBoolean(L, true);
+	return 1;
+}
+
 // Player
 int LuaScriptInterface::luaPlayerCreate(lua_State* L)
 {
@@ -9681,46 +9721,6 @@ int LuaScriptInterface::luaPlayerSetBankBalance(lua_State* L)
 
 	player->setBankBalance(balance);
 	pushBoolean(L, true);
-	return 1;
-}
-
-int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
-{
-	// player:getStorageValue(key)
-	Player* player = getUserdata<Player>(L, 1);
-	if (!player) {
-		lua_pushnil(L);
-		return 1;
-	}
-
-	uint32_t key = getNumber<uint32_t>(L, 2);
-	int32_t value;
-	if (player->getStorageValue(key, value)) {
-		lua_pushnumber(L, value);
-	} else {
-		lua_pushnumber(L, -1);
-	}
-	return 1;
-}
-
-int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
-{
-	// player:setStorageValue(key, value)
-	int32_t value = getNumber<int32_t>(L, 3);
-	uint32_t key = getNumber<uint32_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
-		reportErrorFunc(L, fmt::format("Accessing reserved range: {:d}", key));
-		pushBoolean(L, false);
-		return 1;
-	}
-
-	if (player) {
-		player->addStorageValue(key, value);
-		pushBoolean(L, true);
-	} else {
-		lua_pushnil(L);
-	}
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -840,6 +840,9 @@ private:
 
 	static int luaCreatureGetZone(lua_State* L);
 
+	static int luaCreatureGetStorageValue(lua_State* L);
+	static int luaCreatureSetStorageValue(lua_State* L);
+
 	// Player
 	static int luaPlayerCreate(lua_State* L);
 
@@ -936,9 +939,6 @@ private:
 
 	static int luaPlayerGetBankBalance(lua_State* L);
 	static int luaPlayerSetBankBalance(lua_State* L);
-
-	static int luaPlayerGetStorageValue(lua_State* L);
-	static int luaPlayerSetStorageValue(lua_State* L);
 
 	static int luaPlayerAddItem(lua_State* L);
 	static int luaPlayerAddItemEx(lua_State* L);

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include <mysql/mysql.h>
+#include <optional>
 #include <pugixml.hpp>
 #include <random>
 #include <set>

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -702,11 +702,11 @@ uint16_t Player::getLookCorpse() const
 	return ITEM_MALE_CORPSE;
 }
 
-void Player::addStorageValue(const uint32_t key, const int32_t value, const bool isLogin /* = false*/)
+void Player::setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn /* = false*/)
 {
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
 		if (IS_IN_KEYRANGE(key, OUTFITS_RANGE)) {
-			outfits.emplace_back(value >> 16, value & 0xFF);
+			outfits.emplace_back(value.value_or(0) >> 16, value.value_or(0) & 0xFF);
 			return;
 		} else if (IS_IN_KEYRANGE(key, MOUNTS_RANGE)) {
 			// do nothing
@@ -716,28 +716,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 		}
 	}
 
-	int32_t oldValue;
-	getStorageValue(key, oldValue);
-
-	if (value != -1) {
-		storageMap[key] = value;
-	} else {
-		storageMap.erase(key);
-	}
-
-	g_events->eventPlayerOnUpdateStorage(this, key, oldValue, value, isLogin);
-}
-
-bool Player::getStorageValue(const uint32_t key, int32_t& value) const
-{
-	auto it = storageMap.find(key);
-	if (it == storageMap.end()) {
-		value = -1;
-		return false;
-	}
-
-	value = it->second;
-	return true;
+	Creature::setStorageValue(key, value, isSpawn);
 }
 
 bool Player::canSee(const Position& pos) const
@@ -3934,7 +3913,7 @@ void Player::genReservedStorageRange()
 	// generate outfits range
 	uint32_t base_key = PSTRG_OUTFITS_RANGE_START;
 	for (const OutfitEntry& entry : outfits) {
-		storageMap[++base_key] = (entry.lookType << 16) | entry.addons;
+		Creature::setStorageValue(++base_key, (entry.lookType << 16) | entry.addons, true);
 	}
 }
 
@@ -4342,14 +4321,11 @@ uint8_t Player::getRandomMount() const
 
 uint8_t Player::getCurrentMount() const
 {
-	int32_t value;
-	if (getStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, value)) {
-		return value;
-	}
-	return 0;
+	auto storage = getStorageValue(PSTRG_MOUNTS_CURRENTMOUNT);
+	return storage.value_or(0);
 }
 
-void Player::setCurrentMount(uint8_t mountId) { addStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, mountId); }
+void Player::setCurrentMount(uint8_t mountId) { setStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, mountId); }
 
 bool Player::toggleMount(bool mount)
 {
@@ -4431,14 +4407,7 @@ bool Player::tameMount(uint8_t mountId)
 	const uint8_t tmpMountId = mountId - 1;
 	const uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
 
-	int32_t value;
-	if (getStorageValue(key, value)) {
-		value |= (1 << (tmpMountId % 31));
-	} else {
-		value = (1 << (tmpMountId % 31));
-	}
-
-	addStorageValue(key, value);
+	setStorageValue(key, getStorageValue(key).value_or(0) | (1 << (tmpMountId % 31)));
 	return true;
 }
 
@@ -4448,16 +4417,10 @@ bool Player::untameMount(uint8_t mountId)
 		return false;
 	}
 
-	const uint8_t tmpMountId = mountId - 1;
-	const uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
+	uint8_t tmpMountId = mountId - 1;
+	uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
 
-	int32_t value;
-	if (!getStorageValue(key, value)) {
-		return true;
-	}
-
-	value &= ~(1 << (tmpMountId % 31));
-	addStorageValue(key, value);
+	setStorageValue(key, getStorageValue(key).value_or(0) & ~(1 << (tmpMountId % 31)));
 
 	if (getCurrentMount() == mountId) {
 		if (isMounted()) {
@@ -4481,14 +4444,10 @@ bool Player::hasMount(const Mount* mount) const
 		return false;
 	}
 
-	const uint8_t tmpMountId = mount->id - 1;
+	uint8_t tmpMountId = mount->id - 1;
+	uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
 
-	int32_t value;
-	if (!getStorageValue(PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31), value)) {
-		return false;
-	}
-
-	return ((1 << (tmpMountId % 31)) & value) != 0;
+	return ((1 << (tmpMountId % 31)) & getStorageValue(key).value_or(0)) != 0;
 }
 
 bool Player::hasMounts() const

--- a/src/player.h
+++ b/src/player.h
@@ -253,8 +253,7 @@ public:
 
 	bool canOpenCorpse(uint32_t ownerId) const;
 
-	void addStorageValue(const uint32_t key, const int32_t value, const bool isLogin = false);
-	bool getStorageValue(const uint32_t key, int32_t& value) const;
+	void setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn = false) override;
 	void genReservedStorageRange();
 
 	void setGroup(Group* newGroup) { group = newGroup; }
@@ -1169,7 +1168,6 @@ private:
 
 	std::map<uint8_t, OpenContainer> openContainers;
 	std::map<uint32_t, DepotChest*> depotChests;
-	std::map<uint32_t, int32_t> storageMap;
 
 	std::vector<OutfitEntry> outfits;
 	GuildWarVector guildWarVector;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:**
Moves storage values up from players to creatures, meaning that monsters and NPCs also get storage values. 

Only player storage is saved to the database, since creatures are not stable between server restarts. It could be extended to save NPC storage values, though.

Implementation detail: I opted for an ordered map instead of unordered because `std::unordered_map` uses a lot of memory when empty, as it is optimized for high usage.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
