### PR TITLE
Fix normal_random behavior on negative parameters

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -291,9 +291,8 @@ int32_t normal_random(int32_t minNumber, int32_t maxNumber)
 		v = normalRand(getRandomGenerator());
 	} while (v < 0.0 || v > 1.0);
 
-	std::tie(minNumber, maxNumber) = std::minmax(minNumber, maxNumber);
-	const int32_t diff = maxNumber - minNumber;
-	return minNumber + std::lround(v * diff);
+	auto&& [a, b] = std::minmax(minNumber, maxNumber);
+	return a + std::lround(v * (b - a));
 }
 
 bool boolean_random(double probability /* = 0.5*/)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

When the algorithm was updated to avoid skew #4539 I accidentally broke passing negative numbers in reverse order (e.g. calling `normal_random(-1, -100)` instead of `normal_random(-100, -1)`) due to the way `std::minmax` works: it returns references to the minimum and maximum element, and combined with `std::tie` it would replace `minNumber` in-place before it's value was moved to `maxNumber`.

Storing the values in local variables fixes the problem without adding an explicit branch + swap as proposed in the comments.

**Issues addressed:** fixes #4554 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
