### PR TITLE
fix issues with house invites string cases

### DIFF
--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -38,8 +38,8 @@ GuildRank_ptr Guild::getRankById(uint32_t rankId)
 
 GuildRank_ptr Guild::getRankByName(const std::string& name) const
 {
-	for (auto rank : ranks) { 
-		if (caseInsensitiveEqual(rank->name, name))  {
+	for (auto rank : ranks) {
+		if (caseInsensitiveEqual(rank->name, name)) {
 			return rank;
 		}
 	}

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -37,8 +37,12 @@ GuildRank_ptr Guild::getRankById(uint32_t rankId)
 
 GuildRank_ptr Guild::getRankByName(const std::string& name) const
 {
+	auto nameToLower = name;
+	toLowerCaseString(nameToLower);
 	for (auto rank : ranks) {
-		if (rank->name == name) {
+		auto rankToLower = rank->name;
+		toLowerCaseString(rankToLower);
+		if (rankToLower == nameToLower) {
 			return rank;
 		}
 	}

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -4,6 +4,7 @@
 #include "otpch.h"
 
 #include "guild.h"
+#include "tools.h"
 
 #include "game.h"
 
@@ -37,12 +38,8 @@ GuildRank_ptr Guild::getRankById(uint32_t rankId)
 
 GuildRank_ptr Guild::getRankByName(const std::string& name) const
 {
-	auto nameToLower = name;
-	toLowerCaseString(nameToLower);
-	for (auto rank : ranks) {
-		auto rankToLower = rank->name;
-		toLowerCaseString(rankToLower);
-		if (rankToLower == nameToLower) {
+	for (auto rank : ranks) { 
+		if (caseInsensitiveEqual(rank->name, name))  {
 			return rank;
 		}
 	}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -390,11 +390,10 @@ void AccessList::parseList(std::string_view list)
 			break;
 		}
 
+		boost::algorithm::trim(line);
 		if (line.empty() || line.front() == '#' || line.length() > 100) {
 			continue;
 		}
-
-		boost::algorithm::to_lower(line);
 
 		std::string::size_type at_pos = line.find("@");
 		if (at_pos != std::string::npos) {
@@ -409,7 +408,7 @@ void AccessList::parseList(std::string_view list)
 		           line.find("?") != std::string::npos) {
 			continue; // regexp no longer supported
 		} else {
-			boost::algorithm::trim(line);
+			boost::algorithm::to_lower(line);
 			addPlayer(line);
 		}
 	}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -390,8 +390,6 @@ void AccessList::parseList(std::string_view list)
 			break;
 		}
 
-		boost::algorithm::trim(line);
-
 		if (line.empty() || line.front() == '#' || line.length() > 100) {
 			continue;
 		}
@@ -403,7 +401,7 @@ void AccessList::parseList(std::string_view list)
 			if (at_pos == 0) {
 				addGuild(line.substr(1));
 			} else {
-				addGuildRank(line.substr(0, at_pos - 1), line.substr(at_pos + 1));
+				addGuildRank(line.substr(0, at_pos), line.substr(at_pos + 1));
 			}
 		} else if (line == "*") {
 			allowEveryone = true;
@@ -411,6 +409,7 @@ void AccessList::parseList(std::string_view list)
 		           line.find("?") != std::string::npos) {
 			continue; // regexp no longer supported
 		} else {
+			boost::algorithm::trim(line);
 			addPlayer(line);
 		}
 	}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -408,7 +408,6 @@ void AccessList::parseList(std::string_view list)
 		           line.find("?") != std::string::npos) {
 			continue; // regexp no longer supported
 		} else {
-			boost::algorithm::to_lower(line);
 			addPlayer(line);
 		}
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
1. Do not use `toLower()` on player inputs for House, Subowner, and Door invite list, it will break for guilds and/or guild ranks with uppercase letters.
2. Fix an issue where `parseList(...)` did not properly parse strings for guild rank (off-by-1 error in substring math)
3. Additionally, to prevent issues like this in the future, compare guild names and ranks ignoring case.

**Issues addressed:** <!-- Write here the issue number, if any. -->

The code in TFS does not ignore case for guild invites, but it does force `toLower()` on inputs, so any guilds with uppercase letters in the name, or ranks with uppercase letters in the name, will not work via `@guildName` or `guildName@rank` invites, subowners, or for door control.  

Note that this is okay on some versions, including master, for guild names.  Guild names in fact *will* function on master here, but guild RANKS are still compared by string comparison across the board.  However, I think forcing both to be `toLower()` is much more readable in both scenarios, despite the fact that it is only fixing a bug for the *ranks* not the *guild names*.

### example
aleta sio -->
```
@guildName  
guildName@guildRank
guildName@guildrank
```
1. first line would work on most systems, although it would previously have done `toLower()` for no real reason
2. second line would be broken because of the capital R in guild Rank 
3. third line would also be broken, because of the bug in the substring math

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
