### PR TITLE
Set writer and date in setItemText method

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1066,13 +1066,13 @@ function doSetItemText(uid, text, writer, date)
 		item:removeAttribute(ITEM_ATTRIBUTE_TEXT)
 	end
 
-	if writer ~= "" then
+	if writer then
 		item:setAttribute(ITEM_ATTRIBUTE_WRITER, tostring(writer))
 	else
 		item:removeAttribute(ITEM_ATTRIBUTE_WRITER)
 	end
 
-	if date ~= "" then
+	if date then
 		item:setAttribute(ITEM_ATTRIBUTE_DATE, tonumber(date))
 	else
 		item:removeAttribute(ITEM_ATTRIBUTE_DATE)

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1054,7 +1054,7 @@ function hasProperty(uid, prop)
 	return item:hasProperty(prop)
 end
 
-function doSetItemText(uid, text)
+function doSetItemText(uid, text, writer, date)
 	local item = Item(uid)
 	if not item then
 		return false
@@ -1065,6 +1065,19 @@ function doSetItemText(uid, text)
 	else
 		item:removeAttribute(ITEM_ATTRIBUTE_TEXT)
 	end
+
+	if writer ~= "" then
+		item:setAttribute(ITEM_ATTRIBUTE_WRITER, tostring(writer))
+	else
+		item:removeAttribute(ITEM_ATTRIBUTE_WRITER)
+	end
+
+	if date ~= "" then
+		item:setAttribute(ITEM_ATTRIBUTE_DATE, tonumber(date))
+	else
+		item:removeAttribute(ITEM_ATTRIBUTE_DATE)
+	end
+
 	return true
 end
 function doSetItemSpecialDescription(uid, desc)


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Since you can set the text of the item, it may also be useful for someone to add the author and date, e.g. to a parcel given by the server or to a quest where a letter is given to the player.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
