### PR TITLE
onDeEquip properly handled at logout/death

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1250,6 +1250,13 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 	Creature::onRemoveCreature(creature, isLogout);
 
 	if (creature == this) {
+		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+			Item* item = inventory[slot];
+			if (item) {
+				g_moveEvents->onPlayerDeEquip(this, item, static_cast<slots_t>(slot));
+			}
+		}
+
 		if (isLogout) {
 			loginPosition = getPosition();
 		}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
We didn't deequip items on logout/death but we equip everytime the player login.
That way onDeEquip didn't work correctly as intended.
following example code shows what the problem is:
```lua
function onEquip(player, item, slot)
    player:setMaxHealth(player:getMaxHealth() + 100)
    return true
end

function onDeEquip(player, item, slot)
    player:setMaxHealth(player:getMaxHealth() - 100)
    return true
end
```
The above would have resulted on every logout/login that the HP would increase by 100 but not decrease on logout/death
which is now fixed

**Issues addressed:** <!-- Write here the issue number, if any. -->
none


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
