### PR TITLE
Creature.addSummon - Only notify if the master is a player

### DIFF
--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -105,7 +105,10 @@ function Creature:addSummon(monster)
 	summon:setDropLoot(false)
 	summon:setSkillLoss(false)
 	summon:setMaster(self)
-	summon:getPosition():notifySummonAppear(summon)
+
+	if self:isPlayer() then
+		summon:getPosition():notifySummonAppear(summon)
+	end
 
 	return true
 end


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Sometimes we want to use the `Creature.addSummon` method to add a summon to a non-player creature, so the new summon won't necessarily always be a target of other monsters.

**Issues addressed:** Nothing!