### PR TITLE
Dont recreate stackables every move

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1214,7 +1214,7 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		}
 
 		int32_t newCount = m - n;
-		if (newCount == item->getItemCount()) {
+		if (!updateItem && newCount == item->getItemCount()) {
 			// full item is moved (move count is the same as item count)
 		} else if (newCount > 0) {
 			moveItem = item->clone();
@@ -1222,18 +1222,26 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		} else {
 			moveItem = nullptr;
 		}
+
+		if (item->isRemoved()) {
+			item->onRemoved();
+		}
 	}
 
 	// add item
-	toCylinder->addThing(index, moveItem);
+	if (moveItem) {
+		toCylinder->addThing(index, moveItem);
+	}
 
 	if (itemIndex != -1) {
 		fromCylinder->postRemoveNotification(item, toCylinder, itemIndex);
 	}
 
-	int32_t moveItemIndex = toCylinder->getThingIndex(moveItem);
-	if (moveItemIndex != -1) {
-		toCylinder->postAddNotification(moveItem, fromCylinder, moveItemIndex);
+	if (moveItem) {
+		int32_t moveItemIndex = toCylinder->getThingIndex(moveItem);
+		if (moveItemIndex != -1) {
+			toCylinder->postAddNotification(moveItem, fromCylinder, moveItemIndex);
+		}
 	}
 
 	if (updateItem) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1173,8 +1173,6 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		m = maxQueryCount;
 	}
 
-	Item* moveItem = item;
-
 	// check if we can remove this item
 	ret = fromCylinder->queryRemove(*item, m, flags, actor);
 	if (ret != RETURNVALUE_NOERROR) {
@@ -1196,6 +1194,8 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		}
 	}
 
+	Item* moveItem = item;
+
 	// remove the item
 	int32_t itemIndex = fromCylinder->getThingIndex(item);
 	Item* updateItem = nullptr;
@@ -1214,32 +1214,26 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		}
 
 		int32_t newCount = m - n;
-		if (newCount > 0) {
+		if (newCount == item->getItemCount()) {
+			// full item is moved (move count is the same as item count)
+		} else if (newCount > 0) {
 			moveItem = item->clone();
 			moveItem->setItemCount(newCount);
 		} else {
 			moveItem = nullptr;
 		}
-
-		if (item->isRemoved()) {
-			ReleaseItem(item);
-		}
 	}
 
 	// add item
-	if (moveItem /*m - n > 0*/) {
-		toCylinder->addThing(index, moveItem);
-	}
+	toCylinder->addThing(index, moveItem);
 
 	if (itemIndex != -1) {
 		fromCylinder->postRemoveNotification(item, toCylinder, itemIndex);
 	}
 
-	if (moveItem) {
-		int32_t moveItemIndex = toCylinder->getThingIndex(moveItem);
-		if (moveItemIndex != -1) {
-			toCylinder->postAddNotification(moveItem, fromCylinder, moveItemIndex);
-		}
+	int32_t moveItemIndex = toCylinder->getThingIndex(moveItem);
+	if (moveItemIndex != -1) {
+		toCylinder->postAddNotification(moveItem, fromCylinder, moveItemIndex);
 	}
 
 	if (updateItem) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1214,17 +1214,17 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		}
 
 		int32_t newCount = m - n;
-		if (!updateItem && newCount == item->getItemCount()) {
+		if (newCount == item->getItemCount()) {
 			// full item is moved (move count is the same as item count)
 		} else if (newCount > 0) {
 			moveItem = item->clone();
 			moveItem->setItemCount(newCount);
 		} else {
+			if (item->isRemoved()) {
+				ReleaseItem(item);
+			}
+			
 			moveItem = nullptr;
-		}
-
-		if (item->isRemoved()) {
-			item->onRemoved();
 		}
 	}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Don't recreate stackables on every move, create new stackables only when splitting the stack.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Stackable items are recreated even when they shouldn't, if you move a full stack of stackable item, why would you create a new item and delete the old one?
This seems pretty wasteful and unnecessary.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
