### PR TITLE
Fix normal random skew towards mean

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -285,23 +285,15 @@ int32_t uniform_random(int32_t minNumber, int32_t maxNumber)
 int32_t normal_random(int32_t minNumber, int32_t maxNumber)
 {
 	static std::normal_distribution<float> normalRand(0.5f, 0.25f);
-	if (minNumber == maxNumber) {
-		return minNumber;
-	} else if (minNumber > maxNumber) {
-		std::swap(minNumber, maxNumber);
-	}
 
-	int32_t increment;
+	float v;
+	do {
+		v = normalRand(getRandomGenerator());
+	} while (v < 0.0 || v > 1.0);
+
+	std::tie(minNumber, maxNumber) = std::minmax(minNumber, maxNumber);
 	const int32_t diff = maxNumber - minNumber;
-	const float v = normalRand(getRandomGenerator());
-	if (v < 0.0) {
-		increment = diff / 2;
-	} else if (v > 1.0) {
-		increment = (diff + 1) / 2;
-	} else {
-		increment = round(v * diff);
-	}
-	return minNumber + increment;
+	return minNumber + std::lround(v * diff);
 }
 
 bool boolean_random(double probability /* = 0.5*/)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The current code for normal distribution is skewed and tends to generate much more times the central element than the rest of the distribution, more than is expected of a normal distribution.


<details>
<summary>Comparison of results generating 2^27 random values between 0 and 20 (click to expand)</summary>

```
>> TFS normal random:
0	* (800928)
1	**** (2126010)
2	***** (2982546)
3	******* (4027064)
4	********* (5222481)
5	************ (6495756)
6	************** (7770920)
7	***************** (8940450)
8	****************** (9872740)
9	******************* (10476202)
10	******************************** (16807803)
11	******************* (10474301)
12	****************** (9872670)
13	***************** (8924956)
14	************** (7778402)
15	************ (6496375)
16	********* (5210797)
17	******* (4026227)
18	***** (2983148)
19	**** (2126458)
20	* (801494)
```

```
>> Fixed normal random:
0	* (838123)
1	**** (2227927)
2	***** (3127189)
3	******** (4214630)
4	********** (5465489)
5	************ (6800608)
6	*************** (8147614)
7	***************** (9362439)
8	******************* (10342027)
9	******************** (10982638)
10	********************* (11204545)
11	******************** (10982142)
12	******************* (10342200)
13	***************** (9359764)
14	*************** (8140484)
15	************ (6804640)
16	********** (5465333)
17	******** (4215876)
18	***** (3128459)
19	**** (2226383)
20	* (839218)
```

</details>

This happens because of the following path:
```cpp
if (v < 0.0) {
	increment = diff / 2;
} else if (v > 1.0) {
	increment = (diff + 1) / 2;
}
```

This causes values below or above two standard deviations (stdev is 0.25) from the mean (0.5) to simply be replaced by the central element. In normal distributions, about 5% of the results will be farther than two standard deviations from the mean, and those would all generate the central element instead.

![image](https://github.com/otland/forgottenserver/assets/1993083/55062597-9b85-4724-ab63-be4e189b5192)

The proper solution is to just discard the result and generate a new value. The while loop will only run once in 95% of the calls. There is an infinitely small chance of an infinite loop.

The new code is also roughly 30% faster (on a Ryzen 7 4800H chip) due to it performing less branching and having only one return.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
