### PR TITLE
Fix LuaJIT flag in CMake configuration

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -50,8 +50,9 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: vcpkg
-          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}', '-DUSE_LUAJIT=${{ matrix.luajit }}']"
+          buildPresetAdditionalArgs: "['--config', '${{ matrix.buildtype }}']"
           configurePreset: vcpkg
+          configurePresetAdditionalArgs: "['-DUSE_LUAJIT=${{ matrix.luajit }}']"
 
       - name: Upload artifact binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -30,8 +30,9 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           buildPreset: vcpkg
-          buildPresetAdditionalArgs: "['--config', 'RelWithDebInfo', '--clean-first', '-DUSE_LUAJIT=ON']"
+          buildPresetAdditionalArgs: "['--config', 'RelWithDebInfo']"
           configurePreset: vcpkg
+          configurePresetAdditionalArgs: "['-DUSE_LUAJIT=ON']"
 
       - name: Prepare datapack contents
         run: |


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`-DUSE_LUAJIT=ON` is being used in the wrong step (build instead of configure) so the flag does not apply as expected.

It can be [noticed in builds](https://github.com/otland/forgottenserver/actions/runs/9246468713/job/25434050923) where CMake says

```
Unknown argument -DUSE_LUAJIT=on
```

![image](https://github.com/otland/forgottenserver/assets/1993083/625d5ee4-c101-4fc7-8afd-fbbec8e099c7)


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
