### PR TITLE
Monster.getId in onSpawn event

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -15,7 +15,11 @@ class Tile;
 
 enum class EventInfoId
 {
-	CREATURE_ONHEAR
+	// Creature
+	CREATURE_ONHEAR,
+
+	// Monster
+	MONSTER_ONSPAWN
 };
 
 class Events
@@ -133,6 +137,8 @@ public:
 		switch (eventInfoId) {
 			case EventInfoId::CREATURE_ONHEAR:
 				return info.creatureOnHear;
+			case EventInfoId::MONSTER_ONSPAWN:
+				return info.monsterOnSpawn;
 			default:
 				return -1;
 		}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2764,6 +2764,7 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("Monster", "isMonster", LuaScriptInterface::luaMonsterIsMonster);
 
+	registerMethod("Monster", "getId", LuaScriptInterface::luaMonsterGetId);
 	registerMethod("Monster", "getType", LuaScriptInterface::luaMonsterGetType);
 
 	registerMethod("Monster", "rename", LuaScriptInterface::luaMonsterRename);
@@ -11038,6 +11039,23 @@ int LuaScriptInterface::luaMonsterIsMonster(lua_State* L)
 {
 	// monster:isMonster()
 	pushBoolean(L, getUserdata<const Monster>(L, 1) != nullptr);
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterGetId(lua_State* L)
+{
+	// monster:getId()
+	Monster* monster = getUserdata<Monster>(L, 1);
+	if (monster) {
+		// Set monster id if it's not set yet (only for onSpawn event)
+		if (getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::MONSTER_ONSPAWN)) {
+			monster->setID();
+		}
+
+		lua_pushinteger(L, monster->getID());
+	} else {
+		lua_pushnil(L);
+	}
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1039,6 +1039,7 @@ private:
 
 	static int luaMonsterIsMonster(lua_State* L);
 
+	static int luaMonsterGetId(lua_State* L);
 	static int luaMonsterGetType(lua_State* L);
 
 	static int luaMonsterRename(lua_State* L);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
An ID will be assigned automatically if you call Monster.getId in the onSpawn event, this gives us the possibility to obtain an ID from the monster for our purposes when necessary.

**Issues addressed:** #4077