### PR TITLE
New global event: OnSave

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -251,6 +251,10 @@ do
 			self:type("record")
 			self:onRecord(value)
 			return
+		elseif key == "onSave" then
+			self:type("save")
+			self:onSave(value)
+			return
 		end
 		rawset(self, key, value)
 	end

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -112,7 +112,8 @@ void Game::setGameState(GameState_t newState)
 		}
 
 		case GAME_STATE_SHUTDOWN: {
-			g_globalEvents->execute(GLOBALEVENT_SHUTDOWN);
+			g_globalEvents->save();
+			g_globalEvents->shutdown();
 
 			// kick all players that are still online
 			auto it = players.begin();
@@ -132,6 +133,8 @@ void Game::setGameState(GameState_t newState)
 		}
 
 		case GAME_STATE_CLOSED: {
+			g_globalEvents->save();
+
 			/* kick all players without the CanAlwaysLogin flag */
 			auto it = players.begin();
 			while (it != players.end()) {

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -112,6 +112,8 @@ bool GlobalEvents::registerLuaEvent(GlobalEvent* event)
 }
 
 void GlobalEvents::startup() const { execute(GLOBALEVENT_STARTUP); }
+void GlobalEvents::shutdown() const { execute(GLOBALEVENT_SHUTDOWN); }
+void GlobalEvents::save() const { execute(GLOBALEVENT_SAVE); }
 
 void GlobalEvents::timer()
 {
@@ -208,7 +210,8 @@ GlobalEventMap GlobalEvents::getEventMap(GlobalEvent_t type)
 			return timerMap;
 		case GLOBALEVENT_STARTUP:
 		case GLOBALEVENT_SHUTDOWN:
-		case GLOBALEVENT_RECORD: {
+		case GLOBALEVENT_RECORD:
+		case GLOBALEVENT_SAVE: {
 			GlobalEventMap retMap;
 			for (const auto& it : serverMap) {
 				if (it.second.getEventType() == type) {
@@ -289,6 +292,8 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 			eventType = GLOBALEVENT_SHUTDOWN;
 		} else if (caseInsensitiveEqual(value, "record")) {
 			eventType = GLOBALEVENT_RECORD;
+		} else if (caseInsensitiveEqual(value, "save")) {
+			eventType = GLOBALEVENT_SAVE;
 		} else {
 			std::cout << "[Error - GlobalEvent::configureEvent] No valid type \"" << attr.as_string()
 			          << "\" for globalevent with name " << name << std::endl;
@@ -314,6 +319,8 @@ std::string_view GlobalEvent::getScriptEventName() const
 			return "onShutdown";
 		case GLOBALEVENT_RECORD:
 			return "onRecord";
+		case GLOBALEVENT_SAVE:
+			return "onSave";
 		case GLOBALEVENT_TIMER:
 			return "onTime";
 		default:

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -19,6 +19,7 @@ enum GlobalEvent_t
 	GLOBALEVENT_STARTUP,
 	GLOBALEVENT_SHUTDOWN,
 	GLOBALEVENT_RECORD,
+	GLOBALEVENT_SAVE,
 };
 
 class GlobalEvents final : public BaseEvents
@@ -32,6 +33,8 @@ public:
 	GlobalEvents& operator=(const GlobalEvents&) = delete;
 
 	void startup() const;
+	void shutdown() const;
+	void save() const;
 
 	void timer();
 	void think();

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3960,6 +3960,7 @@ int LuaScriptInterface::luaStopEvent(lua_State* L)
 
 int LuaScriptInterface::luaSaveServer(lua_State* L)
 {
+	g_globalEvents->save();
 	g_game.saveGameState();
 	pushBoolean(L, true);
 	return 1;

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -49,6 +49,7 @@ void sigusr1Handler()
 {
 	// Dispatcher thread
 	std::cout << "SIGUSR1 received, saving the game state..." << std::endl;
+	g_globalEvents->save();
 	g_game.saveGameState();
 }
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Add new global event: On Save.

Why don't we call in saveGameState? In situations like shutdown, things happen beforehand (players being sent off, etc.), so we call individually.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
