### PR TITLE
Change lua_pushnumber to lua_pushinteger for non floating point values

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -229,7 +229,7 @@ bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, 
 	tfs::lua::pushUserdata(L, &player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, type);
+	lua_pushinteger(L, type);
 	tfs::lua::pushString(L, message);
 
 	bool result = false;

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1079,8 +1079,8 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage) const
 	switch (type) {
 		case COMBAT_FORMULA_LEVELMAGIC: {
 			// onGetPlayerMinMaxValues(player, level, maglevel)
-			lua_pushnumber(L, player->getLevel());
-			lua_pushnumber(L, player->getMagicLevel() + player->getSpecialMagicLevel(damage.primary.type));
+			lua_pushinteger(L, player->getLevel());
+			lua_pushinteger(L, player->getMagicLevel() + player->getSpecialMagicLevel(damage.primary.type));
 			parameters += 2;
 			break;
 		}
@@ -1105,8 +1105,8 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage) const
 				damage.secondary.value = weapon->getElementDamage(player, nullptr, tool);
 			}
 
-			lua_pushnumber(L, player->getWeaponSkill(item ? item : tool));
-			lua_pushnumber(L, attackValue);
+			lua_pushinteger(L, player->getWeaponSkill(item ? item : tool));
+			lua_pushinteger(L, attackValue);
 			lua_pushnumber(L, player->getAttackFactor());
 			parameters += 3;
 			break;

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -312,7 +312,7 @@ bool CreatureEvent::executeOnThink(Creature* creature, uint32_t interval)
 	scriptInterface->pushFunction(scriptId);
 	tfs::lua::pushUserdata(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
-	lua_pushnumber(L, interval);
+	lua_pushinteger(L, interval);
 
 	return scriptInterface->callFunction(2);
 }
@@ -401,9 +401,9 @@ bool CreatureEvent::executeAdvance(Player* player, skills_t skill, uint32_t oldL
 	scriptInterface->pushFunction(scriptId);
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
-	lua_pushnumber(L, static_cast<uint32_t>(skill));
-	lua_pushnumber(L, oldLevel);
-	lua_pushnumber(L, newLevel);
+	lua_pushinteger(L, static_cast<uint32_t>(skill));
+	lua_pushinteger(L, oldLevel);
+	lua_pushinteger(L, newLevel);
 
 	return scriptInterface->callFunction(4);
 }
@@ -446,9 +446,9 @@ void CreatureEvent::executeModalWindow(Player* player, uint32_t modalWindowId, u
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, modalWindowId);
-	lua_pushnumber(L, buttonId);
-	lua_pushnumber(L, choiceId);
+	lua_pushinteger(L, modalWindowId);
+	lua_pushinteger(L, buttonId);
+	lua_pushinteger(L, choiceId);
 
 	scriptInterface->callVoidFunction(4);
 }
@@ -590,7 +590,7 @@ void CreatureEvent::executeExtendedOpcode(Player* player, uint8_t opcode, const 
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, opcode);
+	lua_pushinteger(L, opcode);
 	tfs::lua::pushString(L, buffer);
 
 	scriptInterface->callVoidFunction(3);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -306,7 +306,7 @@ void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const st
 	tfs::lua::setCreatureMetatable(L, -1, speaker);
 
 	tfs::lua::pushString(L, words);
-	lua_pushnumber(L, type);
+	lua_pushinteger(L, type);
 
 	scriptInterface.callVoidFunction(4);
 }
@@ -332,8 +332,8 @@ void Events::eventCreatureOnChangeZone(Creature* creature, ZoneType_t fromZone, 
 	tfs::lua::pushUserdata(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
-	lua_pushnumber(L, fromZone);
-	lua_pushnumber(L, toZone);
+	lua_pushinteger(L, fromZone);
+	lua_pushinteger(L, toZone);
 
 	scriptInterface.callVoidFunction(3);
 }
@@ -360,16 +360,16 @@ void Events::eventCreatureOnUpdateStorage(Creature* creature, uint32_t key, std:
 	tfs::lua::pushUserdata(L, creature);
 	tfs::lua::setMetatable(L, -1, "Creature");
 
-	lua_pushnumber(L, key);
+	lua_pushinteger(L, key);
 
 	if (value) {
-		lua_pushnumber(L, value.value());
+		lua_pushinteger(L, value.value());
 	} else {
 		lua_pushnil(L);
 	}
 
 	if (oldValue) {
-		lua_pushnumber(L, oldValue.value());
+		lua_pushinteger(L, oldValue.value());
 	} else {
 		lua_pushnil(L);
 	}
@@ -560,7 +560,7 @@ void Events::eventPartyOnShareExperience(Party* party, uint64_t& exp)
 	tfs::lua::pushUserdata(L, party);
 	tfs::lua::setMetatable(L, -1, "Party");
 
-	lua_pushnumber(L, exp);
+	lua_pushinteger(L, exp);
 
 	if (tfs::lua::protectedCall(L, 2, 1) != 0) {
 		reportErrorFunc(L, tfs::lua::popString(L));
@@ -632,7 +632,7 @@ void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* 
 	}
 
 	tfs::lua::pushPosition(L, position, stackpos);
-	lua_pushnumber(L, lookDistance);
+	lua_pushinteger(L, lookDistance);
 
 	scriptInterface.callVoidFunction(4);
 }
@@ -662,7 +662,7 @@ void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, i
 	tfs::lua::pushUserdata(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
-	lua_pushnumber(L, lookDistance);
+	lua_pushinteger(L, lookDistance);
 
 	scriptInterface.callVoidFunction(3);
 }
@@ -694,7 +694,7 @@ void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* ite
 	tfs::lua::pushUserdata(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
-	lua_pushnumber(L, lookDistance);
+	lua_pushinteger(L, lookDistance);
 
 	scriptInterface.callVoidFunction(4);
 }
@@ -723,7 +723,7 @@ bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, u
 	tfs::lua::pushUserdata(L, itemType);
 	tfs::lua::setMetatable(L, -1, "ItemType");
 
-	lua_pushnumber(L, count);
+	lua_pushinteger(L, count);
 
 	return scriptInterface.callFunction(3);
 }
@@ -781,7 +781,7 @@ ReturnValue Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t c
 	tfs::lua::pushUserdata(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
-	lua_pushnumber(L, count);
+	lua_pushinteger(L, count);
 	tfs::lua::pushPosition(L, fromPosition);
 	tfs::lua::pushPosition(L, toPosition);
 
@@ -827,7 +827,7 @@ void Events::eventPlayerOnItemMoved(Player* player, Item* item, uint16_t count, 
 	tfs::lua::pushUserdata(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
-	lua_pushnumber(L, count);
+	lua_pushinteger(L, count);
 	tfs::lua::pushPosition(L, fromPosition);
 	tfs::lua::pushPosition(L, toPosition);
 
@@ -894,8 +894,8 @@ void Events::eventPlayerOnReportRuleViolation(Player* player, const std::string&
 
 	tfs::lua::pushString(L, targetName);
 
-	lua_pushnumber(L, reportType);
-	lua_pushnumber(L, reportReason);
+	lua_pushinteger(L, reportType);
+	lua_pushinteger(L, reportReason);
 
 	tfs::lua::pushString(L, comment);
 	tfs::lua::pushString(L, translation);
@@ -927,7 +927,7 @@ bool Events::eventPlayerOnReportBug(Player* player, const std::string& message, 
 
 	tfs::lua::pushString(L, message);
 	tfs::lua::pushPosition(L, position);
-	lua_pushnumber(L, category);
+	lua_pushinteger(L, category);
 
 	return scriptInterface.callFunction(4);
 }
@@ -980,7 +980,7 @@ bool Events::eventPlayerOnTurn(Player* player, Direction direction)
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, direction);
+	lua_pushinteger(L, direction);
 
 	return scriptInterface.callFunction(2);
 }
@@ -1138,7 +1138,7 @@ void Events::eventPlayerOnPodiumEdit(Player* player, Item* item, const Outfit_t&
 
 	tfs::lua::pushOutfit(L, outfit);
 
-	lua_pushnumber(L, direction);
+	lua_pushinteger(L, direction);
 	lua_pushboolean(L, podiumVisible);
 
 	scriptInterface.callFunction(5);
@@ -1173,8 +1173,8 @@ void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint6
 		lua_pushnil(L);
 	}
 
-	lua_pushnumber(L, exp);
-	lua_pushnumber(L, rawExp);
+	lua_pushinteger(L, exp);
+	lua_pushinteger(L, rawExp);
 	tfs::lua::pushBoolean(L, sendText);
 
 	if (tfs::lua::protectedCall(L, 5, 1) != 0) {
@@ -1208,7 +1208,7 @@ void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, exp);
+	lua_pushinteger(L, exp);
 
 	if (tfs::lua::protectedCall(L, 2, 1) != 0) {
 		reportErrorFunc(L, tfs::lua::popString(L));
@@ -1241,8 +1241,8 @@ void Events::eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, skill);
-	lua_pushnumber(L, tries);
+	lua_pushinteger(L, skill);
+	lua_pushinteger(L, tries);
 
 	if (tfs::lua::protectedCall(L, 3, 1) != 0) {
 		reportErrorFunc(L, tfs::lua::popString(L));
@@ -1305,7 +1305,7 @@ void Events::eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t sl
 	tfs::lua::pushUserdata(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
-	lua_pushnumber(L, slot);
+	lua_pushinteger(L, slot);
 	tfs::lua::pushBoolean(L, equip);
 
 	scriptInterface.callVoidFunction(4);
@@ -1332,7 +1332,7 @@ void Events::eventPlayerOnNetworkMessage(Player* player, uint8_t recvByte, Netwo
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	lua_pushnumber(L, recvByte);
+	lua_pushinteger(L, recvByte);
 
 	tfs::lua::pushUserdata(L, msg);
 	tfs::lua::setMetatable(L, -1, "NetworkMessage");

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -340,8 +340,8 @@ bool GlobalEvent::executeRecord(uint32_t current, uint32_t old)
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(scriptId);
 
-	lua_pushnumber(L, current);
-	lua_pushnumber(L, old);
+	lua_pushinteger(L, current);
+	lua_pushinteger(L, old);
 	return scriptInterface->callFunction(2);
 }
 
@@ -359,7 +359,7 @@ bool GlobalEvent::executeEvent() const
 
 	int32_t params = 0;
 	if (eventType == GLOBALEVENT_NONE || eventType == GLOBALEVENT_TIMER) {
-		lua_pushnumber(L, interval);
+		lua_pushinteger(L, interval);
 		params = 1;
 	}
 

--- a/src/item.h
+++ b/src/item.h
@@ -186,7 +186,7 @@ public:
 
 			void operator()(bool v) const { tfs::lua::pushBoolean(L, v); }
 
-			void operator()(const int64_t& v) const { lua_pushnumber(L, v); }
+			void operator()(const int64_t& v) const { lua_pushinteger(L, v); }
 
 			void operator()(const double& v) const { lua_pushnumber(L, v); }
 		};

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3695,7 +3695,7 @@ int LuaScriptInterface::luaDoPlayerAddItem(lua_State* L)
 		if (--itemCount == 0) {
 			if (newItem->getParent()) {
 				uint32_t uid = tfs::lua::getScriptEnv()->addThing(newItem);
-				lua_pushnumber(L, uid);
+				lua_pushinteger(L, uid);
 				return 1;
 			} else {
 				// stackable item stacked with existing object, newItem will be released
@@ -3720,7 +3720,7 @@ int LuaScriptInterface::luaGetWorldUpTime(lua_State* L)
 {
 	// getWorldUpTime()
 	uint64_t uptime = (OTSYS_TIME() - ProtocolStatus::start) / 1000;
-	lua_pushnumber(L, uptime);
+	lua_pushinteger(L, uptime);
 	return 1;
 }
 
@@ -3770,7 +3770,7 @@ int LuaScriptInterface::luaCreateCombatArea(lua_State* L)
 	}
 
 	area->setupArea(vecArea, rowsArea);
-	lua_pushnumber(L, areaId);
+	lua_pushinteger(L, areaId);
 	return 1;
 }
 
@@ -3919,7 +3919,7 @@ int LuaScriptInterface::luaGetDepotId(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, depotLocker->getDepotId());
+	lua_pushinteger(L, depotLocker->getDepotId());
 	return 1;
 }
 
@@ -4039,7 +4039,7 @@ int LuaScriptInterface::luaAddEvent(lua_State* L)
 	    createSchedulerTask(delay, [=]() { g_luaEnvironment.executeTimerEvent(lastTimerEventId); }));
 
 	g_luaEnvironment.timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
-	lua_pushnumber(L, lastTimerEventId++);
+	lua_pushinteger(L, lastTimerEventId++);
 	return 1;
 }
 
@@ -4079,7 +4079,7 @@ int LuaScriptInterface::luaSaveServer(lua_State* L)
 
 int LuaScriptInterface::luaCleanMap(lua_State* L)
 {
-	lua_pushnumber(L, g_game.map.clean());
+	lua_pushinteger(L, g_game.map.clean());
 	return 1;
 }
 
@@ -4182,7 +4182,7 @@ const luaL_Reg LuaScriptInterface::luaBitReg[] = {
 
 int LuaScriptInterface::luaBitNot(lua_State* L)
 {
-	lua_pushnumber(L, ~tfs::lua::getNumber<uint32_t>(L, -1));
+	lua_pushinteger(L, ~tfs::lua::getNumber<uint32_t>(L, -1));
 	return 1;
 }
 
@@ -4192,7 +4192,7 @@ int LuaScriptInterface::luaBitNot(lua_State* L)
 		int n = lua_gettop(L); \
 		uint32_t w = tfs::lua::getNumber<uint32_t>(L, -1); \
 		for (int i = 1; i < n; ++i) w op tfs::lua::getNumber<uint32_t>(L, i); \
-		lua_pushnumber(L, w); \
+		lua_pushinteger(L, w); \
 		return 1; \
 	}
 
@@ -4204,7 +4204,7 @@ MULTIOP(Xor, ^=)
 	int LuaScriptInterface::luaBit##name(lua_State* L) \
 	{ \
 		uint32_t n1 = tfs::lua::getNumber<uint32_t>(L, 1), n2 = tfs::lua::getNumber<uint32_t>(L, 2); \
-		lua_pushnumber(L, (n1 op n2)); \
+		lua_pushinteger(L, (n1 op n2)); \
 		return 1; \
 	}
 
@@ -4226,7 +4226,7 @@ int LuaScriptInterface::luaConfigManagerGetString(lua_State* L)
 
 int LuaScriptInterface::luaConfigManagerGetNumber(lua_State* L)
 {
-	lua_pushnumber(L, ConfigManager::getNumber(tfs::lua::getNumber<ConfigManager::integer_config_t>(L, -1)));
+	lua_pushinteger(L, ConfigManager::getNumber(tfs::lua::getNumber<ConfigManager::integer_config_t>(L, -1)));
 	return 1;
 }
 
@@ -4289,7 +4289,7 @@ int LuaScriptInterface::luaDatabaseStoreQuery(lua_State* L)
 {
 	// db.storeQuery(query)
 	if (DBResult_ptr res = Database::getInstance().storeQuery(tfs::lua::getString(L, -1))) {
-		lua_pushnumber(L, addResult(res));
+		lua_pushinteger(L, addResult(res));
 	} else {
 		tfs::lua::pushBoolean(L, false);
 	}
@@ -4316,7 +4316,7 @@ int LuaScriptInterface::luaDatabaseAsyncStoreQuery(lua_State* L)
 
 			lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
 			if (result) {
-				lua_pushnumber(L, addResult(result));
+				lua_pushinteger(L, addResult(result));
 			} else {
 				tfs::lua::pushBoolean(L, false);
 			}
@@ -4349,7 +4349,7 @@ int LuaScriptInterface::luaDatabaseEscapeBlob(lua_State* L)
 int LuaScriptInterface::luaDatabaseLastInsertId(lua_State* L)
 {
 	// db.lastInsertId()
-	lua_pushnumber(L, Database::getInstance().getLastInsertId());
+	lua_pushinteger(L, Database::getInstance().getLastInsertId());
 	return 1;
 }
 
@@ -4374,7 +4374,7 @@ int LuaScriptInterface::luaResultGetNumber(lua_State* L)
 	}
 
 	const std::string& s = tfs::lua::getString(L, 2);
-	lua_pushnumber(L, res->getNumber<int64_t>(s));
+	lua_pushinteger(L, res->getNumber<int64_t>(s));
 	return 1;
 }
 
@@ -4401,7 +4401,7 @@ int LuaScriptInterface::luaResultGetStream(lua_State* L)
 
 	auto stream = res->getString(tfs::lua::getString(L, 2));
 	lua_pushlstring(L, stream.data(), stream.size());
-	lua_pushnumber(L, stream.size());
+	lua_pushinteger(L, stream.size());
 	return 2;
 }
 
@@ -4469,7 +4469,7 @@ int LuaScriptInterface::luaRawGetMetatable(lua_State* L)
 int LuaScriptInterface::luaSystemTime(lua_State* L)
 {
 	// os.mtime()
-	lua_pushnumber(L, OTSYS_TIME());
+	lua_pushinteger(L, OTSYS_TIME());
 	return 1;
 }
 
@@ -4685,9 +4685,9 @@ int LuaScriptInterface::luaGameGetExperienceForLevel(lua_State* L)
 	// Game.getExperienceForLevel(level)
 	const uint32_t level = tfs::lua::getNumber<uint32_t>(L, 1);
 	if (level == 0) {
-		lua_pushnumber(L, 0);
+		lua_pushinteger(L, 0);
 	} else {
-		lua_pushnumber(L, Player::getExpForLevel(level));
+		lua_pushinteger(L, Player::getExpForLevel(level));
 	}
 	return 1;
 }
@@ -4695,21 +4695,21 @@ int LuaScriptInterface::luaGameGetExperienceForLevel(lua_State* L)
 int LuaScriptInterface::luaGameGetMonsterCount(lua_State* L)
 {
 	// Game.getMonsterCount()
-	lua_pushnumber(L, g_game.getMonstersOnline());
+	lua_pushinteger(L, g_game.getMonstersOnline());
 	return 1;
 }
 
 int LuaScriptInterface::luaGameGetPlayerCount(lua_State* L)
 {
 	// Game.getPlayerCount()
-	lua_pushnumber(L, g_game.getPlayersOnline());
+	lua_pushinteger(L, g_game.getPlayersOnline());
 	return 1;
 }
 
 int LuaScriptInterface::luaGameGetNpcCount(lua_State* L)
 {
 	// Game.getNpcCount()
-	lua_pushnumber(L, g_game.getNpcsOnline());
+	lua_pushinteger(L, g_game.getNpcsOnline());
 	return 1;
 }
 
@@ -4791,7 +4791,7 @@ int LuaScriptInterface::luaGameGetMountIdByLookType(lua_State* L)
 	}
 
 	if (mount) {
-		lua_pushnumber(L, mount->id);
+		lua_pushinteger(L, mount->id);
 	} else {
 		lua_pushnil(L);
 	}
@@ -4895,7 +4895,7 @@ int LuaScriptInterface::luaGameGetVocations(lua_State* L)
 int LuaScriptInterface::luaGameGetGameState(lua_State* L)
 {
 	// Game.getGameState()
-	lua_pushnumber(L, g_game.getGameState());
+	lua_pushinteger(L, g_game.getGameState());
 	return 1;
 }
 
@@ -4911,7 +4911,7 @@ int LuaScriptInterface::luaGameSetGameState(lua_State* L)
 int LuaScriptInterface::luaGameGetWorldType(lua_State* L)
 {
 	// Game.getWorldType()
-	lua_pushnumber(L, g_game.getWorldType());
+	lua_pushinteger(L, g_game.getWorldType());
 	return 1;
 }
 
@@ -4935,7 +4935,7 @@ int LuaScriptInterface::luaGameGetReturnMessage(lua_State* L)
 int LuaScriptInterface::luaGameGetItemAttributeByName(lua_State* L)
 {
 	// Game.getItemAttributeByName(name)
-	lua_pushnumber(L, stringToItemAttribute(tfs::lua::getString(L, 1)));
+	lua_pushinteger(L, stringToItemAttribute(tfs::lua::getString(L, 1)));
 	return 1;
 }
 
@@ -5240,9 +5240,9 @@ int LuaScriptInterface::luaVariantGetNumber(lua_State* L)
 	// Variant:getNumber()
 	const LuaVariant& variant = getVariant(L, 1);
 	if (variant.isNumber()) {
-		lua_pushnumber(L, variant.getNumber());
+		lua_pushinteger(L, variant.getNumber());
 	} else {
-		lua_pushnumber(L, 0);
+		lua_pushinteger(L, 0);
 	}
 	return 1;
 }
@@ -5460,7 +5460,7 @@ int LuaScriptInterface::luaTileGetThingCount(lua_State* L)
 	// tile:getThingCount()
 	Tile* tile = tfs::lua::getUserdata<Tile>(L, 1);
 	if (tile) {
-		lua_pushnumber(L, tile->getThingCount());
+		lua_pushinteger(L, tile->getThingCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -5692,7 +5692,7 @@ int LuaScriptInterface::luaTileGetItemCountById(lua_State* L)
 		}
 	}
 
-	lua_pushnumber(L, tile->getItemTypeCount(itemId, subType));
+	lua_pushinteger(L, tile->getItemTypeCount(itemId, subType));
 	return 1;
 }
 
@@ -5821,7 +5821,7 @@ int LuaScriptInterface::luaTileGetItemCount(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, tile->getItemCount());
+	lua_pushinteger(L, tile->getItemCount());
 	return 1;
 }
 
@@ -5830,7 +5830,7 @@ int LuaScriptInterface::luaTileGetDownItemCount(lua_State* L)
 	// tile:getDownItemCount()
 	Tile* tile = tfs::lua::getUserdata<Tile>(L, 1);
 	if (tile) {
-		lua_pushnumber(L, tile->getDownItemCount());
+		lua_pushinteger(L, tile->getDownItemCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -5846,7 +5846,7 @@ int LuaScriptInterface::luaTileGetTopItemCount(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, tile->getTopItemCount());
+	lua_pushinteger(L, tile->getTopItemCount());
 	return 1;
 }
 
@@ -5885,7 +5885,7 @@ int LuaScriptInterface::luaTileGetCreatureCount(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, tile->getCreatureCount());
+	lua_pushinteger(L, tile->getCreatureCount());
 	return 1;
 }
 
@@ -5925,7 +5925,7 @@ int LuaScriptInterface::luaTileGetThingIndex(lua_State* L)
 
 	Thing* thing = tfs::lua::getThing(L, 2);
 	if (thing) {
-		lua_pushnumber(L, tile->getThingIndex(thing));
+		lua_pushinteger(L, tile->getThingIndex(thing));
 	} else {
 		lua_pushnil(L);
 	}
@@ -5957,7 +5957,7 @@ int LuaScriptInterface::luaTileQueryAdd(lua_State* L)
 	Thing* thing = tfs::lua::getThing(L, 2);
 	if (thing) {
 		uint32_t flags = tfs::lua::getNumber<uint32_t>(L, 3, 0);
-		lua_pushnumber(L, tile->queryAdd(0, *thing, 1, flags));
+		lua_pushinteger(L, tile->queryAdd(0, *thing, 1, flags));
 	} else {
 		lua_pushnil(L);
 	}
@@ -6031,7 +6031,7 @@ int LuaScriptInterface::luaTileAddItemEx(lua_State* L)
 	if (ret == RETURNVALUE_NOERROR) {
 		tfs::lua::removeTempItem(item);
 	}
-	lua_pushnumber(L, ret);
+	lua_pushinteger(L, ret);
 	return 1;
 }
 
@@ -6077,7 +6077,7 @@ int LuaScriptInterface::luaNetworkMessageGetByte(lua_State* L)
 	// networkMessage:getByte()
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (message) {
-		lua_pushnumber(L, message->getByte());
+		lua_pushinteger(L, message->getByte());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6089,7 +6089,7 @@ int LuaScriptInterface::luaNetworkMessageGetU16(lua_State* L)
 	// networkMessage:getU16()
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (message) {
-		lua_pushnumber(L, message->get<uint16_t>());
+		lua_pushinteger(L, message->get<uint16_t>());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6101,7 +6101,7 @@ int LuaScriptInterface::luaNetworkMessageGetU32(lua_State* L)
 	// networkMessage:getU32()
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (message) {
-		lua_pushnumber(L, message->get<uint32_t>());
+		lua_pushinteger(L, message->get<uint32_t>());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6113,7 +6113,7 @@ int LuaScriptInterface::luaNetworkMessageGetU64(lua_State* L)
 	// networkMessage:getU64()
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (message) {
-		lua_pushnumber(L, message->get<uint64_t>());
+		lua_pushinteger(L, message->get<uint64_t>());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6317,7 +6317,7 @@ int LuaScriptInterface::luaNetworkMessageTell(lua_State* L)
 	// networkMessage:tell()
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (message) {
-		lua_pushnumber(L, message->getBufferPosition() - message->INITIAL_BUFFER_POSITION);
+		lua_pushinteger(L, message->getBufferPosition() - message->INITIAL_BUFFER_POSITION);
 	} else {
 		lua_pushnil(L);
 	}
@@ -6329,7 +6329,7 @@ int LuaScriptInterface::luaNetworkMessageLength(lua_State* L)
 	// networkMessage:len()
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (message) {
-		lua_pushnumber(L, message->getLength());
+		lua_pushinteger(L, message->getLength());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6398,7 +6398,7 @@ int LuaScriptInterface::luaModalWindowGetId(lua_State* L)
 	// modalWindow:getId()
 	ModalWindow* window = tfs::lua::getUserdata<ModalWindow>(L, 1);
 	if (window) {
-		lua_pushnumber(L, window->id);
+		lua_pushinteger(L, window->id);
 	} else {
 		lua_pushnil(L);
 	}
@@ -6462,7 +6462,7 @@ int LuaScriptInterface::luaModalWindowGetButtonCount(lua_State* L)
 	// modalWindow:getButtonCount()
 	ModalWindow* window = tfs::lua::getUserdata<ModalWindow>(L, 1);
 	if (window) {
-		lua_pushnumber(L, window->buttons.size());
+		lua_pushinteger(L, window->buttons.size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6474,7 +6474,7 @@ int LuaScriptInterface::luaModalWindowGetChoiceCount(lua_State* L)
 	// modalWindow:getChoiceCount()
 	ModalWindow* window = tfs::lua::getUserdata<ModalWindow>(L, 1);
 	if (window) {
-		lua_pushnumber(L, window->choices.size());
+		lua_pushinteger(L, window->choices.size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6516,7 +6516,7 @@ int LuaScriptInterface::luaModalWindowGetDefaultEnterButton(lua_State* L)
 	// modalWindow:getDefaultEnterButton()
 	ModalWindow* window = tfs::lua::getUserdata<ModalWindow>(L, 1);
 	if (window) {
-		lua_pushnumber(L, window->defaultEnterButton);
+		lua_pushinteger(L, window->defaultEnterButton);
 	} else {
 		lua_pushnil(L);
 	}
@@ -6541,7 +6541,7 @@ int LuaScriptInterface::luaModalWindowGetDefaultEscapeButton(lua_State* L)
 	// modalWindow:getDefaultEscapeButton()
 	ModalWindow* window = tfs::lua::getUserdata<ModalWindow>(L, 1);
 	if (window) {
-		lua_pushnumber(L, window->defaultEscapeButton);
+		lua_pushinteger(L, window->defaultEscapeButton);
 	} else {
 		lua_pushnil(L);
 	}
@@ -6673,7 +6673,7 @@ int LuaScriptInterface::luaItemGetId(lua_State* L)
 	// item:getId()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getID());
+		lua_pushinteger(L, item->getID());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6773,7 +6773,7 @@ int LuaScriptInterface::luaItemGetUniqueId(lua_State* L)
 		if (uniqueId == 0) {
 			uniqueId = tfs::lua::getScriptEnv()->addThing(item);
 		}
-		lua_pushnumber(L, uniqueId);
+		lua_pushinteger(L, uniqueId);
 	} else {
 		lua_pushnil(L);
 	}
@@ -6785,7 +6785,7 @@ int LuaScriptInterface::luaItemGetActionId(lua_State* L)
 	// item:getActionId()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getActionId());
+		lua_pushinteger(L, item->getActionId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6811,7 +6811,7 @@ int LuaScriptInterface::luaItemGetCount(lua_State* L)
 	// item:getCount()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getItemCount());
+		lua_pushinteger(L, item->getItemCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6823,7 +6823,7 @@ int LuaScriptInterface::luaItemGetCharges(lua_State* L)
 	// item:getCharges()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getCharges());
+		lua_pushinteger(L, item->getCharges());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6835,7 +6835,7 @@ int LuaScriptInterface::luaItemGetFluidType(lua_State* L)
 	// item:getFluidType()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getFluidType());
+		lua_pushinteger(L, item->getFluidType());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6847,7 +6847,7 @@ int LuaScriptInterface::luaItemGetWeight(lua_State* L)
 	// item:getWeight()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getWeight());
+		lua_pushinteger(L, item->getWeight());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6859,7 +6859,7 @@ int LuaScriptInterface::luaItemGetWorth(lua_State* L)
 	// item:getWorth()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getWorth());
+		lua_pushinteger(L, item->getWorth());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6871,7 +6871,7 @@ int LuaScriptInterface::luaItemGetSubType(lua_State* L)
 	// item:getSubType()
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(L, item->getSubType());
+		lua_pushinteger(L, item->getSubType());
 	} else {
 		lua_pushnil(L);
 	}
@@ -6986,7 +6986,7 @@ int LuaScriptInterface::luaItemGetAttribute(lua_State* L)
 	}
 
 	if (ItemAttributes::isIntAttrType(attribute)) {
-		lua_pushnumber(L, item->getIntAttr(attribute));
+		lua_pushinteger(L, item->getIntAttr(attribute));
 	} else if (ItemAttributes::isStrAttrType(attribute)) {
 		tfs::lua::pushString(L, item->getStrAttr(attribute));
 	} else {
@@ -7399,7 +7399,7 @@ int LuaScriptInterface::luaItemGetBoostPercent(lua_State* L)
 	// item:getBoostPercent(combatType[, total = true])
 	Item* item = tfs::lua::getUserdata<Item>(L, 1);
 	if (item) {
-		lua_pushnumber(
+		lua_pushinteger(
 		    L, item->getBoostPercent(tfs::lua::getNumber<CombatType_t>(L, 2), tfs::lua::getBoolean(L, 3, true)));
 	} else {
 		lua_pushnil(L);
@@ -7428,7 +7428,7 @@ int LuaScriptInterface::luaContainerGetSize(lua_State* L)
 	// container:getSize()
 	Container* container = tfs::lua::getUserdata<Container>(L, 1);
 	if (container) {
-		lua_pushnumber(L, container->size());
+		lua_pushinteger(L, container->size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -7440,7 +7440,7 @@ int LuaScriptInterface::luaContainerGetCapacity(lua_State* L)
 	// container:getCapacity()
 	Container* container = tfs::lua::getUserdata<Container>(L, 1);
 	if (container) {
-		lua_pushnumber(L, container->capacity());
+		lua_pushinteger(L, container->capacity());
 	} else {
 		lua_pushnil(L);
 	}
@@ -7465,7 +7465,7 @@ int LuaScriptInterface::luaContainerGetEmptySlots(lua_State* L)
 			}
 		}
 	}
-	lua_pushnumber(L, slots);
+	lua_pushinteger(L, slots);
 	return 1;
 }
 
@@ -7474,7 +7474,7 @@ int LuaScriptInterface::luaContainerGetItemHoldingCount(lua_State* L)
 	// container:getItemHoldingCount()
 	Container* container = tfs::lua::getUserdata<Container>(L, 1);
 	if (container) {
-		lua_pushnumber(L, container->getItemHoldingCount());
+		lua_pushinteger(L, container->getItemHoldingCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -7586,7 +7586,7 @@ int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 		}
 
 		if (hasTable) {
-			lua_pushnumber(L, i);
+			lua_pushinteger(L, i);
 			tfs::lua::pushUserdata(L, item);
 			tfs::lua::setItemMetatable(L, -1, item);
 			lua_settable(L, -3);
@@ -7625,7 +7625,7 @@ int LuaScriptInterface::luaContainerAddItemEx(lua_State* L)
 	if (ret == RETURNVALUE_NOERROR) {
 		tfs::lua::removeTempItem(item);
 	}
-	lua_pushnumber(L, ret);
+	lua_pushinteger(L, ret);
 	return 1;
 }
 
@@ -7634,7 +7634,7 @@ int LuaScriptInterface::luaContainerGetCorpseOwner(lua_State* L)
 	// container:getCorpseOwner()
 	Container* container = tfs::lua::getUserdata<Container>(L, 1);
 	if (container) {
-		lua_pushnumber(L, container->getCorpseOwner());
+		lua_pushinteger(L, container->getCorpseOwner());
 	} else {
 		lua_pushnil(L);
 	}
@@ -7662,7 +7662,7 @@ int LuaScriptInterface::luaContainerGetItemCountById(lua_State* L)
 	}
 
 	int32_t subType = tfs::lua::getNumber<int32_t>(L, 3, -1);
-	lua_pushnumber(L, container->getItemTypeCount(itemId, subType));
+	lua_pushinteger(L, container->getItemTypeCount(itemId, subType));
 	return 1;
 }
 
@@ -7807,7 +7807,7 @@ int LuaScriptInterface::luaPodiumGetDirection(lua_State* L)
 	// podium:getDirection()
 	const Podium* podium = tfs::lua::getUserdata<const Podium>(L, 1);
 	if (podium) {
-		lua_pushnumber(L, podium->getDirection());
+		lua_pushinteger(L, podium->getDirection());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8046,7 +8046,7 @@ int LuaScriptInterface::luaCreatureGetId(lua_State* L)
 	// creature:getId()
 	const Creature* creature = tfs::lua::getUserdata<const Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getID());
+		lua_pushinteger(L, creature->getID());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8173,8 +8173,8 @@ int LuaScriptInterface::luaCreatureGetLight(lua_State* L)
 	}
 
 	LightInfo lightInfo = creature->getCreatureLight();
-	lua_pushnumber(L, lightInfo.level);
-	lua_pushnumber(L, lightInfo.color);
+	lua_pushinteger(L, lightInfo.level);
+	lua_pushinteger(L, lightInfo.color);
 	return 2;
 }
 
@@ -8201,7 +8201,7 @@ int LuaScriptInterface::luaCreatureGetSpeed(lua_State* L)
 	// creature:getSpeed()
 	const Creature* creature = tfs::lua::getUserdata<const Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getSpeed());
+		lua_pushinteger(L, creature->getSpeed());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8213,7 +8213,7 @@ int LuaScriptInterface::luaCreatureGetBaseSpeed(lua_State* L)
 	// creature:getBaseSpeed()
 	const Creature* creature = tfs::lua::getUserdata<const Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getBaseSpeed());
+		lua_pushinteger(L, creature->getBaseSpeed());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8298,7 +8298,7 @@ int LuaScriptInterface::luaCreatureGetDirection(lua_State* L)
 	// creature:getDirection()
 	const Creature* creature = tfs::lua::getUserdata<const Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getDirection());
+		lua_pushinteger(L, creature->getDirection());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8322,7 +8322,7 @@ int LuaScriptInterface::luaCreatureGetHealth(lua_State* L)
 	// creature:getHealth()
 	const Creature* creature = tfs::lua::getUserdata<const Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getHealth());
+		lua_pushinteger(L, creature->getHealth());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8374,7 +8374,7 @@ int LuaScriptInterface::luaCreatureGetMaxHealth(lua_State* L)
 	// creature:getMaxHealth()
 	const Creature* creature = tfs::lua::getUserdata<const Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getMaxHealth());
+		lua_pushinteger(L, creature->getMaxHealth());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8434,7 +8434,7 @@ int LuaScriptInterface::luaCreatureGetSkull(lua_State* L)
 	// creature:getSkull()
 	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getSkull());
+		lua_pushinteger(L, creature->getSkull());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8772,8 +8772,8 @@ int LuaScriptInterface::luaCreatureGetPathTo(lua_State* L)
 		lua_newtable(L);
 
 		int index = 0;
-		for (auto it = dirList.rbegin(); it != dirList.rend(); ++it) {
-			lua_pushnumber(L, *it);
+		for (auto dir : dirList) {
+			lua_pushinteger(L, dir);
 			lua_rawseti(L, -2, ++index);
 		}
 	} else {
@@ -8798,14 +8798,14 @@ int LuaScriptInterface::luaCreatureMove(lua_State* L)
 			lua_pushnil(L);
 			return 1;
 		}
-		lua_pushnumber(L, g_game.internalMoveCreature(creature, direction, FLAG_NOLIMIT));
+		lua_pushinteger(L, g_game.internalMoveCreature(creature, direction, FLAG_NOLIMIT));
 	} else {
 		Tile* tile = tfs::lua::getUserdata<Tile>(L, 2);
 		if (!tile) {
 			lua_pushnil(L);
 			return 1;
 		}
-		lua_pushnumber(L, g_game.internalMoveCreature(*creature, *tile, tfs::lua::getNumber<uint32_t>(L, 3)));
+		lua_pushinteger(L, g_game.internalMoveCreature(*creature, *tile, tfs::lua::getNumber<uint32_t>(L, 3)));
 	}
 	return 1;
 }
@@ -8815,7 +8815,7 @@ int LuaScriptInterface::luaCreatureGetZone(lua_State* L)
 	// creature:getZone()
 	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
 	if (creature) {
-		lua_pushnumber(L, creature->getZone());
+		lua_pushinteger(L, creature->getZone());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8911,7 +8911,7 @@ int LuaScriptInterface::luaCreatureGetStorageValue(lua_State* L)
 
 	uint32_t key = tfs::lua::getNumber<uint32_t>(L, 2);
 	if (auto storage = creature->getStorageValue(key)) {
-		lua_pushnumber(L, storage.value());
+		lua_pushinteger(L, storage.value());
 	} else {
 		lua_pushnil(L);
 	}
@@ -8961,7 +8961,7 @@ int LuaScriptInterface::luaPlayerCreate(lua_State* L)
 		ReturnValue ret = g_game.getPlayerByNameWildcard(tfs::lua::getString(L, 2), player);
 		if (ret != RETURNVALUE_NOERROR) {
 			lua_pushnil(L);
-			lua_pushnumber(L, ret);
+			lua_pushinteger(L, ret);
 			return 2;
 		}
 	} else if (lua_isuserdata(L, 2)) {
@@ -8995,7 +8995,7 @@ int LuaScriptInterface::luaPlayerGetGuid(lua_State* L)
 	// player:getGuid()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getGUID());
+		lua_pushinteger(L, player->getGUID());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9019,7 +9019,7 @@ int LuaScriptInterface::luaPlayerGetAccountId(lua_State* L)
 	// player:getAccountId()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getAccount());
+		lua_pushinteger(L, player->getAccount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9031,7 +9031,7 @@ int LuaScriptInterface::luaPlayerGetLastLoginSaved(lua_State* L)
 	// player:getLastLoginSaved()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getLastLoginSaved());
+		lua_pushinteger(L, player->getLastLoginSaved());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9043,7 +9043,7 @@ int LuaScriptInterface::luaPlayerGetLastLogout(lua_State* L)
 	// player:getLastLogout()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getLastLogout());
+		lua_pushinteger(L, player->getLastLogout());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9055,7 +9055,7 @@ int LuaScriptInterface::luaPlayerGetAccountType(lua_State* L)
 	// player:getAccountType()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getAccountType());
+		lua_pushinteger(L, player->getAccountType());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9081,7 +9081,7 @@ int LuaScriptInterface::luaPlayerGetCapacity(lua_State* L)
 	// player:getCapacity()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getCapacity());
+		lua_pushinteger(L, player->getCapacity());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9107,7 +9107,7 @@ int LuaScriptInterface::luaPlayerGetFreeCapacity(lua_State* L)
 	// player:getFreeCapacity()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getFreeCapacity());
+		lua_pushinteger(L, player->getFreeCapacity());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9159,7 +9159,7 @@ int LuaScriptInterface::luaPlayerGetSkullTime(lua_State* L)
 	// player:getSkullTime()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getSkullTicks());
+		lua_pushinteger(L, player->getSkullTicks());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9196,7 +9196,7 @@ int LuaScriptInterface::luaPlayerGetExperience(lua_State* L)
 	// player:getExperience()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getExperience());
+		lua_pushinteger(L, player->getExperience());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9238,7 +9238,7 @@ int LuaScriptInterface::luaPlayerGetLevel(lua_State* L)
 	// player:getLevel()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getLevel());
+		lua_pushinteger(L, player->getLevel());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9250,7 +9250,7 @@ int LuaScriptInterface::luaPlayerGetLevelPercent(lua_State* L)
 	// player:getLevelPercent()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getLevelPercent());
+		lua_pushinteger(L, player->getLevelPercent());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9262,7 +9262,7 @@ int LuaScriptInterface::luaPlayerGetMagicLevel(lua_State* L)
 	// player:getMagicLevel()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getMagicLevel());
+		lua_pushinteger(L, player->getMagicLevel());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9274,7 +9274,7 @@ int LuaScriptInterface::luaPlayerGetMagicLevelPercent(lua_State* L)
 	// player:getMagicLevelPercent()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getMagicLevelPercent());
+		lua_pushinteger(L, player->getMagicLevelPercent());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9286,7 +9286,7 @@ int LuaScriptInterface::luaPlayerGetBaseMagicLevel(lua_State* L)
 	// player:getBaseMagicLevel()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getBaseMagicLevel());
+		lua_pushinteger(L, player->getBaseMagicLevel());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9298,7 +9298,7 @@ int LuaScriptInterface::luaPlayerGetMana(lua_State* L)
 	// player:getMana()
 	const Player* player = tfs::lua::getUserdata<const Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getMana());
+		lua_pushinteger(L, player->getMana());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9333,7 +9333,7 @@ int LuaScriptInterface::luaPlayerGetMaxMana(lua_State* L)
 	// player:getMaxMana()
 	const Player* player = tfs::lua::getUserdata<const Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getMaxMana());
+		lua_pushinteger(L, player->getMaxMana());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9375,7 +9375,7 @@ int LuaScriptInterface::luaPlayerGetManaSpent(lua_State* L)
 	// player:getManaSpent()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getSpentMana());
+		lua_pushinteger(L, player->getSpentMana());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9413,7 +9413,7 @@ int LuaScriptInterface::luaPlayerGetBaseMaxHealth(lua_State* L)
 	// player:getBaseMaxHealth()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->healthMax);
+		lua_pushinteger(L, player->healthMax);
 	} else {
 		lua_pushnil(L);
 	}
@@ -9425,7 +9425,7 @@ int LuaScriptInterface::luaPlayerGetBaseMaxMana(lua_State* L)
 	// player:getBaseMaxMana()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->manaMax);
+		lua_pushinteger(L, player->manaMax);
 	} else {
 		lua_pushnil(L);
 	}
@@ -9438,7 +9438,7 @@ int LuaScriptInterface::luaPlayerGetSkillLevel(lua_State* L)
 	skills_t skillType = tfs::lua::getNumber<skills_t>(L, 2);
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
-		lua_pushnumber(L, player->skills[skillType].level);
+		lua_pushinteger(L, player->skills[skillType].level);
 	} else {
 		lua_pushnil(L);
 	}
@@ -9451,7 +9451,7 @@ int LuaScriptInterface::luaPlayerGetEffectiveSkillLevel(lua_State* L)
 	skills_t skillType = tfs::lua::getNumber<skills_t>(L, 2);
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
-		lua_pushnumber(L, player->getSkillLevel(skillType));
+		lua_pushinteger(L, player->getSkillLevel(skillType));
 	} else {
 		lua_pushnil(L);
 	}
@@ -9464,7 +9464,7 @@ int LuaScriptInterface::luaPlayerGetSkillPercent(lua_State* L)
 	skills_t skillType = tfs::lua::getNumber<skills_t>(L, 2);
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
-		lua_pushnumber(L, player->skills[skillType].percent);
+		lua_pushinteger(L, player->skills[skillType].percent);
 	} else {
 		lua_pushnil(L);
 	}
@@ -9477,7 +9477,7 @@ int LuaScriptInterface::luaPlayerGetSkillTries(lua_State* L)
 	skills_t skillType = tfs::lua::getNumber<skills_t>(L, 2);
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
-		lua_pushnumber(L, player->skills[skillType].tries);
+		lua_pushinteger(L, player->skills[skillType].tries);
 	} else {
 		lua_pushnil(L);
 	}
@@ -9520,7 +9520,7 @@ int LuaScriptInterface::luaPlayerGetSpecialSkill(lua_State* L)
 	SpecialSkills_t specialSkillType = tfs::lua::getNumber<SpecialSkills_t>(L, 2);
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && specialSkillType <= SPECIALSKILL_LAST) {
-		lua_pushnumber(L, player->getSpecialSkill(specialSkillType));
+		lua_pushinteger(L, player->getSpecialSkill(specialSkillType));
 	} else {
 		lua_pushnil(L);
 	}
@@ -9568,7 +9568,7 @@ int LuaScriptInterface::luaPlayerGetOfflineTrainingTime(lua_State* L)
 	// player:getOfflineTrainingTime()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getOfflineTrainingTime());
+		lua_pushinteger(L, player->getOfflineTrainingTime());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9609,7 +9609,7 @@ int LuaScriptInterface::luaPlayerGetOfflineTrainingSkill(lua_State* L)
 	// player:getOfflineTrainingSkill()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getOfflineTrainingSkill());
+		lua_pushinteger(L, player->getOfflineTrainingSkill());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9652,7 +9652,7 @@ int LuaScriptInterface::luaPlayerGetItemCount(lua_State* L)
 
 	int32_t subType = tfs::lua::getNumber<int32_t>(L, 3, -1);
 	bool ignoreEquipped = tfs::lua::getBoolean(L, 4, false);
-	lua_pushnumber(L, player->getItemTypeCount(itemId, subType, ignoreEquipped));
+	lua_pushinteger(L, player->getItemTypeCount(itemId, subType, ignoreEquipped));
 	return 1;
 }
 
@@ -9736,7 +9736,7 @@ int LuaScriptInterface::luaPlayerGetSex(lua_State* L)
 	// player:getSex()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getSex());
+		lua_pushinteger(L, player->getSex());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9826,7 +9826,7 @@ int LuaScriptInterface::luaPlayerGetGuildLevel(lua_State* L)
 	// player:getGuildLevel()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && player->getGuild()) {
-		lua_pushnumber(L, player->getGuildRank()->level);
+		lua_pushinteger(L, player->getGuildRank()->level);
 	} else {
 		lua_pushnil(L);
 	}
@@ -9921,7 +9921,7 @@ int LuaScriptInterface::luaPlayerGetStamina(lua_State* L)
 	// player:getStamina()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getStaminaMinutes());
+		lua_pushinteger(L, player->getStaminaMinutes());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9948,7 +9948,7 @@ int LuaScriptInterface::luaPlayerGetSoul(lua_State* L)
 	// player:getSoul()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getSoul());
+		lua_pushinteger(L, player->getSoul());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9974,7 +9974,7 @@ int LuaScriptInterface::luaPlayerGetMaxSoul(lua_State* L)
 	// player:getMaxSoul()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player && player->vocation) {
-		lua_pushnumber(L, player->vocation->getSoulMax());
+		lua_pushinteger(L, player->vocation->getSoulMax());
 	} else {
 		lua_pushnil(L);
 	}
@@ -9986,7 +9986,7 @@ int LuaScriptInterface::luaPlayerGetBankBalance(lua_State* L)
 	// player:getBankBalance()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getBankBalance());
+		lua_pushinteger(L, player->getBankBalance());
 	} else {
 		lua_pushnil(L);
 	}
@@ -10088,7 +10088,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 		}
 
 		if (hasTable) {
-			lua_pushnumber(L, i);
+			lua_pushinteger(L, i);
 			tfs::lua::pushUserdata(L, item);
 			tfs::lua::setItemMetatable(L, -1, item);
 			lua_settable(L, -3);
@@ -10137,7 +10137,7 @@ int LuaScriptInterface::luaPlayerAddItemEx(lua_State* L)
 	if (returnValue == RETURNVALUE_NOERROR) {
 		tfs::lua::removeTempItem(item);
 	}
-	lua_pushnumber(L, returnValue);
+	lua_pushinteger(L, returnValue);
 	return 1;
 }
 
@@ -10195,7 +10195,7 @@ int LuaScriptInterface::luaPlayerGetMoney(lua_State* L)
 	// player:getMoney()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getMoney());
+		lua_pushinteger(L, player->getMoney());
 	} else {
 		lua_pushnil(L);
 	}
@@ -10641,7 +10641,7 @@ int LuaScriptInterface::luaPlayerGetPremiumEndsAt(lua_State* L)
 	// player:getPremiumEndsAt()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->premiumEndsAt);
+		lua_pushinteger(L, player->premiumEndsAt);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11012,7 +11012,7 @@ int LuaScriptInterface::luaPlayerGetContainerId(lua_State* L)
 
 	Container* container = tfs::lua::getUserdata<Container>(L, 2);
 	if (container) {
-		lua_pushnumber(L, player->getContainerID(container));
+		lua_pushinteger(L, player->getContainerID(container));
 	} else {
 		lua_pushnil(L);
 	}
@@ -11043,7 +11043,7 @@ int LuaScriptInterface::luaPlayerGetContainerIndex(lua_State* L)
 	// player:getContainerIndex(id)
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getContainerIndex(tfs::lua::getNumber<uint8_t>(L, 2)));
+		lua_pushinteger(L, player->getContainerIndex(tfs::lua::getNumber<uint8_t>(L, 2)));
 	} else {
 		lua_pushnil(L);
 	}
@@ -11128,7 +11128,7 @@ int LuaScriptInterface::luaPlayerGetFightMode(lua_State* L)
 	// player:getFightMode()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->fightMode);
+		lua_pushinteger(L, player->fightMode);
 	} else {
 		lua_pushnil(L);
 	}
@@ -11177,7 +11177,7 @@ int LuaScriptInterface::luaPlayerGetIdleTime(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, player->getIdleTime());
+	lua_pushinteger(L, player->getIdleTime());
 	return 1;
 }
 
@@ -11221,7 +11221,7 @@ int LuaScriptInterface::luaPlayerGetClientExpDisplay(lua_State* L)
 	// player:getClientExpDisplay()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getClientExpDisplay());
+		lua_pushinteger(L, player->getClientExpDisplay());
 	} else {
 		lua_pushnil(L);
 	}
@@ -11247,7 +11247,7 @@ int LuaScriptInterface::luaPlayerGetClientStaminaBonusDisplay(lua_State* L)
 	// player:getClientStaminaBonusDisplay()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getClientStaminaBonusDisplay());
+		lua_pushinteger(L, player->getClientStaminaBonusDisplay());
 	} else {
 		lua_pushnil(L);
 	}
@@ -11273,7 +11273,7 @@ int LuaScriptInterface::luaPlayerGetClientLowLevelBonusDisplay(lua_State* L)
 	// player:getClientLowLevelBonusDisplay()
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getClientLowLevelBonusDisplay());
+		lua_pushinteger(L, player->getClientLowLevelBonusDisplay());
 	} else {
 		lua_pushnil(L);
 	}
@@ -11564,7 +11564,7 @@ int LuaScriptInterface::luaMonsterGetFriendCount(lua_State* L)
 	// monster:getFriendCount()
 	Monster* monster = tfs::lua::getUserdata<Monster>(L, 1);
 	if (monster) {
-		lua_pushnumber(L, monster->getFriendList().size());
+		lua_pushinteger(L, monster->getFriendList().size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -11640,7 +11640,7 @@ int LuaScriptInterface::luaMonsterGetTargetCount(lua_State* L)
 	// monster:getTargetCount()
 	Monster* monster = tfs::lua::getUserdata<Monster>(L, 1);
 	if (monster) {
-		lua_pushnumber(L, monster->getTargetList().size());
+		lua_pushinteger(L, monster->getTargetList().size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -11840,7 +11840,7 @@ int LuaScriptInterface::luaNpcGetSpeechBubble(lua_State* L)
 	// npc:getSpeechBubble()
 	Npc* npc = tfs::lua::getUserdata<Npc>(L, 1);
 	if (npc) {
-		lua_pushnumber(L, npc->getSpeechBubble());
+		lua_pushinteger(L, npc->getSpeechBubble());
 	} else {
 		lua_pushnil(L);
 	}
@@ -11985,7 +11985,7 @@ int LuaScriptInterface::luaNpcTypeSpeechBubble(lua_State* L)
 	NpcType* npcType = tfs::lua::getUserdata<NpcType>(L, 1);
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, npcType->speechBubble);
+			lua_pushinteger(L, npcType->speechBubble);
 		} else {
 			uint8_t bubble = tfs::lua::getNumber<uint8_t>(L, 2);
 			npcType->speechBubble = bubble;
@@ -12003,7 +12003,7 @@ int LuaScriptInterface::luaNpcTypeWalkTicks(lua_State* L)
 	NpcType* npcType = tfs::lua::getUserdata<NpcType>(L, 1);
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, npcType->walkTicks);
+			lua_pushinteger(L, npcType->walkTicks);
 		} else {
 			uint32_t ticks = tfs::lua::getNumber<uint32_t>(L, 2);
 			npcType->walkTicks = ticks;
@@ -12021,7 +12021,7 @@ int LuaScriptInterface::luaNpcTypeBaseSpeed(lua_State* L)
 	NpcType* npcType = tfs::lua::getUserdata<NpcType>(L, 1);
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, npcType->baseSpeed);
+			lua_pushinteger(L, npcType->baseSpeed);
 		} else {
 			uint32_t speed = tfs::lua::getNumber<uint32_t>(L, 2);
 			npcType->baseSpeed = speed;
@@ -12039,7 +12039,7 @@ int LuaScriptInterface::luaNpcTypeMasterRadius(lua_State* L)
 	NpcType* npcType = tfs::lua::getUserdata<NpcType>(L, 1);
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, npcType->masterRadius);
+			lua_pushinteger(L, npcType->masterRadius);
 		} else {
 			int32_t radius = tfs::lua::getNumber<int32_t>(L, 2);
 			npcType->masterRadius = radius;
@@ -12187,7 +12187,7 @@ int LuaScriptInterface::luaNpcTypeHealth(lua_State* L)
 	NpcType* npcType = tfs::lua::getUserdata<NpcType>(L, 1);
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, npcType->health);
+			lua_pushinteger(L, npcType->health);
 		} else {
 			int32_t health = tfs::lua::getNumber<int32_t>(L, 2);
 			npcType->health = health;
@@ -12205,7 +12205,7 @@ int LuaScriptInterface::luaNpcTypeMaxHealth(lua_State* L)
 	NpcType* npcType = tfs::lua::getUserdata<NpcType>(L, 1);
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, npcType->healthMax);
+			lua_pushinteger(L, npcType->healthMax);
 		} else {
 			int32_t health = tfs::lua::getNumber<int32_t>(L, 2);
 			npcType->healthMax = health;
@@ -12236,7 +12236,7 @@ int LuaScriptInterface::luaGuildGetId(lua_State* L)
 {
 	// guild:getId()
 	if (const auto& guild = getSharedPtr<Guild>(L, 1)) {
-		lua_pushnumber(L, guild->getId());
+		lua_pushinteger(L, guild->getId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12377,7 +12377,7 @@ int LuaScriptInterface::luaGroupGetId(lua_State* L)
 	// group:getId()
 	Group* group = tfs::lua::getUserdata<Group>(L, 1);
 	if (group) {
-		lua_pushnumber(L, group->id);
+		lua_pushinteger(L, group->id);
 	} else {
 		lua_pushnil(L);
 	}
@@ -12401,7 +12401,7 @@ int LuaScriptInterface::luaGroupGetFlags(lua_State* L)
 	// group:getFlags()
 	Group* group = tfs::lua::getUserdata<Group>(L, 1);
 	if (group) {
-		lua_pushnumber(L, group->flags);
+		lua_pushinteger(L, group->flags);
 	} else {
 		lua_pushnil(L);
 	}
@@ -12425,7 +12425,7 @@ int LuaScriptInterface::luaGroupGetMaxDepotItems(lua_State* L)
 	// group:getMaxDepotItems()
 	Group* group = tfs::lua::getUserdata<Group>(L, 1);
 	if (group) {
-		lua_pushnumber(L, group->maxDepotItems);
+		lua_pushinteger(L, group->maxDepotItems);
 	} else {
 		lua_pushnil(L);
 	}
@@ -12437,7 +12437,7 @@ int LuaScriptInterface::luaGroupGetMaxVipEntries(lua_State* L)
 	// group:getMaxVipEntries()
 	Group* group = tfs::lua::getUserdata<Group>(L, 1);
 	if (group) {
-		lua_pushnumber(L, group->maxVipEntries);
+		lua_pushinteger(L, group->maxVipEntries);
 	} else {
 		lua_pushnil(L);
 	}
@@ -12483,7 +12483,7 @@ int LuaScriptInterface::luaVocationGetId(lua_State* L)
 	// vocation:getId()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getId());
+		lua_pushinteger(L, vocation->getId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12495,7 +12495,7 @@ int LuaScriptInterface::luaVocationGetClientId(lua_State* L)
 	// vocation:getClientId()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getClientId());
+		lua_pushinteger(L, vocation->getClientId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12533,7 +12533,7 @@ int LuaScriptInterface::luaVocationGetRequiredSkillTries(lua_State* L)
 	if (vocation) {
 		skills_t skillType = tfs::lua::getNumber<skills_t>(L, 2);
 		uint16_t skillLevel = tfs::lua::getNumber<uint16_t>(L, 3);
-		lua_pushnumber(L, vocation->getReqSkillTries(skillType, skillLevel));
+		lua_pushinteger(L, vocation->getReqSkillTries(skillType, skillLevel));
 	} else {
 		lua_pushnil(L);
 	}
@@ -12546,7 +12546,7 @@ int LuaScriptInterface::luaVocationGetRequiredManaSpent(lua_State* L)
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
 		uint32_t magicLevel = tfs::lua::getNumber<uint32_t>(L, 2);
-		lua_pushnumber(L, vocation->getReqMana(magicLevel));
+		lua_pushinteger(L, vocation->getReqMana(magicLevel));
 	} else {
 		lua_pushnil(L);
 	}
@@ -12558,7 +12558,7 @@ int LuaScriptInterface::luaVocationGetCapacityGain(lua_State* L)
 	// vocation:getCapacityGain()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getCapGain());
+		lua_pushinteger(L, vocation->getCapGain());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12570,7 +12570,7 @@ int LuaScriptInterface::luaVocationGetHealthGain(lua_State* L)
 	// vocation:getHealthGain()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getHPGain());
+		lua_pushinteger(L, vocation->getHPGain());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12582,7 +12582,7 @@ int LuaScriptInterface::luaVocationGetHealthGainTicks(lua_State* L)
 	// vocation:getHealthGainTicks()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getHealthGainTicks());
+		lua_pushinteger(L, vocation->getHealthGainTicks());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12594,7 +12594,7 @@ int LuaScriptInterface::luaVocationGetHealthGainAmount(lua_State* L)
 	// vocation:getHealthGainAmount()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getHealthGainAmount());
+		lua_pushinteger(L, vocation->getHealthGainAmount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12606,7 +12606,7 @@ int LuaScriptInterface::luaVocationGetManaGain(lua_State* L)
 	// vocation:getManaGain()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getManaGain());
+		lua_pushinteger(L, vocation->getManaGain());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12618,7 +12618,7 @@ int LuaScriptInterface::luaVocationGetManaGainTicks(lua_State* L)
 	// vocation:getManaGainTicks()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getManaGainTicks());
+		lua_pushinteger(L, vocation->getManaGainTicks());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12630,7 +12630,7 @@ int LuaScriptInterface::luaVocationGetManaGainAmount(lua_State* L)
 	// vocation:getManaGainAmount()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getManaGainAmount());
+		lua_pushinteger(L, vocation->getManaGainAmount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12642,7 +12642,7 @@ int LuaScriptInterface::luaVocationGetMaxSoul(lua_State* L)
 	// vocation:getMaxSoul()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getSoulMax());
+		lua_pushinteger(L, vocation->getSoulMax());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12654,7 +12654,7 @@ int LuaScriptInterface::luaVocationGetSoulGainTicks(lua_State* L)
 	// vocation:getSoulGainTicks()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getSoulGainTicks());
+		lua_pushinteger(L, vocation->getSoulGainTicks());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12666,7 +12666,7 @@ int LuaScriptInterface::luaVocationGetAttackSpeed(lua_State* L)
 	// vocation:getAttackSpeed()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getAttackSpeed());
+		lua_pushinteger(L, vocation->getAttackSpeed());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12678,7 +12678,7 @@ int LuaScriptInterface::luaVocationGetBaseSpeed(lua_State* L)
 	// vocation:getBaseSpeed()
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
-		lua_pushnumber(L, vocation->getBaseSpeed());
+		lua_pushinteger(L, vocation->getBaseSpeed());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12774,7 +12774,7 @@ int LuaScriptInterface::luaTownGetId(lua_State* L)
 	// town:getId()
 	Town* town = tfs::lua::getUserdata<Town>(L, 1);
 	if (town) {
-		lua_pushnumber(L, town->getID());
+		lua_pushinteger(L, town->getID());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12824,7 +12824,7 @@ int LuaScriptInterface::luaHouseGetId(lua_State* L)
 	// house:getId()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getId());
+		lua_pushinteger(L, house->getId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12879,7 +12879,7 @@ int LuaScriptInterface::luaHouseGetRent(lua_State* L)
 	// house:getRent()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getRent());
+		lua_pushinteger(L, house->getRent());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12905,7 +12905,7 @@ int LuaScriptInterface::luaHouseGetPaidUntil(lua_State* L)
 	// house:getPaidUntil()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getPaidUntil());
+		lua_pushinteger(L, house->getPaidUntil());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12931,7 +12931,7 @@ int LuaScriptInterface::luaHouseGetPayRentWarnings(lua_State* L)
 	// house:getPayRentWarnings()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getPayRentWarnings());
+		lua_pushinteger(L, house->getPayRentWarnings());
 	} else {
 		lua_pushnil(L);
 	}
@@ -12969,7 +12969,7 @@ int LuaScriptInterface::luaHouseGetOwnerGuid(lua_State* L)
 	// house:getOwnerGuid()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getOwner());
+		lua_pushinteger(L, house->getOwner());
 	} else {
 		lua_pushnil(L);
 	}
@@ -13004,28 +13004,28 @@ int LuaScriptInterface::luaHouseStartTrade(lua_State* L)
 	}
 
 	if (!tradePartner->getPosition().isInRange(player->getPosition(), 2, 2, 0)) {
-		lua_pushnumber(L, RETURNVALUE_TRADEPLAYERFARAWAY);
+		lua_pushinteger(L, RETURNVALUE_TRADEPLAYERFARAWAY);
 		return 1;
 	}
 
 	if (house->getOwner() != player->getGUID()) {
-		lua_pushnumber(L, RETURNVALUE_YOUDONTOWNTHISHOUSE);
+		lua_pushinteger(L, RETURNVALUE_YOUDONTOWNTHISHOUSE);
 		return 1;
 	}
 
 	if (g_game.map.houses.getHouseByPlayerId(tradePartner->getGUID())) {
-		lua_pushnumber(L, RETURNVALUE_TRADEPLAYERALREADYOWNSAHOUSE);
+		lua_pushinteger(L, RETURNVALUE_TRADEPLAYERALREADYOWNSAHOUSE);
 		return 1;
 	}
 
 	if (IOLoginData::hasBiddedOnHouse(tradePartner->getGUID())) {
-		lua_pushnumber(L, RETURNVALUE_TRADEPLAYERHIGHESTBIDDER);
+		lua_pushinteger(L, RETURNVALUE_TRADEPLAYERHIGHESTBIDDER);
 		return 1;
 	}
 
 	Item* transferItem = house->getTransferItem();
 	if (!transferItem) {
-		lua_pushnumber(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
+		lua_pushinteger(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
 		return 1;
 	}
 
@@ -13034,7 +13034,7 @@ int LuaScriptInterface::luaHouseStartTrade(lua_State* L)
 		house->resetTransferItem();
 	}
 
-	lua_pushnumber(L, RETURNVALUE_NOERROR);
+	lua_pushinteger(L, RETURNVALUE_NOERROR);
 	return 1;
 }
 
@@ -13064,7 +13064,7 @@ int LuaScriptInterface::luaHouseGetBedCount(lua_State* L)
 	// house:getBedCount()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getBedCount());
+		lua_pushinteger(L, house->getBedCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -13097,7 +13097,7 @@ int LuaScriptInterface::luaHouseGetDoorCount(lua_State* L)
 	// house:getDoorCount()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getDoors().size());
+		lua_pushinteger(L, house->getDoors().size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -13115,7 +13115,7 @@ int LuaScriptInterface::luaHouseGetDoorIdByPosition(lua_State* L)
 
 	Door* door = house->getDoorByPosition(tfs::lua::getPosition(L, 2));
 	if (door) {
-		lua_pushnumber(L, door->getDoorId());
+		lua_pushinteger(L, door->getDoorId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -13174,7 +13174,7 @@ int LuaScriptInterface::luaHouseGetTileCount(lua_State* L)
 	// house:getTileCount()
 	House* house = tfs::lua::getUserdata<House>(L, 1);
 	if (house) {
-		lua_pushnumber(L, house->getTiles().size());
+		lua_pushinteger(L, house->getTiles().size());
 	} else {
 		lua_pushnil(L);
 	}
@@ -13463,7 +13463,7 @@ int LuaScriptInterface::luaItemTypeGetType(lua_State* L)
 	// itemType:getType()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->type);
+		lua_pushinteger(L, itemType->type);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13475,7 +13475,7 @@ int LuaScriptInterface::luaItemTypeGetGroup(lua_State* L)
 	// itemType:getGroup()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->group);
+		lua_pushinteger(L, itemType->group);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13487,7 +13487,7 @@ int LuaScriptInterface::luaItemTypeGetId(lua_State* L)
 	// itemType:getId()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->id);
+		lua_pushinteger(L, itemType->id);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13499,7 +13499,7 @@ int LuaScriptInterface::luaItemTypeGetClientId(lua_State* L)
 	// itemType:getClientId()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->clientId);
+		lua_pushinteger(L, itemType->clientId);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13535,7 +13535,7 @@ int LuaScriptInterface::luaItemTypeGetRotateTo(lua_State* L)
 	// itemType:getRotateTo()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->rotateTo);
+		lua_pushinteger(L, itemType->rotateTo);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13571,7 +13571,7 @@ int LuaScriptInterface::luaItemTypeGetSlotPosition(lua_State* L)
 	// itemType:getSlotPosition()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->slotPosition);
+		lua_pushinteger(L, itemType->slotPosition);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13583,7 +13583,7 @@ int LuaScriptInterface::luaItemTypeGetCharges(lua_State* L)
 	// itemType:getCharges()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->charges);
+		lua_pushinteger(L, itemType->charges);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13595,7 +13595,7 @@ int LuaScriptInterface::luaItemTypeGetFluidSource(lua_State* L)
 	// itemType:getFluidSource()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->fluidSource);
+		lua_pushinteger(L, itemType->fluidSource);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13607,7 +13607,7 @@ int LuaScriptInterface::luaItemTypeGetCapacity(lua_State* L)
 	// itemType:getCapacity()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->maxItems);
+		lua_pushinteger(L, itemType->maxItems);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13626,7 +13626,7 @@ int LuaScriptInterface::luaItemTypeGetWeight(lua_State* L)
 	}
 
 	uint64_t weight = static_cast<uint64_t>(itemType->weight) * std::max<int32_t>(1, count);
-	lua_pushnumber(L, weight);
+	lua_pushinteger(L, weight);
 	return 1;
 }
 
@@ -13639,7 +13639,7 @@ int LuaScriptInterface::luaItemTypeGetWorth(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, itemType->worth);
+	lua_pushinteger(L, itemType->worth);
 	return 1;
 }
 
@@ -13648,7 +13648,7 @@ int LuaScriptInterface::luaItemTypeGetHitChance(lua_State* L)
 	// itemType:getHitChance()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->hitChance);
+		lua_pushinteger(L, itemType->hitChance);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13660,7 +13660,7 @@ int LuaScriptInterface::luaItemTypeGetShootRange(lua_State* L)
 	// itemType:getShootRange()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->shootRange);
+		lua_pushinteger(L, itemType->shootRange);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13672,7 +13672,7 @@ int LuaScriptInterface::luaItemTypeGetAttack(lua_State* L)
 	// itemType:getAttack()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->attack);
+		lua_pushinteger(L, itemType->attack);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13684,7 +13684,7 @@ int LuaScriptInterface::luaItemTypeGetAttackSpeed(lua_State* L)
 	// itemType:getAttackSpeed()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->attackSpeed);
+		lua_pushinteger(L, itemType->attackSpeed);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13696,7 +13696,7 @@ int LuaScriptInterface::luaItemTypeGetDefense(lua_State* L)
 	// itemType:getDefense()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->defense);
+		lua_pushinteger(L, itemType->defense);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13708,7 +13708,7 @@ int LuaScriptInterface::luaItemTypeGetExtraDefense(lua_State* L)
 	// itemType:getExtraDefense()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->extraDefense);
+		lua_pushinteger(L, itemType->extraDefense);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13720,7 +13720,7 @@ int LuaScriptInterface::luaItemTypeGetArmor(lua_State* L)
 	// itemType:getArmor()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->armor);
+		lua_pushinteger(L, itemType->armor);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13732,7 +13732,7 @@ int LuaScriptInterface::luaItemTypeGetWeaponType(lua_State* L)
 	// itemType:getWeaponType()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->weaponType);
+		lua_pushinteger(L, itemType->weaponType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13744,7 +13744,7 @@ int LuaScriptInterface::luaItemTypeGetAmmoType(lua_State* L)
 	// itemType:getAmmoType()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->ammoType);
+		lua_pushinteger(L, itemType->ammoType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13756,7 +13756,7 @@ int LuaScriptInterface::luaItemTypeGetCorpseType(lua_State* L)
 	// itemType:getCorpseType()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->corpseType);
+		lua_pushinteger(L, itemType->corpseType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13768,7 +13768,7 @@ int LuaScriptInterface::luaItemTypeGetClassification(lua_State* L)
 	// itemType:getClassification()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->classification);
+		lua_pushinteger(L, itemType->classification);
 	} else {
 		lua_pushnil(L);
 	}
@@ -13802,7 +13802,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Stats
 		lua_createtable(L, 0, STAT_LAST + 1);
 		for (int32_t i = STAT_FIRST; i <= STAT_LAST; i++) {
-			lua_pushnumber(L, abilities.stats[i]);
+			lua_pushinteger(L, abilities.stats[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "stats");
@@ -13810,7 +13810,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Stats percent
 		lua_createtable(L, 0, STAT_LAST + 1);
 		for (int32_t i = STAT_FIRST; i <= STAT_LAST; i++) {
-			lua_pushnumber(L, abilities.statsPercent[i]);
+			lua_pushinteger(L, abilities.statsPercent[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "statsPercent");
@@ -13818,7 +13818,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Skills
 		lua_createtable(L, 0, SKILL_LAST + 1);
 		for (int32_t i = SKILL_FIRST; i <= SKILL_LAST; i++) {
-			lua_pushnumber(L, abilities.skills[i]);
+			lua_pushinteger(L, abilities.skills[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "skills");
@@ -13826,7 +13826,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Special skills
 		lua_createtable(L, 0, SPECIALSKILL_LAST + 1);
 		for (int32_t i = SPECIALSKILL_FIRST; i <= SPECIALSKILL_LAST; i++) {
-			lua_pushnumber(L, abilities.specialSkills[i]);
+			lua_pushinteger(L, abilities.specialSkills[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "specialSkills");
@@ -13834,7 +13834,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Field absorb percent
 		lua_createtable(L, 0, COMBAT_COUNT);
 		for (int32_t i = 0; i < COMBAT_COUNT; i++) {
-			lua_pushnumber(L, abilities.fieldAbsorbPercent[i]);
+			lua_pushinteger(L, abilities.fieldAbsorbPercent[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "fieldAbsorbPercent");
@@ -13842,7 +13842,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Absorb percent
 		lua_createtable(L, 0, COMBAT_COUNT);
 		for (int32_t i = 0; i < COMBAT_COUNT; i++) {
-			lua_pushnumber(L, abilities.absorbPercent[i]);
+			lua_pushinteger(L, abilities.absorbPercent[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "absorbPercent");
@@ -13850,7 +13850,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// special magic level
 		lua_createtable(L, 0, COMBAT_COUNT);
 		for (int32_t i = 0; i < COMBAT_COUNT; i++) {
-			lua_pushnumber(L, abilities.specialMagicLevelSkill[i]);
+			lua_pushinteger(L, abilities.specialMagicLevelSkill[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "specialMagicLevel");
@@ -13858,7 +13858,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Damage boost percent
 		lua_createtable(L, 0, COMBAT_COUNT);
 		for (int32_t i = 0; i < COMBAT_COUNT; i++) {
-			lua_pushnumber(L, abilities.boostPercent[i]);
+			lua_pushinteger(L, abilities.boostPercent[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "boostPercent");
@@ -13866,7 +13866,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Reflect chance
 		lua_createtable(L, 0, COMBAT_COUNT);
 		for (int32_t i = 0; i < COMBAT_COUNT; i++) {
-			lua_pushnumber(L, abilities.reflect[i].chance);
+			lua_pushinteger(L, abilities.reflect[i].chance);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "reflectChance");
@@ -13874,7 +13874,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 		// Reflect percent
 		lua_createtable(L, 0, COMBAT_COUNT);
 		for (int32_t i = 0; i < COMBAT_COUNT; i++) {
-			lua_pushnumber(L, abilities.reflect[i].percent);
+			lua_pushinteger(L, abilities.reflect[i].percent);
 			lua_rawseti(L, -2, i + 1);
 		}
 		lua_setfield(L, -2, "reflectPercent");
@@ -14091,7 +14091,7 @@ int LuaScriptInterface::luaItemTypeGetElementType(lua_State* L)
 
 	auto& abilities = itemType->abilities;
 	if (abilities) {
-		lua_pushnumber(L, abilities->elementType);
+		lua_pushinteger(L, abilities->elementType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14109,7 +14109,7 @@ int LuaScriptInterface::luaItemTypeGetElementDamage(lua_State* L)
 
 	auto& abilities = itemType->abilities;
 	if (abilities) {
-		lua_pushnumber(L, abilities->elementDamage);
+		lua_pushinteger(L, abilities->elementDamage);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14121,7 +14121,7 @@ int LuaScriptInterface::luaItemTypeGetTransformEquipId(lua_State* L)
 	// itemType:getTransformEquipId()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->transformEquipTo);
+		lua_pushinteger(L, itemType->transformEquipTo);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14133,7 +14133,7 @@ int LuaScriptInterface::luaItemTypeGetTransformDeEquipId(lua_State* L)
 	// itemType:getTransformDeEquipId()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->transformDeEquipTo);
+		lua_pushinteger(L, itemType->transformDeEquipTo);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14145,7 +14145,7 @@ int LuaScriptInterface::luaItemTypeGetDestroyId(lua_State* L)
 	// itemType:getDestroyId()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->destroyTo);
+		lua_pushinteger(L, itemType->destroyTo);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14157,7 +14157,7 @@ int LuaScriptInterface::luaItemTypeGetDecayId(lua_State* L)
 	// itemType:getDecayId()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->decayTo);
+		lua_pushinteger(L, itemType->decayTo);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14169,7 +14169,7 @@ int LuaScriptInterface::luaItemTypeGetRequiredLevel(lua_State* L)
 	// itemType:getRequiredLevel()
 	const ItemType* itemType = tfs::lua::getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		lua_pushnumber(L, itemType->minReqLevel);
+		lua_pushinteger(L, itemType->minReqLevel);
 	} else {
 		lua_pushnil(L);
 	}
@@ -14257,7 +14257,7 @@ int LuaScriptInterface::luaCombatGetParameter(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, value);
+	lua_pushinteger(L, value);
 	return 1;
 }
 
@@ -14497,7 +14497,7 @@ int LuaScriptInterface::luaConditionGetId(lua_State* L)
 	// condition:getId()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		lua_pushnumber(L, condition->getId());
+		lua_pushinteger(L, condition->getId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -14509,7 +14509,7 @@ int LuaScriptInterface::luaConditionGetSubId(lua_State* L)
 	// condition:getSubId()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		lua_pushnumber(L, condition->getSubId());
+		lua_pushinteger(L, condition->getSubId());
 	} else {
 		lua_pushnil(L);
 	}
@@ -14521,7 +14521,7 @@ int LuaScriptInterface::luaConditionGetType(lua_State* L)
 	// condition:getType()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		lua_pushnumber(L, condition->getType());
+		lua_pushinteger(L, condition->getType());
 	} else {
 		lua_pushnil(L);
 	}
@@ -14533,7 +14533,7 @@ int LuaScriptInterface::luaConditionGetIcons(lua_State* L)
 	// condition:getIcons()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		lua_pushnumber(L, condition->getIcons());
+		lua_pushinteger(L, condition->getIcons());
 	} else {
 		lua_pushnil(L);
 	}
@@ -14545,7 +14545,7 @@ int LuaScriptInterface::luaConditionGetEndTime(lua_State* L)
 	// condition:getEndTime()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		lua_pushnumber(L, condition->getEndTime());
+		lua_pushinteger(L, condition->getEndTime());
 	} else {
 		lua_pushnil(L);
 	}
@@ -14570,7 +14570,7 @@ int LuaScriptInterface::luaConditionGetTicks(lua_State* L)
 	// condition:getTicks()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		lua_pushnumber(L, condition->getTicks());
+		lua_pushinteger(L, condition->getTicks());
 	} else {
 		lua_pushnil(L);
 	}
@@ -14627,7 +14627,7 @@ int LuaScriptInterface::luaConditionGetParameter(lua_State* L)
 		return 1;
 	}
 
-	lua_pushnumber(L, value);
+	lua_pushinteger(L, value);
 	return 1;
 }
 
@@ -15028,7 +15028,7 @@ int LuaScriptInterface::luaMonsterTypeHealth(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.health);
+			lua_pushinteger(L, monsterType->info.health);
 		} else {
 			monsterType->info.health = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15045,7 +15045,7 @@ int LuaScriptInterface::luaMonsterTypeMaxHealth(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.healthMax);
+			lua_pushinteger(L, monsterType->info.healthMax);
 		} else {
 			monsterType->info.healthMax = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15062,7 +15062,7 @@ int LuaScriptInterface::luaMonsterTypeRunHealth(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.runAwayHealth);
+			lua_pushinteger(L, monsterType->info.runAwayHealth);
 		} else {
 			monsterType->info.runAwayHealth = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15079,7 +15079,7 @@ int LuaScriptInterface::luaMonsterTypeExperience(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.experience);
+			lua_pushinteger(L, monsterType->info.experience);
 		} else {
 			monsterType->info.experience = tfs::lua::getNumber<uint64_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15096,7 +15096,7 @@ int LuaScriptInterface::luaMonsterTypeSkull(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.skull);
+			lua_pushinteger(L, monsterType->info.skull);
 		} else {
 			if (isNumber(L, 2)) {
 				monsterType->info.skull = tfs::lua::getNumber<Skulls_t>(L, 2);
@@ -15117,7 +15117,7 @@ int LuaScriptInterface::luaMonsterTypeCombatImmunities(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.damageImmunities);
+			lua_pushinteger(L, monsterType->info.damageImmunities);
 		} else {
 			std::string immunity = tfs::lua::getString(L, 2);
 			if (immunity == "physical") {
@@ -15168,7 +15168,7 @@ int LuaScriptInterface::luaMonsterTypeConditionImmunities(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.conditionImmunities);
+			lua_pushinteger(L, monsterType->info.conditionImmunities);
 		} else {
 			std::string immunity = tfs::lua::getString(L, 2);
 			if (immunity == "physical") {
@@ -15339,7 +15339,7 @@ int LuaScriptInterface::luaMonsterTypeGetElementList(lua_State* L)
 
 	lua_createtable(L, monsterType->info.elementMap.size(), 0);
 	for (const auto& elementEntry : monsterType->info.elementMap) {
-		lua_pushnumber(L, elementEntry.second);
+		lua_pushinteger(L, elementEntry.second);
 		lua_rawseti(L, -2, elementEntry.first);
 	}
 	return 1;
@@ -15543,7 +15543,7 @@ int LuaScriptInterface::luaMonsterTypeMaxSummons(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.maxSummons);
+			lua_pushinteger(L, monsterType->info.maxSummons);
 		} else {
 			monsterType->info.maxSummons = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15560,7 +15560,7 @@ int LuaScriptInterface::luaMonsterTypeArmor(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.armor);
+			lua_pushinteger(L, monsterType->info.armor);
 		} else {
 			monsterType->info.armor = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15577,7 +15577,7 @@ int LuaScriptInterface::luaMonsterTypeDefense(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.defense);
+			lua_pushinteger(L, monsterType->info.defense);
 		} else {
 			monsterType->info.defense = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15612,7 +15612,7 @@ int LuaScriptInterface::luaMonsterTypeRace(lua_State* L)
 	std::string race = tfs::lua::getString(L, 2);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.race);
+			lua_pushinteger(L, monsterType->info.race);
 		} else {
 			if (race == "venom") {
 				monsterType->info.race = RACE_VENOM;
@@ -15643,7 +15643,7 @@ int LuaScriptInterface::luaMonsterTypeCorpseId(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.lookcorpse);
+			lua_pushinteger(L, monsterType->info.lookcorpse);
 		} else {
 			monsterType->info.lookcorpse = tfs::lua::getNumber<uint16_t>(L, 2);
 			lua_pushboolean(L, true);
@@ -15660,7 +15660,7 @@ int LuaScriptInterface::luaMonsterTypeManaCost(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.manaCost);
+			lua_pushinteger(L, monsterType->info.manaCost);
 		} else {
 			monsterType->info.manaCost = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15677,7 +15677,7 @@ int LuaScriptInterface::luaMonsterTypeBaseSpeed(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.baseSpeed);
+			lua_pushinteger(L, monsterType->info.baseSpeed);
 		} else {
 			monsterType->info.baseSpeed = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15697,8 +15697,8 @@ int LuaScriptInterface::luaMonsterTypeLight(lua_State* L)
 		return 1;
 	}
 	if (lua_gettop(L) == 1) {
-		lua_pushnumber(L, monsterType->info.light.level);
-		lua_pushnumber(L, monsterType->info.light.color);
+		lua_pushinteger(L, monsterType->info.light.level);
+		lua_pushinteger(L, monsterType->info.light.color);
 		return 2;
 	} else {
 		monsterType->info.light.color = tfs::lua::getNumber<uint8_t>(L, 2);
@@ -15714,7 +15714,7 @@ int LuaScriptInterface::luaMonsterTypeStaticAttackChance(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.staticAttackChance);
+			lua_pushinteger(L, monsterType->info.staticAttackChance);
 		} else {
 			monsterType->info.staticAttackChance = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15731,7 +15731,7 @@ int LuaScriptInterface::luaMonsterTypeTargetDistance(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.targetDistance);
+			lua_pushinteger(L, monsterType->info.targetDistance);
 		} else {
 			monsterType->info.targetDistance = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15748,7 +15748,7 @@ int LuaScriptInterface::luaMonsterTypeYellChance(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.yellChance);
+			lua_pushinteger(L, monsterType->info.yellChance);
 		} else {
 			monsterType->info.yellChance = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15765,7 +15765,7 @@ int LuaScriptInterface::luaMonsterTypeYellSpeedTicks(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.yellSpeedTicks);
+			lua_pushinteger(L, monsterType->info.yellSpeedTicks);
 		} else {
 			monsterType->info.yellSpeedTicks = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15782,7 +15782,7 @@ int LuaScriptInterface::luaMonsterTypeChangeTargetChance(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.changeTargetChance);
+			lua_pushinteger(L, monsterType->info.changeTargetChance);
 		} else {
 			monsterType->info.changeTargetChance = tfs::lua::getNumber<int32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -15799,7 +15799,7 @@ int LuaScriptInterface::luaMonsterTypeChangeTargetSpeed(lua_State* L)
 	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.changeTargetSpeed);
+			lua_pushinteger(L, monsterType->info.changeTargetSpeed);
 		} else {
 			monsterType->info.changeTargetSpeed = tfs::lua::getNumber<uint32_t>(L, 2);
 			tfs::lua::pushBoolean(L, true);
@@ -16425,7 +16425,7 @@ int LuaScriptInterface::luaPartyGetMemberCount(lua_State* L)
 	// party:getMemberCount()
 	Party* party = tfs::lua::getUserdata<Party>(L, 1);
 	if (party) {
-		lua_pushnumber(L, party->getMemberCount());
+		lua_pushinteger(L, party->getMemberCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -16456,7 +16456,7 @@ int LuaScriptInterface::luaPartyGetInviteeCount(lua_State* L)
 	// party:getInviteeCount()
 	Party* party = tfs::lua::getUserdata<Party>(L, 1);
 	if (party) {
-		lua_pushnumber(L, party->getInvitationCount());
+		lua_pushinteger(L, party->getInvitationCount());
 	} else {
 		lua_pushnil(L);
 	}
@@ -16737,7 +16737,7 @@ int LuaScriptInterface::luaSpellId(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getId());
+			lua_pushinteger(L, spell->getId());
 		} else {
 			spell->setId(tfs::lua::getNumber<uint8_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16754,8 +16754,8 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getGroup());
-			lua_pushnumber(L, spell->getSecondaryGroup());
+			lua_pushinteger(L, spell->getGroup());
+			lua_pushinteger(L, spell->getSecondaryGroup());
 			return 2;
 		} else if (lua_gettop(L) == 2) {
 			SpellGroup_t group = tfs::lua::getNumber<SpellGroup_t>(L, 2);
@@ -16822,7 +16822,7 @@ int LuaScriptInterface::luaSpellCooldown(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getCooldown());
+			lua_pushinteger(L, spell->getCooldown());
 		} else {
 			spell->setCooldown(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16839,8 +16839,8 @@ int LuaScriptInterface::luaSpellGroupCooldown(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getGroupCooldown());
-			lua_pushnumber(L, spell->getSecondaryCooldown());
+			lua_pushinteger(L, spell->getGroupCooldown());
+			lua_pushinteger(L, spell->getSecondaryCooldown());
 			return 2;
 		} else if (lua_gettop(L) == 2) {
 			spell->setGroupCooldown(tfs::lua::getNumber<uint32_t>(L, 2));
@@ -16862,7 +16862,7 @@ int LuaScriptInterface::luaSpellLevel(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getLevel());
+			lua_pushinteger(L, spell->getLevel());
 		} else {
 			spell->setLevel(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16879,7 +16879,7 @@ int LuaScriptInterface::luaSpellMagicLevel(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getMagicLevel());
+			lua_pushinteger(L, spell->getMagicLevel());
 		} else {
 			spell->setMagicLevel(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16896,7 +16896,7 @@ int LuaScriptInterface::luaSpellMana(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getMana());
+			lua_pushinteger(L, spell->getMana());
 		} else {
 			spell->setMana(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16913,7 +16913,7 @@ int LuaScriptInterface::luaSpellManaPercent(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getManaPercent());
+			lua_pushinteger(L, spell->getManaPercent());
 		} else {
 			spell->setManaPercent(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16930,7 +16930,7 @@ int LuaScriptInterface::luaSpellSoul(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getSoulCost());
+			lua_pushinteger(L, spell->getSoulCost());
 		} else {
 			spell->setSoulCost(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -16947,7 +16947,7 @@ int LuaScriptInterface::luaSpellRange(lua_State* L)
 	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getRange());
+			lua_pushinteger(L, spell->getRange());
 		} else {
 			spell->setRange(tfs::lua::getNumber<int32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -17308,7 +17308,7 @@ int LuaScriptInterface::luaSpellRuneLevel(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getLevel());
+			lua_pushinteger(L, spell->getLevel());
 		} else {
 			spell->setLevel(level);
 			tfs::lua::pushBoolean(L, true);
@@ -17333,7 +17333,7 @@ int LuaScriptInterface::luaSpellRuneMagicLevel(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getMagicLevel());
+			lua_pushinteger(L, spell->getMagicLevel());
 		} else {
 			spell->setMagicLevel(magLevel);
 			tfs::lua::pushBoolean(L, true);
@@ -17357,7 +17357,7 @@ int LuaScriptInterface::luaSpellRuneId(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, rune->getRuneItemId());
+			lua_pushinteger(L, rune->getRuneItemId());
 		} else {
 			rune->setRuneItemId(tfs::lua::getNumber<uint16_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);
@@ -17381,7 +17381,7 @@ int LuaScriptInterface::luaSpellCharges(lua_State* L)
 		}
 
 		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, spell->getCharges());
+			lua_pushinteger(L, spell->getCharges());
 		} else {
 			spell->setCharges(tfs::lua::getNumber<uint32_t>(L, 2));
 			tfs::lua::pushBoolean(L, true);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -298,7 +298,7 @@ void Monster::onCreatureSay(Creature* creature, SpeakClasses type, const std::st
 		tfs::lua::pushUserdata(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 
-		lua_pushnumber(L, type);
+		lua_pushinteger(L, type);
 		tfs::lua::pushString(L, text);
 
 		scriptInterface->callVoidFunction(4);
@@ -723,7 +723,7 @@ void Monster::onThink(uint32_t interval)
 		tfs::lua::pushUserdata(L, this);
 		tfs::lua::setMetatable(L, -1, "Monster");
 
-		lua_pushnumber(L, interval);
+		lua_pushinteger(L, interval);
 
 		if (scriptInterface->callFunction(2)) {
 			return;

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -1022,7 +1022,7 @@ bool MoveEvent::executeEquip(Player* player, Item* item, slots_t slot, bool isCh
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 	tfs::lua::pushThing(L, item);
-	lua_pushnumber(L, slot);
+	lua_pushinteger(L, slot);
 	tfs::lua::pushBoolean(L, isCheck);
 
 	return scriptInterface->callFunction(4);

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -790,9 +790,9 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 	const Position& thingPos = thing->getPosition();
 	const Position& npcPos = npc->getPosition();
 	if (npcPos.z != thingPos.z) {
-		lua_pushnumber(L, -1);
+		lua_pushinteger(L, -1);
 	} else {
-		lua_pushnumber(L, std::max(npcPos.getDistanceX(thingPos), npcPos.getDistanceY(thingPos)));
+		lua_pushinteger(L, std::max(npcPos.getDistanceX(thingPos), npcPos.getDistanceY(thingPos)));
 	}
 	return 1;
 }
@@ -812,7 +812,7 @@ int NpcScriptInterface::luaGetNpcCid(lua_State* L)
 	// getNpcCid()
 	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
 	if (npc) {
-		lua_pushnumber(L, npc->getID());
+		lua_pushinteger(L, npc->getID());
 	} else {
 		lua_pushnil(L);
 	}
@@ -990,7 +990,7 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 
 			if (g_game.internalPlayerAddItem(player, item, canDropOnMap) != RETURNVALUE_NOERROR) {
 				delete item;
-				lua_pushnumber(L, sellCount);
+				lua_pushinteger(L, sellCount);
 				return 1;
 			}
 
@@ -1006,7 +1006,7 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 
 			if (g_game.internalPlayerAddItem(player, item, canDropOnMap) != RETURNVALUE_NOERROR) {
 				delete item;
-				lua_pushnumber(L, sellCount);
+				lua_pushinteger(L, sellCount);
 				return 1;
 			}
 
@@ -1014,7 +1014,7 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 		}
 	}
 
-	lua_pushnumber(L, sellCount);
+	lua_pushinteger(L, sellCount);
 	return 1;
 }
 
@@ -1277,7 +1277,7 @@ void NpcEventsHandler::onCreatureSay(Creature* creature, SpeakClasses type, cons
 	scriptInterface->pushFunction(creatureSayEvent);
 	tfs::lua::pushUserdata(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
-	lua_pushnumber(L, type);
+	lua_pushinteger(L, type);
 	tfs::lua::pushString(L, text);
 	scriptInterface->callFunction(3);
 }
@@ -1303,9 +1303,9 @@ void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t 
 	tfs::lua::pushCallback(L, callback);
 	tfs::lua::pushUserdata(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
-	lua_pushnumber(L, itemId);
-	lua_pushnumber(L, count);
-	lua_pushnumber(L, amount);
+	lua_pushinteger(L, itemId);
+	lua_pushinteger(L, count);
+	lua_pushinteger(L, amount);
 	tfs::lua::pushBoolean(L, ignore);
 	tfs::lua::pushBoolean(L, inBackpacks);
 	scriptInterface->callFunction(6);

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -155,7 +155,7 @@ bool TalkAction::executeSay(Player* player, const std::string& words, const std:
 
 	tfs::lua::pushString(L, words);
 	tfs::lua::pushString(L, param);
-	lua_pushnumber(L, type);
+	lua_pushinteger(L, type);
 
 	return scriptInterface->callFunction(4);
 }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Replace some `lua_pushnumber` with `lua_pushinteger` to fix display of some integer values in game.
I'm not sure if it's a valid approach and also I'm not sure about changes in:
- `setField`
- `LuaScriptInterface::registerVariable`


**Issues addressed:** <!-- Write here the issue number, if any. -->
 #4522

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
