### PR TITLE
Use Ninja multi-config with CMake

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -61,7 +61,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: default
-          buildPresetAdditionalArgs: "['--config ${{ matrix.buildtype }}']"
+          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}']"
           configurePreset: default
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -31,6 +31,9 @@ jobs:
         buildtype: [Debug, Release]
         luajit: [on, off]
 
+    env:
+      VCPKG_BUILD_TYPE: release
+
     steps:
       - uses: actions/checkout@v3
 
@@ -49,9 +52,8 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: vcpkg
-          buildPresetAdditionalArgs: "['--config ${{ matrix.buildtype }}', '--clean-first']"
+          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}']"
           configurePreset: vcpkg
-          configurePresetAdditionalArgs: "['-G Ninja']"
 
       - name: Upload artifact binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -14,6 +14,7 @@ jobs:
         os: [ubuntu, macos, windows]
 
     env:
+      VCPKG_BUILD_TYPE: release
       VCPKG_FEATURE_FLAGS: luajit
 
     steps:
@@ -30,9 +31,8 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: vcpkg
-          buildPresetAdditionalArgs: "['--config Release', '--clean-first']"
+          buildPresetAdditionalArgs: "['--config', 'RelWithDebInfo', '--clean-first']"
           configurePreset: vcpkg
-          configurePresetAdditionalArgs: "['-G Ninja']"
 
       - name: Prepare datapack contents
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,6 @@ jobs:
         with:
           buildPreset: default
           configurePreset: default
-          configurePresetAdditionalArgs: "['-G Ninja', '-DBUILD_TESTING=ON']"
+          configurePresetAdditionalArgs: "['-DBUILD_TESTING=ON']"
           testPreset: default
+          testPresetAdditionalArgs: "['--build-config', 'Debug']"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.17)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,6 +4,7 @@
     {
       "name": "default",
       "description": "Generate Ninja project files",
+      "generator": "Ninja Multi-Config",
       "binaryDir": "${sourceDir}/build"
     },
     {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:**

Using Ninja multi-config allows us to build in multiple configurations, such as Debug, RelWithDebInfo and Release.

Currently, one needs to pass the build type prior to generating makefiles, with `cmake --preset default -DCMAKE_BUILD_TYPE=<buildtype>` followed by `cmake --build --preset default`, and rebuilding with a different config required regenerating makefiles.

Now, a clearer invocation of `cmake` is possible with `cmake --preset default` to generate makefiles, and then `cmake --build --preset default --config <buildtype>` is possible without regenerating makefiles, and in separate folders so that one can maintain multiple builds (for debugging and running in production, for example)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
