### PR TITLE
[bugfix] default duration on decaying items with no min or maxvalue set

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -944,6 +944,8 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 					if (maxValueAttr) {
 						it.decayTimeMax = pugi::cast<uint32_t>(maxValueAttr.value());
+					} else {
+						it.decayTimeMax = pugi::cast<uint32_t>(valueAttribute.value());
 					}
 					break;
 				}


### PR DESCRIPTION
This fixes an issue with items that have no min or max value set. For example.
Before:
`<attribute key="duration" value="300"/>`
Means duration 1-300 seconds.
After
`<attribute key="duration" value="300"/>`
Means duration 300-300 seconds.
Same as
`<attribute key="duration" minvalue="300" maxvalue="300"/>`

problem was introduced in #4531 