### PR TITLE
Refactoring goToFollowCreature into Npc, Player and Monster

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -467,6 +467,18 @@ void Creature::onCreatureDisappear(const Creature* creature, bool isLogout)
 	}
 }
 
+void Creature::updateWalkPathToFollowCreature(FindPathParams& fpp)
+{
+	listWalkDir.clear();
+
+	if (getPathTo(followCreature->getPosition(), listWalkDir, fpp)) {
+		hasFollowPath = true;
+		startAutoWalk();
+	} else {
+		hasFollowPath = false;
+	}
+}
+
 void Creature::onChangeZone(ZoneType_t zone)
 {
 	if (attackedCreature && zone == ZONE_PROTECTION) {
@@ -954,53 +966,6 @@ void Creature::getPathSearchParams(const Creature*, FindPathParams& fpp) const
 	fpp.maxSearchDist = 12;
 	fpp.minTargetDist = 1;
 	fpp.maxTargetDist = 1;
-}
-
-void Creature::goToFollowCreature()
-{
-	if (followCreature) {
-		FindPathParams fpp;
-		getPathSearchParams(followCreature, fpp);
-
-		Monster* monster = getMonster();
-		if (monster && !monster->getMaster() && (monster->isFleeing() || fpp.maxTargetDist > 1)) {
-			Direction dir = DIRECTION_NONE;
-
-			if (monster->isFleeing()) {
-				monster->getDistanceStep(followCreature->getPosition(), dir, true);
-			} else { // maxTargetDist > 1
-				if (!monster->getDistanceStep(followCreature->getPosition(), dir)) {
-					// if we can't get anything then let the A* calculate
-					listWalkDir.clear();
-					if (getPathTo(followCreature->getPosition(), listWalkDir, fpp)) {
-						hasFollowPath = true;
-						startAutoWalk();
-					} else {
-						hasFollowPath = false;
-					}
-					return;
-				}
-			}
-
-			if (dir != DIRECTION_NONE) {
-				listWalkDir.clear();
-				listWalkDir.push_back(dir);
-
-				hasFollowPath = true;
-				startAutoWalk();
-			}
-		} else {
-			listWalkDir.clear();
-			if (getPathTo(followCreature->getPosition(), listWalkDir, fpp)) {
-				hasFollowPath = true;
-				startAutoWalk();
-			} else {
-				hasFollowPath = false;
-			}
-		}
-	}
-
-	onFollowCreatureComplete(followCreature);
 }
 
 bool Creature::setFollowCreature(Creature* creature)

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -467,7 +467,7 @@ void Creature::onCreatureDisappear(const Creature* creature, bool isLogout)
 	}
 }
 
-void Creature::updateWalkPathToFollowCreature(FindPathParams& fpp)
+void Creature::updateFollowCreaturePath(FindPathParams& fpp)
 {
 	listWalkDir.clear();
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -181,7 +181,7 @@ public:
 	void addEventWalk(bool firstStep = false);
 	void stopEventWalk();
 	virtual void goToFollowCreature() = 0;
-	void updateWalkPathToFollowCreature(FindPathParams& fpp);
+	void updateFollowCreaturePath(FindPathParams& fpp);
 
 	// walk events
 	virtual void onWalk(Direction& dir);

--- a/src/creature.h
+++ b/src/creature.h
@@ -180,7 +180,8 @@ public:
 	void startAutoWalk(const std::vector<Direction>& listDir);
 	void addEventWalk(bool firstStep = false);
 	void stopEventWalk();
-	virtual void goToFollowCreature();
+	virtual void goToFollowCreature() = 0;
+	void updateWalkPathToFollowCreature(FindPathParams& fpp);
 
 	// walk events
 	virtual void onWalk(Direction& dir);
@@ -193,7 +194,6 @@ public:
 
 	// follow events
 	virtual void onFollowCreature(const Creature*) {}
-	virtual void onFollowCreatureComplete(const Creature*) {}
 
 	// combat functions
 	Creature* getAttackedCreature() { return attackedCreature; }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -585,7 +585,7 @@ void Monster::goToFollowCreature()
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
 
-	if (isSummon()) {
+	if (!isSummon()) {
 		Direction dir = DIRECTION_NONE;
 
 		if (isFleeing()) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -593,7 +593,7 @@ void Monster::goToFollowCreature()
 		} else if (fpp.maxTargetDist > 1) {
 			if (!getDistanceStep(followCreature->getPosition(), dir)) {
 				// if we can't get anything then let the A* calculate
-				updateWalkPathToFollowCreature(fpp);
+				updateFollowCreaturePath(fpp);
 				return;
 			}
 		}
@@ -606,7 +606,7 @@ void Monster::goToFollowCreature()
 			startAutoWalk();
 		}
 	} else {
-		updateWalkPathToFollowCreature(fpp);
+		updateFollowCreaturePath(fpp);
 	}
 
 	onFollowCreatureComplete();

--- a/src/monster.h
+++ b/src/monster.h
@@ -98,7 +98,8 @@ public:
 	void onWalk() override;
 	void onWalkComplete() override;
 	bool getNextStep(Direction& direction, uint32_t& flags) override;
-	void onFollowCreatureComplete(const Creature* creature) override;
+	void goToFollowCreature() override;
+	void onFollowCreatureComplete();
 
 	void onThink(uint32_t interval) override;
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -410,6 +410,17 @@ void Npc::loadNpcTypeInfo()
 	sightY = npcType->sightY;
 }
 
+void Npc::goToFollowCreature()
+{
+	if (!followCreature) {
+		return;
+	}
+
+	FindPathParams fpp;
+	getPathSearchParams(followCreature, fpp);
+	updateWalkPathToFollowCreature(fpp);
+}
+
 void Npc::onCreatureAppear(Creature* creature, bool isLogin)
 {
 	Creature::onCreatureAppear(creature, isLogin);

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -418,7 +418,7 @@ void Npc::goToFollowCreature()
 
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
-	updateWalkPathToFollowCreature(fpp);
+	updateFollowCreaturePath(fpp);
 }
 
 void Npc::onCreatureAppear(Creature* creature, bool isLogin)

--- a/src/npc.h
+++ b/src/npc.h
@@ -222,6 +222,8 @@ public:
 
 	void loadNpcTypeInfo();
 
+	void goToFollowCreature() override;
+
 	std::unique_ptr<NpcEventsHandler> npcEventHandler;
 	bool fromLua = false;
 	NpcType* npcType;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3356,16 +3356,20 @@ bool Player::setAttackedCreature(Creature* creature)
 
 void Player::goToFollowCreature()
 {
-	if (!walkTask) {
-		if ((OTSYS_TIME() - lastFailedFollow) < 2000) {
-			return;
-		}
+	if (walkTask || !followCreature) {
+		return;
+	}
 
-		Creature::goToFollowCreature();
+	if ((OTSYS_TIME() - lastFailedFollow) < 2000) {
+		return;
+	}
 
-		if (followCreature && !hasFollowPath) {
-			lastFailedFollow = OTSYS_TIME();
-		}
+	FindPathParams fpp;
+	getPathSearchParams(followCreature, fpp);
+	updateWalkPathToFollowCreature(fpp);
+
+	if (!hasFollowPath) {
+		lastFailedFollow = OTSYS_TIME();
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3366,7 +3366,7 @@ void Player::goToFollowCreature()
 
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
-	updateWalkPathToFollowCreature(fpp);
+	updateFollowCreaturePath(fpp);
 
 	if (!hasFollowPath) {
 		lastFailedFollow = OTSYS_TIME();


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Move the `Creature::goToFollowCreature` method from the base `Creature` class and its impl to the specific classes Npc, Player and Monster. This change ensures that the follow behavior is handled where it is most relevant, providing greater clarity and making debugging easier; allowing each to adapt or extend the follow behavior as needed, eliminating unnecessary checks (see you `Monster* monster = getMonster();`).

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
