### PR TITLE
Add an option to disable CMake Unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,4 +111,10 @@ if(NOT SKIP_GIT)
 endif()
 ### END  Git Version ###
 
+# Option to disable unity builds
+option(ENABLE_UNITY_BUILD "Enable unity build" ON)
+if(ENABLE_UNITY_BUILD)
+    set_target_properties(tfslib PROPERTIES UNITY_BUILD ON)
+endif()
+
 target_precompile_headers(tfs PUBLIC src/otpch.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,6 +180,5 @@ target_link_libraries(tfslib PRIVATE
 	${LUA_LIBRARIES}
 	${MYSQL_CLIENT_LIBS}
 	)
-set_target_properties(tfslib PROPERTIES UNITY_BUILD ON)
 
 add_custom_target(format COMMAND /usr/bin/clang-format -style=file -i ${tfs_HDR} ${tfs_SRC} ${tfs_MAIN})


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add a CMake option to disable Unity builds. `clangd`, for instance, does not support unity builds, so we'd rather add this convenient switch to turn them off.

**Issues addressed:** None

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
