### PR TITLE
Move static IOMarket methods to namespace

### DIFF
--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -14,10 +14,6 @@ struct VIPEntry;
 
 using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
 
-namespace tfs::io::logindata {
-Account loadAccount(uint32_t accno);
-}
-
 class IOLoginData
 {
 public:

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -14,6 +14,10 @@ struct VIPEntry;
 
 using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
 
+namespace tfs::io::logindata {
+Account loadAccount(uint32_t accno);
+}
+
 class IOLoginData
 {
 public:

--- a/src/iomarket.cpp
+++ b/src/iomarket.cpp
@@ -14,7 +14,16 @@
 
 extern Game g_game;
 
-MarketOfferList IOMarket::getActiveOffers(MarketAction_t action, uint16_t itemId)
+namespace {
+
+std::map<uint16_t, MarketStatistics> purchaseStatistics;
+std::map<uint16_t, MarketStatistics> saleStatistics;
+
+} // namespace
+
+namespace tfs::io::market {
+
+MarketOfferList getActiveOffers(MarketAction_t action, uint16_t itemId)
 {
 	MarketOfferList offerList;
 
@@ -44,7 +53,7 @@ MarketOfferList IOMarket::getActiveOffers(MarketAction_t action, uint16_t itemId
 	return offerList;
 }
 
-MarketOfferList IOMarket::getOwnOffers(MarketAction_t action, uint32_t playerId)
+MarketOfferList getOwnOffers(MarketAction_t action, uint32_t playerId)
 {
 	MarketOfferList offerList;
 
@@ -69,7 +78,7 @@ MarketOfferList IOMarket::getOwnOffers(MarketAction_t action, uint32_t playerId)
 	return offerList;
 }
 
-HistoryMarketOfferList IOMarket::getOwnHistory(MarketAction_t action, uint32_t playerId)
+HistoryMarketOfferList getOwnHistory(MarketAction_t action, uint32_t playerId)
 {
 	HistoryMarketOfferList offerList;
 
@@ -99,14 +108,14 @@ HistoryMarketOfferList IOMarket::getOwnHistory(MarketAction_t action, uint32_t p
 	return offerList;
 }
 
-void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
+void processExpiredOffers(DBResult_ptr result, bool)
 {
 	if (!result) {
 		return;
 	}
 
 	do {
-		if (!IOMarket::moveOfferToHistory(result->getNumber<uint32_t>("id"), OFFERSTATE_EXPIRED)) {
+		if (!moveOfferToHistory(result->getNumber<uint32_t>("id"), OFFERSTATE_EXPIRED)) {
 			continue;
 		}
 
@@ -175,7 +184,7 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
 	} while (result->next());
 }
 
-void IOMarket::checkExpiredOffers()
+void checkExpiredOffers()
 {
 	const time_t lastExpireDate = time(nullptr) - getNumber(ConfigManager::MARKET_OFFER_DURATION);
 
@@ -183,18 +192,17 @@ void IOMarket::checkExpiredOffers()
 	    fmt::format(
 	        "SELECT `id`, `amount`, `price`, `itemtype`, `player_id`, `sale` FROM `market_offers` WHERE `created` <= {:d}",
 	        lastExpireDate),
-	    IOMarket::processExpiredOffers, true);
+	    processExpiredOffers, true);
 
 	int32_t checkExpiredMarketOffersEachMinutes = getNumber(ConfigManager::CHECK_EXPIRED_MARKET_OFFERS_EACH_MINUTES);
 	if (checkExpiredMarketOffersEachMinutes <= 0) {
 		return;
 	}
 
-	g_scheduler.addEvent(
-	    createSchedulerTask(checkExpiredMarketOffersEachMinutes * 60 * 1000, &IOMarket::checkExpiredOffers));
+	g_scheduler.addEvent(createSchedulerTask(checkExpiredMarketOffersEachMinutes * 60 * 1000, &checkExpiredOffers));
 }
 
-uint32_t IOMarket::getPlayerOfferCount(uint32_t playerId)
+uint32_t getPlayerOfferCount(uint32_t playerId)
 {
 	DBResult_ptr result = Database::getInstance().storeQuery(
 	    fmt::format("SELECT COUNT(*) AS `count` FROM `market_offers` WHERE `player_id` = {:d}", playerId));
@@ -204,7 +212,7 @@ uint32_t IOMarket::getPlayerOfferCount(uint32_t playerId)
 	return result->getNumber<int32_t>("count");
 }
 
-MarketOfferEx IOMarket::getOfferByCounter(uint32_t timestamp, uint16_t counter)
+MarketOfferEx getOfferByCounter(uint32_t timestamp, uint16_t counter)
 {
 	MarketOfferEx offer;
 
@@ -235,27 +243,27 @@ MarketOfferEx IOMarket::getOfferByCounter(uint32_t timestamp, uint16_t counter)
 	return offer;
 }
 
-void IOMarket::createOffer(uint32_t playerId, MarketAction_t action, uint32_t itemId, uint16_t amount, uint64_t price,
-                           bool anonymous)
+void createOffer(uint32_t playerId, MarketAction_t action, uint32_t itemId, uint16_t amount, uint64_t price,
+                 bool anonymous)
 {
 	Database::getInstance().executeQuery(fmt::format(
 	    "INSERT INTO `market_offers` (`player_id`, `sale`, `itemtype`, `amount`, `price`, `created`, `anonymous`) VALUES ({:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d})",
 	    playerId, tfs::to_underlying(action), itemId, amount, price, time(nullptr), anonymous));
 }
 
-void IOMarket::acceptOffer(uint32_t offerId, uint16_t amount)
+void acceptOffer(uint32_t offerId, uint16_t amount)
 {
 	Database::getInstance().executeQuery(
 	    fmt::format("UPDATE `market_offers` SET `amount` = `amount` - {:d} WHERE `id` = {:d}", amount, offerId));
 }
 
-void IOMarket::deleteOffer(uint32_t offerId)
+void deleteOffer(uint32_t offerId)
 {
 	Database::getInstance().executeQuery(fmt::format("DELETE FROM `market_offers` WHERE `id` = {:d}", offerId));
 }
 
-void IOMarket::appendHistory(uint32_t playerId, MarketAction_t action, uint16_t itemId, uint16_t amount, uint64_t price,
-                             time_t timestamp, MarketOfferState_t state)
+void appendHistory(uint32_t playerId, MarketAction_t action, uint16_t itemId, uint16_t amount, uint64_t price,
+                   time_t timestamp, MarketOfferState_t state)
 {
 	g_databaseTasks.addTask(fmt::format(
 	    "INSERT INTO `market_history` (`player_id`, `sale`, `itemtype`, `amount`, `price`, `expires_at`, `inserted`, `state`) VALUES ({:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d})",
@@ -263,7 +271,7 @@ void IOMarket::appendHistory(uint32_t playerId, MarketAction_t action, uint16_t 
 	    tfs::to_underlying(state)));
 }
 
-bool IOMarket::moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
+bool moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
 {
 	const int32_t marketOfferDuration = getNumber(ConfigManager::MARKET_OFFER_DURATION);
 
@@ -287,7 +295,7 @@ bool IOMarket::moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
 	return true;
 }
 
-void IOMarket::updateStatistics()
+void updateStatistics()
 {
 	DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
 	    "SELECT `sale` AS `sale`, `itemtype` AS `itemtype`, COUNT(`price`) AS `num`, MIN(`price`) AS `min`, MAX(`price`) AS `max`, SUM(`price`) AS `sum` FROM `market_history` WHERE `state` = {:d} GROUP BY `itemtype`, `sale`",
@@ -311,7 +319,7 @@ void IOMarket::updateStatistics()
 	} while (result->next());
 }
 
-MarketStatistics* IOMarket::getPurchaseStatistics(uint16_t itemId)
+MarketStatistics* getPurchaseStatistics(uint16_t itemId)
 {
 	auto it = purchaseStatistics.find(itemId);
 	if (it == purchaseStatistics.end()) {
@@ -320,7 +328,7 @@ MarketStatistics* IOMarket::getPurchaseStatistics(uint16_t itemId)
 	return &it->second;
 }
 
-MarketStatistics* IOMarket::getSaleStatistics(uint16_t itemId)
+MarketStatistics* getSaleStatistics(uint16_t itemId)
 {
 	auto it = saleStatistics.find(itemId);
 	if (it == saleStatistics.end()) {
@@ -328,3 +336,5 @@ MarketStatistics* IOMarket::getSaleStatistics(uint16_t itemId)
 	}
 	return &it->second;
 }
+
+} // namespace tfs::io::market

--- a/src/iomarket.h
+++ b/src/iomarket.h
@@ -8,6 +8,7 @@
 #include "enums.h"
 
 namespace tfs::io::market {
+
 MarketOfferList getActiveOffers(MarketAction_t action, uint16_t itemId);
 MarketOfferList getOwnOffers(MarketAction_t action, uint32_t playerId);
 HistoryMarketOfferList getOwnHistory(MarketAction_t action, uint32_t playerId);
@@ -31,6 +32,7 @@ void updateStatistics();
 
 MarketStatistics* getPurchaseStatistics(uint16_t itemId);
 MarketStatistics* getSaleStatistics(uint16_t itemId);
+
 } // namespace tfs::io::market
 
 #endif // FS_IOMARKET_H

--- a/src/iomarket.h
+++ b/src/iomarket.h
@@ -7,44 +7,30 @@
 #include "database.h"
 #include "enums.h"
 
-class IOMarket
-{
-public:
-	static IOMarket& getInstance()
-	{
-		static IOMarket instance;
-		return instance;
-	}
+namespace tfs::io::market {
+MarketOfferList getActiveOffers(MarketAction_t action, uint16_t itemId);
+MarketOfferList getOwnOffers(MarketAction_t action, uint32_t playerId);
+HistoryMarketOfferList getOwnHistory(MarketAction_t action, uint32_t playerId);
 
-	static MarketOfferList getActiveOffers(MarketAction_t action, uint16_t itemId);
-	static MarketOfferList getOwnOffers(MarketAction_t action, uint32_t playerId);
-	static HistoryMarketOfferList getOwnHistory(MarketAction_t action, uint32_t playerId);
+void processExpiredOffers(DBResult_ptr result, bool);
+void checkExpiredOffers();
 
-	static void processExpiredOffers(DBResult_ptr result, bool);
-	static void checkExpiredOffers();
+uint32_t getPlayerOfferCount(uint32_t playerId);
+MarketOfferEx getOfferByCounter(uint32_t timestamp, uint16_t counter);
 
-	static uint32_t getPlayerOfferCount(uint32_t playerId);
-	static MarketOfferEx getOfferByCounter(uint32_t timestamp, uint16_t counter);
+void createOffer(uint32_t playerId, MarketAction_t action, uint32_t itemId, uint16_t amount, uint64_t price,
+                 bool anonymous);
+void acceptOffer(uint32_t offerId, uint16_t amount);
+void deleteOffer(uint32_t offerId);
 
-	static void createOffer(uint32_t playerId, MarketAction_t action, uint32_t itemId, uint16_t amount, uint64_t price,
-	                        bool anonymous);
-	static void acceptOffer(uint32_t offerId, uint16_t amount);
-	static void deleteOffer(uint32_t offerId);
+void appendHistory(uint32_t playerId, MarketAction_t type, uint16_t itemId, uint16_t amount, uint64_t price,
+                   time_t timestamp, MarketOfferState_t state);
+bool moveOfferToHistory(uint32_t offerId, MarketOfferState_t state);
 
-	static void appendHistory(uint32_t playerId, MarketAction_t type, uint16_t itemId, uint16_t amount, uint64_t price,
-	                          time_t timestamp, MarketOfferState_t state);
-	static bool moveOfferToHistory(uint32_t offerId, MarketOfferState_t state);
+void updateStatistics();
 
-	void updateStatistics();
-
-	MarketStatistics* getPurchaseStatistics(uint16_t itemId);
-	MarketStatistics* getSaleStatistics(uint16_t itemId);
-
-private:
-	IOMarket() = default;
-
-	std::map<uint16_t, MarketStatistics> purchaseStatistics;
-	std::map<uint16_t, MarketStatistics> saleStatistics;
-};
+MarketStatistics* getPurchaseStatistics(uint16_t itemId);
+MarketStatistics* getSaleStatistics(uint16_t itemId);
+} // namespace tfs::io::market
 
 #endif // FS_IOMARKET_H

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -13646,7 +13646,7 @@ int LuaScriptInterface::luaItemTypeGetMarketBuyStatistics(lua_State* L)
 	// itemType:getMarketBuyStatistics()
 	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		MarketStatistics* statistics = IOMarket::getInstance().getPurchaseStatistics(itemType->id);
+		MarketStatistics* statistics = tfs::io::market::getPurchaseStatistics(itemType->id);
 		if (statistics) {
 			lua_createtable(L, 4, 0);
 			setField(L, "numTransactions", statistics->numTransactions);
@@ -13667,7 +13667,7 @@ int LuaScriptInterface::luaItemTypeGetMarketSellStatistics(lua_State* L)
 	// itemType:getMarketSellStatistics()
 	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
-		MarketStatistics* statistics = IOMarket::getInstance().getSaleStatistics(itemType->id);
+		MarketStatistics* statistics = tfs::io::market::getSaleStatistics(itemType->id);
 		if (statistics) {
 			lua_createtable(L, 4, 0);
 			setField(L, "numTransactions", statistics->numTransactions);

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -240,8 +240,8 @@ void mainLoader(ServiceManager* services)
 
 	g_game.map.houses.payHouses(rentPeriod);
 
-	IOMarket::checkExpiredOffers();
-	IOMarket::getInstance().updateStatistics();
+	tfs::io::market::checkExpiredOffers();
+	tfs::io::market::updateStatistics();
 
 	std::cout << ">> Loaded all modules, server starting up..." << std::endl;
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2116,8 +2116,8 @@ void ProtocolGame::sendMarketEnter()
 {
 	NetworkMessage msg;
 	msg.addByte(0xF6);
-	msg.addByte(
-	    std::min<uint32_t>(IOMarket::getPlayerOfferCount(player->getGUID()), std::numeric_limits<uint8_t>::max()));
+	msg.addByte(std::min<uint32_t>(tfs::io::market::getPlayerOfferCount(player->getGUID()),
+	                               std::numeric_limits<uint8_t>::max()));
 
 	player->setInMarket(true);
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Bring closure to the `IOMarket` class and its static instance by moving it to a namespace.

`IOMarket::x` to `tfs::io::market::x`

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
