### PR TITLE
[Revscriptsys] fixing memory leak in Actions & Moveevents

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -191,9 +191,9 @@ bool Actions::registerEvent(Event_ptr event, const pugi::xml_node& node)
 bool Actions::registerLuaEvent(Action* event)
 {
 	Action_ptr action{event};
-	if (!getItemIdRange().empty()) {
-		const auto& range = getItemIdRange();
-		for (auto id : range) {
+	if (!getItemIdRange(event).empty()) {
+		const auto& range = getItemIdRange(event);
+		for (auto& id : range) {
 			auto result = useItemMap.emplace(id, *action);
 			if (!result.second) {
 				std::cout << "[Warning - Actions::registerLuaEvent] Duplicate registered item with id: " << id
@@ -201,9 +201,9 @@ bool Actions::registerLuaEvent(Action* event)
 			}
 		}
 		return true;
-	} else if (!getUniqueIdRange().empty()) {
-		const auto& range = getUniqueIdRange();
-		for (auto id : range) {
+	} else if (!getUniqueIdRange(event).empty()) {
+		const auto& range = getUniqueIdRange(event);
+		for (auto& id : range) {
 			auto result = uniqueItemMap.emplace(id, *action);
 			if (!result.second) {
 				std::cout << "[Warning - Actions::registerLuaEvent] Duplicate registered item with uid: " << id
@@ -211,9 +211,9 @@ bool Actions::registerLuaEvent(Action* event)
 			}
 		}
 		return true;
-	} else if (!getActionIdRange().empty()) {
-		const auto& range = getActionIdRange();
-		for (auto id : range) {
+	} else if (!getActionIdRange(event).empty()) {
+		const auto& range = getActionIdRange(event);
+		for (auto& id : range) {
 			auto result = actionItemMap.emplace(id, *action);
 			if (!result.second) {
 				std::cout << "[Warning - Actions::registerLuaEvent] Duplicate registered item with aid: " << id

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -191,8 +191,8 @@ bool Actions::registerEvent(Event_ptr event, const pugi::xml_node& node)
 bool Actions::registerLuaEvent(Action* event)
 {
 	Action_ptr action{event};
-	if (!action->getItemIdRange().empty()) {
-		const auto& range = action->getItemIdRange();
+	if (!getItemIdRange().empty()) {
+		const auto& range = getItemIdRange();
 		for (auto id : range) {
 			auto result = useItemMap.emplace(id, *action);
 			if (!result.second) {
@@ -201,8 +201,8 @@ bool Actions::registerLuaEvent(Action* event)
 			}
 		}
 		return true;
-	} else if (!action->getUniqueIdRange().empty()) {
-		const auto& range = action->getUniqueIdRange();
+	} else if (!getUniqueIdRange().empty()) {
+		const auto& range = getUniqueIdRange();
 		for (auto id : range) {
 			auto result = uniqueItemMap.emplace(id, *action);
 			if (!result.second) {
@@ -211,8 +211,8 @@ bool Actions::registerLuaEvent(Action* event)
 			}
 		}
 		return true;
-	} else if (!action->getActionIdRange().empty()) {
-		const auto& range = action->getActionIdRange();
+	} else if (!getActionIdRange().empty()) {
+		const auto& range = getActionIdRange();
 		for (auto id : range) {
 			auto result = actionItemMap.emplace(id, *action);
 			if (!result.second) {

--- a/src/actions.h
+++ b/src/actions.h
@@ -70,17 +70,29 @@ public:
 	bool registerLuaEvent(Action* event);
 	void clear(bool fromLua) override final;
 
-	void clearItemIdRange() { return ids.clear(); }
-	const std::vector<uint16_t>& getItemIdRange() const { return ids; }
-	void addItemId(uint16_t id) { ids.emplace_back(id); }
+	void clearItemIdRange(Action* action)
+	{
+		ids[action].clear();
+		ids.erase(action);
+	}
+	const std::vector<uint16_t>& getItemIdRange(Action* action) const { return ids.at(action); }
+	void addItemId(Action* action, uint16_t id) { ids[action].emplace_back(id); }
 
-	void clearUniqueIdRange() { return uids.clear(); }
-	const std::vector<uint16_t>& getUniqueIdRange() const { return uids; }
-	void addUniqueId(uint16_t id) { uids.emplace_back(id); }
+	void clearUniqueIdRange(Action* action)
+	{
+		uids[action].clear();
+		uids.erase(action);
+	}
+	const std::vector<uint16_t>& getUniqueIdRange(Action* action) const { return uids.at(action); }
+	void addUniqueId(Action* action, uint16_t id) { uids[action].emplace_back(id); }
 
-	void clearActionIdRange() { return aids.clear(); }
-	const std::vector<uint16_t>& getActionIdRange() const { return aids; }
-	void addActionId(uint16_t id) { aids.emplace_back(id); }
+	void clearActionIdRange(Action* action)
+	{
+		aids[action].clear();
+		aids.erase(action);
+	}
+	const std::vector<uint16_t>& getActionIdRange(Action* action) const { return aids.at(action); }
+	void addActionId(Action* action, uint16_t id) { aids[action].emplace_back(id); }
 
 private:
 	ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
@@ -94,9 +106,9 @@ private:
 	ActionUseMap useItemMap;
 	ActionUseMap uniqueItemMap;
 	ActionUseMap actionItemMap;
-	std::vector<uint16_t> ids;
-	std::vector<uint16_t> uids;
-	std::vector<uint16_t> aids;
+	std::map<Action*, std::vector<uint16_t>> ids;
+	std::map<Action*, std::vector<uint16_t>> uids;
+	std::map<Action*, std::vector<uint16_t>> aids;
 
 	Action* getAction(const Item* item);
 	void clearMap(ActionUseMap& map, bool fromLua);

--- a/src/actions.h
+++ b/src/actions.h
@@ -70,27 +70,15 @@ public:
 	bool registerLuaEvent(Action* event);
 	void clear(bool fromLua) override final;
 
-	void clearItemIdRange(Action* action)
-	{
-		ids[action].clear();
-		ids.erase(action);
-	}
+	void clearItemIdRange(Action* action) { ids.erase(action); }
 	const std::vector<uint16_t>& getItemIdRange(Action* action) const { return ids.at(action); }
 	void addItemId(Action* action, uint16_t id) { ids[action].emplace_back(id); }
 
-	void clearUniqueIdRange(Action* action)
-	{
-		uids[action].clear();
-		uids.erase(action);
-	}
+	void clearUniqueIdRange(Action* action) { uids.erase(action); }
 	const std::vector<uint16_t>& getUniqueIdRange(Action* action) const { return uids.at(action); }
 	void addUniqueId(Action* action, uint16_t id) { uids[action].emplace_back(id); }
 
-	void clearActionIdRange(Action* action)
-	{
-		aids[action].clear();
-		aids.erase(action);
-	}
+	void clearActionIdRange(Action* action) { aids.erase(action); }
 	const std::vector<uint16_t>& getActionIdRange(Action* action) const { return aids.at(action); }
 	void addActionId(Action* action, uint16_t id) { aids[action].emplace_back(id); }
 

--- a/src/actions.h
+++ b/src/actions.h
@@ -34,18 +34,6 @@ public:
 	bool getCheckFloor() const { return checkFloor; }
 	void setCheckFloor(bool v) { checkFloor = v; }
 
-	void clearItemIdRange() { return ids.clear(); }
-	const std::vector<uint16_t>& getItemIdRange() const { return ids; }
-	void addItemId(uint16_t id) { ids.emplace_back(id); }
-
-	void clearUniqueIdRange() { return uids.clear(); }
-	const std::vector<uint16_t>& getUniqueIdRange() const { return uids; }
-	void addUniqueId(uint16_t id) { uids.emplace_back(id); }
-
-	void clearActionIdRange() { return aids.clear(); }
-	const std::vector<uint16_t>& getActionIdRange() const { return aids; }
-	void addActionId(uint16_t id) { aids.emplace_back(id); }
-
 	virtual ReturnValue canExecuteAction(const Player* player, const Position& toPos);
 	virtual bool hasOwnErrorHandler() { return false; }
 	virtual Thing* getTarget(Player* player, Creature* targetCreature, const Position& toPosition,
@@ -59,9 +47,6 @@ private:
 	bool allowFarUse = false;
 	bool checkFloor = true;
 	bool checkLineOfSight = true;
-	std::vector<uint16_t> ids;
-	std::vector<uint16_t> uids;
-	std::vector<uint16_t> aids;
 };
 
 class Actions final : public BaseEvents
@@ -85,6 +70,18 @@ public:
 	bool registerLuaEvent(Action* event);
 	void clear(bool fromLua) override final;
 
+	void clearItemIdRange() { return ids.clear(); }
+	const std::vector<uint16_t>& getItemIdRange() const { return ids; }
+	void addItemId(uint16_t id) { ids.emplace_back(id); }
+
+	void clearUniqueIdRange() { return uids.clear(); }
+	const std::vector<uint16_t>& getUniqueIdRange() const { return uids; }
+	void addUniqueId(uint16_t id) { uids.emplace_back(id); }
+
+	void clearActionIdRange() { return aids.clear(); }
+	const std::vector<uint16_t>& getActionIdRange() const { return aids; }
+	void addActionId(uint16_t id) { aids.emplace_back(id); }
+
 private:
 	ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
 
@@ -97,6 +94,9 @@ private:
 	ActionUseMap useItemMap;
 	ActionUseMap uniqueItemMap;
 	ActionUseMap actionItemMap;
+	std::vector<uint16_t> ids;
+	std::vector<uint16_t> uids;
+	std::vector<uint16_t> aids;
 
 	Action* getAction(const Item* item);
 	void clearMap(ActionUseMap& map, bool fromLua);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17507,9 +17507,9 @@ int LuaScriptInterface::luaActionRegister(lua_State* L)
 			return 1;
 		}
 		tfs::lua::pushBoolean(L, g_actions->registerLuaEvent(action));
-		g_actions->clearItemIdRange();
-		g_actions->clearUniqueIdRange();
-		g_actions->clearActionIdRange();
+		g_actions->clearItemIdRange(action);
+		g_actions->clearUniqueIdRange(action);
+		g_actions->clearActionIdRange(action);
 	} else {
 		lua_pushnil(L);
 	}
@@ -17524,10 +17524,10 @@ int LuaScriptInterface::luaActionItemId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_actions->addItemId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_actions->addItemId(action, tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			g_actions->addItemId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_actions->addItemId(action, tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -17544,10 +17544,10 @@ int LuaScriptInterface::luaActionActionId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_actions->addActionId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_actions->addActionId(action, tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			g_actions->addActionId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_actions->addActionId(action, tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -17564,10 +17564,10 @@ int LuaScriptInterface::luaActionUniqueId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_actions->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_actions->addUniqueId(action, tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			g_actions->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_actions->addUniqueId(action, tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -17857,20 +17857,20 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 	if (moveevent) {
 		if ((moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP) &&
 		    moveevent->getSlot() == SLOTP_WHEREEVER) {
-			uint32_t id = g_moveEvents->getItemIdRange().at(0);
+			uint32_t id = g_moveEvents->getItemIdRange(moveevent).at(0);
 			ItemType& it = Item::items.getItemType(id);
 			moveevent->setSlot(it.slotPosition);
 		}
 		if (!moveevent->isScripted()) {
 			tfs::lua::pushBoolean(L, g_moveEvents->registerLuaFunction(moveevent));
-			g_actions->clearItemIdRange();
+			g_moveEvents->clearItemIdRange(moveevent);
 			return 1;
 		}
 		tfs::lua::pushBoolean(L, g_moveEvents->registerLuaEvent(moveevent));
-		g_moveEvents->clearItemIdRange();
-		g_moveEvents->clearActionIdRange();
-		g_moveEvents->clearUniqueIdRange();
-		g_moveEvents->clearPosList();
+		g_moveEvents->clearItemIdRange(moveevent);
+		g_moveEvents->clearActionIdRange(moveevent);
+		g_moveEvents->clearUniqueIdRange(moveevent);
+		g_moveEvents->clearPosList(moveevent);
 	} else {
 		lua_pushnil(L);
 	}
@@ -18040,10 +18040,10 @@ int LuaScriptInterface::luaMoveEventItemId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_moveEvents->addItemId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_moveEvents->addItemId(moveevent, tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			g_moveEvents->addItemId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_moveEvents->addItemId(moveevent, tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -18060,10 +18060,10 @@ int LuaScriptInterface::luaMoveEventActionId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_moveEvents->addActionId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_moveEvents->addActionId(moveevent, tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			g_moveEvents->addActionId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_moveEvents->addActionId(moveevent, tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -18080,10 +18080,10 @@ int LuaScriptInterface::luaMoveEventUniqueId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_moveEvents->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_moveEvents->addUniqueId(moveevent, tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			g_moveEvents->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_moveEvents->addUniqueId(moveevent, tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -18100,10 +18100,10 @@ int LuaScriptInterface::luaMoveEventPosition(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				g_moveEvents->addPosList(tfs::lua::getPosition(L, 2 + i));
+				g_moveEvents->addPosList(moveevent, tfs::lua::getPosition(L, 2 + i));
 			}
 		} else {
-			g_moveEvents->addPosList(tfs::lua::getPosition(L, 2));
+			g_moveEvents->addPosList(moveevent, tfs::lua::getPosition(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17507,9 +17507,9 @@ int LuaScriptInterface::luaActionRegister(lua_State* L)
 			return 1;
 		}
 		tfs::lua::pushBoolean(L, g_actions->registerLuaEvent(action));
-		action->clearActionIdRange();
-		action->clearItemIdRange();
-		action->clearUniqueIdRange();
+		g_actions->clearItemIdRange();
+		g_actions->clearUniqueIdRange();
+		g_actions->clearActionIdRange();
 	} else {
 		lua_pushnil(L);
 	}
@@ -17524,10 +17524,10 @@ int LuaScriptInterface::luaActionItemId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				action->addItemId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_actions->addItemId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			action->addItemId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_actions->addItemId(tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -17544,10 +17544,10 @@ int LuaScriptInterface::luaActionActionId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				action->addActionId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_actions->addActionId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			action->addActionId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_actions->addActionId(tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -17564,10 +17564,10 @@ int LuaScriptInterface::luaActionUniqueId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				action->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_actions->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			action->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_actions->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -17857,19 +17857,20 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 	if (moveevent) {
 		if ((moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP) &&
 		    moveevent->getSlot() == SLOTP_WHEREEVER) {
-			uint32_t id = moveevent->getItemIdRange().at(0);
+			uint32_t id = g_moveEvents->getItemIdRange().at(0);
 			ItemType& it = Item::items.getItemType(id);
 			moveevent->setSlot(it.slotPosition);
 		}
 		if (!moveevent->isScripted()) {
 			tfs::lua::pushBoolean(L, g_moveEvents->registerLuaFunction(moveevent));
+			g_actions->clearItemIdRange();
 			return 1;
 		}
 		tfs::lua::pushBoolean(L, g_moveEvents->registerLuaEvent(moveevent));
-		moveevent->clearItemIdRange();
-		moveevent->clearActionIdRange();
-		moveevent->clearUniqueIdRange();
-		moveevent->clearPosList();
+		g_moveEvents->clearItemIdRange();
+		g_moveEvents->clearActionIdRange();
+		g_moveEvents->clearUniqueIdRange();
+		g_moveEvents->clearPosList();
 	} else {
 		lua_pushnil(L);
 	}
@@ -18039,10 +18040,10 @@ int LuaScriptInterface::luaMoveEventItemId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addItemId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_moveEvents->addItemId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			moveevent->addItemId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_moveEvents->addItemId(tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -18059,10 +18060,10 @@ int LuaScriptInterface::luaMoveEventActionId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addActionId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_moveEvents->addActionId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			moveevent->addActionId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_moveEvents->addActionId(tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -18079,10 +18080,10 @@ int LuaScriptInterface::luaMoveEventUniqueId(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
+				g_moveEvents->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			moveevent->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2));
+			g_moveEvents->addUniqueId(tfs::lua::getNumber<uint32_t>(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -18099,10 +18100,10 @@ int LuaScriptInterface::luaMoveEventPosition(lua_State* L)
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addPosList(tfs::lua::getPosition(L, 2 + i));
+				g_moveEvents->addPosList(tfs::lua::getPosition(L, 2 + i));
 			}
 		} else {
-			moveevent->addPosList(tfs::lua::getPosition(L, 2));
+			g_moveEvents->addPosList(tfs::lua::getPosition(L, 2));
 		}
 		tfs::lua::pushBoolean(L, true);
 	} else {

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -190,9 +190,9 @@ bool MoveEvents::registerLuaFunction(MoveEvent* event)
 		}
 	}
 
-	if (!getItemIdRange().empty()) {
-		const auto& range = getItemIdRange();
-		for (auto id : range) {
+	if (!getItemIdRange(event).empty()) {
+		const auto& range = getItemIdRange(event);
+		for (auto& id : range) {
 			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
 				ItemType& it = Item::items.getItemType(id);
 				it.wieldInfo = moveEvent->getWieldInfo();
@@ -228,9 +228,9 @@ bool MoveEvents::registerLuaEvent(MoveEvent* event)
 		}
 	}
 
-	if (!getItemIdRange().empty()) {
-		const auto& range = getItemIdRange();
-		for (auto id : range) {
+	if (!getItemIdRange(event).empty()) {
+		const auto& range = getItemIdRange(event);
+		for (auto& id : range) {
 			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
 				ItemType& it = Item::items.getItemType(id);
 				it.wieldInfo = moveEvent->getWieldInfo();
@@ -240,18 +240,18 @@ bool MoveEvents::registerLuaEvent(MoveEvent* event)
 			}
 			addEvent(*moveEvent, id, itemIdMap);
 		}
-	} else if (!getActionIdRange().empty()) {
-		const auto& range = getActionIdRange();
-		for (auto id : range) {
+	} else if (!getActionIdRange(event).empty()) {
+		const auto& range = getActionIdRange(event);
+		for (auto& id : range) {
 			addEvent(*moveEvent, id, actionIdMap);
 		}
-	} else if (!getUniqueIdRange().empty()) {
-		const auto& range = getUniqueIdRange();
-		for (auto id : range) {
+	} else if (!getUniqueIdRange(event).empty()) {
+		const auto& range = getUniqueIdRange(event);
+		for (auto& id : range) {
 			addEvent(*moveEvent, id, uniqueIdMap);
 		}
-	} else if (!getPosList().empty()) {
-		const auto& range = getPosList();
+	} else if (!getPosList(event).empty()) {
+		const auto& range = getPosList(event);
 		for (auto& pos : range) {
 			addEvent(*moveEvent, pos, positionMap);
 		}

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -190,10 +190,9 @@ bool MoveEvents::registerLuaFunction(MoveEvent* event)
 		}
 	}
 
-	if (moveEvent->getItemIdRange().size() > 0) {
-		if (moveEvent->getItemIdRange().size() == 1) {
-			uint32_t id = moveEvent->getItemIdRange().at(0);
-			addEvent(*moveEvent, id, itemIdMap);
+	if (!getItemIdRange().empty()) {
+		const auto& range = getItemIdRange();
+		for (auto id : range) {
 			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
 				ItemType& it = Item::items.getItemType(id);
 				it.wieldInfo = moveEvent->getWieldInfo();
@@ -201,18 +200,7 @@ bool MoveEvents::registerLuaFunction(MoveEvent* event)
 				it.minReqMagicLevel = moveEvent->getReqMagLv();
 				it.vocationString = moveEvent->getVocationString();
 			}
-		} else {
-			uint32_t iterId = 0;
-			while (++iterId < moveEvent->getItemIdRange().size()) {
-				if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-					ItemType& it = Item::items.getItemType(moveEvent->getItemIdRange().at(iterId));
-					it.wieldInfo = moveEvent->getWieldInfo();
-					it.minReqLevel = moveEvent->getReqLevel();
-					it.minReqMagicLevel = moveEvent->getReqMagLv();
-					it.vocationString = moveEvent->getVocationString();
-				}
-				addEvent(*moveEvent, moveEvent->getItemIdRange().at(iterId), itemIdMap);
-			}
+			addEvent(*moveEvent, id, itemIdMap);
 		}
 	} else {
 		return false;
@@ -240,10 +228,9 @@ bool MoveEvents::registerLuaEvent(MoveEvent* event)
 		}
 	}
 
-	if (moveEvent->getItemIdRange().size() > 0) {
-		if (moveEvent->getItemIdRange().size() == 1) {
-			uint32_t id = moveEvent->getItemIdRange().at(0);
-			addEvent(*moveEvent, id, itemIdMap);
+	if (!getItemIdRange().empty()) {
+		const auto& range = getItemIdRange();
+		for (auto id : range) {
 			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
 				ItemType& it = Item::items.getItemType(id);
 				it.wieldInfo = moveEvent->getWieldInfo();
@@ -251,53 +238,26 @@ bool MoveEvents::registerLuaEvent(MoveEvent* event)
 				it.minReqMagicLevel = moveEvent->getReqMagLv();
 				it.vocationString = moveEvent->getVocationString();
 			}
-		} else {
-			auto v = moveEvent->getItemIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-					ItemType& it = Item::items.getItemType(*i);
-					it.wieldInfo = moveEvent->getWieldInfo();
-					it.minReqLevel = moveEvent->getReqLevel();
-					it.minReqMagicLevel = moveEvent->getReqMagLv();
-					it.vocationString = moveEvent->getVocationString();
-				}
-				addEvent(*moveEvent, *i, itemIdMap);
-			}
+			addEvent(*moveEvent, id, itemIdMap);
 		}
-	} else if (moveEvent->getActionIdRange().size() > 0) {
-		if (moveEvent->getActionIdRange().size() == 1) {
-			int32_t id = moveEvent->getActionIdRange().at(0);
+	} else if (!getActionIdRange().empty()) {
+		const auto& range = getActionIdRange();
+		for (auto id : range) {
 			addEvent(*moveEvent, id, actionIdMap);
-		} else {
-			auto v = moveEvent->getActionIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, actionIdMap);
-			}
 		}
-	} else if (moveEvent->getUniqueIdRange().size() > 0) {
-		if (moveEvent->getUniqueIdRange().size() == 1) {
-			int32_t id = moveEvent->getUniqueIdRange().at(0);
+	} else if (!getUniqueIdRange().empty()) {
+		const auto& range = getUniqueIdRange();
+		for (auto id : range) {
 			addEvent(*moveEvent, id, uniqueIdMap);
-		} else {
-			auto v = moveEvent->getUniqueIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, uniqueIdMap);
-			}
 		}
-	} else if (moveEvent->getPosList().size() > 0) {
-		if (moveEvent->getPosList().size() == 1) {
-			Position pos = moveEvent->getPosList().at(0);
+	} else if (!getPosList().empty()) {
+		const auto& range = getPosList();
+		for (auto& pos : range) {
 			addEvent(*moveEvent, pos, positionMap);
-		} else {
-			auto v = moveEvent->getPosList();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, positionMap);
-			}
 		}
 	} else {
 		return false;
 	}
-
 	return true;
 }
 

--- a/src/movement.h
+++ b/src/movement.h
@@ -55,6 +55,18 @@ public:
 	bool registerLuaEvent(MoveEvent* event);
 	bool registerLuaFunction(MoveEvent* event);
 	void clear(bool fromLua) override final;
+	void clearItemIdRange() { return itemIdRange.clear(); }
+	const std::vector<uint32_t>& getItemIdRange() const { return itemIdRange; }
+	void addItemId(uint32_t id) { itemIdRange.emplace_back(id); }
+	void clearActionIdRange() { return actionIdRange.clear(); }
+	const std::vector<uint32_t>& getActionIdRange() const { return actionIdRange; }
+	void addActionId(uint32_t id) { actionIdRange.emplace_back(id); }
+	void clearUniqueIdRange() { return uniqueIdRange.clear(); }
+	const std::vector<uint32_t>& getUniqueIdRange() const { return uniqueIdRange; }
+	void addUniqueId(uint32_t id) { uniqueIdRange.emplace_back(id); }
+	void clearPosList() { return posList.clear(); }
+	const std::vector<Position>& getPosList() const { return posList; }
+	void addPosList(Position pos) { posList.emplace_back(pos); }
 
 private:
 	using MoveListMap = std::map<int32_t, MoveEventList>;
@@ -78,6 +90,10 @@ private:
 	MoveListMap actionIdMap;
 	MoveListMap itemIdMap;
 	MovePosListMap positionMap;
+	std::vector<uint32_t> itemIdRange;
+	std::vector<uint32_t> actionIdRange;
+	std::vector<uint32_t> uniqueIdRange;
+	std::vector<Position> posList;
 
 	LuaScriptInterface scriptInterface;
 };
@@ -132,18 +148,6 @@ public:
 	}
 	bool getTileItem() const { return tileItem; }
 	void setTileItem(bool b) { tileItem = b; }
-	void clearItemIdRange() { return itemIdRange.clear(); }
-	const std::vector<uint32_t>& getItemIdRange() const { return itemIdRange; }
-	void addItemId(uint32_t id) { itemIdRange.emplace_back(id); }
-	void clearActionIdRange() { return actionIdRange.clear(); }
-	const std::vector<uint32_t>& getActionIdRange() const { return actionIdRange; }
-	void addActionId(uint32_t id) { actionIdRange.emplace_back(id); }
-	void clearUniqueIdRange() { return uniqueIdRange.clear(); }
-	const std::vector<uint32_t>& getUniqueIdRange() const { return uniqueIdRange; }
-	void addUniqueId(uint32_t id) { uniqueIdRange.emplace_back(id); }
-	void clearPosList() { return posList.clear(); }
-	const std::vector<Position>& getPosList() const { return posList; }
-	void addPosList(Position pos) { posList.emplace_back(pos); }
 	void setSlot(uint32_t s) { slot = s; }
 	uint32_t getRequiredLevel() { return reqLevel; }
 	void setRequiredLevel(uint32_t level) { reqLevel = level; }
@@ -181,11 +185,6 @@ private:
 	uint32_t wieldInfo = 0;
 	std::unordered_set<uint16_t> vocationEquipSet;
 	bool tileItem = false;
-
-	std::vector<uint32_t> itemIdRange;
-	std::vector<uint32_t> actionIdRange;
-	std::vector<uint32_t> uniqueIdRange;
-	std::vector<Position> posList;
 };
 
 #endif // FS_MOVEMENT_H

--- a/src/movement.h
+++ b/src/movement.h
@@ -55,32 +55,20 @@ public:
 	bool registerLuaEvent(MoveEvent* event);
 	bool registerLuaFunction(MoveEvent* event);
 	void clear(bool fromLua) override final;
-	void clearItemIdRange(MoveEvent* event)
-	{
-		itemIdRange[event].clear();
-		itemIdRange.erase(event);
-	}
+
+	void clearItemIdRange(MoveEvent* event) { itemIdRange.erase(event); }
 	const std::vector<uint32_t>& getItemIdRange(MoveEvent* event) const { return itemIdRange.at(event); }
 	void addItemId(MoveEvent* event, uint32_t id) { itemIdRange[event].emplace_back(id); }
-	void clearActionIdRange(MoveEvent* event)
-	{
-		actionIdRange[event].clear();
-		actionIdRange.erase(event);
-	}
+
+	void clearActionIdRange(MoveEvent* event) { actionIdRange.erase(event); }
 	const std::vector<uint32_t>& getActionIdRange(MoveEvent* event) const { return actionIdRange.at(event); }
 	void addActionId(MoveEvent* event, uint32_t id) { actionIdRange[event].emplace_back(id); }
-	void clearUniqueIdRange(MoveEvent* event)
-	{
-		uniqueIdRange[event].clear();
-		uniqueIdRange.erase(event);
-	}
+
+	void clearUniqueIdRange(MoveEvent* event) { uniqueIdRange.erase(event); }
 	const std::vector<uint32_t>& getUniqueIdRange(MoveEvent* event) const { return uniqueIdRange.at(event); }
 	void addUniqueId(MoveEvent* event, uint32_t id) { uniqueIdRange[event].emplace_back(id); }
-	void clearPosList(MoveEvent* event)
-	{
-		posList[event].clear();
-		posList.erase(event);
-	}
+
+	void clearPosList(MoveEvent* event) { posList.erase(event); }
 	const std::vector<Position>& getPosList(MoveEvent* event) const { return posList.at(event); }
 	void addPosList(MoveEvent* event, Position pos) { posList[event].emplace_back(pos); }
 

--- a/src/movement.h
+++ b/src/movement.h
@@ -55,18 +55,34 @@ public:
 	bool registerLuaEvent(MoveEvent* event);
 	bool registerLuaFunction(MoveEvent* event);
 	void clear(bool fromLua) override final;
-	void clearItemIdRange() { return itemIdRange.clear(); }
-	const std::vector<uint32_t>& getItemIdRange() const { return itemIdRange; }
-	void addItemId(uint32_t id) { itemIdRange.emplace_back(id); }
-	void clearActionIdRange() { return actionIdRange.clear(); }
-	const std::vector<uint32_t>& getActionIdRange() const { return actionIdRange; }
-	void addActionId(uint32_t id) { actionIdRange.emplace_back(id); }
-	void clearUniqueIdRange() { return uniqueIdRange.clear(); }
-	const std::vector<uint32_t>& getUniqueIdRange() const { return uniqueIdRange; }
-	void addUniqueId(uint32_t id) { uniqueIdRange.emplace_back(id); }
-	void clearPosList() { return posList.clear(); }
-	const std::vector<Position>& getPosList() const { return posList; }
-	void addPosList(Position pos) { posList.emplace_back(pos); }
+	void clearItemIdRange(MoveEvent* event)
+	{
+		itemIdRange[event].clear();
+		itemIdRange.erase(event);
+	}
+	const std::vector<uint32_t>& getItemIdRange(MoveEvent* event) const { return itemIdRange.at(event); }
+	void addItemId(MoveEvent* event, uint32_t id) { itemIdRange[event].emplace_back(id); }
+	void clearActionIdRange(MoveEvent* event)
+	{
+		actionIdRange[event].clear();
+		actionIdRange.erase(event);
+	}
+	const std::vector<uint32_t>& getActionIdRange(MoveEvent* event) const { return actionIdRange.at(event); }
+	void addActionId(MoveEvent* event, uint32_t id) { actionIdRange[event].emplace_back(id); }
+	void clearUniqueIdRange(MoveEvent* event)
+	{
+		uniqueIdRange[event].clear();
+		uniqueIdRange.erase(event);
+	}
+	const std::vector<uint32_t>& getUniqueIdRange(MoveEvent* event) const { return uniqueIdRange.at(event); }
+	void addUniqueId(MoveEvent* event, uint32_t id) { uniqueIdRange[event].emplace_back(id); }
+	void clearPosList(MoveEvent* event)
+	{
+		posList[event].clear();
+		posList.erase(event);
+	}
+	const std::vector<Position>& getPosList(MoveEvent* event) const { return posList.at(event); }
+	void addPosList(MoveEvent* event, Position pos) { posList[event].emplace_back(pos); }
 
 private:
 	using MoveListMap = std::map<int32_t, MoveEventList>;
@@ -90,10 +106,10 @@ private:
 	MoveListMap actionIdMap;
 	MoveListMap itemIdMap;
 	MovePosListMap positionMap;
-	std::vector<uint32_t> itemIdRange;
-	std::vector<uint32_t> actionIdRange;
-	std::vector<uint32_t> uniqueIdRange;
-	std::vector<Position> posList;
+	std::map<MoveEvent*, std::vector<uint32_t>> itemIdRange;
+	std::map<MoveEvent*, std::vector<uint32_t>> actionIdRange;
+	std::map<MoveEvent*, std::vector<uint32_t>> uniqueIdRange;
+	std::map<MoveEvent*, std::vector<Position>> posList;
 
 	LuaScriptInterface scriptInterface;
 };


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Actions and Moveevents where leaking memory due to having the temporary vectors for registering ids in the pointer itself
Since we copy the values when we register the event we also copied the vectors which wheren't cleared already thus creating memory which was not intended.
I've moved them to their singletons (Actions/MoveEvents) and clear them every registration
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
- #3694 
- #3692

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
