### PR TITLE
Rewrite Position methods in constexpr

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -236,7 +236,7 @@ ReturnValue Actions::canUse(const Player* player, const Position& pos)
 			return playerPos.z > pos.z ? RETURNVALUE_FIRSTGOUPSTAIRS : RETURNVALUE_FIRSTGODOWNSTAIRS;
 		}
 
-		if (!Position::areInRange<1, 1>(playerPos, pos)) {
+		if (!playerPos.isInRange(pos, 1, 1)) {
 			return RETURNVALUE_TOOFARAWAY;
 		}
 	}
@@ -263,7 +263,7 @@ ReturnValue Actions::canUseFar(const Creature* creature, const Position& toPos, 
 		return creaturePos.z > toPos.z ? RETURNVALUE_FIRSTGOUPSTAIRS : RETURNVALUE_FIRSTGODOWNSTAIRS;
 	}
 
-	if (!Position::areInRange<Map::maxClientViewportX - 1, Map::maxClientViewportY - 1>(toPos, creaturePos)) {
+	if (!toPos.isInRange(creaturePos, Map::maxClientViewportX - 1, Map::maxClientViewportY - 1)) {
 		return RETURNVALUE_TOOFARAWAY;
 	}
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -717,22 +717,14 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 		                    : getCombatArea(position, position, area.get());
 
 		SpectatorVec spectators;
-		uint32_t maxX = 0;
-		uint32_t maxY = 0;
+		int32_t maxX = 0;
+		int32_t maxY = 0;
 
 		// calculate the max viewable range
 		for (Tile* tile : tiles) {
 			const Position& tilePos = tile->getPosition();
-
-			uint32_t diff = Position::getDistanceX(tilePos, position);
-			if (diff > maxX) {
-				maxX = diff;
-			}
-
-			diff = Position::getDistanceY(tilePos, position);
-			if (diff > maxY) {
-				maxY = diff;
-			}
+			maxX = std::max(maxX, tilePos.getDistanceX(position));
+			maxY = std::max(maxY, tilePos.getDistanceY(position));
 		}
 
 		const int32_t rangeX = maxX + Map::maxViewportX;
@@ -914,22 +906,14 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		}
 	}
 
-	uint32_t maxX = 0;
-	uint32_t maxY = 0;
+	int32_t maxX = 0;
+	int32_t maxY = 0;
 
 	// calculate the max viewable range
 	for (Tile* tile : tiles) {
 		const Position& tilePos = tile->getPosition();
-
-		uint32_t diff = Position::getDistanceX(tilePos, position);
-		if (diff > maxX) {
-			maxX = diff;
-		}
-
-		diff = Position::getDistanceY(tilePos, position);
-		if (diff > maxY) {
-			maxY = diff;
-		}
+		maxX = std::max(maxX, tilePos.getDistanceX(position));
+		maxY = std::max(maxY, tilePos.getDistanceY(position));
 	}
 
 	const int32_t rangeX = maxX + Map::maxViewportX;
@@ -1231,8 +1215,8 @@ void TargetCallback::onTargetCombat(Creature* creature, Creature* target) const
 
 const MatrixArea& AreaCombat::getArea(const Position& centerPos, const Position& targetPos) const
 {
-	int32_t dx = Position::getOffsetX(targetPos, centerPos);
-	int32_t dy = Position::getOffsetY(targetPos, centerPos);
+	int32_t dx = centerPos.getOffsetX(targetPos);
+	int32_t dy = centerPos.getOffsetY(targetPos);
 
 	Direction dir;
 	if (dx < 0) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -637,7 +637,7 @@ void Game::playerMoveThing(uint32_t playerId, const Position& fromPos, uint16_t 
 			return;
 		}
 
-		if (Position::areInRange<1, 1, 0>(movingCreature->getPosition(), player->getPosition())) {
+		if (movingCreature->getPosition().isInRange(player->getPosition(), 1, 1, 0)) {
 			SchedulerTask* task = createSchedulerTask(
 			    MOVE_CREATURE_INTERVAL, [=, this, playerID = player->getID(), creatureID = movingCreature->getID()]() {
 				    playerMoveCreatureByID(playerID, creatureID, fromPos, toPos);
@@ -700,7 +700,7 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 
 	player->setNextActionTask(nullptr);
 
-	if (!Position::areInRange<1, 1, 0>(movingCreatureOrigPos, player->getPosition())) {
+	if (!movingCreatureOrigPos.isInRange(player->getPosition(), 1, 1, 0)) {
 		// need to walk to the creature first before moving it
 		std::vector<Direction> listDir;
 		if (player->getPathTo(movingCreatureOrigPos, listDir, 0, 1, true, true)) {
@@ -729,14 +729,14 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 	// check throw distance
 	const Position& movingCreaturePos = movingCreature->getPosition();
 	const Position& toPos = toTile->getPosition();
-	if ((Position::getDistanceX(movingCreaturePos, toPos) > movingCreature->getThrowRange()) ||
-	    (Position::getDistanceY(movingCreaturePos, toPos) > movingCreature->getThrowRange()) ||
-	    (Position::getDistanceZ(movingCreaturePos, toPos) * 4 > movingCreature->getThrowRange())) {
+	if ((movingCreaturePos.getDistanceX(toPos) > movingCreature->getThrowRange()) ||
+	    (movingCreaturePos.getDistanceY(toPos) > movingCreature->getThrowRange()) ||
+	    (movingCreaturePos.getDistanceZ(toPos) * 4 > movingCreature->getThrowRange())) {
 		player->sendCancelMessage(RETURNVALUE_DESTINATIONOUTOFREACH);
 		return;
 	}
 
-	if (!Position::areInRange<1, 1, 0>(movingCreaturePos, player->getPosition())) {
+	if (!movingCreaturePos.isInRange(player->getPosition(), 1, 1, 0)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
@@ -957,7 +957,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 		return;
 	}
 
-	if (!Position::areInRange<1, 1>(playerPos, mapFromPos)) {
+	if (!playerPos.isInRange(mapFromPos, 1, 1)) {
 		// need to walk to the item first before using it
 		std::vector<Direction> listDir;
 		if (player->getPathTo(item->getPosition(), listDir, 0, 1, true, true)) {
@@ -994,7 +994,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 			}
 		}
 
-		if (!Position::areInRange<1, 1, 0>(playerPos, mapToPos)) {
+		if (!playerPos.isInRange(mapToPos, 1, 1, 0)) {
 			Position walkPos = mapToPos;
 			if (vertical) {
 				walkPos.x++;
@@ -1005,8 +1005,8 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 			Position itemPos = fromPos;
 			uint8_t itemStackPos = fromStackPos;
 
-			if (fromPos.x != 0xFFFF && Position::areInRange<1, 1>(mapFromPos, playerPos) &&
-			    !Position::areInRange<1, 1, 0>(mapFromPos, walkPos)) {
+			if (fromPos.x != 0xFFFF && mapFromPos.isInRange(playerPos, 1, 1) &&
+			    !mapFromPos.isInRange(walkPos, 1, 1, 0)) {
 				// need to pickup the item first
 				Item* moveItem = nullptr;
 
@@ -1045,8 +1045,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spri
 	}
 
 	int32_t throwRange = item->getThrowRange();
-	if ((Position::getDistanceX(playerPos, mapToPos) > throwRange) ||
-	    (Position::getDistanceY(playerPos, mapToPos) > throwRange)) {
+	if ((playerPos.getDistanceX(mapToPos) > throwRange) || (playerPos.getDistanceY(mapToPos) > throwRange)) {
 		player->sendCancelMessage(RETURNVALUE_DESTINATIONOUTOFREACH);
 		return;
 	}
@@ -2120,9 +2119,8 @@ void Game::playerUseItemEx(uint32_t playerId, const Position& fromPos, uint8_t f
 			Position itemPos = fromPos;
 			uint8_t itemStackPos = fromStackPos;
 
-			if (fromPos.x != 0xFFFF && toPos.x != 0xFFFF &&
-			    Position::areInRange<1, 1, 0>(fromPos, player->getPosition()) &&
-			    !Position::areInRange<1, 1, 0>(fromPos, toPos)) {
+			if (fromPos.x != 0xFFFF && toPos.x != 0xFFFF && fromPos.isInRange(player->getPosition(), 1, 1, 0) &&
+			    !fromPos.isInRange(toPos, 1, 1, 0)) {
 				Item* moveItem = nullptr;
 
 				ret = internalMoveItem(item->getParent(), player, INDEX_WHEREEVER, item, item->getItemCount(),
@@ -2242,8 +2240,8 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position& fromPos, uin
 		return;
 	}
 
-	if (!Position::areInRange<Map::maxClientViewportX - 1, Map::maxClientViewportY - 1, 0>(creature->getPosition(),
-	                                                                                       player->getPosition())) {
+	if (!creature->getPosition().isInRange(player->getPosition(), Map::maxClientViewportX - 1,
+	                                       Map::maxClientViewportY - 1, 0)) {
 		return;
 	}
 
@@ -2282,8 +2280,8 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position& fromPos, uin
 			Position itemPos = fromPos;
 			uint8_t itemStackPos = fromStackPos;
 
-			if (fromPos.x != 0xFFFF && Position::areInRange<1, 1, 0>(fromPos, player->getPosition()) &&
-			    !Position::areInRange<1, 1, 0>(fromPos, toPos)) {
+			if (fromPos.x != 0xFFFF && fromPos.isInRange(player->getPosition(), 1, 1, 0) &&
+			    !fromPos.isInRange(toPos, 1, 1, 0)) {
 				Item* moveItem = nullptr;
 				ret = internalMoveItem(item->getParent(), player, INDEX_WHEREEVER, item, item->getItemCount(),
 				                       &moveItem, 0, player, nullptr, &fromPos, &toPos);
@@ -2414,7 +2412,7 @@ void Game::playerRotateItem(uint32_t playerId, const Position& pos, uint8_t stac
 		return;
 	}
 
-	if (pos.x != 0xFFFF && !Position::areInRange<1, 1, 0>(pos, player->getPosition())) {
+	if (pos.x != 0xFFFF && !pos.isInRange(player->getPosition(), 1, 1, 0)) {
 		std::vector<Direction> listDir;
 		if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
 			g_dispatcher.addTask([this, playerID = player->getID(), listDir = std::move(listDir)]() {
@@ -2465,7 +2463,7 @@ void Game::playerWriteItem(uint32_t playerId, uint32_t windowTextId, std::string
 		return;
 	}
 
-	if (!Position::areInRange<1, 1, 0>(writeItem->getPosition(), player->getPosition())) {
+	if (!writeItem->getPosition().isInRange(player->getPosition(), 1, 1, 0)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
@@ -2510,7 +2508,7 @@ void Game::playerBrowseField(uint32_t playerId, const Position& pos)
 		return;
 	}
 
-	if (!Position::areInRange<1, 1>(playerPos, pos)) {
+	if (!playerPos.isInRange(pos, 1, 1)) {
 		std::vector<Direction> listDir;
 		if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
 			g_dispatcher.addTask([this, playerID = player->getID(), listDir = std::move(listDir)]() {
@@ -2616,7 +2614,7 @@ void Game::playerWrapItem(uint32_t playerId, const Position& position, uint8_t s
 		return;
 	}
 
-	if (position.x != 0xFFFF && !Position::areInRange<1, 1, 0>(position, player->getPosition())) {
+	if (position.x != 0xFFFF && !position.isInRange(player->getPosition(), 1, 1, 0)) {
 		std::vector<Direction> listDir;
 		if (player->getPathTo(position, listDir, 0, 1, true, true)) {
 			g_dispatcher.addTask([this, playerID = player->getID(), listDir = std::move(listDir)]() {
@@ -2648,7 +2646,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 		return;
 	}
 
-	if (!Position::areInRange<2, 2, 0>(tradePartner->getPosition(), player->getPosition())) {
+	if (!tradePartner->getPosition().isInRange(player->getPosition(), 2, 2, 0)) {
 		player->sendCancelMessage(RETURNVALUE_DESTINATIONOUTOFREACH);
 		return;
 	}
@@ -2688,7 +2686,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 		return;
 	}
 
-	if (!Position::areInRange<1, 1>(tradeItemPosition, playerPosition)) {
+	if (!tradeItemPosition.isInRange(playerPosition, 1, 1)) {
 		std::vector<Direction> listDir;
 		if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
 			g_dispatcher.addTask([this, playerID = player->getID(), listDir = std::move(listDir)]() {
@@ -2950,8 +2948,8 @@ void Game::playerLookInTrade(uint32_t playerId, bool lookAtCounterOffer, uint8_t
 	const Position& playerPosition = player->getPosition();
 	const Position& tradeItemPosition = tradeItem->getPosition();
 
-	int32_t lookDistance = std::max<int32_t>(Position::getDistanceX(playerPosition, tradeItemPosition),
-	                                         Position::getDistanceY(playerPosition, tradeItemPosition));
+	int32_t lookDistance =
+	    std::max(playerPosition.getDistanceX(tradeItemPosition), playerPosition.getDistanceY(tradeItemPosition));
 	if (index == 0) {
 		g_events->eventPlayerOnLookInTrade(player, tradePartner, tradeItem, lookDistance);
 		return;
@@ -3174,15 +3172,12 @@ void Game::playerLookAt(uint32_t playerId, const Position& pos, uint8_t stackPos
 
 	Position playerPos = player->getPosition();
 
-	int32_t lookDistance;
+	int32_t lookDistance = -1;
 	if (thing != player) {
-		lookDistance =
-		    std::max<int32_t>(Position::getDistanceX(playerPos, thingPos), Position::getDistanceY(playerPos, thingPos));
+		lookDistance = std::max(playerPos.getDistanceX(thingPos), thingPos.getDistanceY(playerPos));
 		if (playerPos.z != thingPos.z) {
 			lookDistance += 15;
 		}
-	} else {
-		lookDistance = -1;
 	}
 
 	g_events->eventPlayerOnLook(player, pos, thing, stackPos, lookDistance);
@@ -3209,16 +3204,13 @@ void Game::playerLookInBattleList(uint32_t playerId, uint32_t creatureId)
 		return;
 	}
 
-	int32_t lookDistance;
+	int32_t lookDistance = -1;
 	if (creature != player) {
 		const Position& playerPos = player->getPosition();
-		lookDistance = std::max<int32_t>(Position::getDistanceX(playerPos, creaturePos),
-		                                 Position::getDistanceY(playerPos, creaturePos));
+		lookDistance = std::max(playerPos.getDistanceX(creaturePos), playerPos.getDistanceY(creaturePos));
 		if (playerPos.z != creaturePos.z) {
 			lookDistance += 15;
 		}
-	} else {
-		lookDistance = -1;
 	}
 
 	g_events->eventPlayerOnLookInBattleList(player, creature, lookDistance);
@@ -3410,7 +3402,7 @@ void Game::playerRequestEditPodium(uint32_t playerId, const Position& position, 
 	// player has to walk to podium
 	// gm/god can edit instantly
 	if (!player->isAccessPlayer()) {
-		if (position.x != 0xFFFF && !Position::areInRange<1, 1, 0>(position, player->getPosition())) {
+		if (position.x != 0xFFFF && !position.isInRange(player->getPosition(), 1, 1, 0)) {
 			std::vector<Direction> listDir;
 			if (player->getPathTo(position, listDir, 0, 1, true, true)) {
 				g_dispatcher.addTask([this, playerID = player->getID(), listDir = std::move(listDir)]() {
@@ -3626,7 +3618,7 @@ void Game::playerWhisper(Player* player, const std::string& text)
 	// send to client
 	for (Creature* spectator : spectators) {
 		if (Player* spectatorPlayer = spectator->getPlayer()) {
-			if (!Position::areInRange<1, 1>(player->getPosition(), spectatorPlayer->getPosition())) {
+			if (!player->getPosition().isInRange(spectatorPlayer->getPosition(), 1, 1)) {
 				spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, "pspsps");
 			} else {
 				spectatorPlayer->sendCreatureSay(player, TALKTYPE_WHISPER, text);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -12387,7 +12387,7 @@ int LuaScriptInterface::luaHouseStartTrade(lua_State* L)
 		return 1;
 	}
 
-	if (!Position::areInRange<2, 2, 0>(tradePartner->getPosition(), player->getPosition())) {
+	if (!tradePartner->getPosition().isInRange(player->getPosition(), 2, 2, 0)) {
 		lua_pushnumber(L, RETURNVALUE_TRADEPLAYERFARAWAY);
 		return 1;
 	}

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -464,8 +464,8 @@ void Npc::turnToCreature(Creature* creature)
 {
 	const Position& creaturePos = creature->getPosition();
 	const Position& myPos = getPosition();
-	const auto dx = Position::getOffsetX(myPos, creaturePos);
-	const auto dy = Position::getOffsetY(myPos, creaturePos);
+	const auto dx = creaturePos.getOffsetX(myPos);
+	const auto dy = creaturePos.getOffsetY(myPos);
 
 	float tan;
 	if (dx != 0) {
@@ -689,9 +689,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 	if (npcPos.z != thingPos.z) {
 		lua_pushnumber(L, -1);
 	} else {
-		int32_t dist =
-		    std::max<int32_t>(Position::getDistanceX(npcPos, thingPos), Position::getDistanceY(npcPos, thingPos));
-		lua_pushnumber(L, dist);
+		lua_pushnumber(L, std::max(npcPos.getDistanceX(thingPos), thingPos.getDistanceY(npcPos)));
 	}
 	return 1;
 }

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -18,6 +18,7 @@
 #include <boost/lockfree/stack.hpp>
 #include <boost/variant.hpp>
 #include <cassert>
+#include <concepts>
 #include <condition_variable>
 #include <cryptopp/rsa.h>
 #include <cstdint>

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -412,8 +412,8 @@ SharedExpStatus_t Party::getMemberSharedExperienceStatus(const Player* player) c
 		return SHAREDEXP_LEVELDIFFTOOLARGE;
 	}
 
-	if (!Position::areInRange<EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_FLOORS>(
-	        leader->getPosition(), player->getPosition())) {
+	if (!leader->getPosition().isInRange(player->getPosition(), EXPERIENCE_SHARE_RANGE, EXPERIENCE_SHARE_RANGE,
+	                                     EXPERIENCE_SHARE_FLOORS)) {
 		return SHAREDEXP_TOOFARAWAY;
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1350,11 +1350,11 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 
 	if (tradeState != TRADE_TRANSFER) {
 		// check if we should close trade
-		if (tradeItem && !Position::areInRange<1, 1, 0>(tradeItem->getPosition(), getPosition())) {
+		if (tradeItem && !tradeItem->getPosition().isInRange(getPosition(), 1, 1, 0)) {
 			g_game.internalCloseTrade(this);
 		}
 
-		if (tradePartner && !Position::areInRange<2, 2, 0>(tradePartner->getPosition(), getPosition())) {
+		if (tradePartner && !tradePartner->getPosition().isInRange(getPosition(), 2, 2, 0)) {
 			g_game.internalCloseTrade(this);
 		}
 	}
@@ -3137,7 +3137,7 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 
 			for (const auto& it : openContainers) {
 				Container* container = it.second.container;
-				if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
+				if (!container->getPosition().isInRange(getPosition(), 1, 1, 0)) {
 					containers.push_back(container);
 				}
 			}
@@ -3187,7 +3187,7 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 		}
 
 		if (const Container* container = item->getContainer()) {
-			if (container->isRemoved() || !Position::areInRange<1, 1, 0>(getPosition(), container->getPosition())) {
+			if (container->isRemoved() || !getPosition().isInRange(container->getPosition(), 1, 1, 0)) {
 				autoCloseContainers(container);
 			} else if (container->getTopParent() == this) {
 				onSendContainer(container);

--- a/src/position.h
+++ b/src/position.h
@@ -26,81 +26,35 @@ struct Position
 	constexpr Position() = default;
 	constexpr Position(uint16_t x, uint16_t y, uint8_t z) : x(x), y(y), z(z) {}
 
-	template <int_fast32_t deltax, int_fast32_t deltay>
-	static bool areInRange(const Position& p1, const Position& p2)
+	constexpr bool isInRange(const Position& p, int32_t deltax, int32_t deltay) const
 	{
-		return Position::getDistanceX(p1, p2) <= deltax && Position::getDistanceY(p1, p2) <= deltay;
+		return getDistanceX(p) <= deltax && getDistanceY(p) <= deltay;
 	}
 
-	template <int_fast32_t deltax, int_fast32_t deltay, int_fast16_t deltaz>
-	static bool areInRange(const Position& p1, const Position& p2)
+	constexpr bool isInRange(const Position& p, int32_t deltax, int32_t deltay, int16_t deltaz) const
 	{
-		return Position::getDistanceX(p1, p2) <= deltax && Position::getDistanceY(p1, p2) <= deltay &&
-		       Position::getDistanceZ(p1, p2) <= deltaz;
+		return getDistanceX(p) <= deltax && getDistanceY(p) <= deltay && getDistanceZ(p) <= deltaz;
 	}
 
-	static bool areInRange(const Position& p1, const Position& p2, int_fast32_t deltax, int_fast32_t deltay)
-	{
-		return Position::getDistanceX(p1, p2) <= deltax && Position::getDistanceY(p1, p2) <= deltay;
-	}
+	constexpr int32_t getOffsetX(const Position& p) const { return getX() - p.getX(); }
+	constexpr int32_t getOffsetY(const Position& p) const { return getY() - p.getY(); }
+	constexpr int16_t getOffsetZ(const Position& p) const { return getZ() - p.getZ(); }
 
-	static int_fast32_t getOffsetX(const Position& p1, const Position& p2) { return p1.getX() - p2.getX(); }
-	static int_fast32_t getOffsetY(const Position& p1, const Position& p2) { return p1.getY() - p2.getY(); }
-	static int_fast16_t getOffsetZ(const Position& p1, const Position& p2) { return p1.getZ() - p2.getZ(); }
-
-	static int32_t getDistanceX(const Position& p1, const Position& p2)
-	{
-		return std::abs(Position::getOffsetX(p1, p2));
-	}
-	static int32_t getDistanceY(const Position& p1, const Position& p2)
-	{
-		return std::abs(Position::getOffsetY(p1, p2));
-	}
-	static int16_t getDistanceZ(const Position& p1, const Position& p2)
-	{
-		return static_cast<int16_t>(std::abs(Position::getOffsetZ(p1, p2)));
-	}
+	constexpr int32_t getDistanceX(const Position& p) const { return std::abs(getOffsetX(p)); }
+	constexpr int32_t getDistanceY(const Position& p) const { return std::abs(getOffsetY(p)); }
+	constexpr int16_t getDistanceZ(const Position& p) const { return std::abs(getOffsetZ(p)); }
 
 	uint16_t x = 0;
 	uint16_t y = 0;
 	uint8_t z = 0;
 
-	bool operator<(const Position& p) const
-	{
-		if (z < p.z) {
-			return true;
-		}
+	constexpr bool operator==(const Position& p) const { return std::tie(x, y, z) == std::tie(p.x, p.y, p.z); }
+	constexpr bool operator!=(const Position& p) const { return std::tie(x, y, z) != std::tie(p.x, p.y, p.z); }
+	constexpr bool operator<(const Position& p) const { return std::tie(z, y, x) < std::tie(p.z, p.y, p.x); }
 
-		if (z > p.z) {
-			return false;
-		}
-
-		if (y < p.y) {
-			return true;
-		}
-
-		if (y > p.y) {
-			return false;
-		}
-
-		if (x < p.x) {
-			return true;
-		}
-
-		if (x > p.x) {
-			return false;
-		}
-
-		return false;
-	}
-
-	bool operator==(const Position& p) const { return p.x == x && p.y == y && p.z == z; }
-
-	bool operator!=(const Position& p) const { return p.x != x || p.y != y || p.z != z; }
-
-	int_fast32_t getX() const { return x; }
-	int_fast32_t getY() const { return y; }
-	int_fast16_t getZ() const { return z; }
+	constexpr int32_t getX() const { return x; }
+	constexpr int32_t getY() const { return y; }
+	constexpr int16_t getZ() const { return z; }
 };
 
 std::ostream& operator<<(std::ostream&, const Position&);

--- a/src/position.h
+++ b/src/position.h
@@ -21,6 +21,12 @@ enum Direction : uint8_t
 	DIRECTION_NONE = 8,
 };
 
+namespace tfs {
+
+inline constexpr auto abs(std::integral auto num) { return num < 0 ? -num : num; }
+
+} // namespace tfs
+
 struct Position
 {
 	constexpr Position() = default;
@@ -40,9 +46,9 @@ struct Position
 	constexpr int32_t getOffsetY(const Position& p) const { return getY() - p.getY(); }
 	constexpr int16_t getOffsetZ(const Position& p) const { return getZ() - p.getZ(); }
 
-	constexpr int32_t getDistanceX(const Position& p) const { return std::abs(getOffsetX(p)); }
-	constexpr int32_t getDistanceY(const Position& p) const { return std::abs(getOffsetY(p)); }
-	constexpr int16_t getDistanceZ(const Position& p) const { return std::abs(getOffsetZ(p)); }
+	constexpr int32_t getDistanceX(const Position& p) const { return tfs::abs(getOffsetX(p)); }
+	constexpr int32_t getDistanceY(const Position& p) const { return tfs::abs(getOffsetY(p)); }
+	constexpr int16_t getDistanceZ(const Position& p) const { return tfs::abs(getOffsetZ(p)); }
 
 	uint16_t x = 0;
 	uint16_t y = 0;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -359,7 +359,7 @@ Direction getDirectionTo(const Position& from, const Position& to)
 
 	Direction dir;
 
-	int32_t x_offset = Position::getOffsetX(from, to);
+	int32_t x_offset = to.getOffsetX(from);
 	if (x_offset < 0) {
 		dir = DIRECTION_EAST;
 		x_offset = std::abs(x_offset);
@@ -367,7 +367,7 @@ Direction getDirectionTo(const Position& from, const Position& to)
 		dir = DIRECTION_WEST;
 	}
 
-	int32_t y_offset = Position::getOffsetY(from, to);
+	int32_t y_offset = to.getOffsetY(from);
 	if (y_offset >= 0) {
 		if (y_offset > x_offset) {
 			dir = DIRECTION_NORTH;

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -253,8 +253,7 @@ int32_t Weapon::playerWeaponCheck(Player* player, Creature* target, uint8_t shoo
 		return 0;
 	}
 
-	if (std::max<uint32_t>(Position::getDistanceX(playerPos, targetPos), Position::getDistanceY(playerPos, targetPos)) >
-	    shootRange) {
+	if (std::max(playerPos.getDistanceX(targetPos), targetPos.getDistanceY(playerPos)) > shootRange) {
 		return 0;
 	}
 
@@ -353,7 +352,7 @@ bool Weapon::useWeapon(Player* player, Item* item, Creature* target) const
 
 bool Weapon::useFist(Player* player, Creature* target)
 {
-	if (!Position::areInRange<1, 1>(player->getPosition(), target->getPosition())) {
+	if (!player->getPosition().isInRange(target->getPosition(), 1, 1)) {
 		return false;
 	}
 
@@ -678,8 +677,7 @@ bool WeaponDistance::useWeapon(Player* player, Item* item, Creature* target) con
 		uint32_t skill = player->getSkillLevel(SKILL_DISTANCE);
 		const Position& playerPos = player->getPosition();
 		const Position& targetPos = target->getPosition();
-		uint32_t distance = std::max<uint32_t>(Position::getDistanceX(playerPos, targetPos),
-		                                       Position::getDistanceY(playerPos, targetPos));
+		int32_t distance = std::max(playerPos.getDistanceX(targetPos), playerPos.getDistanceY(targetPos));
 
 		uint32_t maxHitChance;
 		if (it.maxHitChance != -1) {
@@ -787,7 +785,7 @@ bool WeaponDistance::useWeapon(Player* player, Item* item, Creature* target) con
 		// miss target
 		Tile* destTile = target->getTile();
 
-		if (!Position::areInRange<1, 1, 0>(player->getPosition(), target->getPosition())) {
+		if (!player->getPosition().isInRange(target->getPosition(), 1, 1, 0)) {
 			static std::vector<std::pair<int32_t, int32_t>> destList{{-1, -1}, {0, -1}, {1, -1}, {-1, 0}, {0, 0},
 			                                                         {1, 0},   {-1, 1}, {0, 1},  {1, 1}};
 			std::shuffle(destList.begin(), destList.end(), getRandomGenerator());


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

- Refactor static template functions to constexpr member functions for `Position`
- Drop unnecessary fast integer variants
- Remove redundant template parameter to `std::max`/`std::min` where applicable

Performance should be identical or slightly better due to less accidental size conversion, but the readability improves (IMO significantly)

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
