### PR TITLE
Add NetworkMessage deletion in Player.sendHotkeyPreset function

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -724,6 +724,7 @@ function Player.sendHotkeyPreset(self)
 	msg:addByte(0x9D)
 	msg:addU32(self:getVocation():getClientId())
 	msg:sendToPlayer(self)
+	msg:delete()
 	return true
 end
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
Adds network message deletion in the Player.sendHotkeyPreset function for optimization.

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
