### PR TITLE
Allow multiple different slot type items in single moveevent

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17214,9 +17214,15 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 	if (moveevent) {
 		if ((moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP) &&
 		    moveevent->getSlot() == SLOTP_WHEREEVER) {
+			std::vector<uint16_t> slots;
 			for (const auto id : moveevent->getItemIdRange()) {
 				ItemType& it = Item::items.getItemType(id);
-				moveevent->setSlot(it.slotPosition);
+				uint16_t itemSlot = it.slotPosition;
+
+				if (std::find(slots.begin(), slots.end(), itemSlot) != slots.end()) {
+					moveevent->setSlot(itemSlot);
+					slots.push_back(itemSlot);
+				}
 			}
 		}
 		if (!moveevent->isScripted()) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17214,9 +17214,10 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 	if (moveevent) {
 		if ((moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP) &&
 		    moveevent->getSlot() == SLOTP_WHEREEVER) {
-			uint32_t id = moveevent->getItemIdRange().at(0);
-			ItemType& it = Item::items.getItemType(id);
-			moveevent->setSlot(it.slotPosition);
+			for (const auto id : moveevent->getItemIdRange()) {
+				ItemType& it = Item::items.getItemType(id);
+				moveevent->setSlot(it.slotPosition);
+			}
 		}
 		if (!moveevent->isScripted()) {
 			pushBoolean(L, g_moveEvents->registerLuaFunction(moveevent));


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Iterate over all id's linked in onEquip and onDequip to allow multiple slot types to be registered with the same event.
Currently it only selects the first id and assumes all other ids will use the same slot type.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
