### PR TITLE
Move map cache to monster

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -334,8 +334,6 @@ void Creature::onCreatureAppear(Creature* creature, bool isLogin)
 	}
 }
 
-void Creature::onRemoveCreature(Creature* creature, bool) { onCreatureDisappear(creature, true); }
-
 void Creature::onCreatureDisappear(const Creature* creature, bool isLogout)
 {
 	if (attackedCreature == creature) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -289,7 +289,7 @@ public:
 	virtual void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item) {}
 
 	virtual void onCreatureAppear(Creature* creature, bool isLogin);
-	virtual void onRemoveCreature(Creature* creature, bool isLogout);
+	virtual void onRemoveCreature(Creature* creature, bool isLogout) {}
 	virtual void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
 	                            const Position& oldPos, bool teleport);
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -282,11 +282,11 @@ public:
 	virtual void onWalk();
 	virtual bool getNextStep(Direction& dir, uint32_t& flags);
 
-	virtual void onAddTileItem(const Tile* tile, const Position& pos) {}
-	virtual void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
-	                              const Item* newItem, const ItemType& newType)
+	virtual void onAddTileItem(const Tile*, const Position&) {}
+	virtual void onUpdateTileItem(const Tile*, const Position&, const Item*, const ItemType&, const Item*,
+	                              const ItemType&)
 	{}
-	virtual void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item) {}
+	virtual void onRemoveTileItem(const Tile*, const Position&, const ItemType&, const Item*) {}
 
 	virtual void onCreatureAppear(Creature* creature, bool isLogin);
 	virtual void onRemoveCreature(Creature* creature, bool isLogout) {}

--- a/src/creature.h
+++ b/src/creature.h
@@ -282,10 +282,11 @@ public:
 	virtual void onWalk();
 	virtual bool getNextStep(Direction& dir, uint32_t& flags);
 
-	void onAddTileItem(const Tile* tile, const Position& pos);
+	virtual void onAddTileItem(const Tile* tile, const Position& pos) {}
 	virtual void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
-	                              const Item* newItem, const ItemType& newType);
-	virtual void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item);
+	                              const Item* newItem, const ItemType& newType)
+	{}
+	virtual void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item) {}
 
 	virtual void onCreatureAppear(Creature* creature, bool isLogin);
 	virtual void onRemoveCreature(Creature* creature, bool isLogout);
@@ -328,8 +329,6 @@ public:
 	Tile* getTile() override final { return tile; }
 	const Tile* getTile() const override final { return tile; }
 
-	int32_t getWalkCache(const Position& pos) const;
-
 	const Position& getLastPosition() const { return lastPosition; }
 	void setLastPosition(Position newLastPos) { lastPosition = newLastPos; }
 
@@ -355,18 +354,11 @@ public:
 	decltype(auto) getStorageMap() const { return storageMap; }
 
 protected:
-	virtual bool useCacheMap() const { return false; }
-
 	struct CountBlock_t
 	{
 		int32_t total;
 		int64_t ticks;
 	};
-
-	static constexpr int32_t mapWalkWidth = Map::maxViewportX * 2 + 1;
-	static constexpr int32_t mapWalkHeight = Map::maxViewportY * 2 + 1;
-	static constexpr int32_t maxWalkCacheWidth = (mapWalkWidth - 1) / 2;
-	static constexpr int32_t maxWalkCacheHeight = (mapWalkHeight - 1) / 2;
 
 	Position position;
 
@@ -411,9 +403,7 @@ protected:
 	Direction direction = DIRECTION_SOUTH;
 	Skulls_t skull = SKULL_NONE;
 
-	bool localMapCache[mapWalkHeight][mapWalkWidth] = {{false}};
 	bool isInternalRemoved = false;
-	bool isMapLoaded = false;
 	bool isUpdatingPath = false;
 	bool creatureCheck = false;
 	bool inCheckCreaturesVector = false;
@@ -433,9 +423,6 @@ protected:
 	}
 	CreatureEventList getCreatureEvents(CreatureEventType_t type);
 
-	void updateMapCache();
-	void updateTileCache(const Tile* tile, int32_t dx, int32_t dy);
-	void updateTileCache(const Tile* tile, const Position& pos);
 	void onCreatureDisappear(const Creature* creature, bool isLogout);
 	virtual void doAttacking(uint32_t) {}
 	virtual bool hasExtraSwing() { return false; }

--- a/src/creature.h
+++ b/src/creature.h
@@ -289,7 +289,7 @@ public:
 	virtual void onRemoveTileItem(const Tile*, const Position&, const ItemType&, const Item*) {}
 
 	virtual void onCreatureAppear(Creature* creature, bool isLogin);
-	virtual void onRemoveCreature(Creature* creature, bool isLogout) {}
+	virtual void onRemoveCreature(Creature*, bool) {}
 	virtual void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
 	                            const Position& oldPos, bool teleport);
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -633,9 +633,9 @@ const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 {
 	if (auto monster = creature.getMonster()) {
 		auto walk_cache = monster->getWalkCache(pos);
-		if (walk_cache == 0) {
+		if (walk_cache == WALKCACHE_NOTFOUND) {
 			return nullptr;
-		} else if (walk_cache == 1) {
+		} else if (walk_cache == WALKCACHE_FOUND) {
 			return getTile(pos.x, pos.y, pos.z);
 		}
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -631,11 +631,13 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 
 const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 {
-	int32_t walkCache = creature.getWalkCache(pos);
-	if (walkCache == 0) {
-		return nullptr;
-	} else if (walkCache == 1) {
-		return getTile(pos.x, pos.y, pos.z);
+	if (auto monster = creature.getMonster()) {
+		auto walk_cache = monster->getWalkCache(pos);
+		if (walk_cache == 0) {
+			return nullptr;
+		} else if (walk_cache == 1) {
+			return getTile(pos.x, pos.y, pos.z);
+		}
 	}
 
 	// used for non-cached tiles

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -632,10 +632,10 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 {
 	if (auto monster = creature.getMonster()) {
-		auto walk_cache = monster->getWalkCache(pos);
-		if (walk_cache == WALKCACHE_NOTFOUND) {
+		auto walkCache = monster->getWalkCache(pos);
+		if (walkCache == WALKCACHE_NOTFOUND) {
 			return nullptr;
-		} else if (walk_cache == WALKCACHE_FOUND) {
+		} else if (walkCache == WALKCACHE_FOUND) {
 			return getTile(pos.x, pos.y, pos.z);
 		}
 	}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -465,8 +465,8 @@ void Monster::updateTileWalkCache(const Tile* tile, const Position& pos)
 {
 	const auto& myPos = getPosition();
 	if (pos.z == myPos.z) {
-		int32_t dx = pos.getOffsetX(myPos);
-		int32_t dy = pos.getOffsetY(myPos);
+		auto dx = pos.getOffsetX(myPos);
+		auto dy = pos.getOffsetY(myPos);
 		updateTileWalkCache(tile, dx, dy);
 	}
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -24,6 +24,13 @@ enum TargetSearchType_t
 	TARGETSEARCH_NEAREST,
 };
 
+enum WalkCacheResult
+{
+	WALKCACHE_DISABLED,
+	WALKCACHE_NOTFOUND,
+	WALKCACHE_FOUND,
+};
+
 class Monster final : public Creature
 {
 public:
@@ -130,7 +137,7 @@ public:
 	                     bool checkArmor = false, bool field = false, bool ignoreResistances = false) override;
 
 	// map cache
-	int32_t getWalkCache(const Position& pos) const;
+	WalkCacheResult getWalkCache(const Position& pos) const;
 
 	// monster icons
 	MonsterIconHashMap& getSpecialIcons() { return monsterIcons; }
@@ -141,8 +148,6 @@ public:
 private:
 	static constexpr int32_t walkCacheWidth = Map::maxViewportX * 2 + 1;
 	static constexpr int32_t walkCacheHeight = Map::maxViewportY * 2 + 1;
-	static constexpr int32_t maxWalkCacheWidth = (walkCacheWidth - 1) / 2;
-	static constexpr int32_t maxWalkCacheHeight = (walkCacheHeight - 1) / 2;
 
 	CreatureHashSet friendList;
 	CreatureList targetList;
@@ -242,6 +247,8 @@ private:
 	void updateWalkCache();
 	void updateTileWalkCache(const Tile* tile, int32_t dx, int32_t dy);
 	void updateTileWalkCache(const Tile* tile, const Position& pos);
+	void updateMoveWalkCache(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
+	                         const Position& oldPos, bool teleport);
 
 	friend class LuaScriptInterface;
 };

--- a/src/monster.h
+++ b/src/monster.h
@@ -239,7 +239,7 @@ private:
 
 	// map cache
 	bool mapLoaded = false;
-	bool walkabilityCache[walkCacheHeight][walkCacheWidth] = {{false}};
+	bool walkabilityCache[walkCacheHeight][walkCacheWidth] = {};
 
 	bool useWalkCache() const { return !randomStepping; }
 	bool hasLoadedMap() const { return mapLoaded; }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -461,7 +461,7 @@ bool NpcType::loadCallback(NpcScriptInterface* scriptInterface)
 
 void Npc::onRemoveCreature(Creature* creature, bool isLogout)
 {
-	Creature::onRemoveCreature(creature, isLogout);
+	onCreatureDisappear(creature, isLogout);
 
 	if (creature == this) {
 		closeAllShopWindows();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1094,7 +1094,7 @@ void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*
 	}
 }
 
-void Player::onRemoveTileItem(const Tile*, const Position& pos, const ItemType& iType, const Item* item)
+void Player::onRemoveTileItem(const Tile*, const Position&, const ItemType&, const Item* item)
 {
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1081,7 +1081,7 @@ void Player::openSavedContainers()
 }
 
 void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
-                              const Item* newItem, const ItemType& newType)
+                              const Item* newItem, const ItemType&)
 {
 	if (oldItem != newItem) {
 		onRemoveTileItem(tile, pos, oldType, oldItem);
@@ -1094,7 +1094,7 @@ void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*
 	}
 }
 
-void Player::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item)
+void Player::onRemoveTileItem(const Tile*, const Position& pos, const ItemType& iType, const Item* item)
 {
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1083,8 +1083,6 @@ void Player::openSavedContainers()
 void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
                               const Item* newItem, const ItemType& newType)
 {
-	Creature::onUpdateTileItem(tile, pos, oldItem, oldType, newItem, newType);
-
 	if (oldItem != newItem) {
 		onRemoveTileItem(tile, pos, oldType, oldItem);
 	}
@@ -1098,8 +1096,6 @@ void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*
 
 void Player::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item)
 {
-	Creature::onRemoveTileItem(tile, pos, iType, item);
-
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
@@ -1240,7 +1236,7 @@ void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
 
 void Player::onRemoveCreature(Creature* creature, bool isLogout)
 {
-	Creature::onRemoveCreature(creature, isLogout);
+	onCreatureDisappear(creature, isLogout);
 
 	if (creature == this) {
 		onDeEquipInventory();

--- a/src/player.h
+++ b/src/player.h
@@ -769,8 +769,8 @@ public:
 
 	// event methods
 	void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
-	                      const Item* newItem, const ItemType& newType) override;
-	void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item) override;
+	                      const Item* newItem, const ItemType&) override;
+	void onRemoveTileItem(const Tile*, const Position& pos, const ItemType& iType, const Item* item) override;
 
 	void onCreatureAppear(Creature* creature, bool isLogin) override;
 	void onRemoveCreature(Creature* creature, bool isLogout) override;

--- a/src/player.h
+++ b/src/player.h
@@ -770,7 +770,7 @@ public:
 	// event methods
 	void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
 	                      const Item* newItem, const ItemType&) override;
-	void onRemoveTileItem(const Tile*, const Position& pos, const ItemType& iType, const Item* item) override;
+	void onRemoveTileItem(const Tile*, const Position&, const ItemType&, const Item* item) override;
 
 	void onCreatureAppear(Creature* creature, bool isLogin) override;
 	void onRemoveCreature(Creature* creature, bool isLogout) override;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed:
This update aims to enhance of the map cache usage within the codebase. The map cache is currently relevant only for the `Monster` class, which overrides the `useCacheMap` method. 

- **Implementation Details**:
  - The `useCacheMap` method specific to `Monster` is defined as follows:
    ```cpp
    bool useCacheMap() const override { return !randomStepping; }
    ```
    This method provides behavior unique to the `Monster` class by determining when the map cache should be utilized based on the `randomStepping` attribute.

  - In contrast, the base `Creature` class retains a default implementation for the `useCacheMap` method. This default implementation indicates that creatures, by default, do not use the map cache:
    ```cpp
    virtual bool useCacheMap() const { return false; }
    ```

By relocating the map cache functionality directly into the `Monster` class, we improve and reduces unnecessary complexity delineates the responsibilities of each class regarding map cache usage.

#### Additional Considerations
- This refactor does not alter any existing functionality for the `Creature` class, ensuring backward compatibility.


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
