### PR TITLE
Fix classicAttackSpeed makes server lag (#4676)

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3394,7 +3394,8 @@ void Player::doAttacking(uint32_t)
 		if (!classicSpeed) {
 			setNextActionTask(task, false);
 		} else {
-			g_scheduler.addEvent(task);
+			g_scheduler.stopEvent(classicAttackEvent);
+			classicAttackEvent = g_scheduler.addEvent(task);
 		}
 
 		if (result) {

--- a/src/player.h
+++ b/src/player.h
@@ -1226,6 +1226,7 @@ private:
 	uint32_t magLevel = 0;
 	uint32_t actionTaskEvent = 0;
 	uint32_t walkTaskEvent = 0;
+	uint32_t classicAttackEvent = 0;
 	uint32_t MessageBufferTicks = 0;
 	uint32_t accountNumber = 0;
 	uint32_t guid = 0;


### PR DESCRIPTION
`classicAttackSpeed` algorithm is bugged and may generate infinite number of scheduler (dispatcher) events.
1. TFS calls Player::doAttacking every second for every player.
2. It creates new event `g_scheduler.addEvent(task);`, which calls `Player::doAttacking` again with `getAttackSpeed()` delay. So there is repeating event every 0.2 sec (with attack speed 200) and TFS still calls `Player::doAttacking` every second creating new event.
That way server can create infinite number of events for 1 player. 1 new event every second.

Often it all stops on `if ((OTSYS_TIME() - lastAttack) >= getAttackSpeed()) {` - player cannot attack as fast as these events execute, so if there is more than 1 dispatcher event for given player, it won't re-create it after execution (`addEvent` is inside that IF).
But if player uses melee weapon and his target is not within 1 sqm, his attack will never execute and `lastAttack` will never update, so it will be able to re-create events, even if there is more than 1 running in same time.

Fixed code limits number of scheduled `doAttacking` events to 1 per player.
