### PR TITLE
Fix use-after-free in creature conditions

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -33,6 +33,9 @@ Creature::~Creature()
 
 	for (Condition* condition : conditions) {
 		condition->endCondition(this);
+	}
+
+	for (auto condition : conditions) {
 		delete condition;
 	}
 }


### PR DESCRIPTION
The `Creature` class destructor loops over the `conditions` member variable and calls `condition->endCondition` then `delete`s the condition object, however, `ConditionInvisible::endCondition` calls `Creature::isInvisible`, which subsequently loops over the `conditions`  (which are not erased when being deleted in the destructor), calling `condition->getType` on an already deleted memory, resulting in UAF. This fixes the issue by first ending all conditions, then deleting them separately (as erasing the elements one-by-one in the `Creature` destructor does not make much sense).