### PR TITLE
Remove .c_str() where string_view is expected

### DIFF
--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -165,7 +165,7 @@ bool CallBack::loadCallBack(LuaScriptInterface* interface, const std::string& na
 
 	scriptInterface = interface;
 
-	int32_t id = scriptInterface->getEvent(name.c_str());
+	int32_t id = scriptInterface->getEvent(name);
 	if (id == -1) {
 		std::cout << "[Warning - CallBack::loadCallBack] Event " << name << " not found." << std::endl;
 		return false;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16893,7 +16893,7 @@ int LuaScriptInterface::luaTalkactionSeparator(lua_State* L)
 	// talkAction:separator(sep)
 	TalkAction* talk = getUserdata<TalkAction>(L, 1);
 	if (talk) {
-		talk->setSeparator(getString(L, 2).c_str());
+		talk->setSeparator(getString(L, 2));
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
`string_view`s are optimized to work with `string`s, there is no need for `c_str` here (probably just some legacy code)

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
