### PR TITLE
Bank.lua fix on transfer if params are shifted #4680

### DIFF
--- a/data/npc/scripts/bank.lua
+++ b/data/npc/scripts/bank.lua
@@ -199,6 +199,10 @@ local function creatureSayCallback(cid, type, msg)
 			receiver = receiver:trim()
 
 			-- Immediate topicList.TRANSFER_PLAYER_GOLD simulation
+			if tonumber(parts[3]) then
+				npcHandler:say("I'm afraid there is no character with the name ".. parts[3] ..".", cid)
+				return true
+			end
 			count[cid] = getMoneyCount(parts[2])
 			if player:getBankBalance() < count[cid] then
 				npcHandler:say("There is not enough gold in your account.", cid)

--- a/data/npc/scripts/bank.lua
+++ b/data/npc/scripts/bank.lua
@@ -199,8 +199,9 @@ local function creatureSayCallback(cid, type, msg)
 			receiver = receiver:trim()
 
 			-- Immediate topicList.TRANSFER_PLAYER_GOLD simulation
-			if tonumber(parts[3]) then
-				npcHandler:say("I'm afraid there is no character with the name ".. parts[3] ..".", cid)
+			if not tonumber(parts[2]) then
+				npcHandler:say("Hmm, my ledgers have no records of anyone with the name " .. receiver .. ". Please ensure the name is correct.", cid)
+				npcHandler.topic[cid] = topicList.NONE
 				return true
 			end
 			count[cid] = getMoneyCount(parts[2])
@@ -212,6 +213,11 @@ local function creatureSayCallback(cid, type, msg)
 			if isValidMoney(count[cid]) then
 				-- Immediate topicList.TRANSFER_PLAYER_WHO simulation
 				transfer[cid] = getPlayerDatabaseInfo(receiver)
+				if not transfer[cid] then
+					npcHandler:say("Hmm, my ledgers have no records of anyone with the name " .. receiver .. ". Please ensure the name is correct.", cid)
+					npcHandler.topic[cid] = topicList.NONE
+					return true
+				end
 				if player:getName() == transfer[cid].name then
 					npcHandler:say("Why would you want to transfer money to yourself? You already have it!", cid)
 					npcHandler.topic[cid] = topicList.NONE


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Now it doesn't throw up an error if you say `transfer playername 1000` instead of `transfer 1000 playername`
The npc will just replay with `Hmm, my ledgers have no records of anyone with the name <1000>. Please ensure the name is correct.`

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#4680 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
