### PR TITLE
Fix summon walk behavior

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1178,21 +1178,26 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 			result = getRandomStep(getPosition(), direction);
 		}
 	} else if ((isSummon() && isMasterInRange) || followCreature || walkingToSpawn) {
-		randomStepping = false;
-		result = Creature::getNextStep(direction, flags);
-		if (result) {
-			flags |= FLAG_PATHFINDING;
+		if (!hasFollowPath && !getMaster()->getPlayer()) {
+			randomStepping = true;
+			result = getRandomStep(getPosition(), direction);
 		} else {
-			if (ignoreFieldDamage) {
-				ignoreFieldDamage = false;
-				updateMapCache();
-			}
-			// target dancing
-			if (attackedCreature && attackedCreature == followCreature) {
-				if (isFleeing()) {
-					result = getDanceStep(getPosition(), direction, false, false);
-				} else if (mType->info.staticAttackChance < static_cast<uint32_t>(uniform_random(1, 100))) {
-					result = getDanceStep(getPosition(), direction);
+			randomStepping = false;
+			result = Creature::getNextStep(direction, flags);
+			if (result) {
+				flags |= FLAG_PATHFINDING;
+			} else {
+				if (ignoreFieldDamage) {
+					ignoreFieldDamage = false;
+					updateMapCache();
+				}
+				// target dancing
+				if (attackedCreature && attackedCreature == followCreature) {
+					if (isFleeing()) {
+						result = getDanceStep(getPosition(), direction, false, false);
+					} else if (mType->info.staticAttackChance < static_cast<uint32_t>(uniform_random(1, 100))) {
+						result = getDanceStep(getPosition(), direction);
+					}
 				}
 			}
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1178,7 +1178,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 			result = getRandomStep(getPosition(), direction);
 		}
 	} else if ((isSummon() && isMasterInRange) || followCreature || walkingToSpawn) {
-		if (!hasFollowPath && !getMaster()->getPlayer()) {
+		if (!hasFollowPath && getMaster() && !getMaster()->getPlayer()) {
 			randomStepping = true;
 			result = getRandomStep(getPosition(), direction);
 		} else {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Allows monsters summons to walk around when their path is blocked
**Issues addressed:** <!-- Write here the issue number, if any. -->
closes #4352

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
