### PR TITLE
Use Guild shared_ptr instead of raw pointers

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -76,11 +76,9 @@ bool ChatChannel::addUser(Player& player)
 
 	// TODO: Move to script when guild channels can be scripted
 	if (id == CHANNEL_GUILD) {
-		if (const auto& guild = player.getGuild()) {
-			if (!guild->getMotd().empty()) {
-				g_scheduler.addEvent(
-				    createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
-			}
+		if (const auto& guild = player.getGuild(); !guild->getMotd().empty()) {
+			g_scheduler.addEvent(
+			    createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
 		}
 	}
 

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -476,7 +476,7 @@ bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::str
 	}
 
 	if (channelId == CHANNEL_GUILD) {
-		const auto rank = player.getGuildRank();
+		const auto& rank = player.getGuildRank();
 		if (rank && rank->level > 1) {
 			type = TALKTYPE_CHANNEL_O;
 		} else if (type != TALKTYPE_CHANNEL_Y) {

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -76,7 +76,7 @@ bool ChatChannel::addUser(Player& player)
 
 	// TODO: Move to script when guild channels can be scripted
 	if (id == CHANNEL_GUILD) {
-		if (const auto guild = player.getGuild()) {
+		if (const auto& guild = player.getGuild()) {
 			if (!guild->getMotd().empty()) {
 				g_scheduler.addEvent(
 				    createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
@@ -330,7 +330,7 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			if (const auto guild = player.getGuild()) {
+			if (const auto& guild = player.getGuild()) {
 				auto ret =
 				    guildChannels.emplace(std::make_pair(guild->getId(), ChatChannel(channelId, guild->getName())));
 				return &ret.first->second;
@@ -553,7 +553,7 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			if (const auto guild = player.getGuild()) {
+			if (const auto& guild = player.getGuild()) {
 				auto it = guildChannels.find(guild->getId());
 				if (it != guildChannels.end()) {
 					return &it->second;

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -374,7 +374,7 @@ bool Chat::deleteChannel(const Player& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			const auto guild = player.getGuild();
+			const auto& guild = player.getGuild();
 			if (!guild) {
 				return false;
 			}

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -76,10 +76,11 @@ bool ChatChannel::addUser(Player& player)
 
 	// TODO: Move to script when guild channels can be scripted
 	if (id == CHANNEL_GUILD) {
-		Guild* guild = player.getGuild();
-		if (guild && !guild->getMotd().empty()) {
-			g_scheduler.addEvent(
-			    createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
+		if (const auto guild = player.getGuild()) {
+			if (!guild->getMotd().empty()) {
+				g_scheduler.addEvent(
+				    createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
+			}
 		}
 	}
 
@@ -329,8 +330,7 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			Guild* guild = player.getGuild();
-			if (guild) {
+			if (const auto guild = player.getGuild()) {
 				auto ret =
 				    guildChannels.emplace(std::make_pair(guild->getId(), ChatChannel(channelId, guild->getName())));
 				return &ret.first->second;
@@ -376,7 +376,7 @@ bool Chat::deleteChannel(const Player& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			Guild* guild = player.getGuild();
+			const auto guild = player.getGuild();
 			if (!guild) {
 				return false;
 			}
@@ -478,7 +478,7 @@ bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::str
 	}
 
 	if (channelId == CHANNEL_GUILD) {
-		GuildRank_ptr rank = player.getGuildRank();
+		const auto rank = player.getGuildRank();
 		if (rank && rank->level > 1) {
 			type = TALKTYPE_CHANNEL_O;
 		} else if (type != TALKTYPE_CHANNEL_Y) {
@@ -553,8 +553,7 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			Guild* guild = player.getGuild();
-			if (guild) {
+			if (const auto guild = player.getGuild()) {
 				auto it = guildChannels.find(guild->getId());
 				if (it != guildChannels.end()) {
 					return &it->second;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5061,7 +5061,7 @@ void Game::sendGuildMotd(uint32_t playerId)
 		return;
 	}
 
-	if (const auto guild = player->getGuild()) {
+	if (const auto& guild = player->getGuild()) {
 		player->sendChannelMessage("Message of the Day", guild->getMotd(), TALKTYPE_CHANNEL_R1, CHANNEL_GUILD);
 	}
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -61,12 +61,7 @@ Game::Game()
 	offlineTrainingWindow.priority = true;
 }
 
-Game::~Game()
-{
-	for (const auto& it : guilds) {
-		delete it.second;
-	}
-}
+Game::~Game() = default;
 
 void Game::start(ServiceManager* manager)
 {
@@ -5066,8 +5061,7 @@ void Game::sendGuildMotd(uint32_t playerId)
 		return;
 	}
 
-	Guild* guild = player->getGuild();
-	if (guild) {
+	if (const auto guild = player->getGuild()) {
 		player->sendChannelMessage("Message of the Day", guild->getMotd(), TALKTYPE_CHANNEL_R1, CHANNEL_GUILD);
 	}
 }
@@ -5702,7 +5696,7 @@ void Game::addMonster(Monster* monster) { monsters[monster->getID()] = monster; 
 
 void Game::removeMonster(Monster* monster) { monsters.erase(monster->getID()); }
 
-Guild* Game::getGuild(uint32_t id) const
+std::shared_ptr<Guild> Game::getGuild(uint32_t id) const
 {
 	auto it = guilds.find(id);
 	if (it == guilds.end()) {
@@ -5711,7 +5705,7 @@ Guild* Game::getGuild(uint32_t id) const
 	return it->second;
 }
 
-void Game::addGuild(Guild* guild) { guilds[guild->getId()] = guild; }
+void Game::addGuild(std::shared_ptr<Guild> guild) { guilds[guild->getId()] = guild; }
 
 void Game::removeGuild(uint32_t guildId) { guilds.erase(guildId); }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5696,7 +5696,7 @@ void Game::addMonster(Monster* monster) { monsters[monster->getID()] = monster; 
 
 void Game::removeMonster(Monster* monster) { monsters.erase(monster->getID()); }
 
-std::shared_ptr<Guild> Game::getGuild(uint32_t id) const
+Guild_ptr Game::getGuild(uint32_t id) const
 {
 	auto it = guilds.find(id);
 	if (it == guilds.end()) {
@@ -5705,7 +5705,7 @@ std::shared_ptr<Guild> Game::getGuild(uint32_t id) const
 	return it->second;
 }
 
-void Game::addGuild(std::shared_ptr<Guild> guild) { guilds[guild->getId()] = guild; }
+void Game::addGuild(Guild_ptr guild) { guilds[guild->getId()] = guild; }
 
 void Game::removeGuild(uint32_t guildId) { guilds.erase(guildId); }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -61,8 +61,6 @@ Game::Game()
 	offlineTrainingWindow.priority = true;
 }
 
-Game::~Game() = default;
-
 void Game::start(ServiceManager* manager)
 {
 	serviceManager = manager;

--- a/src/game.h
+++ b/src/game.h
@@ -464,8 +464,8 @@ public:
 	void addMonster(Monster* monster);
 	void removeMonster(Monster* monster);
 
-	Guild* getGuild(uint32_t id) const;
-	void addGuild(Guild* guild);
+	std::shared_ptr<Guild> getGuild(uint32_t id) const;
+	void addGuild(std::shared_ptr<Guild> guild);
 	void removeGuild(uint32_t guildId);
 	void decreaseBrowseFieldRef(const Position& pos);
 
@@ -510,7 +510,7 @@ private:
 	std::unordered_map<uint32_t, Player*> players;
 	std::unordered_map<std::string, Player*> mappedPlayerNames;
 	std::unordered_map<uint32_t, Player*> mappedPlayerGuids;
-	std::unordered_map<uint32_t, Guild*> guilds;
+	std::unordered_map<uint32_t, std::shared_ptr<Guild>> guilds;
 	std::unordered_map<uint16_t, Item*> uniqueItems;
 
 	std::list<Item*> decayItems[EVENT_DECAY_BUCKETS];

--- a/src/game.h
+++ b/src/game.h
@@ -464,8 +464,8 @@ public:
 	void addMonster(Monster* monster);
 	void removeMonster(Monster* monster);
 
-	std::shared_ptr<Guild> getGuild(uint32_t id) const;
-	void addGuild(std::shared_ptr<Guild> guild);
+	Guild_ptr getGuild(uint32_t id) const;
+	void addGuild(Guild_ptr guild);
 	void removeGuild(uint32_t guildId);
 	void decreaseBrowseFieldRef(const Position& pos);
 
@@ -510,7 +510,7 @@ private:
 	std::unordered_map<uint32_t, Player*> players;
 	std::unordered_map<std::string, Player*> mappedPlayerNames;
 	std::unordered_map<uint32_t, Player*> mappedPlayerGuids;
-	std::unordered_map<uint32_t, std::shared_ptr<Guild>> guilds;
+	std::unordered_map<uint32_t, Guild_ptr> guilds;
 	std::unordered_map<uint16_t, Item*> uniqueItems;
 
 	std::list<Item*> decayItems[EVENT_DECAY_BUCKETS];

--- a/src/game.h
+++ b/src/game.h
@@ -73,7 +73,6 @@ class Game
 {
 public:
 	Game();
-	~Game();
 
 	// non-copyable
 	Game(const Game&) = delete;

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -26,7 +26,7 @@ void Guild::addRank(uint32_t rankId, std::string_view rankName, uint8_t level)
 	ranks.emplace_back(std::make_shared<GuildRank>(rankId, rankName, level));
 }
 
-std::shared_ptr<GuildRank> Guild::getRankById(uint32_t rankId)
+GuildRank_ptr Guild::getRankById(uint32_t rankId)
 {
 	for (auto rank : ranks) {
 		if (rank->id == rankId) {
@@ -36,7 +36,7 @@ std::shared_ptr<GuildRank> Guild::getRankById(uint32_t rankId)
 	return nullptr;
 }
 
-std::shared_ptr<GuildRank> Guild::getRankByName(const std::string& name) const
+GuildRank_ptr Guild::getRankByName(const std::string& name) const
 {
 	for (auto rank : ranks) {
 		if (rank->name == name) {
@@ -46,7 +46,7 @@ std::shared_ptr<GuildRank> Guild::getRankByName(const std::string& name) const
 	return nullptr;
 }
 
-std::shared_ptr<GuildRank> Guild::getRankByLevel(uint8_t level) const
+GuildRank_ptr Guild::getRankByLevel(uint8_t level) const
 {
 	for (auto rank : ranks) {
 		if (rank->level == level) {
@@ -56,7 +56,7 @@ std::shared_ptr<GuildRank> Guild::getRankByLevel(uint8_t level) const
 	return nullptr;
 }
 
-std::shared_ptr<Guild> IOGuild::loadGuild(uint32_t guildId)
+Guild_ptr IOGuild::loadGuild(uint32_t guildId)
 {
 	Database& db = Database::getInstance();
 	DBResult_ptr result = db.storeQuery(fmt::format("SELECT `name` FROM `guilds` WHERE `id` = {:d}", guildId));

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -63,7 +63,7 @@ Guild_ptr IOGuild::loadGuild(uint32_t guildId)
 		return nullptr;
 	}
 
-	const auto guild = std::make_shared<Guild>(guildId, result->getString("name"));
+	const auto& guild = std::make_shared<Guild>(guildId, result->getString("name"));
 	if ((result = db.storeQuery(
 	         fmt::format("SELECT `id`, `name`, `level` FROM `guild_ranks` WHERE `guild_id` = {:d}", guildId)))) {
 		do {

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -64,8 +64,8 @@ Guild_ptr IOGuild::loadGuild(uint32_t guildId)
 	}
 
 	const auto& guild = std::make_shared<Guild>(guildId, result->getString("name"));
-	if ((result = db.storeQuery(
-	         fmt::format("SELECT `id`, `name`, `level` FROM `guild_ranks` WHERE `guild_id` = {:d}", guildId)))) {
+	if (auto result = db.storeQuery(
+	        fmt::format("SELECT `id`, `name`, `level` FROM `guild_ranks` WHERE `guild_id` = {:d}", guildId))) {
 		do {
 			guild->addRank(result->getNumber<uint32_t>("id"), result->getString("name"),
 			               result->getNumber<uint16_t>("level"));

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -17,7 +17,6 @@ void Guild::removeMember(Player* player)
 
 	if (membersOnline.empty()) {
 		g_game.removeGuild(id);
-		delete this;
 	}
 }
 

--- a/src/guild.h
+++ b/src/guild.h
@@ -6,6 +6,8 @@
 
 class Player;
 
+using GuildWarVector = std::vector<uint32_t>;
+
 struct GuildRank
 {
 	uint32_t id;

--- a/src/guild.h
+++ b/src/guild.h
@@ -15,44 +15,40 @@ struct GuildRank
 	GuildRank(uint32_t id, std::string_view name, uint8_t level) : id{id}, name{name}, level{level} {}
 };
 
-using GuildRank_ptr = std::shared_ptr<GuildRank>;
-
 class Guild
 {
 public:
 	Guild(uint32_t id, std::string_view name) : name{name}, id{id} {}
 
-	void addMember(Player* player);
-	void removeMember(Player* player);
-
 	uint32_t getId() const { return id; }
 	const std::string& getName() const { return name; }
+
+	void addMember(Player* player);
+	void removeMember(Player* player);
 	const std::list<Player*>& getMembersOnline() const { return membersOnline; }
 	uint32_t getMemberCount() const { return memberCount; }
 	void setMemberCount(uint32_t count) { memberCount = count; }
 
-	const std::vector<GuildRank_ptr>& getRanks() const { return ranks; }
-	GuildRank_ptr getRankById(uint32_t rankId);
-	GuildRank_ptr getRankByName(const std::string& name) const;
-	GuildRank_ptr getRankByLevel(uint8_t level) const;
 	void addRank(uint32_t rankId, std::string_view rankName, uint8_t level);
+	const std::vector<std::shared_ptr<GuildRank>>& getRanks() const { return ranks; }
+	std::shared_ptr<GuildRank> getRankById(uint32_t rankId);
+	std::shared_ptr<GuildRank> getRankByName(const std::string& name) const;
+	std::shared_ptr<GuildRank> getRankByLevel(uint8_t level) const;
 
 	const std::string& getMotd() const { return motd; }
 	void setMotd(const std::string& motd) { this->motd = motd; }
 
 private:
 	std::list<Player*> membersOnline;
-	std::vector<GuildRank_ptr> ranks;
+	std::vector<std::shared_ptr<GuildRank>> ranks;
 	std::string name;
 	std::string motd;
 	uint32_t id;
 	uint32_t memberCount = 0;
 };
 
-using GuildWarVector = std::vector<uint32_t>;
-
 namespace IOGuild {
-Guild* loadGuild(uint32_t guildId);
+std::shared_ptr<Guild> loadGuild(uint32_t guildId);
 uint32_t getGuildIdByName(const std::string& name);
 }; // namespace IOGuild
 

--- a/src/guild.h
+++ b/src/guild.h
@@ -6,6 +6,9 @@
 
 class Player;
 
+using Guild_ptr = std::shared_ptr<Guild>;
+using GuildRank_ptr = std::shared_ptr<GuildRank>;
+
 struct GuildRank
 {
 	uint32_t id;
@@ -32,17 +35,17 @@ public:
 	void setMemberCount(uint32_t count) { memberCount = count; }
 
 	void addRank(uint32_t rankId, std::string_view rankName, uint8_t level);
-	const std::vector<std::shared_ptr<GuildRank>>& getRanks() const { return ranks; }
-	std::shared_ptr<GuildRank> getRankById(uint32_t rankId);
-	std::shared_ptr<GuildRank> getRankByName(const std::string& name) const;
-	std::shared_ptr<GuildRank> getRankByLevel(uint8_t level) const;
+	const std::vector<GuildRank_ptr>& getRanks() const { return ranks; }
+	GuildRank_ptr getRankById(uint32_t rankId);
+	GuildRank_ptr getRankByName(const std::string& name) const;
+	GuildRank_ptr getRankByLevel(uint8_t level) const;
 
 	const std::string& getMotd() const { return motd; }
 	void setMotd(const std::string& motd) { this->motd = motd; }
 
 private:
 	std::list<Player*> membersOnline;
-	std::vector<std::shared_ptr<GuildRank>> ranks;
+	std::vector<GuildRank_ptr> ranks;
 	std::string name;
 	std::string motd;
 	uint32_t id;
@@ -50,7 +53,7 @@ private:
 };
 
 namespace IOGuild {
-std::shared_ptr<Guild> loadGuild(uint32_t guildId);
+Guild_ptr loadGuild(uint32_t guildId);
 uint32_t getGuildIdByName(const std::string& name);
 }; // namespace IOGuild
 

--- a/src/guild.h
+++ b/src/guild.h
@@ -6,9 +6,6 @@
 
 class Player;
 
-using Guild_ptr = std::shared_ptr<Guild>;
-using GuildRank_ptr = std::shared_ptr<GuildRank>;
-
 struct GuildRank
 {
 	uint32_t id;
@@ -17,6 +14,8 @@ struct GuildRank
 
 	GuildRank(uint32_t id, std::string_view name, uint8_t level) : id{id}, name{name}, level{level} {}
 };
+
+using GuildRank_ptr = std::shared_ptr<GuildRank>;
 
 class Guild
 {
@@ -51,6 +50,8 @@ private:
 	uint32_t id;
 	uint32_t memberCount = 0;
 };
+
+using Guild_ptr = std::shared_ptr<Guild>;
 
 namespace IOGuild {
 Guild_ptr loadGuild(uint32_t guildId);

--- a/src/guild.h
+++ b/src/guild.h
@@ -18,6 +18,8 @@ struct GuildRank
 class Guild
 {
 public:
+	static constexpr uint8_t MEMBER_RANK_LEVEL_DEFAULT = 1;
+
 	Guild(uint32_t id, std::string_view name) : name{name}, id{id} {}
 
 	uint32_t getId() const { return id; }

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -438,7 +438,7 @@ const Guild_ptr getGuildByName(const std::string& name)
 		return nullptr;
 	}
 
-	if (const auto guild = g_game.getGuild(guildId)) {
+	if (const auto& guild = g_game.getGuild(guildId)) {
 		return guild;
 	}
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -431,14 +431,14 @@ void AccessList::addPlayer(const std::string& name)
 
 namespace {
 
-const Guild* getGuildByName(const std::string& name)
+const std::shared_ptr<Guild> getGuildByName(const std::string& name)
 {
 	uint32_t guildId = IOGuild::getGuildIdByName(name);
 	if (guildId == 0) {
 		return nullptr;
 	}
 
-	const Guild* guild = g_game.getGuild(guildId);
+	const auto guild = g_game.getGuild(guildId);
 	if (guild) {
 		return guild;
 	}
@@ -450,7 +450,7 @@ const Guild* getGuildByName(const std::string& name)
 
 void AccessList::addGuild(const std::string& name)
 {
-	const Guild* guild = getGuildByName(name);
+	const auto guild = getGuildByName(name);
 	if (guild) {
 		for (auto rank : guild->getRanks()) {
 			guildRankList.insert(rank->id);
@@ -460,9 +460,9 @@ void AccessList::addGuild(const std::string& name)
 
 void AccessList::addGuildRank(const std::string& name, const std::string& rankName)
 {
-	const Guild* guild = getGuildByName(name);
+	const auto guild = getGuildByName(name);
 	if (guild) {
-		GuildRank_ptr rank = guild->getRankByName(rankName);
+		const auto rank = guild->getRankByName(rankName);
 		if (rank) {
 			guildRankList.insert(rank->id);
 		}
@@ -480,7 +480,7 @@ bool AccessList::isInList(const Player* player) const
 		return true;
 	}
 
-	GuildRank_ptr rank = player->getGuildRank();
+	const auto rank = player->getGuildRank();
 	return rank && guildRankList.find(rank->id) != guildRankList.end();
 }
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -449,8 +449,8 @@ const std::shared_ptr<Guild> getGuildByName(const std::string& name)
 
 void AccessList::addGuild(const std::string& name)
 {
-	if (const auto guild = getGuildByName(name)) {
-		for (const auto rank : guild->getRanks()) {
+	if (const auto& guild = getGuildByName(name)) {
+		for (const auto& rank : guild->getRanks()) {
 			guildRankList.insert(rank->id);
 		}
 	}
@@ -458,8 +458,8 @@ void AccessList::addGuild(const std::string& name)
 
 void AccessList::addGuildRank(const std::string& name, const std::string& rankName)
 {
-	if (const auto guild = getGuildByName(name)) {
-		if (const auto rank = guild->getRankByName(rankName)) {
+	if (const auto& guild = getGuildByName(name)) {
+		if (const auto& rank = guild->getRankByName(rankName)) {
 			guildRankList.insert(rank->id);
 		}
 	}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -438,8 +438,7 @@ const std::shared_ptr<Guild> getGuildByName(const std::string& name)
 		return nullptr;
 	}
 
-	const auto guild = g_game.getGuild(guildId);
-	if (guild) {
+	if (const auto guild = g_game.getGuild(guildId)) {
 		return guild;
 	}
 
@@ -450,8 +449,7 @@ const std::shared_ptr<Guild> getGuildByName(const std::string& name)
 
 void AccessList::addGuild(const std::string& name)
 {
-	const auto guild = getGuildByName(name);
-	if (guild) {
+	if (const auto guild = getGuildByName(name)) {
 		for (auto rank : guild->getRanks()) {
 			guildRankList.insert(rank->id);
 		}
@@ -460,10 +458,8 @@ void AccessList::addGuild(const std::string& name)
 
 void AccessList::addGuildRank(const std::string& name, const std::string& rankName)
 {
-	const auto guild = getGuildByName(name);
-	if (guild) {
-		const auto rank = guild->getRankByName(rankName);
-		if (rank) {
+	if (const auto guild = getGuildByName(name)) {
+		if (const auto rank = guild->getRankByName(rankName)) {
 			guildRankList.insert(rank->id);
 		}
 	}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -431,7 +431,7 @@ void AccessList::addPlayer(const std::string& name)
 
 namespace {
 
-const std::shared_ptr<Guild> getGuildByName(const std::string& name)
+const Guild_ptr getGuildByName(const std::string& name)
 {
 	uint32_t guildId = IOGuild::getGuildIdByName(name);
 	if (guildId == 0) {

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -476,7 +476,7 @@ bool AccessList::isInList(const Player* player) const
 		return true;
 	}
 
-	const auto rank = player->getGuildRank();
+	const auto& rank = player->getGuildRank();
 	return rank && guildRankList.find(rank->id) != guildRankList.end();
 }
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -450,7 +450,7 @@ const std::shared_ptr<Guild> getGuildByName(const std::string& name)
 void AccessList::addGuild(const std::string& name)
 {
 	if (const auto guild = getGuildByName(name)) {
-		for (auto rank : guild->getRanks()) {
+		for (const auto rank : guild->getRanks()) {
 			guildRankList.insert(rank->id);
 		}
 	}

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -229,7 +229,7 @@ bool IOLoginData::loadPlayerByName(Player* player, const std::string& name)
 	        db.escapeString(name))));
 }
 
-static std::vector<uint32_t> getWarList(uint32_t guildId)
+static GuildWarVector getWarList(uint32_t guildId)
 {
 	DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
 	    "SELECT `guild1`, `guild2` FROM `guild_wars` WHERE (`guild1` = {:d} OR `guild2` = {:d}) AND `ended` = 0 AND `status` = 1",
@@ -238,7 +238,7 @@ static std::vector<uint32_t> getWarList(uint32_t guildId)
 		return {};
 	}
 
-	std::vector<uint32_t> guildWarVector;
+	GuildWarVector guildWarVector;
 	do {
 		uint32_t guild1 = result->getNumber<uint32_t>("guild1");
 		if (guildId != guild1) {

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -229,7 +229,7 @@ bool IOLoginData::loadPlayerByName(Player* player, const std::string& name)
 	        db.escapeString(name))));
 }
 
-static GuildWarVector getWarList(uint32_t guildId)
+static std::vector<uint32_t> getWarList(uint32_t guildId)
 {
 	DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
 	    "SELECT `guild1`, `guild2` FROM `guild_wars` WHERE (`guild1` = {:d} OR `guild2` = {:d}) AND `ended` = 0 AND `status` = 1",
@@ -238,7 +238,7 @@ static GuildWarVector getWarList(uint32_t guildId)
 		return {};
 	}
 
-	GuildWarVector guildWarVector;
+	std::vector<uint32_t> guildWarVector;
 	do {
 		uint32_t guild1 = result->getNumber<uint32_t>("guild1");
 		if (guildId != guild1) {
@@ -422,7 +422,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 		uint32_t playerRankId = result->getNumber<uint32_t>("rank_id");
 		player->guildNick = result->getString("nick");
 
-		Guild* guild = g_game.getGuild(guildId);
+		auto guild = g_game.getGuild(guildId);
 		if (!guild) {
 			guild = IOGuild::loadGuild(guildId);
 			if (guild) {
@@ -435,7 +435,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 		if (guild) {
 			player->guild = guild;
-			GuildRank_ptr rank = guild->getRankById(playerRankId);
+			auto rank = guild->getRankById(playerRankId);
 			if (!rank) {
 				if ((result = db.storeQuery(fmt::format(
 				         "SELECT `id`, `name`, `level` FROM `guild_ranks` WHERE `id` = {:d}", playerRankId)))) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9771,8 +9771,7 @@ int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 	}
 
 	uint8_t level = getNumber<uint8_t>(L, 2);
-	auto rank = guild->getRankByLevel(level);
-	if (rank) {
+	if (auto rank = guild->getRankByLevel(level)) {
 		player->setGuildRank(rank);
 		pushBoolean(L, true);
 	} else {
@@ -11875,8 +11874,7 @@ int LuaScriptInterface::luaGuildGetRankById(lua_State* L)
 	}
 
 	uint32_t id = getNumber<uint32_t>(L, 2);
-	auto rank = guild->getRankById(id);
-	if (rank) {
+	if (auto rank = guild->getRankById(id)) {
 		lua_createtable(L, 0, 3);
 		setField(L, "id", rank->id);
 		setField(L, "name", rank->name);
@@ -11897,8 +11895,7 @@ int LuaScriptInterface::luaGuildGetRankByLevel(lua_State* L)
 	}
 
 	uint8_t level = getNumber<uint8_t>(L, 2);
-	auto rank = guild->getRankByLevel(level);
-	if (rank) {
+	if (auto rank = guild->getRankByLevel(level)) {
 		lua_createtable(L, 0, 3);
 		setField(L, "id", rank->id);
 		setField(L, "name", rank->name);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9760,14 +9760,20 @@ int LuaScriptInterface::luaPlayerGetGuildLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 {
 	// player:setGuildLevel(level)
-	uint8_t level = getNumber<uint8_t>(L, 2);
 	Player* player = getUserdata<Player>(L, 1);
-	if (!player || !player->getGuild()) {
+	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	auto rank = player->getGuild()->getRankByLevel(level);
+	auto guild = player->getGuild();
+	if (!guild) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	uint8_t level = getNumber<uint8_t>(L, 2);
+	auto rank = guild->getRankByLevel(level);
 	if (rank) {
 		player->setGuildRank(rank);
 		pushBoolean(L, true);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -11798,7 +11798,7 @@ int LuaScriptInterface::luaGuildCreate(lua_State* L)
 	// Guild(id)
 	uint32_t id = getNumber<uint32_t>(L, 2);
 
-	if (const auto guild = g_game.getGuild(id)) {
+	if (const auto& guild = g_game.getGuild(id)) {
 		pushSharedPtr(L, guild);
 		setMetatable(L, -1, "Guild");
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9720,13 +9720,13 @@ int LuaScriptInterface::luaPlayerGetGuild(lua_State* L)
 		return 1;
 	}
 
-	Guild* guild = player->getGuild();
+	auto guild = player->getGuild();
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	pushUserdata<Guild>(L, guild);
+	pushSharedPtr(L, guild);
 	setMetatable(L, -1, "Guild");
 	return 1;
 }
@@ -9740,7 +9740,7 @@ int LuaScriptInterface::luaPlayerSetGuild(lua_State* L)
 		return 1;
 	}
 
-	player->setGuild(getUserdata<Guild>(L, 2));
+	player->setGuild(getSharedPtr<Guild>(L, 2));
 	pushBoolean(L, true);
 	return 1;
 }
@@ -9767,12 +9767,12 @@ int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 		return 1;
 	}
 
-	GuildRank_ptr rank = player->getGuild()->getRankByLevel(level);
-	if (!rank) {
-		pushBoolean(L, false);
-	} else {
+	auto rank = player->getGuild()->getRankByLevel(level);
+	if (rank) {
 		player->setGuildRank(rank);
 		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
 	}
 
 	return 1;
@@ -11795,9 +11795,9 @@ int LuaScriptInterface::luaGuildCreate(lua_State* L)
 	// Guild(id)
 	uint32_t id = getNumber<uint32_t>(L, 2);
 
-	Guild* guild = g_game.getGuild(id);
+	auto guild = g_game.getGuild(id);
 	if (guild) {
-		pushUserdata<Guild>(L, guild);
+		pushSharedPtr(L, guild);
 		setMetatable(L, -1, "Guild");
 	} else {
 		lua_pushnil(L);
@@ -11808,7 +11808,7 @@ int LuaScriptInterface::luaGuildCreate(lua_State* L)
 int LuaScriptInterface::luaGuildGetId(lua_State* L)
 {
 	// guild:getId()
-	Guild* guild = getUserdata<Guild>(L, 1);
+	auto& guild = getSharedPtr<Guild>(L, 1);
 	if (guild) {
 		lua_pushnumber(L, guild->getId());
 	} else {
@@ -11820,7 +11820,7 @@ int LuaScriptInterface::luaGuildGetId(lua_State* L)
 int LuaScriptInterface::luaGuildGetName(lua_State* L)
 {
 	// guild:getName()
-	Guild* guild = getUserdata<Guild>(L, 1);
+	auto& guild = getSharedPtr<Guild>(L, 1);
 	if (guild) {
 		pushString(L, guild->getName());
 	} else {
@@ -11832,7 +11832,7 @@ int LuaScriptInterface::luaGuildGetName(lua_State* L)
 int LuaScriptInterface::luaGuildGetMembersOnline(lua_State* L)
 {
 	// guild:getMembersOnline()
-	const Guild* guild = getUserdata<const Guild>(L, 1);
+	const auto& guild = getSharedPtr<const Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -11853,7 +11853,7 @@ int LuaScriptInterface::luaGuildGetMembersOnline(lua_State* L)
 int LuaScriptInterface::luaGuildAddRank(lua_State* L)
 {
 	// guild:addRank(id, name, level)
-	Guild* guild = getUserdata<Guild>(L, 1);
+	auto& guild = getSharedPtr<Guild>(L, 1);
 	if (guild) {
 		uint32_t id = getNumber<uint32_t>(L, 2);
 		const std::string& name = getString(L, 3);
@@ -11869,14 +11869,14 @@ int LuaScriptInterface::luaGuildAddRank(lua_State* L)
 int LuaScriptInterface::luaGuildGetRankById(lua_State* L)
 {
 	// guild:getRankById(id)
-	Guild* guild = getUserdata<Guild>(L, 1);
+	auto& guild = getSharedPtr<Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	uint32_t id = getNumber<uint32_t>(L, 2);
-	GuildRank_ptr rank = guild->getRankById(id);
+	auto rank = guild->getRankById(id);
 	if (rank) {
 		lua_createtable(L, 0, 3);
 		setField(L, "id", rank->id);
@@ -11891,14 +11891,14 @@ int LuaScriptInterface::luaGuildGetRankById(lua_State* L)
 int LuaScriptInterface::luaGuildGetRankByLevel(lua_State* L)
 {
 	// guild:getRankByLevel(level)
-	const Guild* guild = getUserdata<const Guild>(L, 1);
+	const auto& guild = getSharedPtr<const Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	uint8_t level = getNumber<uint8_t>(L, 2);
-	GuildRank_ptr rank = guild->getRankByLevel(level);
+	auto rank = guild->getRankByLevel(level);
 	if (rank) {
 		lua_createtable(L, 0, 3);
 		setField(L, "id", rank->id);
@@ -11913,7 +11913,7 @@ int LuaScriptInterface::luaGuildGetRankByLevel(lua_State* L)
 int LuaScriptInterface::luaGuildGetMotd(lua_State* L)
 {
 	// guild:getMotd()
-	Guild* guild = getUserdata<Guild>(L, 1);
+	const auto& guild = getSharedPtr<Guild>(L, 1);
 	if (guild) {
 		pushString(L, guild->getMotd());
 	} else {
@@ -11926,7 +11926,7 @@ int LuaScriptInterface::luaGuildSetMotd(lua_State* L)
 {
 	// guild:setMotd(motd)
 	const std::string& motd = getString(L, 2);
-	Guild* guild = getUserdata<Guild>(L, 1);
+	auto& guild = getSharedPtr<Guild>(L, 1);
 	if (guild) {
 		guild->setMotd(motd);
 		pushBoolean(L, true);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9720,14 +9720,12 @@ int LuaScriptInterface::luaPlayerGetGuild(lua_State* L)
 		return 1;
 	}
 
-	auto guild = player->getGuild();
-	if (!guild) {
+	if (const auto& guild = player->getGuild()) {
+		pushSharedPtr(L, guild);
+		setMetatable(L, -1, "Guild");
+	} else {
 		lua_pushnil(L);
-		return 1;
 	}
-
-	pushSharedPtr(L, guild);
-	setMetatable(L, -1, "Guild");
 	return 1;
 }
 
@@ -9766,7 +9764,7 @@ int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 		return 1;
 	}
 
-	auto guild = player->getGuild();
+	const auto& guild = player->getGuild();
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -9780,7 +9778,6 @@ int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
-
 	return 1;
 }
 
@@ -11801,8 +11798,7 @@ int LuaScriptInterface::luaGuildCreate(lua_State* L)
 	// Guild(id)
 	uint32_t id = getNumber<uint32_t>(L, 2);
 
-	auto guild = g_game.getGuild(id);
-	if (guild) {
+	if (const auto guild = g_game.getGuild(id)) {
 		pushSharedPtr(L, guild);
 		setMetatable(L, -1, "Guild");
 	} else {
@@ -11814,8 +11810,7 @@ int LuaScriptInterface::luaGuildCreate(lua_State* L)
 int LuaScriptInterface::luaGuildGetId(lua_State* L)
 {
 	// guild:getId()
-	auto& guild = getSharedPtr<Guild>(L, 1);
-	if (guild) {
+	if (const auto& guild = getSharedPtr<Guild>(L, 1)) {
 		lua_pushnumber(L, guild->getId());
 	} else {
 		lua_pushnil(L);
@@ -11826,8 +11821,7 @@ int LuaScriptInterface::luaGuildGetId(lua_State* L)
 int LuaScriptInterface::luaGuildGetName(lua_State* L)
 {
 	// guild:getName()
-	auto& guild = getSharedPtr<Guild>(L, 1);
-	if (guild) {
+	if (const auto& guild = getSharedPtr<Guild>(L, 1)) {
 		pushString(L, guild->getName());
 	} else {
 		lua_pushnil(L);
@@ -11859,8 +11853,7 @@ int LuaScriptInterface::luaGuildGetMembersOnline(lua_State* L)
 int LuaScriptInterface::luaGuildAddRank(lua_State* L)
 {
 	// guild:addRank(id, name, level)
-	auto& guild = getSharedPtr<Guild>(L, 1);
-	if (guild) {
+	if (const auto& guild = getSharedPtr<Guild>(L, 1)) {
 		uint32_t id = getNumber<uint32_t>(L, 2);
 		const std::string& name = getString(L, 3);
 		uint8_t level = getNumber<uint8_t>(L, 4);
@@ -11875,7 +11868,7 @@ int LuaScriptInterface::luaGuildAddRank(lua_State* L)
 int LuaScriptInterface::luaGuildGetRankById(lua_State* L)
 {
 	// guild:getRankById(id)
-	auto& guild = getSharedPtr<Guild>(L, 1);
+	const auto& guild = getSharedPtr<Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -11919,8 +11912,7 @@ int LuaScriptInterface::luaGuildGetRankByLevel(lua_State* L)
 int LuaScriptInterface::luaGuildGetMotd(lua_State* L)
 {
 	// guild:getMotd()
-	const auto& guild = getSharedPtr<Guild>(L, 1);
-	if (guild) {
+	if (const auto& guild = getSharedPtr<Guild>(L, 1)) {
 		pushString(L, guild->getMotd());
 	} else {
 		lua_pushnil(L);
@@ -11931,9 +11923,8 @@ int LuaScriptInterface::luaGuildGetMotd(lua_State* L)
 int LuaScriptInterface::luaGuildSetMotd(lua_State* L)
 {
 	// guild:setMotd(motd)
-	const std::string& motd = getString(L, 2);
-	auto& guild = getSharedPtr<Guild>(L, 1);
-	if (guild) {
+	if (const auto& guild = getSharedPtr<Guild>(L, 1)) {
+		const std::string& motd = getString(L, 2);
 		guild->setMotd(motd);
 		pushBoolean(L, true);
 	} else {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4114,7 +4114,7 @@ bool Player::isInWar(const Player* player) const
 		return false;
 	}
 
-	const Guild* playerGuild = player->getGuild();
+	const auto playerGuild = player->getGuild();
 	if (!playerGuild) {
 		return false;
 	}
@@ -4255,7 +4255,7 @@ GuildEmblems_t Player::getGuildEmblem(const Player* player) const
 		return GUILDEMBLEM_NONE;
 	}
 
-	const Guild* playerGuild = player->getGuild();
+	const auto playerGuild = player->getGuild();
 	if (!playerGuild) {
 		return GUILDEMBLEM_NONE;
 	}
@@ -4666,20 +4666,20 @@ std::forward_list<Condition*> Player::getMuteConditions() const
 	return muteConditions;
 }
 
-void Player::setGuild(Guild* guild)
+void Player::setGuild(std::shared_ptr<Guild> guild)
 {
 	if (guild == this->guild) {
 		return;
 	}
 
-	Guild* oldGuild = this->guild;
+	auto oldGuild = this->guild;
 
 	this->guildNick.clear();
 	this->guild = nullptr;
 	this->guildRank = nullptr;
 
 	if (guild) {
-		GuildRank_ptr rank = guild->getRankByLevel(1);
+		const auto rank = guild->getRankByLevel(1);
 		if (!rank) {
 			return;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4114,7 +4114,7 @@ bool Player::isInWar(const Player* player) const
 		return false;
 	}
 
-	const auto playerGuild = player->getGuild();
+	const auto& playerGuild = player->getGuild();
 	if (!playerGuild) {
 		return false;
 	}
@@ -4255,7 +4255,7 @@ GuildEmblems_t Player::getGuildEmblem(const Player* player) const
 		return GUILDEMBLEM_NONE;
 	}
 
-	const auto playerGuild = player->getGuild();
+	const auto& playerGuild = player->getGuild();
 	if (!playerGuild) {
 		return GUILDEMBLEM_NONE;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4679,7 +4679,7 @@ void Player::setGuild(std::shared_ptr<Guild> guild)
 	this->guildRank = nullptr;
 
 	if (guild) {
-		const auto rank = guild->getRankByLevel(1);
+		const auto rank = guild->getRankByLevel(Guild::MEMBER_RANK_LEVEL_DEFAULT);
 		if (!rank) {
 			return;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4679,7 +4679,7 @@ void Player::setGuild(Guild_ptr guild)
 	this->guildRank = nullptr;
 
 	if (guild) {
-		const auto rank = guild->getRankByLevel(Guild::MEMBER_RANK_LEVEL_DEFAULT);
+		const auto& rank = guild->getRankByLevel(Guild::MEMBER_RANK_LEVEL_DEFAULT);
 		if (!rank) {
 			return;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4666,7 +4666,7 @@ std::forward_list<Condition*> Player::getMuteConditions() const
 	return muteConditions;
 }
 
-void Player::setGuild(std::shared_ptr<Guild> guild)
+void Player::setGuild(Guild_ptr guild)
 {
 	if (guild == this->guild) {
 		return;

--- a/src/player.h
+++ b/src/player.h
@@ -164,11 +164,11 @@ public:
 	uint64_t getBankBalance() const { return bankBalance; }
 	void setBankBalance(uint64_t balance) { bankBalance = balance; }
 
-	Guild* getGuild() const { return guild; }
-	void setGuild(Guild* guild);
+	std::shared_ptr<Guild> getGuild() const { return guild; }
+	void setGuild(std::shared_ptr<Guild> guild);
 
-	GuildRank_ptr getGuildRank() const { return guildRank; }
-	void setGuildRank(GuildRank_ptr newGuildRank) { guildRank = newGuildRank; }
+	std::shared_ptr<GuildRank> getGuildRank() const { return guildRank; }
+	void setGuildRank(std::shared_ptr<GuildRank> newGuildRank) { guildRank = newGuildRank; }
 
 	bool isGuildMate(const Player* player) const;
 
@@ -187,7 +187,7 @@ public:
 
 	uint32_t getClientIcons() const;
 
-	const GuildWarVector& getGuildWarVector() const { return guildWarVector; }
+	const std::vector<uint32_t>& getGuildWarVector() const { return guildWarVector; }
 
 	Vocation* getVocation() const { return vocation; }
 
@@ -1163,7 +1163,7 @@ private:
 
 	std::map<uint16_t, uint8_t> outfits;
 	std::unordered_set<uint16_t> mounts;
-	GuildWarVector guildWarVector;
+	std::vector<uint32_t> guildWarVector;
 
 	std::list<ShopInfo> shopItemList;
 
@@ -1200,8 +1200,8 @@ private:
 	ProtocolGame_ptr client;
 	Connection::Address lastIP = {};
 	BedItem* bedItem = nullptr;
-	Guild* guild = nullptr;
-	GuildRank_ptr guildRank = nullptr;
+	std::shared_ptr<Guild> guild = nullptr;
+	std::shared_ptr<GuildRank> guildRank = nullptr;
 	Group* group = nullptr;
 	Inbox* inbox;
 	Item* tradeItem = nullptr;

--- a/src/player.h
+++ b/src/player.h
@@ -187,7 +187,7 @@ public:
 
 	uint32_t getClientIcons() const;
 
-	const std::vector<uint32_t>& getGuildWarVector() const { return guildWarVector; }
+	const GuildWarVector& getGuildWarVector() const { return guildWarVector; }
 
 	Vocation* getVocation() const { return vocation; }
 
@@ -1163,7 +1163,7 @@ private:
 
 	std::map<uint16_t, uint8_t> outfits;
 	std::unordered_set<uint16_t> mounts;
-	std::vector<uint32_t> guildWarVector;
+	GuildWarVector guildWarVector;
 
 	std::list<ShopInfo> shopItemList;
 

--- a/src/player.h
+++ b/src/player.h
@@ -164,11 +164,11 @@ public:
 	uint64_t getBankBalance() const { return bankBalance; }
 	void setBankBalance(uint64_t balance) { bankBalance = balance; }
 
-	std::shared_ptr<Guild> getGuild() const { return guild; }
-	void setGuild(std::shared_ptr<Guild> guild);
+	Guild_ptr getGuild() const { return guild; }
+	void setGuild(Guild_ptr guild);
 
-	std::shared_ptr<GuildRank> getGuildRank() const { return guildRank; }
-	void setGuildRank(std::shared_ptr<GuildRank> newGuildRank) { guildRank = newGuildRank; }
+	GuildRank_ptr getGuildRank() const { return guildRank; }
+	void setGuildRank(GuildRank_ptr newGuildRank) { guildRank = newGuildRank; }
 
 	bool isGuildMate(const Player* player) const;
 
@@ -1200,8 +1200,8 @@ private:
 	ProtocolGame_ptr client;
 	Connection::Address lastIP = {};
 	BedItem* bedItem = nullptr;
-	std::shared_ptr<Guild> guild = nullptr;
-	std::shared_ptr<GuildRank> guildRank = nullptr;
+	Guild_ptr guild = nullptr;
+	GuildRank_ptr guildRank = nullptr;
 	Group* group = nullptr;
 	Inbox* inbox;
 	Item* tradeItem = nullptr;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Replace guild raw pointers with shared_ptr.
- Use `auto` and `const auto`, at all, when possible.
- Added `Guild::MEMBER_RANK_LEVEL_DEFAULT`.

### Discussion
Should we use `shared_ptr<T>` or `T_ptr` at all?
`GuildWars` instead of `GuildWarVector`?

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
