### PR TITLE
Encode Latin-1 to UTF-8 and vice versa

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -54,7 +54,7 @@ jobs:
         run: >
           sudo apt update -q &&
           sudo apt install -yq build-essential libluajit-5.1-dev libmysqlclient-dev
-          libboost-system-dev libboost-iostreams-dev
+          libboost-system-dev libboost-iostreams-dev libboost-locale-dev
           libpugixml-dev libcrypto++-dev libfmt-dev
 
       - name: Build with cmake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: >
           sudo apt update -q &&
           sudo apt install -yq git build-essential libluajit-5.1-dev libmysqlclient-dev
-          libboost-system-dev libboost-iostreams-dev libboost-test-dev
+          libboost-system-dev libboost-iostreams-dev libboost-locale-dev libboost-test-dev
           libpugixml-dev libcrypto++-dev libfmt-dev
 
       - name: Build with CMake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,10 @@ if (NOT FORCE_LUAJIT)
     find_package(Lua REQUIRED)
 endif ()
 
+if (APPLE)
+    find_package(Iconv REQUIRED)
+endif()
+
 find_package(Boost 1.66.0 REQUIRED COMPONENTS system iostreams locale)
 
 option(BUILD_TESTING "Build unit tests" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT FORCE_LUAJIT)
     find_package(Lua REQUIRED)
 endif ()
 
-find_package(Boost 1.66.0 REQUIRED COMPONENTS system iostreams)
+find_package(Boost 1.66.0 REQUIRED COMPONENTS system iostreams locale)
 
 option(BUILD_TESTING "Build unit tests" OFF)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM alpine:3.17.3
 # crypto++ is in edge/community
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
   boost-iostreams \
+  boost-locale \
   boost-system \
   crypto++ \
   fmt \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(tfslib ${tfs_SRC})
 target_link_libraries(tfslib PRIVATE
 	Boost::iostreams
 	Boost::system
+	Boost::locale
 	fmt::fmt
 	pugixml::pugixml
 	${CMAKE_THREAD_LIBS_INIT}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,5 +181,8 @@ target_link_libraries(tfslib PRIVATE
 	${LUA_LIBRARIES}
 	${MYSQL_CLIENT_LIBS}
 	)
+if (APPLE)
+	target_link_libraries(tfslib PRIVATE Iconv::Iconv)
+endif()
 
 add_custom_target(format COMMAND /usr/bin/clang-format -style=file -i ${tfs_HDR} ${tfs_SRC} ${tfs_MAIN})

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -70,7 +70,7 @@ public:
 		return value;
 	}
 
-	std::string_view getString(uint16_t stringLen = 0);
+	std::string getString(uint16_t stringLen = 0);
 	Position getPosition();
 
 	// skips count unknown/unused bytes in an incoming message

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "dependencies": [
+    "libiconv",
     "boost-asio",
     "boost-iostreams",
     "boost-locale",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "boost-lockfree",
     "boost-system",
     "boost-variant",
+    "boost-locale",
     "cryptopp",
     "fmt",
     "libmariadb",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,7 @@
   "dependencies": [
     "boost-asio",
     "boost-iostreams",
+    "boost-locale",
     "boost-lockfree",
     "boost-system",
     "boost-variant",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,6 @@
     "boost-lockfree",
     "boost-system",
     "boost-variant",
-    "boost-locale",
     "cryptopp",
     "fmt",
     "libmariadb",


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The issue at hand is that since #2403 (which addressed issue #2175), all text in the database has been stored using UTF-8 encoding. However, the data that comes from the client is Latin-1 encoded. This isn't problematic as long as the characters from the client stay within the ASCII range, as both Latin-1 and UTF-8 encode these characters the same way. However, if we receive from the client a string of text containing characters beyond the ASCII range (e.g., "ñññççç"), this is where data loss occurs, resulting in the situation described by the original poster in #4560. We end up storing in the database a set of characters that are not UTF-8 encoded.

This commit addresses this issue by implementing explicit conversion mechanisms to handle text encoding conversions seamlessly during data transmission between the client and server.

The solution at hand may incur too much overhead and should be evaluated.

### How to reproduce

1. From server to client (character name is not displayed correctly):

https://github.com/otland/forgottenserver/assets/34030065/1432cb35-dda6-4bb7-97d9-6d29ea8dc8c0

2. From client to server (can't login because the password hash is Latin-1 encoded):

https://github.com/otland/forgottenserver/assets/34030065/0587773c-de43-4f8b-a363-629b364b1ca3

**Issues addressed:** #4560

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
