### PR TITLE
Send 0/1 as value in quest completion check

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -417,7 +417,7 @@ function Player.sendQuestLog(self)
 	for _, quest in pairs(quests) do
 		msg:addU16(quest.id)
 		msg:addString(quest.name)
-		msg:addByte(quest:isCompleted(self))
+		msg:addByte(quest:isCompleted(self) and 0x01 or 0x00)
 	end
 
 	msg:sendToPlayer(self)


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

We should send 0 or 1 as value instead of true/false in addByte, just like here https://github.com/otland/forgottenserver/blob/a9049040279bba57ef987196fd548b6c730593ef/data/lib/core/player.lua#L380

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
