### PR TITLE
Fix: null comparison issue in Player.hasAchievement function

### DIFF
--- a/data/lib/core/achievements.lua
+++ b/data/lib/core/achievements.lua
@@ -694,12 +694,18 @@ function Player.hasAchievement(self, ach)
 	else
 		achievement = getAchievementInfoByName(ach)
 	end
+
 	if not achievement then
 		print("[!] -> Invalid achievement \"" .. ach .. "\".")
 		return false
 	end
 
-	return self:getStorageValue(PlayerStorageKeys.achievementsBase + achievement.id) > 0
+	local achievementValue = self:getStorageValue(PlayerStorageKeys.achievementsBase + achievement.id)
+	if achievementValue ~= nil and achievementValue > 0 then
+		return true
+	end
+
+	return false
 end
 
 function Player.getAchievements(self)


### PR DESCRIPTION
…ith null values

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
Fixes an issue in the Player.hasAchievement function where an attempt to compare with a null value was occurring.

**Issues addressed:** <!-- Write here the issue number, if any. -->
```
Lua Script Error: [CreatureScript Interface]
data/creaturescripts/scripts/login.lua:onLogin
data/lib/core/achievements.lua:702: attempt to compare number with nil
stack traceback:
        data/lib/core/achievements.lua:702: in function 'hasAchievement'
        data/lib/core/achievements.lua:708: in function 'getAchievements'
        data/lib/core/achievements.lua:803: in function 'getAchievementPoints'
        data/creaturescripts/scripts/login.lua:36: in function <data/creaturescripts/scripts/login.lua:1>
```

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
