### PR TITLE
Replace boost::variant and tagged unions with std::variant

### DIFF
--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -125,7 +125,7 @@ public:
 		std::copy(addr, addr + sizeof(T), std::back_inserter(buffer));
 	}
 
-	void writeString(const std::string& str)
+	void writeString(std::string_view str)
 	{
 		size_t strLength = str.size();
 		if (strLength > std::numeric_limits<uint16_t>::max()) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1183,19 +1183,14 @@ void ItemAttributes::removeAttribute(itemAttrTypes type)
 		return;
 	}
 
-	auto prev_it = attributes.rbegin();
-	if ((*prev_it).type == type) {
-		attributes.pop_back();
-	} else {
-		auto it = prev_it, end = attributes.rend();
-		while (++it != end) {
-			if ((*it).type == type) {
-				(*it) = std::move(attributes.back());
-				attributes.pop_back();
-				break;
-			}
-		}
+	auto it =
+	    std::find_if(attributes.begin(), attributes.end(), [type](const Attribute& attr) { return attr.type == type; });
+	if (it == attributes.end()) {
+		return;
 	}
+
+	std::iter_swap(it, attributes.rbegin()); // swap with last element (to avoid moving all elements
+	attributes.pop_back();
 	attributeBits &= ~type;
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -670,10 +670,11 @@ public:
 		}
 		return items[id].name;
 	}
-	std::string_view getPluralName() const
+	std::string getPluralName() const
 	{
 		if (hasAttribute(ITEM_ATTRIBUTE_PLURALNAME)) {
-			return getStrAttr(ITEM_ATTRIBUTE_PLURALNAME);
+			auto pluralName = getStrAttr(ITEM_ATTRIBUTE_PLURALNAME);
+			return {pluralName.data(), pluralName.size()};
 		}
 		return items[id].getPluralName();
 	}

--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -116,7 +116,7 @@ bool Mailbox::getReceiver(Item* item, std::string& name) const
 		return false;
 	}
 
-	const std::string& text = item->getText();
+	std::string_view text = item->getText();
 	if (text.empty()) {
 		return false;
 	}

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -16,7 +16,6 @@
 #include <boost/asio.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <boost/lockfree/stack.hpp>
-#include <boost/variant.hpp>
 #include <cassert>
 #include <concepts>
 #include <condition_variable>

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3005,12 +3005,12 @@ void ProtocolGame::sendTextWindow(uint32_t windowTextId, Item* item, uint16_t ma
 		msg.add<uint16_t>(maxlen);
 		msg.addString(item->getText());
 	} else {
-		const std::string& text = item->getText();
+		std::string_view text = item->getText();
 		msg.add<uint16_t>(text.size());
 		msg.addString(text);
 	}
 
-	const std::string& writer = item->getWriter();
+	std::string_view writer = item->getWriter();
 	if (!writer.empty()) {
 		msg.addString(writer);
 	} else {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -872,7 +872,7 @@ itemAttrTypes stringToItemAttribute(const std::string& str)
 	return ITEM_ATTRIBUTE_NONE;
 }
 
-std::string getFirstLine(const std::string& str)
+std::string getFirstLine(std::string_view str)
 {
 	std::string firstLine;
 	firstLine.reserve(str.length());

--- a/src/tools.h
+++ b/src/tools.h
@@ -35,7 +35,7 @@ bool boolean_random(double probability = 0.5);
 Position getNextPosition(Direction direction, Position pos);
 Direction getDirectionTo(const Position& from, const Position& to);
 
-std::string getFirstLine(const std::string& str);
+std::string getFirstLine(std::string_view str);
 
 std::string formatDate(time_t time);
 std::string formatDateShort(time_t time);
@@ -74,6 +74,13 @@ SpellGroup_t stringToSpellGroup(const std::string& value);
 const std::vector<Direction>& getShuffleDirections();
 
 namespace tfs {
+
+// helper type for variant visitors
+template <class... Ts>
+struct visitors : Ts...
+{
+	using Ts::operator()...;
+};
 
 #if __has_cpp_attribute(__cpp_lib_to_underlying)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,6 @@
     "boost-locale",
     "boost-lockfree",
     "boost-system",
-    "boost-variant",
     "fmt",
     "libmariadb",
     "lua",


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

An effort to reduce the amount of code in headers and remove a dependency, uses `std::variant` to hold values that can have varying types. This is used for item attributes.

Added a `tfs::visitors` helper class to avoid writing verbose classes when using `std::visit`

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
