### PR TITLE
Simplify logic to select Lua interpreter

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: >
           sudo apt update -q &&
-          sudo apt install -yq build-essential libluajit-5.1-dev libmysqlclient-dev
+          sudo apt install -yq build-essential libluajit-5.1-dev liblua5.4-dev libmysqlclient-dev
           libboost-system-dev libboost-iostreams-dev libboost-locale-dev
           libpugixml-dev libfmt-dev
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -63,7 +63,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: default
-          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}']"
+          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}', '-DUSE_LUAJIT=${{ matrix.luajit }}']"
           configurePreset: default
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -75,5 +75,5 @@ jobs:
       - name: Upload artifact binary
         uses: actions/upload-artifact@v4
         with:
-          name: tfs-ubuntu-${{ matrix.buildtype }}-luajit=on-${{ github.sha }}
-          path: ${{ runner.workspace }}/build/tfs
+          name: tfs-ubuntu-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          path: ${{ runner.workspace }}/build/${{ matrix.buildtype }}/tfs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'windows') }}
         with:
           name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
-          path: ${{ runner.workspace }}/build/tfs
+          path: ${{ runner.workspace }}/build/${{ matrix.buildtype }}/tfs
 
       - name: Upload artifact binary (exe)
         uses: actions/upload-artifact@v4
@@ -67,8 +67,8 @@ jobs:
         with:
           name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: |
-            ${{ runner.workspace }}/build/tfs.exe
-            ${{ runner.workspace }}/build/*.dll
+            ${{ runner.workspace }}/build/${{ matrix.buildtype }}/tfs.exe
+            ${{ runner.workspace }}/build/${{ matrix.buildtype }}/*.dll
 
       - name: Prepare datapack contents
         run: find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -43,10 +43,6 @@ jobs:
         # Using 'latest' branch, the latest CMake is installed.
         uses: lukka/get-cmake@latest
 
-      - name: Enable LuaJIT
-        if: ${{ matrix.luajit }} == "on"
-        run: echo "VCPKG_FEATURE_FLAGS=luajit" >> $GITHUB_ENV
-
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v11
 
@@ -54,7 +50,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: vcpkg
-          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}']"
+          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}', '-DUSE_LUAJIT=${{ matrix.luajit }}']"
           configurePreset: vcpkg
 
       - name: Upload artifact binary

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -28,7 +28,6 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         buildtype: [Debug, Release]

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -28,6 +28,7 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         buildtype: [Debug, Release]

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -15,7 +15,6 @@ jobs:
 
     env:
       VCPKG_BUILD_TYPE: release
-      VCPKG_FEATURE_FLAGS: luajit
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +30,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: vcpkg
-          buildPresetAdditionalArgs: "['--config', 'RelWithDebInfo', '--clean-first']"
+          buildPresetAdditionalArgs: "['--config', 'RelWithDebInfo', '--clean-first', '-DUSE_LUAJIT=ON']"
           configurePreset: vcpkg
 
       - name: Prepare datapack contents

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ if (BUILD_TESTING)
     list(APPEND VCPKG_MANIFEST_FEATURES "unit-tests")
 endif()
 
+option(USE_LUAJIT "Use LuaJIT" OFF)
+if (USE_LUAJIT)
+    list(APPEND VCPKG_MANIFEST_FEATURES "luajit")
+else()
+    list(APPEND VCPKG_MANIFEST_FEATURES "lua")
+endif()
+
 project(tfs CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -53,15 +60,9 @@ find_package(Threads REQUIRED)
 find_package(PugiXML CONFIG REQUIRED)
 
 # Selects LuaJIT if user defines or auto-detected
-if (DEFINED USE_LUAJIT AND NOT USE_LUAJIT)
-    set(FORCE_LUAJIT ${USE_LUAJIT})
+if (USE_LUAJIT)
+    find_package(LuaJIT REQUIRED)
 else ()
-    find_package(LuaJIT)
-    set(FORCE_LUAJIT ${LuaJIT_FOUND})
-endif ()
-option(USE_LUAJIT "Use LuaJIT" ${FORCE_LUAJIT})
-
-if (NOT FORCE_LUAJIT)
     find_package(Lua REQUIRED)
 endif ()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY cmake /usr/src/forgottenserver/cmake/
 COPY src /usr/src/forgottenserver/src/
 COPY CMakeLists.txt CMakePresets.json /usr/src/forgottenserver/
 WORKDIR /usr/src/forgottenserver
-RUN cmake --preset default && cmake --build --config RelWithDebInfo --preset default
+RUN cmake --preset default -DUSE_LUAJIT=ON && cmake --build --config RelWithDebInfo --preset default
 
 FROM alpine:3.19
 RUN apk add --no-cache \

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,11 +10,16 @@
     "boost-variant",
     "fmt",
     "libmariadb",
-    "lua",
     "openssl",
     "pugixml"
   ],
   "features": {
+    "lua": {
+      "description": "Use Lua instead of LuaJIT",
+      "dependencies": [
+        "lua"
+      ]
+    },
     "luajit": {
       "description": "Use LuaJIT instead of Lua",
       "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "dependencies": [
-    "libiconv",
     "boost-asio",
     "boost-iostreams",
     "boost-locale",
@@ -9,6 +8,10 @@
     "boost-system",
     "boost-variant",
     "fmt",
+    {
+      "name": "libiconv",
+      "platform": "osx"
+    },
     "libmariadb",
     "openssl",
     "pugixml"
@@ -33,5 +36,8 @@
       ]
     }
   },
+  "default-features": [
+    "lua"
+  ],
   "builtin-baseline": "215a2535590f1f63788ac9bd2ed58ad15e6afdff"
 }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Since auto-detecting LuaJIT installed is quite complicated when using vcpkg, it's better to leave it for the user to choose.

Generating makefiles using `cmake -DUSE_LUAJIT=ON` will automatically download and install LuaJIT using vcpkg, otherwise it will use Lua 5.4. For non-vcpkg builds, it will search for LuaJIT or not depending on the flag, instead of trying to be smart.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
