### PR TITLE
onStepOut FIXED

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -252,6 +252,11 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport /* 
 {
 	Tile& oldTile = *creature.getTile();
 
+	// If the tile does not have the creature it means that the creature is ready for elimination, we skip the move.
+	if (!oldTile.hasCreature(&creature)) {
+		return;
+	}
+
 	Position oldPos = oldTile.getPosition();
 	Position newPos = newTile.getPosition();
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1143,6 +1143,14 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 	}
 }
 
+bool Tile::hasCreature(Creature* creature) const
+{
+	if (const CreatureVector* creatures = getCreatures()) {
+		return std::find(creatures->begin(), creatures->end(), creature) != creatures->end();
+	}
+	return false;
+}
+
 void Tile::removeCreature(Creature* creature)
 {
 	g_game.map.getQTNode(tilePos.x, tilePos.y)->removeCreature(creature);

--- a/src/tile.h
+++ b/src/tile.h
@@ -210,6 +210,7 @@ public:
 
 	void removeThing(Thing* thing, uint32_t count) override final;
 
+	bool hasCreature(Creature* creature) const;
 	void removeCreature(Creature* creature);
 
 	int32_t getThingIndex(const Thing* thing) const override final;


### PR DESCRIPTION

### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Currently, there is a scenario where an `onStepOut` event moves the creature. So, when the creature is removed, the event is triggered, and immediately the `onStepOut` event will try to `move the creature`. However, when the creature is removed from the `tile`, the `onStepOut` event will call the `Map::moveCreature` method, which will try to `remove the creature` from the `tile` again and also attempt to update the `new tile`. This results in unexpected behavior and can lead to any undefined behavior, typically a crash.

This fixes the problem by ignoring the movements... perhaps more checks are needed?

### Steps to reproduce the problem:

Connect any player.
Place the character on top of anything that triggers the onStepOut event.
Test onStepOut event:
```lua
local leave = MoveEvent()

function leave.onStepOut(creature, item, pos, fromPosition)
    local player = creature:getPlayer()
    if player then player:teleportTo(player:getTown():getTemplePosition()) end
    return true
end

leave:aid(3000)
leave:register()

local talkAction = TalkAction("!test")

function talkAction.onSay(player, words, param, type)
    player:remove()
    return false
end

--talkAction:accountType(ACCOUNT_TYPE_GOD)
--talkAction:access(true)
--talkAction:separator(" ")
talkAction:register()
```
- You can use the !test command to delete or simply logout.
- Next you could find a crash server or bugged client

**Issues addressed:** Nothing!