### PR TITLE
Npc: fix nullptr dereference

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -51,7 +51,7 @@ void reload()
 	}
 
 	for (const auto& it : getNpcTypes()) {
-		if (!it.second->fromLua) {
+		if (it.second  && !it.second->fromLua) {
 			it.second->loadFromXml();
 		}
 	}
@@ -1273,7 +1273,7 @@ NpcEventsHandler::~NpcEventsHandler()
 {
 	for (auto eventId : {creatureSayEvent, creatureDisappearEvent, creatureAppearEvent, creatureMoveEvent,
 	                     playerCloseChannelEvent, playerEndTradeEvent, thinkEvent}) {
-		if (!npc->npcType->fromLua) {
+		if (npc && !npc->npcType->fromLua) {
 			scriptInterface->removeEvent(eventId);
 		}
 	}

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -51,7 +51,7 @@ void reload()
 	}
 
 	for (const auto& it : getNpcTypes()) {
-		if (it.second  && !it.second->fromLua) {
+		if (it.second && !it.second->fromLua) {
 			it.second->loadFromXml();
 		}
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixed a crash when the NPC file is not present(not in npc folder) but is present in the spawns.xml file

How to test:

1) open forgotten-spawn.xml
2) change:
```
<npc name="The Oracle" x="0" y="0" z="4" spawntime="60" />
to 
<npc name="The Oracle test" x="0" y="0" z="4" spawntime="60" />
```

3) run server

OR

1) use command /reload npc

## Before:
Crash on server startup
## After:
Error log as expected
[Error - Npc::loadFromXml] Failed to load data/npc/The Oracle test.xml: File was not found