### PR TITLE
Added missing default dependencies for using vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,7 +44,8 @@
     }
   },
   "default-features": [
-    "lua"
+    "lua",
+    "http"
   ],
   "builtin-baseline": "215a2535590f1f63788ac9bd2ed58ad15e6afdff"
 }


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** 
When using manifest mode with vcpkg, you are unable to build as the features called "http" and "unit-tests" are not enabled by default, and therefore their dependencies are not downloaded, yet files that use them are included in the build.

To fix that, we just enable these features by default.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
