### PR TITLE
Fix boost warn: use boost::system instead boost::json error code

### DIFF
--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -35,7 +35,7 @@ beast::http::message_generator tfs::http::handle_request(const beast::http::requ
                                                          std::string_view ip)
 {
 	auto&& [status, responseBody] = [&req, ip]() {
-		json::error_code ec;
+		boost::system::error_code ec;
 		auto requestBody = json::parse(req.body(), ec, &mr);
 		if (ec || !requestBody.is_object()) {
 			return make_error_response({.code = 2, .message = "Invalid request body."});


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Fix boost warn: `warning C4996: 'boost::json::error_code': Use boost::system::error_code instead`

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
