### PR TITLE
[bugfix] fixes bug when player asks to withdraw a string ex; "withdraw" "x"

### DIFF
--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -101,31 +101,37 @@ function doPlayerBuyItemContainer(cid, containerid, itemid, count, cost, charges
 	end
 	return true
 end
-
 function getCount(string)
-	local b, e = string:find("%d+")
-	local count = tonumber(string:sub(b, e))
-	if count > 2 ^ 32 - 1 then
-		print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
-	end
-	return b and e and math.min(2 ^ 32 - 1, count) or -1
+    local b, e = string:find("%d+")
+    if not b then
+        return -1
+    end
+    local count = tonumber(string:sub(b, e))
+    if count > 2 ^ 32 - 1 then
+        print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
+    end
+    return b and e and math.min(2 ^ 32 - 1, count) or -1
 end
+
 
 function isValidMoney(money)
 	return isNumber(money) and money > 0
 end
 
 function getMoneyCount(string)
-	local b, e = string:find("%d+")
-	local count = tonumber(string:sub(b, e))
-	if count > 2 ^ 32 - 1 then
-		print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
-	end
-	local money = b and e and math.min(2 ^ 32 - 1, count) or -1
-	if isValidMoney(money) then
-		return money
-	end
-	return -1
+    local b, e = string:find("%d+")
+    if not b then
+        return -1
+    end
+    local count = tonumber(string:sub(b, e))
+    if count > 2 ^ 32 - 1 then
+        print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
+    end
+    local money = b and e and math.min(2 ^ 32 - 1, count) or -1
+    if isValidMoney(money) then
+        return money
+    end
+    return -1
 end
 
 function getMoneyWeight(money)


### PR DESCRIPTION
If you say "withdraw" "asjdhajsdhajsd" to the banker you will get this error. This PR should fix it.

> Jun 04 07:29:31 Ironcore gdb[1007034]: Lua Script Error: [Npc interface]
> Jun 04 07:29:31 Ironcore gdb[1007034]: data/npc/scripts/Suzy.lua:onCreatureSay
> Jun 04 07:29:31 Ironcore gdb[1007034]: data/npc/lib/npc.lua:122: bad argument https://github.com/otland/forgottenserver/pull/1 to 'sub' (number expected, got nil)
> Jun 04 07:29:31 Ironcore gdb[1007034]: stack traceback:
> Jun 04 07:29:31 Ironcore gdb[1007034]: [C]: at 0x55555560ff80
> Jun 04 07:29:31 Ironcore gdb[1007034]: [C]: in function 'sub'
> Jun 04 07:29:31 Ironcore gdb[1007034]: data/npc/lib/npc.lua:122: in function 'getMoneyCount'
> Jun 04 07:29:31 Ironcore gdb[1007034]: data/npc/scripts/Suzy.lua:140: in function 'callback'
> Jun 04 07:29:31 Ironcore gdb[1007034]: data/npc/lib/npcsystem/npchandler.lua:413: in function 'onCreatureSay'
> Jun 04 07:29:31 Ironcore gdb[1007034]: data/npc/scripts/Suzy.lua:10: in function <data/npc/scripts/Suzy.lua:10>
