### PR TITLE
New event Spell Check

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -42,6 +42,7 @@
 	<event class="Player" method="onWrapItem" enabled="1" />
 	<event class="Player" method="onInventoryUpdate" enabled="1" />
 	<event class="Player" method="onNetworkMessage" enabled="1" />
+	<event class="Player" method="onSpellCheck" enabled="0" />
 
 	<!-- Monster methods -->
 	<event class="Monster" method="onDropLoot" enabled="1" />

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -304,3 +304,11 @@ function Player:onNetworkMessage(recvByte, msg)
 
 	handler(self, msg)
 end
+
+function Player:onSpellCheck(spell)
+	local onSpellCheck = EventCallback.onSpellCheck
+	if onSpellCheck then
+		return onSpellCheck(self, spell)
+	end
+	return true
+end

--- a/data/scripts/lib/event_callbacks.lua
+++ b/data/scripts/lib/event_callbacks.lua
@@ -60,6 +60,7 @@ ec.onGainSkillTries = {[3] = 1}
 ec.onWrapItem = {}
 ec.onInventoryUpdate = {}
 ec.onUpdateStorage = {}
+ec.onSpellCheck = {}
 -- Monster
 ec.onDropLoot = {}
 ec.onSpawn = {}

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1342,7 +1342,7 @@ void Events::eventPlayerOnNetworkMessage(Player* player, uint8_t recvByte, Netwo
 
 bool Events::eventPlayerOnSpellCheck(Player* player, const Spell* spell)
 {
-	// Player:onCanCastSpell(spell)
+	// Player:onSpellCheck(spell)
 	if (info.playerOnSpellCheck == -1) {
 		return true;
 	}

--- a/src/events.h
+++ b/src/events.h
@@ -11,6 +11,7 @@
 class ItemType;
 class NetworkMessage;
 class Party;
+class Spell;
 class Tile;
 
 enum class EventInfoId
@@ -68,6 +69,7 @@ class Events
 		int32_t playerOnWrapItem = -1;
 		int32_t playerOnInventoryUpdate = -1;
 		int32_t playerOnNetworkMessage = -1;
+		int32_t playerOnSpellCheck = -1;
 
 		// Monster
 		int32_t monsterOnDropLoot = -1;
@@ -129,6 +131,7 @@ public:
 	void eventPlayerOnWrapItem(Player* player, Item* item);
 	void eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
 	void eventPlayerOnNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage* msg);
+	bool eventPlayerOnSpellCheck(Player* player, const Spell* spell);
 
 	// Monster
 	void eventMonsterOnDropLoot(Monster* monster, Container* corpse);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -957,6 +957,19 @@ void LuaScriptInterface::pushInstantSpell(lua_State* L, const InstantSpell& spel
 	setMetatable(L, -1, "Spell");
 }
 
+void LuaScriptInterface::pushSpell(lua_State* L, const Spell& spell)
+{
+	lua_createtable(L, 0, 5);
+
+	setField(L, "name", spell.getName());
+	setField(L, "level", spell.getLevel());
+	setField(L, "mlevel", spell.getMagicLevel());
+	setField(L, "mana", spell.getMana());
+	setField(L, "manapercent", spell.getManaPercent());
+
+	setMetatable(L, -1, "Spell");
+}
+
 void LuaScriptInterface::pushPosition(lua_State* L, const Position& position, int32_t stackpos /* = 0*/)
 {
 	lua_createtable(L, 0, 4);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -23,6 +23,7 @@ class Combat;
 class Container;
 class Creature;
 class Cylinder;
+class Spell;
 class InstantSpell;
 class Item;
 class LuaScriptInterface;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -354,6 +354,7 @@ public:
 	static void pushBoolean(lua_State* L, bool value);
 	static void pushCombatDamage(lua_State* L, const CombatDamage& damage);
 	static void pushInstantSpell(lua_State* L, const InstantSpell& spell);
+	static void pushSpell(lua_State* L, const Spell& spell);
 	static void pushPosition(lua_State* L, const Position& position, int32_t stackpos = 0);
 	static void pushOutfit(lua_State* L, const Outfit_t& outfit);
 	static void pushOutfit(lua_State* L, const Outfit* outfit);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -7,6 +7,7 @@
 
 #include "combat.h"
 #include "configmanager.h"
+#include "events.h"
 #include "game.h"
 #include "luavariant.h"
 #include "monsters.h"
@@ -14,6 +15,7 @@
 
 extern Game g_game;
 extern Spells* g_spells;
+extern Events* g_events;
 extern Monsters g_monsters;
 extern ConfigManager g_config;
 extern LuaEnvironment g_luaEnvironment;
@@ -526,6 +528,10 @@ bool Spell::playerSpellCheck(Player* player) const
 	}
 
 	if (!enabled) {
+		return false;
+	}
+
+	if (!g_events->eventPlayerOnSpellCheck(player, this)) {
 		return false;
 	}
 


### PR DESCRIPTION

### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Did you ever think about blocking all spells, or maybe just one specific spell for a player? Or for a group of players? Or maybe something even crazier?

Well, it's actually possible to do that using global variables or player storage. However, in order for it to work properly, we really have to modify and add some extra conditionals to all the spells we want to control. This is totally horrible.

This new event comes to solve this problem. The `onSpellCheck` event has two arguments: one is the player and the other is a table with some fields. In these fields, you can find some properties of the spell in question, for example the name.

Here is an example code fragment using the new event:
```lua
local event = Event()

function event.onSpellCheck(player, spell)
	if BossEvent:hasPlayer(player) then
		player:sendCancelMessage("You can't use spells in this event.")
		return false
	end
	return true
end

event:register()
```

**Issues addressed:** Nothing!