### PR TITLE
enhance storageValue warnings with source location

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -588,7 +588,7 @@ function Player:getStorageValue(key)
 	local source = debug.getinfo(2).source:match("@?(.*)")
 	local v = Creature.getStorageValue(self, key)
 
-	if v == nil then
+	if v == STORAGEVALUE_EMPTY then
 		print(string.format("[Warning - %s:%d] Invoking Creature:getStorageValue will return nil to indicate absence in the future. Please update your scripts accordingly.", source, line))
 	end
 

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -582,17 +582,25 @@ function isPlayerPzLocked(cid) local p = Player(cid) return p and p:isPzLocked()
 function isPremium(cid) local p = Player(cid) return p and p:isPremium() or false end
 
 STORAGEVALUE_EMPTY = -1
-function Player:getStorageValue(key)
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking Creature:getStorageValue will return nil to indicate absence in the future. Please update your scripts accordingly.")
 
+function Player:getStorageValue(key)
+	local line = debug.getinfo(2).currentline
+	local source = debug.getinfo(2).source:match("@?(.*)")
 	local v = Creature.getStorageValue(self, key)
+
+	if v == nil then
+		print(string.format("[Warning - %s:%d] Invoking Creature:getStorageValue will return nil to indicate absence in the future. Please update your scripts accordingly.", source, line))
+	end
+
 	return v or STORAGEVALUE_EMPTY
 end
 
 function Player:setStorageValue(key, value)
+	local line = debug.getinfo(2).currentline
+	local source = debug.getinfo(2).source:match("@?(.*)")
 
 	if value == STORAGEVALUE_EMPTY then
-		print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking Creature:setStorageValue with a value of -1 to remove it is deprecated. Please use Creature:removeStorageValue(key) instead.")
+		print(string.format("[Warning - %s:%d] Invoking Creature:setStorageValue with a value of -1 to remove it is deprecated. Please use Creature:removeStorageValue(key) instead.", source, line))
 		Creature.removeStorageValue(self, key)
 	else
 		Creature.setStorageValue(self, key, value)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
This pull request enhances the warning messages related to `Creature:getStorageValue` and `Creature:setStorageValue` functions in the Player class. The warnings now include source file location information (file name and line number) for better identification of the origin of the deprecated usage. This improvement aims to assist developers in identifying and updating their scripts more effectively.

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
