### PR TITLE
New method: Monster.setId related with onSpawn

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2765,6 +2765,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Monster", "getType", LuaScriptInterface::luaMonsterGetType);
 
 	registerMethod("Monster", "rename", LuaScriptInterface::luaMonsterRename);
+	registerMethod("Monster", "setId", LuaScriptInterface::luaMonsterSetId);
 
 	registerMethod("Monster", "getSpawnPosition", LuaScriptInterface::luaMonsterGetSpawnPosition);
 	registerMethod("Monster", "isInSpawnRange", LuaScriptInterface::luaMonsterIsInSpawnRange);
@@ -11060,6 +11061,20 @@ int LuaScriptInterface::luaMonsterRename(lua_State* L)
 	}
 
 	pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterSetId(lua_State* L)
+{
+	// monster:setId()
+	Monster* monster = getUserdata<Monster>(L, 1);
+	if (!monster) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	pushBoolean(L, monster->getID() == 0);
+	monster->setID();
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1042,6 +1042,7 @@ private:
 	static int luaMonsterGetType(lua_State* L);
 
 	static int luaMonsterRename(lua_State* L);
+	static int luaMonsterSetId(lua_State* L);
 
 	static int luaMonsterGetSpawnPosition(lua_State* L);
 	static int luaMonsterIsInSpawnRange(lua_State* L);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This new method is not something that we should use manually, but there is a very good and particular use case...

The `onSpawn` event is special, since the `Monster` object that arrives in the parameters is a monster not yet placed on the map and therefore does not have an identifier either.

If we are sure that onSpawn will return `true`, then we can call `setId`, otherwise we would only be losing an ID, which is not negative either, it is the same as a monster appearing and dying immediately, which happens very frequently.

### Advantages
Setting an ID to the creature before it is placed on the map gives us the advantage of storing arbitrary information related to the monster through its own ID.

### Notes
With the [new changes that were added a while ago](https://github.com/otland/forgottenserver/pull/4495), information can be saved through storage, which does not depend on the monster's ID.

But if the script requires adding an event with a timer, the easiest way to track the monster that should spawn is through its own ID.

**Issues addressed:** Nothing!