### PR TITLE
Correct misuses of `__has_cpp_attribute`

### DIFF
--- a/src/tools.h
+++ b/src/tools.h
@@ -77,18 +77,17 @@ const std::vector<Direction>& getShuffleDirections();
 
 namespace tfs {
 
-#if __has_cpp_attribute(__cpp_lib_to_underlying)
+#ifdef __cpp_lib_to_underlying
 
-template <class T>
-using std::to_underlying<T>;
+using std::to_underlying;
 
 #else
 
-inline constexpr auto to_underlying(auto e) noexcept { return static_cast<std::underlying_type_t<decltype(e)>>(e); }
+constexpr auto to_underlying(auto e) noexcept { return static_cast<std::underlying_type_t<decltype(e)>>(e); }
 
 #endif
 
-#if __has_cpp_attribute(__cpp_lib_unreachable)
+#ifdef  __cpp_lib_unreachable
 
 using std::unreachable;
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`__has_cpp_attribute` is for detecting support for attribute-tokens like `fallthrough` or `unlikely`. These queries with feature-test macro names are always going to fail since no implementation will ever support an attribute-token with the same name as a feature-test macro. Given the conditional use of library facilities, the intent here is clearly to test the feature-test macros to determine support for those facilities, so let's do that instead.

I've also fixed the using-declaration for `std::to_underlying`.

Drive-by: Removed extraneous `inline` in the definition of the `constexpr` fallback for `to_underlying`; `constexpr` functions are implicitly inline.

**Issues addressed:** None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
