### PR TITLE
Fix check vocations in Movements & Spells

### DIFF
--- a/src/movement.h
+++ b/src/movement.h
@@ -125,9 +125,10 @@ public:
 			vocationEquipSet.insert(vocationId);
 		}
 	}
+	// If the set is empty, it is considered to be for all vocations.
 	bool hasVocationEquipSet(uint16_t vocationId) const
 	{
-		return !vocationEquipSet.empty() && vocationEquipSet.find(vocationId) != vocationEquipSet.end();
+		return vocationEquipSet.empty() || vocationEquipSet.find(vocationId) != vocationEquipSet.end();
 	}
 	bool getTileItem() const { return tileItem; }
 	void setTileItem(bool b) { tileItem = b; }

--- a/src/spells.h
+++ b/src/spells.h
@@ -141,9 +141,10 @@ public:
 			vocationSpellMap[vocationId] = showInDescription;
 		}
 	}
+	// If the set is empty, it is considered to be for all vocations.
 	bool hasVocationSpellMap(uint16_t vocationId) const
 	{
-		return !vocationSpellMap.empty() && vocationSpellMap.find(vocationId) != vocationSpellMap.end();
+		return vocationSpellMap.empty() || vocationSpellMap.find(vocationId) != vocationSpellMap.end();
 	}
 
 	SpellGroup_t getGroup() const { return group; }

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -113,6 +113,7 @@ public:
 			vocationWeaponSet.insert(vocationId);
 		}
 	}
+	// If the set is empty, it is considered to be for all vocations.
 	bool hasVocationWeaponSet(uint16_t vocationId) const
 	{
 		return vocationWeaponSet.empty() || vocationWeaponSet.find(vocationId) != vocationWeaponSet.end();


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixed the way vocations are checked in movements and spells, a while ago [I fixed the one for weapons](https://github.com/otland/forgottenserver/pull/4262), but I had forgotten that I needed this too.

**Issues addressed:** Nothing!