### PR TITLE
Fix CodeQL to run only once per workflow

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -45,7 +45,7 @@ jobs:
           languages: cpp
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           queries: +security-extended,security-and-quality
-        if: ${{ matrix.os }} == "ubuntu" && ${{ matrix.buildtype }} == "Debug"
+        if: matrix.os == "ubuntu" && matrix.buildtype == "Debug"
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.
@@ -66,7 +66,7 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:cpp"
-        if: ${{ matrix.os }} == "ubuntu" && ${{ matrix.buildtype }} == "Debug"
+        if: matrix.os == "ubuntu" && matrix.buildtype == "Debug"
 
       - name: Upload artifact binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

CodeQL currently is running for all builds in the matrix, but it's meant to be run only once per commit because the syntax is incorrect

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
