### PR TITLE
Fix tobool function

### DIFF
--- a/data/scripts/lib/xml.lua
+++ b/data/scripts/lib/xml.lua
@@ -1,7 +1,7 @@
 local boolTrue = {"1", "y", "Y", "t", "T"}
 
 function tobool(str)
-	return str and table.contains(boolTrue, str[0])
+	return str and table.contains(boolTrue, str:sub(1, 1))
 end
 
 function XMLNode.children(self)


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
the `tobool` function was not getting any characters from the str parameter, so it would always return `false`
In this case the correct `string.sub` method is being used and the correct index is `1`

**Issues addressed:** Nothing!