### PR TITLE
[bugfix] fix so that 1% resistance reduces damage taken from element by 1

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -944,6 +944,8 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 					if (maxValueAttr) {
 						it.decayTimeMax = pugi::cast<uint32_t>(maxValueAttr.value());
+					} else {
+						it.decayTimeMax = pugi::cast<uint32_t>(valueAttribute.value());
 					}
 					break;
 				}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2000,7 +2000,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 
 			const int16_t& absorbPercent = it.abilities->absorbPercent[combatIndex];
 			if (absorbPercent != 0) {
-				damage -= std::round(damage * (absorbPercent / 100.));
+				damage -= damage * (absorbPercent / 100.);
 
 				uint16_t charges = item->getCharges();
 				if (charges != 0) {
@@ -2013,7 +2013,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 			if (field) {
 				const int16_t& fieldAbsorbPercent = it.abilities->fieldAbsorbPercent[combatIndex];
 				if (fieldAbsorbPercent != 0) {
-					damage -= std::round(damage * (fieldAbsorbPercent / 100.));
+					damage -= damage * (fieldAbsorbPercent / 100.);
 
 					uint16_t charges = item->getCharges();
 					if (charges != 0) {


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

1% resistance should reduce damage taken by 1. So if you have 1% earth resistance you wont take poison damage from poison spider for example.
