### PR TITLE
Add random session tokens

### DIFF
--- a/data/migrations/36.lua
+++ b/data/migrations/36.lua
@@ -4,13 +4,13 @@ function onUpdateDatabase()
 	db.query([[
 		CREATE TABLE IF NOT EXISTS `sessions` (
 			`id` int NOT NULL AUTO_INCREMENT,
-			`session_token` binary(16) NOT NULL,
+			`token` binary(16) NOT NULL,
 			`account_id` int NOT NULL,
 			`ip` varbinary(16) NOT NULL,
 			`created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			`expired_at` timestamp,
 			PRIMARY KEY (`id`),
-			UNIQUE KEY `session_token` (`session_token`),
+			UNIQUE KEY `token` (`token`),
 			FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE
 		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 	]])

--- a/data/migrations/36.lua
+++ b/data/migrations/36.lua
@@ -1,3 +1,23 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 37 (session tokens)")
+
+	db.query([[
+		CREATE TABLE IF NOT EXISTS `sessions` (
+			`id` int NOT NULL AUTO_INCREMENT,
+			`session_token` binary(16) NOT NULL,
+			`account_id` int NOT NULL,
+			`ip` varbinary(16) NOT NULL,
+			`created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			`expired_at` timestamp,
+			PRIMARY KEY (`id`),
+			UNIQUE KEY `session_token` (`session_token`),
+			FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+	]])
+
+	db.query([[
+		ALTER TABLE `players_online`
+			ADD COLUMN `session_id` int NOT NULL,
+			ADD FOREIGN KEY (`session_id`) REFERENCES `sessions` (`id`) ON DELETE CASCADE;
+	]])
 end

--- a/data/migrations/37.lua
+++ b/data/migrations/37.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -266,7 +266,9 @@ CREATE TABLE IF NOT EXISTS `market_offers` (
 
 CREATE TABLE IF NOT EXISTS `players_online` (
   `player_id` int NOT NULL,
-  PRIMARY KEY (`player_id`)
+  `session_id` int NOT NULL,
+  PRIMARY KEY (`player_id`),
+  FOREIGN KEY (`session_id`) REFERENCES `sessions` (`id`) ON DELETE CASCADE
 ) ENGINE=MEMORY DEFAULT CHARACTER SET=utf8;
 
 CREATE TABLE IF NOT EXISTS `player_deaths` (
@@ -361,6 +363,18 @@ CREATE TABLE IF NOT EXISTS `server_config` (
   `config` varchar(50) NOT NULL,
   `value` varchar(256) NOT NULL DEFAULT '',
   PRIMARY KEY `config` (`config`)
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+
+CREATE TABLE IF NOT EXISTS `sessions` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `session_token` binary(16) NOT NULL,
+  `account_id` int NOT NULL,
+  `ip` varbinary(16) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `expired_at` timestamp,
+  PRIMARY KEY (`session_id`),
+  UNIQUE KEY `session_id` (`session_id`),
+  FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
 CREATE TABLE IF NOT EXISTS `tile_store` (

--- a/schema.sql
+++ b/schema.sql
@@ -367,13 +367,13 @@ CREATE TABLE IF NOT EXISTS `server_config` (
 
 CREATE TABLE IF NOT EXISTS `sessions` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `session_token` binary(16) NOT NULL,
+  `token` binary(16) NOT NULL,
   `account_id` int NOT NULL,
   `ip` varbinary(16) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `expired_at` timestamp,
-  PRIMARY KEY (`session_id`),
-  UNIQUE KEY `session_id` (`session_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`),
   FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/otpch.cpp
 	${CMAKE_CURRENT_LIST_DIR}/actions.cpp
 	${CMAKE_CURRENT_LIST_DIR}/ban.cpp
+	${CMAKE_CURRENT_LIST_DIR}/base64.cpp
 	${CMAKE_CURRENT_LIST_DIR}/baseevents.cpp
 	${CMAKE_CURRENT_LIST_DIR}/bed.cpp
 	${CMAKE_CURRENT_LIST_DIR}/chat.cpp
@@ -82,6 +83,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/account.h
 	${CMAKE_CURRENT_LIST_DIR}/actions.h
 	${CMAKE_CURRENT_LIST_DIR}/ban.h
+	${CMAKE_CURRENT_LIST_DIR}/base64.h
 	${CMAKE_CURRENT_LIST_DIR}/baseevents.h
 	${CMAKE_CURRENT_LIST_DIR}/bed.h
 	${CMAKE_CURRENT_LIST_DIR}/chat.h

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -1,0 +1,35 @@
+#include "otpch.h"
+
+#include "base64.h"
+
+#include <openssl/evp.h>
+
+std::string tfs::base64::encode(std::string_view input)
+{
+	std::unique_ptr<BIO, decltype(&BIO_free_all)> b64(BIO_new(BIO_f_base64()), BIO_free_all);
+	BIO_set_flags(b64.get(), BIO_FLAGS_BASE64_NO_NL);
+
+	BIO* sink = BIO_new(BIO_s_mem());
+	BIO_push(b64.get(), sink);
+	BIO_write(b64.get(), input.data(), input.size());
+	BIO_flush(b64.get());
+
+	const char* encoded;
+	auto len = BIO_get_mem_data(sink, &encoded);
+	return {encoded, static_cast<size_t>(len)};
+}
+
+std::string tfs::base64::decode(std::string_view input)
+{
+	std::unique_ptr<BIO, decltype(&BIO_free_all)> b64(BIO_new(BIO_f_base64()), BIO_free_all);
+	BIO_set_flags(b64.get(), BIO_FLAGS_BASE64_NO_NL);
+
+	BIO* source = BIO_new_mem_buf(input.data(), input.size()); // read-only source
+	BIO_push(b64.get(), source);
+
+	size_t decodedLength = 3 * input.size() / 4;
+	auto decoded = std::string(decodedLength, '\0');
+
+	const int len = BIO_read(b64.get(), decoded.data(), decodedLength);
+	return decoded.substr(0, len);
+}

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,0 +1,11 @@
+#ifndef TFS_BASE64_H
+#define TFS_BASE64_H
+
+namespace tfs::base64 {
+
+std::string encode(std::string_view input);
+std::string decode(std::string_view input);
+
+} // namespace tfs::base64
+
+#endif

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -20,10 +20,6 @@ public:
 	static Account loadAccount(uint32_t accno);
 
 	static bool loginserverAuthentication(const std::string& name, const std::string& password, Account& account);
-	static std::pair<uint32_t, uint32_t> gameworldAuthentication(std::string_view accountName,
-	                                                             std::string_view password,
-	                                                             std::string_view characterName, std::string_view token,
-	                                                             uint32_t tokenTime);
 	static uint32_t getAccountIdByPlayerName(const std::string& playerName);
 	static uint32_t getAccountIdByPlayerId(uint32_t playerId);
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -440,7 +440,6 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	if (ip != boost::asio::ip::make_address(result->getString("session_ip"))) {
-		// TODO: get the correct message
 		disconnectClient("Your game session is already locked to a different IP. Please log in again.");
 		return;
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -441,7 +441,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 
 	if (ip != boost::asio::ip::make_address(result->getString("session_ip"))) {
 		// TODO: get the correct message
-		disconnectClient("Session key is not valid.");
+		disconnectClient("Your game session is already locked to a different IP. Please log in again.");
 		return;
 	}
 

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -53,7 +53,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	}
 
 	// Generate and add session key
-	static std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> rbe;
+	static std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned short> rbe;
 	std::array<char, 16> sessionKey;
 	std::generate(sessionKey.begin(), sessionKey.end(), std::ref(rbe));
 

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -61,7 +61,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	output->addString({sessionKey.data(), sessionKey.size()});
 
 	if (Database& db = Database::getInstance(); !db.executeQuery(fmt::format(
-	        "INSERT INTO `sessions` (`session_token`, `account_id`, `ip`) VALUES ({:s}, {:d}, INET6_ATON({:s}))",
+	        "INSERT INTO `sessions` (`token`, `account_id`, `ip`) VALUES ({:s}, {:d}, INET6_ATON({:s}))",
 	        db.escapeBlob(sessionKey.data(), sessionKey.size()), account.id, getConnection()->getIP().to_string()))) {
 		disconnectClient("Failed to create session.\nPlease try again later.", version);
 		return;

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -6,6 +6,7 @@
 #include "protocollogin.h"
 
 #include "ban.h"
+#include "base64.h"
 #include "configmanager.h"
 #include "game.h"
 #include "iologindata.h"
@@ -54,11 +55,11 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 
 	// Generate and add session key
 	static std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned short> rbe;
-	std::array<char, 16> sessionKey;
+	std::string sessionKey(16, '\x00');
 	std::generate(sessionKey.begin(), sessionKey.end(), std::ref(rbe));
 
 	output->addByte(0x28);
-	output->addString({sessionKey.data(), sessionKey.size()});
+	output->addString(tfs::base64::encode({sessionKey.data(), sessionKey.size()}));
 
 	if (Database& db = Database::getInstance(); !db.executeQuery(fmt::format(
 	        "INSERT INTO `sessions` (`token`, `account_id`, `ip`) VALUES ({:s}, {:d}, INET6_ATON({:s}))",

--- a/src/tests/test_base64.cpp
+++ b/src/tests/test_base64.cpp
@@ -1,0 +1,41 @@
+#define BOOST_TEST_MODULE base64
+
+#include "../otpch.h"
+
+#include "../base64.h"
+
+#include <boost/test/unit_test.hpp>
+
+struct Basee64Fixture
+{
+	std::string_view plain;
+	std::string_view encoded;
+};
+
+// test vectors from https://datatracker.ietf.org/doc/html/rfc4648#section-10
+auto testVectors = std::vector<Basee64Fixture>{
+    {.plain = "", .encoded = ""},
+    {.plain = "f", .encoded = "Zg=="},
+    {.plain = "fo", .encoded = "Zm8="},
+    {.plain = "foo", .encoded = "Zm9v"},
+    {.plain = "foob", .encoded = "Zm9vYg=="},
+    {.plain = "fooba", .encoded = "Zm9vYmE="},
+    {.plain = "foobar", .encoded = "Zm9vYmFy"},
+
+};
+
+BOOST_AUTO_TEST_CASE(test_base64_encode)
+{
+	for (auto&& [plain, encoded] : testVectors) {
+		std::string result = tfs::base64::encode(plain);
+		BOOST_TEST(result == encoded, "expected '" << encoded << "', got '" << result << "'");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(test_base64_decode)
+{
+	for (auto&& [plain, encoded] : testVectors) {
+		std::string result = tfs::base64::decode(encoded);
+		BOOST_TEST(result == plain, "expected '" << plain << "', got '" << result << "'");
+	}
+}

--- a/vc17/theforgottenserver.vcxproj
+++ b/vc17/theforgottenserver.vcxproj
@@ -163,6 +163,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\actions.cpp" />
     <ClCompile Include="..\src\ban.cpp" />
+    <ClCompile Include="..\src\base64.cpp" />
     <ClCompile Include="..\src\baseevents.cpp" />
     <ClCompile Include="..\src\bed.cpp" />
     <ClCompile Include="..\src\chat.cpp" />
@@ -249,6 +250,7 @@
     <ClInclude Include="..\src\account.h" />
     <ClInclude Include="..\src\actions.h" />
     <ClInclude Include="..\src\ban.h" />
+    <ClInclude Include="..\src\base64.h" />
     <ClInclude Include="..\src\baseevents.h" />
     <ClInclude Include="..\src\bed.h" />
     <ClInclude Include="..\src\chat.h" />


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Currently we use a fixed session token that is insecure if sniffed, since it contains plaintext username and password, and vulnerable to replay attacks, although extremely unlikely.

Changing this to a random session token, without any account information, is both safer and integrates better with external tools, while also (slightly) improving game login performance, since there's no verification needed - 16 random bytes is enough that it can't be guessed.

This is not ready yet, I can't test it since I'm not on my PC and there are two disconnection messages that need fixing.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
