### PR TITLE
Use single shared lua interface for all npc

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -424,6 +424,27 @@ int32_t LuaScriptInterface::getMetaEvent(const std::string& globalName, const st
 	return runningEventId++;
 }
 
+void LuaScriptInterface::removeEvent(int32_t scriptId)
+{
+	if (scriptId == -1) {
+		return;
+	}
+
+	// get our events table
+	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
+	if (!isTable(luaState, -1)) {
+		lua_pop(luaState, 1);
+		return;
+	}
+
+	// remove event from table
+	lua_pushnil(luaState);
+	lua_rawseti(luaState, -2, scriptId);
+	lua_pop(luaState, 1);
+
+	cacheFiles.erase(scriptId);
+}
+
 const std::string& LuaScriptInterface::getFileById(int32_t scriptId)
 {
 	if (scriptId == EVENT_ID_LOADING) {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -178,6 +178,7 @@ public:
 	int32_t getEvent(std::string_view eventName);
 	int32_t getEvent();
 	int32_t getMetaEvent(const std::string& globalName, const std::string& eventName);
+	void removeEvent(int32_t scriptId);
 
 	static ScriptEnvironment* getScriptEnv()
 	{

--- a/src/npc.h
+++ b/src/npc.h
@@ -10,11 +10,11 @@
 class Npc;
 class Player;
 
-class Npcs
-{
-public:
-	static void reload();
-};
+namespace Npcs {
+void load(bool reload = false);
+
+void reload();
+} // namespace Npcs
 
 class NpcScriptInterface final : public LuaScriptInterface
 {
@@ -57,6 +57,7 @@ class NpcEventsHandler
 {
 public:
 	NpcEventsHandler(const std::string& file, Npc* npc);
+	~NpcEventsHandler();
 
 	void onCreatureAppear(Creature* creature);
 	void onCreatureDisappear(Creature* creature);
@@ -70,7 +71,7 @@ public:
 
 	bool isLoaded() const;
 
-	std::unique_ptr<NpcScriptInterface> scriptInterface;
+	std::shared_ptr<NpcScriptInterface> scriptInterface;
 
 private:
 	Npc* npc;
@@ -156,6 +157,8 @@ public:
 
 	const auto& getSpectators() { return spectators; }
 
+	void closeAllShopWindows();
+
 private:
 	explicit Npc(const std::string& name);
 
@@ -183,7 +186,6 @@ private:
 
 	void addShopPlayer(Player* player);
 	void removeShopPlayer(Player* player);
-	void closeAllShopWindows();
 
 	std::map<std::string, std::string> parameters;
 
@@ -210,7 +212,6 @@ private:
 	bool isIdle;
 	bool pushable;
 
-	friend class Npcs;
 	friend class NpcScriptInterface;
 };
 


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
A while ago this PR was merged: #4483 and it fixes the memory leak problem with NPCs very well, however that PR includes the creation of a separate instance of NpcLuaScriptInterface, when in reality we can use a single one that is shared with everyone the NPCs, so this PR adds this possibility

- The `Npcs class` has been removed for an `Npcs namespace`, I decided to make this change because it is not possible to have a static shared pointer and this class does not have any singletons to reuse.

- Added a destructor to the `NpcEventsHandler` class to remove loaded event ids from the npc lua interface reference table. (inspired by #3553)

- Now when we do `/reload npc`, the libraries will also be reloaded. It was always annoying to have to restart the server to be able to test changes to the libraries when we are in development. I don't know if maybe we should move it to the `global reload type`?

- Tested with the following simple script:
```lua
local talkAction = TalkAction("!npcs")

function talkAction.onSay(player, words, param, type)
	local pos = player:getPosition()
	local npcs = {}
	for i = 1, 1000 do
		Game.createNpc("Deruno", Position(pos.x + math.random(-5, 5), pos.y + math.random(-5, 5), pos.z)):remove()
	end

	return false
end

talkAction:register()
```

and reloads...

**Issues addressed:** Nothing!