### PR TITLE
Fix monster not updating their look direction

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -171,6 +171,8 @@ void Creature::onAttacking(uint32_t interval)
 
 	if (g_game.isSightClear(getPosition(), attackedCreature->getPosition(), true)) {
 		doAttacking(interval);
+	} else if (getMonster()) {
+		getMonster()->updateLookDirection();
 	}
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -172,7 +172,12 @@ void Creature::onAttacking(uint32_t interval)
 	if (g_game.isSightClear(getPosition(), attackedCreature->getPosition(), true)) {
 		doAttacking(interval);
 	} else if (getMonster()) {
-		getMonster()->updateLookDirection();
+		FindPathParams fpp;
+		getPathSearchParams(attackedCreature, fpp);
+
+		if (g_game.map.getPathMatchingSight(*this, attackedCreature->getPosition(), fpp)) {
+			getMonster()->updateLookDirection();
+		}
 	}
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -822,6 +822,133 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 	return true;
 }
 
+bool Map::getPathMatchingSight(const Creature& creature, const Position& targetPos, const FindPathParams& fpp) const
+{
+	Position pos = creature.getPosition();
+
+	AStarNodes nodes(pos.x, pos.y);
+
+	int32_t bestMatch = 0;
+
+	static int_fast32_t dirNeighbors[8][5][2] = {
+	    {{-1, 0}, {0, 1}, {1, 0}, {1, 1}, {-1, 1}},    {{-1, 0}, {0, 1}, {0, -1}, {-1, -1}, {-1, 1}},
+	    {{-1, 0}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}}, {{0, 1}, {1, 0}, {0, -1}, {1, -1}, {1, 1}},
+	    {{1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}},  {{-1, 0}, {0, -1}, {-1, -1}, {1, -1}, {-1, 1}},
+	    {{0, 1}, {1, 0}, {1, -1}, {1, 1}, {-1, 1}},    {{-1, 0}, {0, 1}, {-1, -1}, {1, 1}, {-1, 1}}};
+	static int_fast32_t allNeighbors[8][2] = {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}};
+
+	const Position startPos = pos;
+
+	AStarNode* found = nullptr;
+	while (fpp.maxSearchDist != 0 || nodes.getClosedNodes() < 100) {
+		AStarNode* n = nodes.getBestNode();
+		if (!n) {
+			if (found) {
+				break;
+			}
+			return false;
+		}
+
+		const int_fast32_t x = n->x;
+		const int_fast32_t y = n->y;
+		pos.x = x;
+		pos.y = y;
+		if (pos.x == targetPos.x && pos.y == targetPos.y) {
+			found = n;
+			break;
+		}
+
+		uint_fast32_t dirCount;
+		int_fast32_t* neighbors;
+		if (n->parent) {
+			const int_fast32_t offset_x = n->parent->x - x;
+			const int_fast32_t offset_y = n->parent->y - y;
+			if (offset_y == 0) {
+				if (offset_x == -1) {
+					neighbors = *dirNeighbors[DIRECTION_WEST];
+				} else {
+					neighbors = *dirNeighbors[DIRECTION_EAST];
+				}
+			} else if (!fpp.allowDiagonal || offset_x == 0) {
+				if (offset_y == -1) {
+					neighbors = *dirNeighbors[DIRECTION_NORTH];
+				} else {
+					neighbors = *dirNeighbors[DIRECTION_SOUTH];
+				}
+			} else if (offset_y == -1) {
+				if (offset_x == -1) {
+					neighbors = *dirNeighbors[DIRECTION_NORTHWEST];
+				} else {
+					neighbors = *dirNeighbors[DIRECTION_NORTHEAST];
+				}
+			} else if (offset_x == -1) {
+				neighbors = *dirNeighbors[DIRECTION_SOUTHWEST];
+			} else {
+				neighbors = *dirNeighbors[DIRECTION_SOUTHEAST];
+			}
+			dirCount = fpp.allowDiagonal ? 5 : 3;
+		} else {
+			dirCount = 8;
+			neighbors = *allNeighbors;
+		}
+
+		const int_fast32_t f = n->f;
+		for (uint_fast32_t i = 0; i < dirCount; ++i) {
+			pos.x = x + *neighbors++;
+			pos.y = y + *neighbors++;
+
+			if (fpp.maxSearchDist != 0 && (Position::getDistanceX(startPos, pos) > fpp.maxSearchDist ||
+			                               Position::getDistanceY(startPos, pos) > fpp.maxSearchDist)) {
+				continue;
+			}
+
+			const Tile* tile;
+			AStarNode* neighborNode = nodes.getNodeByPosition(pos.x, pos.y);
+			const Tile* tile = getTile(pos.x, pos.y, pos.z);
+			if (!tile) {
+				continue;
+			}
+
+			if (tile->hasProperty(CONST_PROP_BLOCKSOLID)) {
+				continue;
+			}
+
+			// The cost (g) for this neighbor
+			const int_fast32_t cost = AStarNodes::getMapWalkCost(n, pos);
+			const int_fast32_t extraCost = AStarNodes::getTileWalkCost(creature, tile);
+			const int_fast32_t newf = f + cost + extraCost;
+
+			if (neighborNode) {
+				if (neighborNode->f <= newf) {
+					// The node on the closed/open list is cheaper than this one
+					continue;
+				}
+
+				neighborNode->f = newf;
+				neighborNode->parent = n;
+				nodes.openNode(neighborNode);
+			} else {
+				// Does not exist in the open/closed list, create a new node
+				neighborNode = nodes.createOpenNode(n, pos.x, pos.y, newf);
+				if (!neighborNode) {
+					if (found) {
+						break;
+					}
+					return false;
+				}
+			}
+		}
+
+		nodes.closeNode(n);
+	}
+
+	if (!found) {
+		return false;
+	}
+
+	return true;
+}
+
 // AStarNodes
 
 AStarNodes::AStarNodes(uint32_t x, uint32_t y) : nodes(), openNodes()

--- a/src/map.h
+++ b/src/map.h
@@ -271,7 +271,9 @@ private:
 	void getSpectatorsInternal(SpectatorVec& spectators, const Position& centerPos, int32_t minRangeX,
 	                           int32_t maxRangeX, int32_t minRangeY, int32_t maxRangeY, int32_t minRangeZ,
 	                           int32_t maxRangeZ, bool onlyPlayers) const;
+	bool getPathMatchingSight(const Creature& creature, const Position& targetPos, const FindPathParams& fpp) const;
 
+	friend class Creature;
 	friend class Game;
 	friend class IOMap;
 };

--- a/src/monster.h
+++ b/src/monster.h
@@ -128,6 +128,8 @@ public:
 	BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage, bool checkDefense = false,
 	                     bool checkArmor = false, bool field = false, bool ignoreResistances = false) override;
 
+	void updateLookDirection();
+
 	static uint32_t monsterAutoID;
 
 private:
@@ -163,8 +165,6 @@ private:
 	void onCreatureEnter(Creature* creature);
 	void onCreatureLeave(Creature* creature);
 	void onCreatureFound(Creature* creature, bool pushFront = false);
-
-	void updateLookDirection();
 
 	void addFriend(Creature* creature);
 	void removeFriend(Creature* creature);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Monster do not update their look direction if they can't attack. They should still update even if they cant.
**Issues addressed:** <!-- Write here the issue number, if any. -->
closes #4339

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
