### PR TITLE
Load MySQL variables from environment

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -66,14 +66,6 @@ premiumToCreateMarketOffer = true
 checkExpiredMarketOffersEachMinutes = 60
 maxMarketOffersAtATimePerPlayer = 100
 
--- MySQL
-mysqlHost = "127.0.0.1"
-mysqlUser = "forgottenserver"
-mysqlPass = ""
-mysqlDatabase = "forgottenserver"
-mysqlPort = 3306
-mysqlSock = ""
-
 -- Misc.
 -- NOTE: classicAttackSpeed set to true makes players constantly attack at regular
 -- intervals regardless of other actions such as item (potion) use. This setting

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -25,6 +25,14 @@ extern Game g_game;
 
 namespace {
 
+const char* getEnv(const char* envVar, const char* defaultValue)
+{
+	if (auto value = std::getenv(envVar)) {
+		return value;
+	}
+	return defaultValue;
+}
+
 std::string getGlobalString(lua_State* L, const char* identifier, const char* defaultValue)
 {
 	lua_getglobal(L, identifier);
@@ -170,10 +178,10 @@ bool ConfigManager::load()
 		string[MAP_NAME] = getGlobalString(L, "mapName", "forgotten");
 		string[MAP_AUTHOR] = getGlobalString(L, "mapAuthor", "Unknown");
 		string[HOUSE_RENT_PERIOD] = getGlobalString(L, "houseRentPeriod", "never");
-		string[MYSQL_HOST] = getGlobalString(L, "mysqlHost", "127.0.0.1");
-		string[MYSQL_USER] = getGlobalString(L, "mysqlUser", "forgottenserver");
-		string[MYSQL_PASS] = getGlobalString(L, "mysqlPass", "");
-		string[MYSQL_DB] = getGlobalString(L, "mysqlDatabase", "forgottenserver");
+		string[MYSQL_HOST] = getGlobalString(L, "mysqlHost", getEnv("MYSQL_HOST", "127.0.0.1"));
+		string[MYSQL_USER] = getGlobalString(L, "mysqlUser", getEnv("MYSQL_USER", "forgottenserver"));
+		string[MYSQL_PASS] = getGlobalString(L, "mysqlPass", getEnv("MYSQL_PASSWORD", ""));
+		string[MYSQL_DB] = getGlobalString(L, "mysqlDatabase", getEnv("MYSQL_DATABASE", "forgottenserver"));
 		string[MYSQL_SOCK] = getGlobalString(L, "mysqlSock", "");
 
 		integer[SQL_PORT] = getGlobalNumber(L, "mysqlPort", 3306);

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -25,10 +25,11 @@ extern Game g_game;
 
 namespace {
 
-const char* getEnv(const char* envVar, const char* defaultValue)
+template <typename T>
+auto getEnv(const char* envVar, T&& defaultValue)
 {
 	if (auto value = std::getenv(envVar)) {
-		return value;
+		return pugi::cast<std::decay_t<T>>(value);
 	}
 	return defaultValue;
 }
@@ -182,9 +183,9 @@ bool ConfigManager::load()
 		string[MYSQL_USER] = getGlobalString(L, "mysqlUser", getEnv("MYSQL_USER", "forgottenserver"));
 		string[MYSQL_PASS] = getGlobalString(L, "mysqlPass", getEnv("MYSQL_PASSWORD", ""));
 		string[MYSQL_DB] = getGlobalString(L, "mysqlDatabase", getEnv("MYSQL_DATABASE", "forgottenserver"));
-		string[MYSQL_SOCK] = getGlobalString(L, "mysqlSock", "");
+		string[MYSQL_SOCK] = getGlobalString(L, "mysqlSock", getEnv("MYSQL_SOCK", ""));
 
-		integer[SQL_PORT] = getGlobalNumber(L, "mysqlPort", 3306);
+		integer[SQL_PORT] = getGlobalNumber(L, "mysqlPort", getEnv<uint16_t>("MYSQL_PORT", 3306));
 
 		if (integer[GAME_PORT] == 0) {
 			integer[GAME_PORT] = getGlobalNumber(L, "gameProtocolPort", 7172);

--- a/src/pugicast.h
+++ b/src/pugicast.h
@@ -10,6 +10,11 @@ template <class T>
 T cast(const char* str);
 
 template <>
+inline const char* cast(const char* str)
+{
+	return str;
+}
+template <>
 inline float cast(const char* str)
 {
 	return std::strtof(str, nullptr);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Loads MySQL configuration from the environment first, keeping compatibility with Lua config.

This allows better compatibility with database containers, such as [Docker's mariadb](https://hub.docker.com/_/mariadb) and a single source of configuration can be used for the database. It's also easier for other software, such as AACs, that can load the credentials from the environment rather than poorly parsing the Lua config.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
