### PR TITLE
[bugfix] make it so that 1% resistance correctly reduces damage taken by 1

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2000,7 +2000,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 
 			const int16_t& absorbPercent = it.abilities->absorbPercent[combatIndex];
 			if (absorbPercent != 0) {
-				damage -= std::round(damage * (absorbPercent / 100.));
+				damage -= damage * (absorbPercent / 100.);
 
 				uint16_t charges = item->getCharges();
 				if (charges != 0) {
@@ -2013,7 +2013,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 			if (field) {
 				const int16_t& fieldAbsorbPercent = it.abilities->fieldAbsorbPercent[combatIndex];
 				if (fieldAbsorbPercent != 0) {
-					damage -= std::round(damage * (fieldAbsorbPercent / 100.));
+					damage -= damage * (fieldAbsorbPercent / 100.);
 
 					uint16_t charges = item->getCharges();
 					if (charges != 0) {


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This will make it so that 1% earth resistance will nullify 1 damage poisons for example.