### PR TITLE
Set correct minimum dependency versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
@@ -11,9 +11,12 @@ if (DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
     set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" CACHE STRING "The vcpkg triplet")
 endif()
 
+set(BOOST_REQUIRED_VERSION 1.71.0)
+
 option(HTTP "Enable HTTP support" ON)
 if (HTTP)
     list(APPEND VCPKG_MANIFEST_FEATURES "http")
+    set(BOOST_REQUIRED_VERSION 1.75.0)
 endif()
 
 option(BUILD_TESTING "Build unit tests" OFF)
@@ -47,9 +50,9 @@ endif ()
 # Find packages.
 find_package(OpenSSL 3.0.0 REQUIRED COMPONENTS Crypto)
 
-find_package(fmt CONFIG)
+find_package(fmt 8.1.1 CONFIG)
 if (NOT fmt_FOUND)
-    find_package(fmt 6.1.2 REQUIRED)
+    find_package(fmt 8.1.1 REQUIRED)
 endif()
 
 # Look for vcpkg-provided libmariadb first
@@ -82,7 +85,7 @@ endif ()
 if (BUILD_TESTING)
     list(APPEND BOOST_REQUIRED_COMPONENTS unit_test_framework)
 endif ()
-find_package(Boost 1.71.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 include_directories(${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${MYSQL_INCLUDE_DIR} ${PUGIXML_INCLUDE_DIR})
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The minimum dependency versions are outdated and set too low. For the HTTP server, Boost 1.75 is the minimum required version. Furthermore, the most outdated still supported Ubuntu version, 20.04 LTS, ships Boost 1.71, it is pointless to support anything before

`fmt` 8.1.0 is a lot faster than 6.1.2 and also widely available. It has gotten [support for formatting time points and named arguments](https://github.com/fmtlib/fmt/blob/master/ChangeLog.md#810---2022-01-02) which I intend to use

CMake 3.19 is already a requirement for the preset feature that we already use

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
