### PR TITLE
Cleanup enabling IPO in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,15 +105,12 @@ add_executable(tfs ${tfs_MAIN})
 target_link_libraries(tfs tfslib)
 
 ### INTERPROCEDURAL_OPTIMIZATION ###
-cmake_policy(SET CMP0069 NEW)
 include(CheckIPOSupported)
 check_ipo_supported(RESULT result OUTPUT error)
 if (result)
-    set(ENABLE_IPO ON)
-    set_target_properties(tfs PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
-    message(STATUS "IPO / LTO enabled")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 else ()
-    message(STATUS "IPO / LTO not supported: <${error}>")
+    message(STATUS "IPO is not supported: ${error}")
 endif ()
 ### END INTERPROCEDURAL_OPTIMIZATION ###
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,10 +188,6 @@ if (APPLE)
 	target_link_libraries(tfslib PRIVATE Iconv::Iconv)
 endif()
 
-if (ENABLE_IPO)
-	set_target_properties(tfslib PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
-endif()
-
 if (HTTP)
 	add_subdirectory(http)
 	target_link_libraries(tfslib PRIVATE http)

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -22,10 +22,6 @@ add_library(http OBJECT ${http_SRC})
 target_link_libraries(http PRIVATE Boost::json)
 set_target_properties(http PROPERTIES UNITY_BUILD ${ENABLE_UNITY_BUILD})
 
-if (ENABLE_IPO)
-	set_target_properties(http PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
-endif()
-
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -8,9 +8,5 @@ foreach(test_src ${tests_SRC})
     add_executable(${test_name} ${test_src})
     target_link_libraries(${test_name} PRIVATE http tfslib Boost::unit_test_framework)
 
-    if (ENABLE_IPO)
-	    set_target_properties(${test_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
-    endif()
-
     add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,9 +12,5 @@ foreach(test_src ${tests_SRC})
     add_executable(${test_name} ${test_src})
     target_link_libraries(${test_name} PRIVATE tfslib Boost::unit_test_framework)
 
-    if (ENABLE_IPO)
-	    set_target_properties(${test_name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
-    endif()
-
     add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Cleanup enabling IPO (LTO) by setting the global value `CMAKE_INTERPROCEDURAL_OPTIMIZATION` which sets the default value for `INTERPROCEDURAL_OPTIMIZATION` in all targets rather than enabling in each target.

Additionally, `CMP0069` does not need to be set to `NEW` since we require a minimum version of CMake 3.19, while it is already set to `NEW` when the minimum required version is 3.9 or higher.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
