### PR TITLE
Revert "Obtain the master of summons on death (#4551)"

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -726,10 +726,6 @@ void Creature::onDeath()
 
 	if (master) {
 		setMaster(nullptr);
-
-		if (dynamic_cast<Monster*>(this) != nullptr) {
-			decrementReferenceCounter();
-		}
 	}
 
 	if (droppedCorpse) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1836,6 +1836,7 @@ void Monster::death(Creature*)
 
 	for (Creature* summon : summons) {
 		summon->changeHealth(-summon->getHealth());
+		summon->removeMaster();
 	}
 	summons.clear();
 


### PR DESCRIPTION
This reverts commit a0c02384a1298be01908aaf64a2422dec4dd42a1.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Code introduced in #4551 is highly unsafe, calling decrementReferenceCounter directly may lead to a decrement that will immediately delete the underlying object, which is prone to use-after-free crashes.

I'm unable to properly deduce why this change was made, so I'm suggesting a revert instead of a fix.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Fix #4786

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
