### PR TITLE
Fix session table in schema

### DIFF
--- a/data/migrations/36.lua
+++ b/data/migrations/36.lua
@@ -8,7 +8,7 @@ function onUpdateDatabase()
 			`account_id` int NOT NULL,
 			`ip` varbinary(16) NOT NULL,
 			`created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			`expired_at` timestamp,
+			`expired_at` timestamp NULL DEFAULT NULL,
 			PRIMARY KEY (`id`),
 			UNIQUE KEY `token` (`token`),
 			FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE

--- a/schema.sql
+++ b/schema.sql
@@ -369,7 +369,7 @@ CREATE TABLE IF NOT EXISTS `sessions` (
   `account_id` int NOT NULL,
   `ip` varbinary(16) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `expired_at` timestamp,
+  `expired_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `token` (`token`),
   FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix session table default value for expired_at field.

**Issues addressed:** <!-- Write here the issue number, if any. -->

https://github.com/otland/forgottenserver/blob/7011488166d1b6a398a51fc56fe854702a69a160/src/protocolgame.cpp#L429 
```CPP
	auto result = db.storeQuery(fmt::format(
	    "SELECT `a`.`id` AS `account_id`, INET6_NTOA(`s`.`ip`) AS `session_ip`, `p`.`id` AS `character_id` FROM `accounts` `a` JOIN `sessions` `s` ON `a`.`id` = `s`.`account_id` JOIN `players` `p` ON `a`.`id` = `p`.`account_id` WHERE `s`.`token` = {:s} AND `s`.`expired_at` IS NULL AND `p`.`name` = {:s} AND `p`.`deletion` = 0",
	    db.escapeString(sessionToken), db.escapeString(characterName)));
```


is checks if expired_at is null(must be null), Xampp for example set default value to 0000-00-00 00:00:00

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
