### PR TITLE
Fix npc baseSpeed & build issue (AccountType_t)

### DIFF
--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -5,6 +5,7 @@
 #define FS_IOLOGINDATA_H
 
 #include "database.h"
+#include "enums.h"
 
 class Item;
 class Player;

--- a/src/npc.h
+++ b/src/npc.h
@@ -259,7 +259,6 @@ private:
 	Position masterPos;
 
 	uint32_t walkTicks;
-	uint32_t baseSpeed;
 	int32_t focusCreature;
 	int32_t masterRadius;
 	uint16_t sightX;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Fix NPC baseSpeed (name hiding)
- resolve issue with build (missing import):

```bash
forgottenserver\src\iologindata.h(22,23): error C3646: 'getAccountType': unknown override specifier
forgottenserver\src\iologindata.h(22,38): error C2275: 'uint32_t': expected an expression instead of a type
forgottenserver\src\iologindata.h(22,47): error C2146: syntax error: missing ')' before identifier 'accountId'
forgottenserver\src\iologindata.h(22,57): error C2238: unexpected token(s) preceding ';'
forgottenserver\src\iologindata.h(23,49): error C2061: syntax error: identifier 'AccountType_t'
forgottenserver\src\item.h(244,6): error C2679: binary '=': no operator found which takes a right-hand operand of type 'int64_t' (or there is no acceptable conversion)
forgottenserver\src\item.h(253,6): error C2679: binary '=': no operator found which takes a right-hand operand of type 'double' (or there is no acceptable conversion)
forgottenserver\src\item.h(262,6): error C2679: binary '=': no operator found which takes a right-hand operand of type 'bool' (or there is no acceptable conversion)
forgottenserver\src\iologindata.cpp(40,28): error C2039: 'getAccountType': is not a member of 'IOLoginData'
forgottenserver\src\iologindata.cpp(50,19): error C2511: 'void IOLoginData::setAccountType(uint32_t,AccountType_t)': overloaded member function not found in 'IOLoginData'
```

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
#4760 [Bug]: NPCs custom speed attribute is ignored

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
