### PR TITLE
fix: depotchest memory leak

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5681,7 +5681,7 @@ std::vector<Item*> Game::getMarketItemList(uint16_t wareId, uint16_t sufficientC
 
 	for (const auto& chest : player.depotChests) {
 		if (!chest.second->empty()) {
-			containers.push_front(chest.second);
+			containers.push_front(chest.second.get());
 		}
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -829,7 +829,7 @@ DepotChest* Player::getDepotChest(uint32_t depotId, bool autoCreate)
 {
 	auto it = depotChests.find(depotId);
 	if (it != depotChests.end()) {
-		return it->second;
+		return it->second.get();
 	}
 
 	if (!autoCreate) {
@@ -841,9 +841,9 @@ DepotChest* Player::getDepotChest(uint32_t depotId, bool autoCreate)
 		return nullptr;
 	}
 
-	it = depotChests.emplace(depotId, new DepotChest(depotItemId)).first;
+	it = depotChests.emplace(depotId, std::make_shared<DepotChest>(depotItemId)).first;
 	it->second->setMaxDepotItems(getMaxDepotItems());
-	return it->second;
+	return it->second.get();
 }
 
 DepotLocker& Player::getDepotLocker()
@@ -3218,7 +3218,7 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 					bool isOwner = false;
 
 					for (const auto& it : depotChests) {
-						if (it.second == depotChest) {
+						if (it.second.get() == depotChest) {
 							isOwner = true;
 							onSendContainer(container);
 						}

--- a/src/player.h
+++ b/src/player.h
@@ -21,6 +21,8 @@ class Npc;
 class Party;
 class SchedulerTask;
 
+using DepotChest_ptr = std::shared_ptr<DepotChest>;
+
 enum skillsid_t
 {
 	SKILLVALUE_LEVEL = 0,
@@ -1170,7 +1172,7 @@ private:
 	std::unordered_set<uint32_t> VIPList;
 
 	std::map<uint8_t, OpenContainer> openContainers;
-	std::map<uint32_t, DepotChest*> depotChests;
+	std::map<uint32_t, DepotChest_ptr> depotChests;
 
 	std::vector<OutfitEntry> outfits;
 	GuildWarVector guildWarVector;

--- a/src/player.h
+++ b/src/player.h
@@ -21,8 +21,6 @@ class Npc;
 class Party;
 class SchedulerTask;
 
-using DepotChest_ptr = std::shared_ptr<DepotChest>;
-
 enum skillsid_t
 {
 	SKILLVALUE_LEVEL = 0,
@@ -1172,7 +1170,7 @@ private:
 	std::unordered_set<uint32_t> VIPList;
 
 	std::map<uint8_t, OpenContainer> openContainers;
-	std::map<uint32_t, DepotChest_ptr> depotChests;
+	std::map<uint32_t, std::shared_ptr<DepotChest>> depotChests;
 
 	std::vector<OutfitEntry> outfits;
 	GuildWarVector guildWarVector;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2152,7 +2152,7 @@ void ProtocolGame::sendMarketEnter()
 
 	for (const auto& chest : player->depotChests) {
 		if (!chest.second->empty()) {
-			containerList.push_front(chest.second);
+			containerList.push_front(chest.second.get());
 		}
 	}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

items on depot cannot destroy after player logout.
after some relogins with around 100k items on depot...

BEFORE FIX:
![Captura de tela 2023-07-23 164438](https://github.com/otland/forgottenserver/assets/40324910/572e80eb-b819-46f2-b78c-79093705e03e)

AFTER FIX:
![Captura de tela 2023-07-23 164420](https://github.com/otland/forgottenserver/assets/40324910/25957507-8466-4ede-912b-ecec38fe0fab)

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
