### PR TITLE
Fix: getWorldTime a nil value

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -155,12 +155,10 @@
 	<action itemid="486" script="others/snow_heap.lua" />
 	<action itemid="1369" script="others/draw_well.lua" />
 	<action itemid="1386" script="others/teleport.lua" />
-	<action fromid="1728" toid="1731" script="others/watch.lua" />
 	<action fromid="1816" toid="1817" script="others/wall_mirror.lua" />
 	<action fromid="1843" toid="1844" script="others/wall_mirror.lua" />
 	<action fromid="1846" toid="1847" script="others/wall_mirror.lua" />
 	<action fromid="1849" toid="1850" script="others/wall_mirror.lua" />
-	<action itemid="2036" script="others/watch.lua" />
 	<action itemid="2093" script="others/water_pipe.lua" />
 	<action itemid="2095" script="others/bird_cage.lua" />
 	<action itemid="2099" script="others/water_pipe.lua" />
@@ -170,16 +168,12 @@
 	<action itemid="2694" script="others/create_bread.lua" />
 	<action itemid="2785" script="others/blueberry_bush.lua" />
 	<action itemid="3678" script="others/teleport.lua" />
-	<action itemid="3900" script="others/watch.lua" />
 	<action itemid="5543" script="others/teleport.lua" />
 	<action fromid="5792" toid="5797" script="others/die.lua" />
-	<action itemid="6092" script="others/watch.lua" />
 	<action itemid="6576" script="others/fireworks_rocket.lua" />
 	<action itemid="6578" script="others/party_hat.lua" />
 	<action itemid="7552" script="others/large_seashell.lua" />
-	<action itemid="7828" script="others/watch.lua" />
 	<action fromid="7904" toid="7907" script="others/bed_modification_kits.lua" />
-	<action fromid="9443" toid="9444" script="others/watch.lua" />
 	<action fromid="18488" toid="18492" script="others/skill_trainer.lua" />
 	<action itemid="20252" script="others/bed_modification_kits.lua" />
 	<action fromid="22845" toid="22846" script="others/teleport.lua" />

--- a/data/actions/scripts/others/watch.lua
+++ b/data/actions/scripts/others/watch.lua
@@ -1,4 +1,0 @@
-function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	player:sendTextMessage(MESSAGE_INFO_DESCR, "The time is " .. getFormattedWorldTime() .. ".")
-	return true
-end

--- a/data/global.lua
+++ b/data/global.lua
@@ -88,17 +88,6 @@ function getDistanceBetween(firstPosition, secondPosition)
 	return posDif
 end
 
-function getFormattedWorldTime()
-	local worldTime = getWorldTime()
-	local hours = math.floor(worldTime / 60)
-
-	local minutes = worldTime % 60
-	if minutes < 10 then
-		minutes = '0' .. minutes
-	end
-	return hours .. ':' .. minutes
-end
-
 function getLootRandom()
 	return math.random(0, MAX_LOOTCHANCE) / configManager.getNumber(configKeys.RATE_LOOT)
 end

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1639,3 +1639,7 @@ function table.maxn(t)
 	end
 	return max
 end
+
+function getFormattedWorldTime()
+	return Game.getFormattedWorldTime()
+end

--- a/data/lib/core/game.lua
+++ b/data/lib/core/game.lua
@@ -191,11 +191,11 @@ end
 do
 	local worldLightLevel = 0
 	local worldLightColor = 0
-	
+
 	function Game.getWorldLight()
 		return worldLightLevel, worldLightColor
 	end
-	
+
 	function Game.setWorldLight(color, level)
 		if not configManager.getBoolean(configKeys.DEFAULT_WORLD_LIGHT) then
 			return
@@ -231,4 +231,18 @@ do
 			end
 		end
 	end
+end
+
+function Game.getFormattedWorldTime()
+	local worldTime = Game.getWorldTime()
+	local hours = math.floor(worldTime / 60)
+
+	local minutes = worldTime % 60
+	if minutes < 10 then
+		minutes = '0' .. minutes
+	end
+
+	minutes = math.floor(minutes)
+
+	return hours .. ':' .. minutes
 end

--- a/data/scripts/actions/tools/watch.lua
+++ b/data/scripts/actions/tools/watch.lua
@@ -2,7 +2,6 @@ local watch = Action()
 
 function watch.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	player:sendTextMessage(MESSAGE_INFO_DESCR, "The time is " .. Game.getFormattedWorldTime() .. ".")
-
 	return true
 end
 

--- a/data/scripts/actions/tools/watch.lua
+++ b/data/scripts/actions/tools/watch.lua
@@ -1,0 +1,10 @@
+local watch = Action()
+
+function watch.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	player:sendTextMessage(MESSAGE_INFO_DESCR, "The time is " .. Game.getFormattedWorldTime() .. ".")
+
+	return true
+end
+
+watch:id(1728, 1729, 1730, 1731, 2036, 3900, 6092, 7828, 9443, 9444)
+watch:register()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->

1. Sets the function to the current standard.
2. Fixes minute sampling from 20:35.2 to 20:35.
3. Turns clock scripts into revscript.
4. Adds compatibility with previous function.

**Issues addressed:** <!-- Write here the issue number, if any. -->
```
Lua Script Error: [Action Interface]
data/actions/scripts/others/watch.lua:onUse
data/global.lua:92: attempt to call global 'getWorldTime' (a nil value)
stack traceback:
        data/global.lua:92: in function 'getFormattedWorldTime'
        data/actions/scripts/others/watch.lua:2: in function <data/actions/scripts/others/watch.lua:1>
 ```

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
