### PR TITLE
[bugfix] make it so that 1% resistance correctly reduces damage taken by 1

### DIFF
--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -101,31 +101,37 @@ function doPlayerBuyItemContainer(cid, containerid, itemid, count, cost, charges
 	end
 	return true
 end
-
 function getCount(string)
-	local b, e = string:find("%d+")
-	local count = tonumber(string:sub(b, e))
-	if count > 2 ^ 32 - 1 then
-		print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
-	end
-	return b and e and math.min(2 ^ 32 - 1, count) or -1
+    local b, e = string:find("%d+")
+    if not b then
+        return -1
+    end
+    local count = tonumber(string:sub(b, e))
+    if count > 2 ^ 32 - 1 then
+        print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
+    end
+    return b and e and math.min(2 ^ 32 - 1, count) or -1
 end
+
 
 function isValidMoney(money)
 	return isNumber(money) and money > 0
 end
 
 function getMoneyCount(string)
-	local b, e = string:find("%d+")
-	local count = tonumber(string:sub(b, e))
-	if count > 2 ^ 32 - 1 then
-		print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
-	end
-	local money = b and e and math.min(2 ^ 32 - 1, count) or -1
-	if isValidMoney(money) then
-		return money
-	end
-	return -1
+    local b, e = string:find("%d+")
+    if not b then
+        return -1
+    end
+    local count = tonumber(string:sub(b, e))
+    if count > 2 ^ 32 - 1 then
+        print("Warning: Casting value to 32bit to prevent crash\n" .. debug.traceback())
+    end
+    local money = b and e and math.min(2 ^ 32 - 1, count) or -1
+    if isValidMoney(money) then
+        return money
+    end
+    return -1
 end
 
 function getMoneyWeight(money)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2000,7 +2000,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 
 			const int16_t& absorbPercent = it.abilities->absorbPercent[combatIndex];
 			if (absorbPercent != 0) {
-				damage -= std::round(damage * (absorbPercent / 100.));
+				damage -= damage * (absorbPercent / 100.);
 
 				uint16_t charges = item->getCharges();
 				if (charges != 0) {
@@ -2013,7 +2013,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 			if (field) {
 				const int16_t& fieldAbsorbPercent = it.abilities->fieldAbsorbPercent[combatIndex];
 				if (fieldAbsorbPercent != 0) {
-					damage -= std::round(damage * (fieldAbsorbPercent / 100.));
+					damage -= damage * (fieldAbsorbPercent / 100.);
 
 					uint16_t charges = item->getCharges();
 					if (charges != 0) {


### PR DESCRIPTION
Accidently deleted this before. This fix will make it so that 1% resistance correctly reduces damage taken by 1.

9 damage
![image](https://github.com/otland/forgottenserver/assets/102702255/a4631770-c8d5-4afd-979b-eae581fb04fc)

200 damage
![image](https://github.com/otland/forgottenserver/assets/102702255/9bd60c58-e292-44f0-b043-0fac11c9ade9)

999 damage
![image](https://github.com/otland/forgottenserver/assets/102702255/a5fc8ea5-e3a7-4a8b-91d5-e5f987224102)

2001 damage
![image](https://github.com/otland/forgottenserver/assets/102702255/b4f5c168-04ce-406c-861a-b38212cfe615)

The damage is being ceiled elsewhere so it doesn't need std::ceil
