### PR TITLE
Run clang-format with updated Ubuntu image

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,14 +23,16 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
 
-    container:
-      image: ubuntu:rolling
-
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup LLVM repository
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
+
       - name: Install dependencies
-        run: apt update -q && apt install -yq clang-format
+        run: sudo apt update -qq && sudo apt install -yqq clang-format
 
       - name: Check code style
         run: clang-format -n -style=file --Werror src/*.{cpp,h}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt update -q && sudo apt install -yq clang-format
+        run: apt update -q && apt install -yq clang-format
 
       - name: Check code style
         run: clang-format -n -style=file --Werror src/*.{cpp,h}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,6 +18,10 @@ on:
 jobs:
   check-format:
     runs-on: ubuntu-latest
+
+    container:
+      image: ubuntu:rolling
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,12 +8,16 @@ on:
 
     paths:
       - .clang-format
+      - .github/workflows/clang-format.yml
       - src/**
 
   pull_request:
     paths:
       - .clang-format
+      - .github/workflows/clang-format.yml
       - src/**
+
+  workflow_dispatch:
 
 jobs:
   check-format:

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -597,7 +597,7 @@ bool Houses::loadHousesXML(const std::string& filename)
 		                  pugi::cast<uint16_t>(houseNode.attribute("entryy").value()),
 		                  pugi::cast<uint16_t>(houseNode.attribute("entryz").value()));
 		if (entryPos.x == 0 && entryPos.y == 0 && entryPos.z == 0) {
-			std::cout << "[Warning - Houses::loadHousesXML] House entry not set" << " - Name: " << house->getName()
+			std::cout << "[Warning - Houses::loadHousesXML] House entry not set - Name: " << house->getName()
 			          << " - House id: " << houseId << std::endl;
 		}
 		house->setEntryPos(entryPos);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

After #4654 the prehistoric Ubuntu used by Github Actions runs clang-format 4 major versions outdated and fails to accept the formatted files. This is an attempt to run a more up-to-date version of Ubuntu and not have this issue.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
