### PR TITLE
Add a new method to check if Thing has a parent

### DIFF
--- a/data/npc/lib/npcsystem/keywordhandler.lua
+++ b/data/npc/lib/npcsystem/keywordhandler.lua
@@ -45,7 +45,7 @@ if not KeywordHandler then
 
 	-- Returns the parent of this node or nil if no such node exists.
 	function KeywordNode:hasParent()
-		return self.parent
+		return self.parent ~= nil
 	end
 
 	function KeywordNode:getParent()

--- a/data/npc/lib/npcsystem/keywordhandler.lua
+++ b/data/npc/lib/npcsystem/keywordhandler.lua
@@ -44,6 +44,10 @@ if not KeywordHandler then
 	end
 
 	-- Returns the parent of this node or nil if no such node exists.
+	function KeywordNode:hasParent()
+		return self.parent
+	end
+
 	function KeywordNode:getParent()
 		return self.parent
 	end
@@ -121,7 +125,7 @@ if not KeywordHandler then
 			return true
 		end
 
-		if node:getParent() then
+		if node:hasParent() then
 			node = node:getParent() -- Search through the parent.
 			local ret = self:processNodeMessage(node, cid, message)
 			if ret then

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -487,7 +487,7 @@ void Container::addThing(int32_t index, Thing* thing)
 	ammoCount += item->getItemCount();
 
 	// send change to client
-	if (getParent() && (getParent() != VirtualCylinder::virtualCylinder)) {
+	if (hasParent() && (getParent() != VirtualCylinder::virtualCylinder)) {
 		onAddContainerItem(item);
 	}
 }
@@ -499,7 +499,7 @@ void Container::addItemBack(Item* item)
 	ammoCount += item->getItemCount();
 
 	// send change to client
-	if (getParent() && (getParent() != VirtualCylinder::virtualCylinder)) {
+	if (hasParent() && (getParent() != VirtualCylinder::virtualCylinder)) {
 		onAddContainerItem(item);
 	}
 }
@@ -525,7 +525,7 @@ void Container::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	updateItemWeight(-oldWeight + item->getWeight());
 
 	// send change to client
-	if (getParent()) {
+	if (hasParent()) {
 		onUpdateContainerItem(index, item, item);
 	}
 }
@@ -551,7 +551,7 @@ void Container::replaceThing(uint32_t index, Thing* thing)
 	ammoCount += item->getItemCount();
 
 	// send change to client
-	if (getParent()) {
+	if (hasParent()) {
 		onUpdateContainerItem(index, replacedItem, item);
 	}
 
@@ -580,7 +580,7 @@ void Container::removeThing(Thing* thing, uint32_t count)
 		updateItemWeight(-oldWeight + item->getWeight());
 
 		// send change to client
-		if (getParent()) {
+		if (hasParent()) {
 			onUpdateContainerItem(index, item, item);
 		}
 	} else {
@@ -589,7 +589,7 @@ void Container::removeThing(Thing* thing, uint32_t count)
 		ammoCount -= item->getItemCount();
 
 		// send change to client
-		if (getParent()) {
+		if (hasParent()) {
 			onRemoveContainerItem(index, item);
 		}
 
@@ -657,7 +657,7 @@ void Container::postAddNotification(Thing* thing, const Cylinder* oldParent, int
 		topParent->postAddNotification(thing, oldParent, index, LINK_TOPPARENT);
 	} else if (topParent == this) {
 		// let the tile class notify surrounding players
-		if (topParent->getParent()) {
+		if (topParent->hasParent()) {
 			topParent->getParent()->postAddNotification(thing, oldParent, index, LINK_NEAR);
 		}
 	} else {
@@ -672,7 +672,7 @@ void Container::postRemoveNotification(Thing* thing, const Cylinder* newParent, 
 		topParent->postRemoveNotification(thing, newParent, index, LINK_TOPPARENT);
 	} else if (topParent == this) {
 		// let the tile class notify surrounding players
-		if (topParent->getParent()) {
+		if (topParent->hasParent()) {
 			topParent->getParent()->postRemoveNotification(thing, newParent, index, LINK_NEAR);
 		}
 	} else {

--- a/src/container.h
+++ b/src/container.h
@@ -50,6 +50,8 @@ public:
 	virtual StoreInbox* getStoreInbox() { return nullptr; }
 	virtual const StoreInbox* getStoreInbox() const { return nullptr; }
 
+	bool hasParent() const override;
+
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 	bool unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, PropStream& propStream) override;
 
@@ -67,7 +69,6 @@ public:
 
 	std::string getName(bool addArticle = false) const;
 
-	bool hasParent() const;
 	void addItem(Item* item);
 	Item* getItemByIndex(size_t index) const;
 	bool isHoldingItem(const Item* item) const;

--- a/src/creature.h
+++ b/src/creature.h
@@ -316,6 +316,7 @@ public:
 	bool registerCreatureEvent(const std::string& name);
 	bool unregisterCreatureEvent(const std::string& name);
 
+	bool hasParent() const override { return getParent(); }
 	Cylinder* getParent() const override final { return tile; }
 	void setParent(Cylinder* cylinder) override final
 	{

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -26,6 +26,7 @@ public:
 	// overrides
 	bool canRemove() const override { return false; }
 
+	bool hasParent() const override { return getParent(); }
 	Cylinder* getParent() const override;
 	Cylinder* getRealParent() const override { return parent; }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -495,7 +495,7 @@ Player* Game::getPlayerByAccount(uint32_t acc)
 bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/,
                                  bool forced /*= false*/)
 {
-	if (creature->getParent()) {
+	if (creature->hasParent()) {
 		return false;
 	}
 

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -17,7 +17,7 @@ void HouseTile::addThing(int32_t index, Thing* thing)
 {
 	Tile::addThing(index, thing);
 
-	if (!thing->getParent()) {
+	if (!thing->hasParent()) {
 		return;
 	}
 
@@ -30,7 +30,7 @@ void HouseTile::internalAddThing(uint32_t index, Thing* thing)
 {
 	Tile::internalAddThing(index, thing);
 
-	if (!thing->getParent()) {
+	if (!thing->hasParent()) {
 		return;
 	}
 

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -23,6 +23,7 @@ public:
 	// overrides
 	bool canRemove() const override { return false; }
 
+	bool hasParent() const override { return getParent(); }
 	Cylinder* getParent() const override;
 	Cylinder* getRealParent() const override { return parent; }
 };

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -120,7 +120,7 @@ bool IOMapSerialize::loadItem(PropStream& propStream, Cylinder* parent)
 	}
 
 	Tile* tile = nullptr;
-	if (!parent->getParent()) {
+	if (!parent->hasParent()) {
 		tile = parent->getTile();
 	}
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -261,7 +261,7 @@ Cylinder* Item::getTopParent()
 		return prevaux;
 	}
 
-	while (aux->getParent()) {
+	while (aux->hasParent()) {
 		prevaux = aux;
 		aux = aux->getParent();
 	}
@@ -280,7 +280,7 @@ const Cylinder* Item::getTopParent() const
 		return prevaux;
 	}
 
-	while (aux->getParent()) {
+	while (aux->hasParent()) {
 		prevaux = aux;
 		aux = aux->getParent();
 	}
@@ -295,7 +295,7 @@ Tile* Item::getTile()
 {
 	Cylinder* cylinder = getTopParent();
 	// get root cylinder
-	if (cylinder && cylinder->getParent()) {
+	if (cylinder && cylinder->hasParent()) {
 		cylinder = cylinder->getParent();
 	}
 	return dynamic_cast<Tile*>(cylinder);
@@ -305,7 +305,7 @@ const Tile* Item::getTile() const
 {
 	const Cylinder* cylinder = getTopParent();
 	// get root cylinder
-	if (cylinder && cylinder->getParent()) {
+	if (cylinder && cylinder->hasParent()) {
 		cylinder = cylinder->getParent();
 	}
 	return dynamic_cast<const Tile*>(cylinder);

--- a/src/item.h
+++ b/src/item.h
@@ -913,6 +913,7 @@ public:
 		}
 	}
 
+	bool hasParent() const override { return getParent(); }
 	Cylinder* getParent() const override { return parent; }
 	void setParent(Cylinder* cylinder) override { parent = cylinder; }
 	Cylinder* getTopParent();

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2562,6 +2562,7 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod(L, "Item", "isItem", LuaScriptInterface::luaItemIsItem);
 
+	registerMethod(L, "Item", "hasParent", LuaScriptInterface::luaItemHasParent);
 	registerMethod(L, "Item", "getParent", LuaScriptInterface::luaItemGetParent);
 	registerMethod(L, "Item", "getTopParent", LuaScriptInterface::luaItemGetTopParent);
 
@@ -2671,6 +2672,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "Creature", "canSeeGhostMode", LuaScriptInterface::luaCreatureCanSeeGhostMode);
 	registerMethod(L, "Creature", "canSeeInvisibility", LuaScriptInterface::luaCreatureCanSeeInvisibility);
 
+	registerMethod(L, "Creature", "hasParent", LuaScriptInterface::luaCreatureHasParent);
 	registerMethod(L, "Creature", "getParent", LuaScriptInterface::luaCreatureGetParent);
 
 	registerMethod(L, "Creature", "getId", LuaScriptInterface::luaCreatureGetId);
@@ -3691,7 +3693,7 @@ int LuaScriptInterface::luaDoPlayerAddItem(lua_State* L)
 		}
 
 		if (--itemCount == 0) {
-			if (newItem->getParent()) {
+			if (newItem->hasParent()) {
 				uint32_t uid = tfs::lua::getScriptEnv()->addThing(newItem);
 				lua_pushnumber(L, uid);
 				return 1;
@@ -6628,6 +6630,19 @@ int LuaScriptInterface::luaItemIsItem(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaItemHasParent(lua_State* L)
+{
+	// item:hasParent()
+	Item* item = tfs::lua::getUserdata<Item>(L, 1);
+	if (!item) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	tfs::lua::pushBoolean(L, item->hasParent());
+	return 1;
+}
+
 int LuaScriptInterface::luaItemGetParent(lua_State* L)
 {
 	// item:getParent()
@@ -8017,6 +8032,19 @@ int LuaScriptInterface::luaCreatureCanSeeInvisibility(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureHasParent(lua_State* L)
+{
+	// creature:hasParent()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	tfs::lua::pushBoolean(L, creature->hasParent());
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -436,6 +436,7 @@ private:
 
 	static int luaItemIsItem(lua_State* L);
 
+	static int luaItemHasParent(lua_State* L);
 	static int luaItemGetParent(lua_State* L);
 	static int luaItemGetTopParent(lua_State* L);
 
@@ -541,6 +542,7 @@ private:
 	static int luaCreatureCanSeeGhostMode(lua_State* L);
 	static int luaCreatureCanSeeInvisibility(lua_State* L);
 
+	static int luaCreatureHasParent(lua_State* L);
 	static int luaCreatureGetParent(lua_State* L);
 
 	static int luaCreatureGetId(lua_State* L);

--- a/src/thing.h
+++ b/src/thing.h
@@ -23,6 +23,7 @@ public:
 
 	virtual std::string getDescription(int32_t lookDistance) const = 0;
 
+	virtual bool hasParent() const { return false; }
 	virtual Cylinder* getParent() const { return nullptr; }
 	virtual Cylinder* getRealParent() const { return getParent(); }
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -582,7 +582,7 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 				}
 			}
 
-			if (!player->getParent() && hasFlag(TILESTATE_NOLOGOUT)) {
+			if (!player->hasParent() && hasFlag(TILESTATE_NOLOGOUT)) {
 				// player is trying to login to a "no logout" tile
 				return RETURNVALUE_NOTPOSSIBLE;
 			}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Introduces a new method to the `Thing` class that allows checking if a Thing instance has a parent. This providing a direct way to determine parent-child relationships, in addition to the existing `if (getParent()) {}`.

Before
```c++
Tile* tile = nullptr;
if (!parent->getParent()) {
    tile = parent->getTile();
}
```

After
```c++
Tile* tile = nullptr;
if (!parent->hasParent()) {
    tile = parent->getTile();
}
```


New Lua method
```lua
local container = Container()
if container:hasParent() then
    ...
end
```

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
