### PR TITLE
Fix MySQL handle leak

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -9,7 +9,7 @@
 
 #include <mysql/errmsg.h>
 
-static bool connectToDatabase(MYSQL*& handle, const bool retryIfError)
+static tfs::detail::Mysql_ptr connectToDatabase(const bool retryIfError)
 {
 	bool isFirstAttemptToConnect = true;
 
@@ -19,29 +19,26 @@ retry:
 	}
 	isFirstAttemptToConnect = false;
 
-	// close the connection handle
-	mysql_close(handle);
-	// connection handle initialization
-	handle = mysql_init(nullptr);
+	tfs::detail::Mysql_ptr handle{mysql_init(nullptr)};
 	if (!handle) {
 		std::cout << std::endl << "Failed to initialize MySQL connection handle." << std::endl;
 		goto error;
 	}
 	// connects to database
-	if (!mysql_real_connect(handle, getString(ConfigManager::MYSQL_HOST).c_str(),
+	if (!mysql_real_connect(handle.get(), getString(ConfigManager::MYSQL_HOST).c_str(),
 	                        getString(ConfigManager::MYSQL_USER).c_str(), getString(ConfigManager::MYSQL_PASS).c_str(),
 	                        getString(ConfigManager::MYSQL_DB).c_str(), getNumber(ConfigManager::SQL_PORT),
 	                        getString(ConfigManager::MYSQL_SOCK).c_str(), 0)) {
-		std::cout << std::endl << "MySQL Error Message: " << mysql_error(handle) << std::endl;
+		std::cout << std::endl << "MySQL Error Message: " << mysql_error(handle.get()) << std::endl;
 		goto error;
 	}
-	return true;
+	return handle;
 
 error:
 	if (retryIfError) {
 		goto retry;
 	}
-	return false;
+	return nullptr;
 }
 
 static bool isLostConnectionError(const unsigned error)
@@ -50,27 +47,28 @@ static bool isLostConnectionError(const unsigned error)
 	       error == 1053 /*ER_SERVER_SHUTDOWN*/ || error == CR_CONNECTION_ERROR;
 }
 
-static bool executeQuery(MYSQL*& handle, std::string_view query, const bool retryIfLostConnection)
+static bool executeQuery(tfs::detail::Mysql_ptr& handle, std::string_view query, const bool retryIfLostConnection)
 {
-	while (mysql_real_query(handle, query.data(), query.length()) != 0) {
+	while (mysql_real_query(handle.get(), query.data(), query.length()) != 0) {
 		std::cout << "[Error - mysql_real_query] Query: " << query.substr(0, 256) << std::endl
-		          << "Message: " << mysql_error(handle) << std::endl;
-		const unsigned error = mysql_errno(handle);
+		          << "Message: " << mysql_error(handle.get()) << std::endl;
+		const unsigned error = mysql_errno(handle.get());
 		if (!isLostConnectionError(error) || !retryIfLostConnection) {
 			return false;
 		}
-		connectToDatabase(handle, true);
+		handle = connectToDatabase(true);
 	}
 	return true;
 }
 
-Database::~Database() { mysql_close(handle); }
-
 bool Database::connect()
 {
-	if (!connectToDatabase(handle, false)) {
+	auto newHandle = connectToDatabase(false);
+	if (!newHandle) {
 		return false;
 	}
+
+	handle = std::move(newHandle);
 	DBResult_ptr result = storeQuery("SHOW VARIABLES LIKE 'max_allowed_packet'");
 	if (result) {
 		maxPacketSize = result->getNumber<uint64_t>("Value");
@@ -122,11 +120,11 @@ retry:
 
 	// we should call that every time as someone would call executeQuery('SELECT...')
 	// as it is described in MySQL manual: "it doesn't hurt" :P
-	MYSQL_RES* res = mysql_store_result(handle);
+	tfs::detail::MysqlResult_ptr res{mysql_store_result(handle.get())};
 	if (!res) {
 		std::cout << "[Error - mysql_store_result] Query: " << query << std::endl
-		          << "Message: " << mysql_error(handle) << std::endl;
-		const unsigned error = mysql_errno(handle);
+		          << "Message: " << mysql_error(handle.get()) << std::endl;
+		const unsigned error = mysql_errno(handle.get());
 		if (!isLostConnectionError(error) || !retryQueries) {
 			return nullptr;
 		}
@@ -134,7 +132,7 @@ retry:
 	}
 
 	// retrieving results of query
-	DBResult_ptr result = std::make_shared<DBResult>(res);
+	DBResult_ptr result = std::make_shared<DBResult>(std::move(res));
 	if (!result->hasNext()) {
 		return nullptr;
 	}
@@ -152,7 +150,7 @@ std::string Database::escapeBlob(const char* s, uint32_t length) const
 
 	if (length != 0) {
 		char* output = new char[maxLength];
-		mysql_real_escape_string(handle, output, s, length);
+		mysql_real_escape_string(handle.get(), output, s, length);
 		escaped.append(output);
 		delete[] output;
 	}
@@ -161,22 +159,18 @@ std::string Database::escapeBlob(const char* s, uint32_t length) const
 	return escaped;
 }
 
-DBResult::DBResult(MYSQL_RES* res)
+DBResult::DBResult(tfs::detail::MysqlResult_ptr&& res) : handle{std::move(res)}
 {
-	handle = res;
-
 	size_t i = 0;
 
-	MYSQL_FIELD* field = mysql_fetch_field(handle);
+	MYSQL_FIELD* field = mysql_fetch_field(handle.get());
 	while (field) {
 		listNames[field->name] = i++;
-		field = mysql_fetch_field(handle);
+		field = mysql_fetch_field(handle.get());
 	}
 
-	row = mysql_fetch_row(handle);
+	row = mysql_fetch_row(handle.get());
 }
-
-DBResult::~DBResult() { mysql_free_result(handle); }
 
 std::string_view DBResult::getString(std::string_view column) const
 {
@@ -191,7 +185,7 @@ std::string_view DBResult::getString(std::string_view column) const
 		return {};
 	}
 
-	auto size = mysql_fetch_lengths(handle)[it->second];
+	auto size = mysql_fetch_lengths(handle.get())[it->second];
 	return {row[it->second], size};
 }
 
@@ -199,7 +193,7 @@ bool DBResult::hasNext() const { return row; }
 
 bool DBResult::next()
 {
-	row = mysql_fetch_row(handle);
+	row = mysql_fetch_row(handle.get());
 	return row;
 }
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

The first leak in #4288 is related to `handle` leaking, I couldn't really reproduce how `mysql_init` is called without `mysql_close` not being called on the line before, but using a `unique_ptr` with a custom deleter fixes the leak.

Using `unique_ptr` for `MYSQL_RES` also fixes eventual leaks that happen on queries.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
