### PR TITLE
Fix inverted positions introduced in #4648

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1214,8 +1214,8 @@ void TargetCallback::onTargetCombat(Creature* creature, Creature* target) const
 
 const MatrixArea& AreaCombat::getArea(const Position& centerPos, const Position& targetPos) const
 {
-	int32_t dx = centerPos.getOffsetX(targetPos);
-	int32_t dy = centerPos.getOffsetY(targetPos);
+	int32_t dx = targetPos.getOffsetX(centerPos);
+	int32_t dy = targetPos.getOffsetY(centerPos);
 
 	Direction dir;
 	if (dx < 0) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -355,8 +355,8 @@ void Creature::updateTileCache(const Tile* tile, const Position& pos)
 {
 	const Position& myPos = getPosition();
 	if (pos.z == myPos.z) {
-		int32_t dx = myPos.getOffsetX(pos);
-		int32_t dy = myPos.getOffsetY(pos);
+		int32_t dx = pos.getOffsetX(myPos);
+		int32_t dy = pos.getOffsetY(myPos);
 		updateTileCache(tile, dx, dy);
 	}
 }
@@ -376,8 +376,8 @@ int32_t Creature::getWalkCache(const Position& pos) const
 		return 1;
 	}
 
-	if (int32_t dx = myPos.getOffsetX(pos); std::abs(dx) <= maxWalkCacheWidth) {
-		if (int32_t dy = myPos.getOffsetY(pos); std::abs(dy) <= maxWalkCacheHeight) {
+	if (int32_t dx = pos.getOffsetX(myPos); std::abs(dx) <= maxWalkCacheWidth) {
+		if (int32_t dy = pos.getOffsetY(myPos); std::abs(dy) <= maxWalkCacheHeight) {
 			if (localMapCache[maxWalkCacheHeight + dy][maxWalkCacheWidth + dx]) {
 				return 1;
 			}
@@ -489,7 +489,7 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 			if (oldPos.z != newPos.z) {
 				// floor change extra cost
 				lastStepCost = 2;
-			} else if (newPos.getDistanceX(oldPos) >= 1 && oldPos.getDistanceY(newPos) >= 1) {
+			} else if (newPos.getDistanceX(oldPos) >= 1 && newPos.getDistanceY(oldPos) >= 1) {
 				// diagonal extra cost
 				lastStepCost = 3;
 			}
@@ -502,7 +502,7 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 			std::forward_list<Creature*> despawnList;
 			for (Creature* summon : summons) {
 				const Position& pos = summon->getPosition();
-				if (newPos.getDistanceZ(pos) > 2 || std::max(newPos.getDistanceX(pos), pos.getDistanceY(newPos)) > 30) {
+				if (newPos.getDistanceZ(pos) > 2 || std::max(newPos.getDistanceX(pos), newPos.getDistanceY(pos)) > 30) {
 					despawnList.push_front(summon);
 				}
 			}
@@ -1589,7 +1589,7 @@ bool FrozenPathingConditionCall::isInRange(const Position& startPos, const Posit
 			return false;
 		}
 	} else {
-		int32_t dx = targetPos.getOffsetX(startPos);
+		int32_t dx = startPos.getOffsetX(targetPos);
 
 		int32_t dxMax = (dx >= 0 ? fpp.maxTargetDist : 0);
 		if (testPos.x > targetPos.x + dxMax) {
@@ -1601,7 +1601,7 @@ bool FrozenPathingConditionCall::isInRange(const Position& startPos, const Posit
 			return false;
 		}
 
-		int32_t dy = targetPos.getOffsetY(startPos);
+		int32_t dy = startPos.getOffsetY(targetPos);
 
 		int32_t dyMax = (dy >= 0 ? fpp.maxTargetDist : 0);
 		if (testPos.y > targetPos.y + dyMax) {
@@ -1627,7 +1627,7 @@ bool FrozenPathingConditionCall::operator()(const Position& startPos, const Posi
 		return false;
 	}
 
-	int32_t testDist = std::max(targetPos.getDistanceX(testPos), testPos.getDistanceY(targetPos));
+	int32_t testDist = std::max(targetPos.getDistanceX(testPos), targetPos.getDistanceY(testPos));
 	if (fpp.maxTargetDist == 1) {
 		if (testDist < fpp.minTargetDist || testDist > fpp.maxTargetDist) {
 			return false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3173,7 +3173,7 @@ void Game::playerLookAt(uint32_t playerId, const Position& pos, uint8_t stackPos
 
 	int32_t lookDistance = -1;
 	if (thing != player) {
-		lookDistance = std::max(playerPos.getDistanceX(thingPos), thingPos.getDistanceY(playerPos));
+		lookDistance = std::max(playerPos.getDistanceX(thingPos), playerPos.getDistanceY(thingPos));
 		if (playerPos.z != thingPos.z) {
 			lookDistance += 15;
 		}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -367,7 +367,7 @@ void Map::getSpectatorsInternal(SpectatorVec& spectators, const Position& center
 						continue;
 					}
 
-					int16_t offsetZ = cpos.getOffsetZ(centerPos);
+					int16_t offsetZ = centerPos.getOffsetZ(cpos);
 					if ((min_y + offsetZ) > cpos.y || (max_y + offsetZ) < cpos.y || (min_x + offsetZ) > cpos.x ||
 					    (max_x + offsetZ) < cpos.x) {
 						continue;
@@ -491,7 +491,7 @@ bool Map::canThrowObjectTo(const Position& fromPos, const Position& toPos, bool 
                            bool sameFloor /*= false*/, int32_t rangex /*= Map::maxClientViewportX*/,
                            int32_t rangey /*= Map::maxClientViewportY*/) const
 {
-	if (fromPos.getDistanceX(toPos) > rangex || toPos.getDistanceY(fromPos) > rangey) {
+	if (fromPos.getDistanceX(toPos) > rangex || fromPos.getDistanceY(toPos) > rangey) {
 		return false;
 	}
 
@@ -575,7 +575,7 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 	// target is on the same floor
 	if (fromPos.z == toPos.z) {
 		// skip checks if toPos is next to us
-		if (fromPos.getDistanceX(toPos) < 2 && toPos.getDistanceY(fromPos) < 2) {
+		if (fromPos.getDistanceX(toPos) < 2 && fromPos.getDistanceY(toPos) < 2) {
 			return true;
 		}
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -518,11 +518,11 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 
 				if (++it != resultList.end()) {
 					const Position& targetPosition = target->getPosition();
-					int32_t minRange = myPos.getDistanceX(targetPosition) + targetPosition.getDistanceY(myPos);
+					int32_t minRange = myPos.getDistanceX(targetPosition) + myPos.getDistanceY(targetPosition);
 					do {
 						const Position& pos = (*it)->getPosition();
 
-						if (int32_t distance = myPos.getDistanceX(pos) + pos.getDistanceY(myPos); distance < minRange) {
+						if (int32_t distance = myPos.getDistanceX(pos) + myPos.getDistanceY(pos); distance < minRange) {
 							target = *it;
 							minRange = distance;
 						}
@@ -536,7 +536,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 					}
 
 					const Position& pos = creature->getPosition();
-					if (int32_t distance = myPos.getDistanceX(pos) + pos.getDistanceY(myPos); distance < minRange) {
+					if (int32_t distance = myPos.getDistanceX(pos) + myPos.getDistanceY(pos); distance < minRange) {
 						target = creature;
 						minRange = distance;
 					}
@@ -841,7 +841,7 @@ bool Monster::canUseAttack(const Position& pos, const Creature* target) const
 {
 	if (isHostile()) {
 		const Position& targetPos = target->getPosition();
-		uint32_t distance = std::max<uint32_t>(pos.getDistanceX(targetPos), targetPos.getDistanceY(pos));
+		uint32_t distance = std::max<uint32_t>(pos.getDistanceX(targetPos), pos.getDistanceY(targetPos));
 		for (const spellBlock_t& spellBlock : mType->info.attackSpells) {
 			if (spellBlock.range != 0 && distance <= spellBlock.range) {
 				return g_game.isSightClear(pos, targetPos, true);
@@ -1034,7 +1034,7 @@ bool Monster::walkToSpawn()
 		return false;
 	}
 
-	int32_t distance = std::max(position.getDistanceX(masterPos), masterPos.getDistanceY(position));
+	int32_t distance = std::max(position.getDistanceX(masterPos), position.getDistanceY(masterPos));
 	if (distance == 0) {
 		return false;
 	}
@@ -1231,8 +1231,8 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction, bo
 	assert(attackedCreature);
 	const Position& centerPos = attackedCreature->getPosition();
 
-	int32_t offset_x = centerPos.getOffsetX(creaturePos);
-	int32_t offset_y = centerPos.getOffsetY(creaturePos);
+	int32_t offset_x = creaturePos.getOffsetX(centerPos);
+	int32_t offset_y = creaturePos.getOffsetY(centerPos);
 
 	int32_t distance_x = std::abs(offset_x);
 	int32_t distance_y = std::abs(offset_y);
@@ -1330,8 +1330,8 @@ bool Monster::getDistanceStep(const Position& targetPos, Direction& direction, b
 		             // in that position)
 	}
 
-	int32_t offsetx = targetPos.getOffsetX(creaturePos);
-	int32_t offsety = targetPos.getOffsetY(creaturePos);
+	int32_t offsetx = creaturePos.getOffsetX(targetPos);
+	int32_t offsety = creaturePos.getOffsetY(targetPos);
 
 	if (dx <= 1 && dy <= 1) {
 		// seems like a target is near, it this case we need to slow down our movements (as a monster)

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -464,8 +464,8 @@ void Npc::turnToCreature(Creature* creature)
 {
 	const Position& creaturePos = creature->getPosition();
 	const Position& myPos = getPosition();
-	const auto dx = creaturePos.getOffsetX(myPos);
-	const auto dy = creaturePos.getOffsetY(myPos);
+	const auto dx = myPos.getOffsetX(creaturePos);
+	const auto dy = myPos.getOffsetY(creaturePos);
 
 	float tan;
 	if (dx != 0) {
@@ -689,7 +689,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 	if (npcPos.z != thingPos.z) {
 		lua_pushnumber(L, -1);
 	} else {
-		lua_pushnumber(L, std::max(npcPos.getDistanceX(thingPos), thingPos.getDistanceY(npcPos)));
+		lua_pushnumber(L, std::max(npcPos.getDistanceX(thingPos), npcPos.getDistanceY(thingPos)));
 	}
 	return 1;
 }

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -252,7 +252,7 @@ int32_t Weapon::playerWeaponCheck(Player* player, Creature* target, uint8_t shoo
 		return 0;
 	}
 
-	if (std::max(playerPos.getDistanceX(targetPos), targetPos.getDistanceY(playerPos)) > shootRange) {
+	if (std::max(playerPos.getDistanceX(targetPos), playerPos.getDistanceY(targetPos)) > shootRange) {
 		return 0;
 	}
 


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
I don't know if more tests are needed, but when this PR #4648 was merged apparently the npc, monsters always turn their back on the player, in fact there are things that seem to be broken, the directional spells don't work, if someone can check with `exevo vis hur` ect...

It was simply a pair of inverted variables.

**Issues addressed:** Nothing!