### PR TITLE
Fix bank NPC overflow protection being bypassed

### DIFF
--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -103,11 +103,11 @@ end
 
 function getCount(string)
 	local b, e = string:find("%d+")
-	local tonumber = tonumber(string:sub(b, e))
-	if tonumber > 2 ^ 32 - 1 then
+	local count = tonumber(string:sub(b, e))
+	if count > 2 ^ 32 - 1 then
 		print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
 	end
-	return b and e and math.min(2 ^ 32 - 1, tonumber) or -1
+	return b and e and math.min(2 ^ 32 - 1, count) or -1
 end
 
 function isValidMoney(money)
@@ -116,11 +116,11 @@ end
 
 function getMoneyCount(string)
 	local b, e = string:find("%d+")
-	local tonumber = tonumber(string:sub(b, e))
-	if tonumber > 2 ^ 32 - 1 then
+	local count = tonumber(string:sub(b, e))
+	if count > 2 ^ 32 - 1 then
 		print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
 	end
-	local money = b and e and math.min(2 ^ 32 - 1, tonumber) or -1
+	local money = b and e and math.min(2 ^ 32 - 1, count) or -1
 	if isValidMoney(money) then
 		return money
 	end


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A bank NPC overflow protection was added back in https://github.com/otland/forgottenserver/pull/3522. However (at least with the current LuaJIT version, haven't tested others), `tonumber` is reserved for (and interpreted as) a standard library basic function.

This change simply renames the variable to avoid the conflict.

As a side note, when testing this (even when the check was being bypassed), I was never able to reproduce any crash, if I said "deposit [number larger than 2^32]" while having that amount of gold in my inventory, the NPC correctly allowed me to deposit & withdraw those amounts. Perhaps the check needs to be removed completly.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide