### PR TITLE
onConnectionRestoration event

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -149,6 +149,10 @@ do
 			self:type("login")
 			self:onLogin(value)
 			return
+		elseif key == "onConnectionRestoration" then
+			self:type("connectionrestoration")
+			self:onConnectionRestoration(value)
+			return
 		elseif key == "onLogout" then
 			self:type("logout")
 			self:onLogout(value)

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -15,6 +15,7 @@ enum CreatureEventType_t
 {
 	CREATURE_EVENT_NONE,
 	CREATURE_EVENT_LOGIN,
+	CREATURE_EVENT_CONNECTIONRESTORATION,
 	CREATURE_EVENT_LOGOUT,
 	CREATURE_EVENT_THINK,
 	CREATURE_EVENT_PREPAREDEATH,
@@ -47,6 +48,7 @@ public:
 
 	// scripting
 	bool executeOnLogin(Player* player) const;
+	bool executeOnConnectionRestoration(Player* player) const;
 	bool executeOnLogout(Player* player) const;
 	bool executeOnThink(Creature* creature, uint32_t interval);
 	bool executeOnPrepareDeath(Creature* creature, Creature* killer);
@@ -80,6 +82,7 @@ public:
 
 	// global events
 	bool playerLogin(Player* player) const;
+	bool playerConnectionRestoration(Player* player) const;
 	bool playerLogout(Player* player) const;
 	bool playerAdvance(Player* player, skills_t, uint32_t, uint32_t);
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3278,6 +3278,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("CreatureEvent", "type", LuaScriptInterface::luaCreatureEventType);
 	registerMethod("CreatureEvent", "register", LuaScriptInterface::luaCreatureEventRegister);
 	registerMethod("CreatureEvent", "onLogin", LuaScriptInterface::luaCreatureEventOnCallback);
+	registerMethod("CreatureEvent", "onConnectionRestoration", LuaScriptInterface::luaCreatureEventOnCallback);
 	registerMethod("CreatureEvent", "onLogout", LuaScriptInterface::luaCreatureEventOnCallback);
 	registerMethod("CreatureEvent", "onThink", LuaScriptInterface::luaCreatureEventOnCallback);
 	registerMethod("CreatureEvent", "onPrepareDeath", LuaScriptInterface::luaCreatureEventOnCallback);
@@ -17087,6 +17088,8 @@ int LuaScriptInterface::luaCreatureEventType(lua_State* L)
 			creature->setEventType(CREATURE_EVENT_LOGIN);
 		} else if (tmpStr == "logout") {
 			creature->setEventType(CREATURE_EVENT_LOGOUT);
+		} else if (tmpStr == "connectionrestoration") {
+			creature->setEventType(CREATURE_EVENT_CONNECTIONRESTORATION);
 		} else if (tmpStr == "think") {
 			creature->setEventType(CREATURE_EVENT_THINK);
 		} else if (tmpStr == "preparedeath") {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3675,6 +3675,14 @@ void Player::onPlacedCreature()
 	}
 }
 
+void Player::onConnectionRestoration()
+{
+	// scripting event - onConnectionRestoration
+	if (!g_creatureEvents->playerConnectionRestoration(this)) {
+		kickPlayer(true);
+	}
+}
+
 void Player::onAttackedCreatureDrainHealth(Creature* target, int32_t points)
 {
 	Creature::onAttackedCreatureDrainHealth(target, points);

--- a/src/player.h
+++ b/src/player.h
@@ -508,6 +508,7 @@ public:
 	void onAttackedCreatureChangeZone(ZoneType_t zone) override;
 	void onIdleStatus() override;
 	void onPlacedCreature() override;
+	void onConnectionRestoration();
 
 	LightInfo getCreatureLight() const override;
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -248,6 +248,10 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 			eventConnect = g_scheduler.addEvent(
 			    createSchedulerTask(1000, [=, thisPtr = getThis(), playerID = foundPlayer->getID()]() {
 				    thisPtr->connect(playerID, operatingSystem);
+				    Player* player = g_game.getPlayerByID(playerID);
+				    if (player) {
+					    player->onConnectionRestoration();
+				    }
 			    }));
 		} else {
 			connect(foundPlayer->getID(), operatingSystem);


### PR DESCRIPTION
### Pull Request Prelude

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
new CreatureEvent `onConnectionRestoration`
Handle switching game client without logout which is currently impossible.
example: call login CreatureEvent that will set bless icon status, after switching the client the icon will not be updated

```lua
local blessStatusLogin = CreatureEvent("blessStatusLogin")
function blessStatusLogin.onLogin(player)
	local blessCount = 0
	for b = 1, 5 do
		if player:hasBlessing(b) then
			blessCount = blessCount + 1
		end
	end

	local msg = NetworkMessage()
	msg:addByte(0x9C);
	if blessCount == 0 then
		msg:addU16(0)
		msg:addByte(1)
		msg:sendToPlayer(player)
		msg:delete()
		return true
	end

	local bits = bit.bor(4, 8, 16, 32, 64)
	if blessCount == 4 then
		msg:addU16(2)
		msg:addByte(2)
	elseif blessCount == 5 then
		msg:addU16(255)
		msg:addByte(3)
	end
	msg:sendToPlayer(player)
	msg:delete()
	return true
end
blessStatusLogin:register()

-- solution

local ce = CreatureEvent("blessStatusConnectionRestoration")
function ce.onConnectionRestoration(player)
	print("blessStatusConnectionRestoration")
	local blessCount = 0
	for b = 1, 5 do
		if player:hasBlessing(b) then
			blessCount = blessCount + 1
		end
	end

	local msg = NetworkMessage()
	msg:addByte(0x9C);
	if blessCount == 0 then
		msg:addU16(0)
		msg:addByte(1)
		msg:sendToPlayer(player)
		msg:delete()
		return true
	end

	local bits = bit.bor(4, 8, 16, 32, 64)
	if blessCount == 4 then
		msg:addU16(2)
		msg:addByte(2)
	elseif blessCount == 5 then
		msg:addU16(255)
		msg:addByte(3)
	end
	msg:sendToPlayer(player)
	msg:delete()
	return true
end
ce:register()
```

