### PR TITLE
Fix executeQuery handle desync

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -112,7 +112,7 @@ bool Database::executeQuery(const std::string& query)
 	// we have to store that result, even though we do not need it, otherwise handle will get blocked
 	auto mysql_res = mysql_store_result(handle.get());
 	mysql_free_result(mysql_res);
-	
+
 	return success;
 }
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -110,8 +110,8 @@ bool Database::executeQuery(const std::string& query)
 
 	// executeQuery can be called with command that produces result (e.g. SELECT)
 	// we have to store that result, even though we do not need it, otherwise handle will get blocked
-	mysql_store_result(handle.get());
-	mysql_free_result(handle.get());
+	auto mysql_res = mysql_store_result(handle.get());
+	mysql_free_result(mysql_res);
 	
 	return success;
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -110,7 +110,7 @@ bool Database::executeQuery(const std::string& query)
 
 	// executeQuery can be called with command that produces result (e.g. SELECT)
 	// we have to store that result, even though we do not need it, otherwise handle will get blocked
-	mysql_store_result(handle.get())
+	mysql_store_result(handle.get());
 	mysql_free_result(handle.get());
 	
 	return success;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Handle should be properly cleaned up after executing a query producing a result, right now it blocks infinitely
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
closes #4787 


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
