### PR TITLE
Move connection manager singleton to namespace

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -38,25 +38,13 @@ class ServicePort;
 using ServicePort_ptr = std::shared_ptr<ServicePort>;
 using ConstServicePort_ptr = std::shared_ptr<const ServicePort>;
 
-class ConnectionManager
-{
-public:
-	static ConnectionManager& getInstance()
-	{
-		static ConnectionManager instance;
-		return instance;
-	}
+namespace tfs::io::connection {
 
-	Connection_ptr createConnection(boost::asio::io_context& io_context, ConstServicePort_ptr servicePort);
-	void releaseConnection(const Connection_ptr& connection);
-	void closeAll();
+Connection_ptr create(boost::asio::io_context& io_context, ConstServicePort_ptr servicePort);
+void release(const Connection_ptr& connection);
+void closeAll();
 
-private:
-	ConnectionManager() = default;
-
-	std::unordered_set<Connection_ptr> connections;
-	std::mutex connectionManagerLock;
-};
+} // namespace tfs::io::connection
 
 class Connection : public std::enable_shared_from_this<Connection>
 {
@@ -80,8 +68,7 @@ public:
 	{}
 	~Connection();
 
-	friend class ConnectionManager;
-
+	void shutdownAndClose();
 	void close(bool force = false);
 	// Used by protocols that require server to send first
 	void accept(Protocol_ptr protocol);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4802,7 +4802,7 @@ void Game::shutdown()
 		serviceManager->stop();
 	}
 
-	ConnectionManager::getInstance().closeAll();
+	tfs::io::connection::closeAll();
 
 	std::cout << " done!" << std::endl;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -88,7 +88,7 @@ void ServicePort::accept()
 		return;
 	}
 
-	auto connection = ConnectionManager::getInstance().createConnection(io_context, shared_from_this());
+	auto connection = tfs::io::connection::create(io_context, shared_from_this());
 	acceptor->async_accept(connection->getSocket(),
 	                       [=, thisPtr = shared_from_this()](const boost::system::error_code& error) {
 		                       thisPtr->onAccept(connection, error);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Removes the ConnectionManager singleton from the `tfs::io` namespace.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
