### PR TITLE
New methods to handle creatures with a master

### DIFF
--- a/data/creaturescripts/scripts/drop_loot.lua
+++ b/data/creaturescripts/scripts/drop_loot.lua
@@ -6,19 +6,7 @@ function onDeath(player, corpse, killer, mostDamageKiller, lastHitUnjustified, m
 	local amulet = player:getSlotItem(CONST_SLOT_NECKLACE)
 	local isRedOrBlack = table.contains({SKULL_RED, SKULL_BLACK}, player:getSkull())
 	if amulet and amulet.itemid == ITEM_AMULETOFLOSS and not isRedOrBlack then
-		local isPlayer = false
-		if killer then
-			if killer:isPlayer() then
-				isPlayer = true
-			else
-				local master = killer:getMaster()
-				if master and master:isPlayer() then
-					isPlayer = true
-				end
-			end
-		end
-
-		if not isPlayer or not player:hasBlessing(6) then
+		if not killer or not killer:hasPlayerOwned() or not player:hasBlessing(6) then
 			player:removeItem(ITEM_AMULETOFLOSS, 1, -1, false)
 		end
 	else

--- a/data/creaturescripts/scripts/player_death.lua
+++ b/data/creaturescripts/scripts/player_death.lua
@@ -6,15 +6,10 @@ local function getKiller(killer)
 		return false, "field item"
 	end
 
-	if killer:isPlayer() then
-		return true, killer:getName()
+	local player = killer:getPlayerOwned()
+	if player and player ~= killer then
+		return true, player:getName()
 	end
-
-	local master = killer:getMaster()
-	if master and master ~= killer and master:isPlayer() then
-		return true, master:getName()
-	end
-
 	return false, killer:getName()
 end
 

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -894,7 +894,7 @@ function doSetMonsterTarget(cid, target)
 		return false
 	end
 
-	if monster:getMaster() then
+	if monster:isSummon() then
 		return true
 	end
 
@@ -913,7 +913,7 @@ function doMonsterChangeTarget(cid)
 		return false
 	end
 
-	if monster:getMaster() then
+	if monster:isSummon() then
 		return true
 	end
 

--- a/data/scripts/actions/others/music_box.lua
+++ b/data/scripts/actions/others/music_box.lua
@@ -58,7 +58,7 @@ local config = {
 local musicBox = Action()
 
 function musicBox.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not target:isCreature() or not target:isMonster() or target:getMaster() then
+	if not target:isCreature() or not target:isMonster() or target:isSummon() then
 		return false
 	end
 

--- a/data/scripts/actions/others/nail_case.lua
+++ b/data/scripts/actions/others/nail_case.lua
@@ -8,7 +8,7 @@ local messages = {
 local nailCase = Action()
 
 function nailCase.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not target:isCreature() or not target:isMonster() or target:getMaster() then
+	if not target:isCreature() or not target:isMonster() or target:isSummon() then
 		return false
 	end
 

--- a/data/scripts/actions/others/taming.lua
+++ b/data/scripts/actions/others/taming.lua
@@ -418,7 +418,7 @@ function taming.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	if target.type == TYPE_MONSTER then
-		if target:getMaster() then
+		if target:isSummon() then
 			return false
 		end
 	end

--- a/data/scripts/creaturescripts/monster/white_deer_death.lua
+++ b/data/scripts/creaturescripts/monster/white_deer_death.lua
@@ -7,7 +7,7 @@ local creatureevent = CreatureEvent("WhiteDeerDeath")
 
 function creatureevent.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUnjustified, mostDamageUnjustified)
 	local targetMonster = creature:getMonster()
-	if not targetMonster or targetMonster:getMaster() then
+	if not targetMonster or targetMonster:isSummon() then
 		return true
 	end
 

--- a/data/scripts/creaturescripts/monster/white_deer_scouts.lua
+++ b/data/scripts/creaturescripts/monster/white_deer_scouts.lua
@@ -2,7 +2,7 @@ local creatureevent = CreatureEvent("WhiteDeerScouts")
 
 function creatureevent.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUnjustified, mostDamageUnjustified)
 	local targetMonster = creature:getMonster()
-	if not targetMonster or targetMonster:getMaster() then
+	if not targetMonster or targetMonster:isSummon() then
 		return true
 	end
 

--- a/data/scripts/creaturescripts/player/bestiary_kills.lua
+++ b/data/scripts/creaturescripts/player/bestiary_kills.lua
@@ -25,7 +25,7 @@ local creatureEvent = CreatureEvent("BestiaryKills")
 
 function creatureEvent.onKill(player, target)
 	local monster = target:getMonster()
-	if not monster or monster:getMaster() then
+	if not monster or monster:isSummon() then
 		return true
 	end
 

--- a/data/scripts/spells/healing/mass_healing.lua
+++ b/data/scripts/spells/healing/mass_healing.lua
@@ -10,8 +10,7 @@ function spell.onCastSpell(creature, variant)
 	local min = (creature:getLevel() / 5) + (creature:getMagicLevel() * 4.6) + 100
 	local max = (creature:getLevel() / 5) + (creature:getMagicLevel() * 9.6) + 125
 	for _, target in ipairs(combat:getTargets(creature, variant)) do
-		local master = target:getMaster()
-		if target:isPlayer() or master and master:isPlayer() then
+		if target:hasPlayerOwned() then
 			doTargetCombat(creature, target, COMBAT_HEALING, min, max)
 		end
 	end

--- a/data/scripts/spells/monster/frozen_minion_beam.lua
+++ b/data/scripts/spells/monster/frozen_minion_beam.lua
@@ -6,12 +6,11 @@ combat:setArea(createCombatArea(AREA_BEAM7))
 function onTargetCreature(creature, target)
 	local min = 200
 	local max = 700
-	local master = target:getMaster()
-	if target:isPlayer() and not master or master and master:isPlayer() then
+	if target:hasPlayerOwned() then
 		doTargetCombat(0, target, COMBAT_ICEDAMAGE, min, max, CONST_ME_NONE)
 		return true
 	end
-
+	
 	doTargetCombat(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end

--- a/data/scripts/spells/monster/frozen_minion_heal.lua
+++ b/data/scripts/spells/monster/frozen_minion_heal.lua
@@ -4,13 +4,12 @@ combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
 combat:setArea(createCombatArea(AREA_CIRCLE2X2))
 
 function onTargetCreature(creature, target)
-	local min = 100
-	local max = 200
-	local master = target:getMaster()
-	if target:isPlayer() and not master or master and master:isPlayer() then
+	if target:hasPlayerOwned() then
 		return true
 	end
-
+	
+	local min = 100
+	local max = 200
 	doTargetCombat(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end

--- a/data/scripts/spells/monster/frozen_minion_wave.lua
+++ b/data/scripts/spells/monster/frozen_minion_wave.lua
@@ -14,12 +14,11 @@ combat:setArea(createCombatArea(area))
 function onTargetCreature(creature, target)
 	local min = 200
 	local max = 700
-	local master = target:getMaster()
-	if target:isPlayer() and not master or master and master:isPlayer() then
+	if target:hasPlayerOwned() then
 		doTargetCombat(0, target, COMBAT_ICEDAMAGE, min, max, CONST_ME_NONE)
 		return true
 	end
-
+	
 	doTargetCombat(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end

--- a/data/scripts/spells/monster/heal_monsters.lua
+++ b/data/scripts/spells/monster/heal_monsters.lua
@@ -1,17 +1,10 @@
 function onTargetCreature(creature, target)
-	local player = creature:getPlayer()
+	if target:hasPlayerOwned() then
+		return true
+	end
+	
 	local min = 100
 	local max = 300
-	local master = target:getMaster()
-
-	if target:isPlayer() then
-		return true
-	end
-
-	if master then
-		return true
-	end
-
 	doTargetCombatHealth(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end

--- a/data/scripts/spells/monster/heal_monsters_9x9.lua
+++ b/data/scripts/spells/monster/heal_monsters_9x9.lua
@@ -1,17 +1,10 @@
 function onTargetCreature(creature, target)
-	local player = creature:getPlayer()
+	if target:hasPlayerOwned() then
+		return true
+	end
+	
 	local min = 0
 	local max = 1000
-	local master = target:getMaster()
-
-	if target:isPlayer() then
-		return true
-	end
-
-	if master then
-		return true
-	end
-
 	doTargetCombatHealth(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end

--- a/data/scripts/spells/monster/icicle_heal.lua
+++ b/data/scripts/spells/monster/icicle_heal.lua
@@ -4,13 +4,12 @@ combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
 combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
 function onTargetCreature(creature, target)
-	local min = 400
-	local max = 600
-	local master = target:getMaster()
-	if target:isPlayer() and not master or master and master:isPlayer() then
+	if target:hasPlayerOwned() then
 		return true
 	end
 
+	local min = 400
+	local max = 600
 	doTargetCombat(0, target, COMBAT_HEALING, min, max, CONST_ME_NONE)
 	return true
 end

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -164,19 +164,6 @@ ConditionType_t Combat::DamageToConditionType(CombatType_t type)
 	}
 }
 
-bool Combat::isPlayerCombat(const Creature* target)
-{
-	if (target->getPlayer()) {
-		return true;
-	}
-
-	if (target->isSummon() && target->getMaster()->getPlayer()) {
-		return true;
-	}
-
-	return false;
-}
-
 ReturnValue Combat::canTargetCreature(Player* attacker, Creature* target)
 {
 	if (attacker == target) {
@@ -194,7 +181,7 @@ ReturnValue Combat::canTargetCreature(Player* attacker, Creature* target)
 		}
 
 		// nopvp-zone
-		if (isPlayerCombat(target)) {
+		if (target->hasPlayerOwned()) {
 			if (attacker->getZone() == ZONE_NOPVP) {
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			}
@@ -317,19 +304,17 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 			}
 		}
 
-		if (attacker->isSummon()) {
-			if (const Player* masterAttackerPlayer = attacker->getMaster()->getPlayer()) {
-				if (masterAttackerPlayer->hasFlag(PlayerFlag_CannotAttackPlayer)) {
-					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
-				}
+		if (const Player* masterAttackerPlayer = attacker->getPlayerMaster()) {
+			if (masterAttackerPlayer->hasFlag(PlayerFlag_CannotAttackPlayer)) {
+				return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
+			}
 
-				if (targetPlayer->getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
-					return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
-				}
+			if (targetPlayer->getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
+				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
+			}
 
-				if (isProtected(masterAttackerPlayer, targetPlayer)) {
-					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
-				}
+			if (isProtected(masterAttackerPlayer, targetPlayer)) {
+				return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 			}
 		}
 	} else if (target->getMonster()) {
@@ -338,34 +323,21 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 				return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 			}
 
-			if (target->isSummon() && target->getMaster()->getPlayer() && target->getZone() == ZONE_NOPVP) {
+			if (target->isPlayerSummon() && target->getZone() == ZONE_NOPVP) {
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			}
 		} else if (attacker->getMonster()) {
-			const Creature* targetMaster = target->getMaster();
-
-			if (!targetMaster || !targetMaster->getPlayer()) {
-				const Creature* attackerMaster = attacker->getMaster();
-
-				if (!attackerMaster || !attackerMaster->getPlayer()) {
-					return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
-				}
+			if (!target->isPlayerSummon() && !attacker->isPlayerSummon()) {
+				return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 			}
 		}
 	}
 
 	if (g_game.getWorldType() == WORLD_TYPE_NO_PVP) {
-		if (attacker->getPlayer() || (attacker->isSummon() && attacker->getMaster()->getPlayer())) {
-			if (target->getPlayer()) {
-				if (!isInPvpZone(attacker, target)) {
-					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
-				}
-			}
-
-			if (target->isSummon() && target->getMaster()->getPlayer()) {
-				if (!isInPvpZone(attacker, target)) {
-					return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
-				}
+		if (attacker->hasPlayerOwned() && target->hasPlayerOwned()) {
+			if (!isInPvpZone(attacker, target)) {
+				return target->getPlayer() ? RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER
+				                           : RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 			}
 		}
 	}
@@ -560,14 +532,7 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 		}
 
 		if (caster) {
-			Player* casterPlayer;
-			if (caster->isSummon()) {
-				casterPlayer = caster->getMaster()->getPlayer();
-			} else {
-				casterPlayer = caster->getPlayer();
-			}
-
-			if (casterPlayer) {
+			if (Player* casterPlayer = caster->getPlayerOwned()) {
 				if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || tile->hasFlag(TILESTATE_NOPVPZONE)) {
 					if (itemId == ITEM_FIREFIELD_PVP_FULL) {
 						itemId = ITEM_FIREFIELD_NOPVP;
@@ -1403,11 +1368,8 @@ void MagicField::onStepInField(Creature* creature)
 			bool harmfulField = true;
 
 			if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
-				Creature* owner = g_game.getCreatureByID(ownerId);
-				if (owner) {
-					if (owner->getPlayer() || (owner->isSummon() && owner->getMaster()->getPlayer())) {
-						harmfulField = false;
-					}
+				if (Creature* owner = g_game.getCreatureByID(ownerId); owner->hasPlayerOwned()) {
+					harmfulField = false;
 				}
 			}
 

--- a/src/combat.h
+++ b/src/combat.h
@@ -90,7 +90,6 @@ public:
 
 	static bool isInPvpZone(const Creature* attacker, const Creature* target);
 	static bool isProtected(const Player* attacker, const Player* target);
-	static bool isPlayerCombat(const Creature* target);
 	static CombatType_t ConditionToDamageType(ConditionType_t type);
 	static ConditionType_t DamageToConditionType(CombatType_t type);
 	static ReturnValue canTargetCreature(Player* attacker, Creature* target);

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -963,7 +963,7 @@ void Creature::goToFollowCreature()
 		getPathSearchParams(followCreature, fpp);
 
 		Monster* monster = getMonster();
-		if (monster && !monster->getMaster() && (monster->isFleeing() || fpp.maxTargetDist > 1)) {
+		if (monster && !monster->isSummon() && (monster->isFleeing() || fpp.maxTargetDist > 1)) {
 			Direction dir = DIRECTION_NONE;
 
 			if (monster->isFleeing()) {
@@ -1463,11 +1463,11 @@ int64_t Creature::getStepDuration() const
 	double duration = std::floor(1000 * groundSpeed / calculatedStepSpeed);
 	int64_t stepDuration = std::ceil(duration / 50) * 50;
 
-	const Monster* monster = getMonster();
-	if (monster && monster->isTargetNearby() && !monster->isFleeing() && !monster->getMaster()) {
-		stepDuration *= 2;
+	if (const Monster* monster = getMonster(); monster->isTargetNearby()) {
+		if (!monster->isFleeing()) {
+			stepDuration *= 2;
+		}
 	}
-
 	return stepDuration;
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -202,8 +202,15 @@ public:
 	                             bool checkDefense = false, bool checkArmor = false, bool field = false,
 	                             bool ignoreResistances = false);
 
+	/// Returns the master of this creature.
+	Creature* getMaster() const { return master; }
+	/// Checks if the creature is a summon, i.e., if it has a master.
+	bool isSummon() const { return master != nullptr; }
+
+	/// Sets a new master for this creature.
 	bool setMaster(Creature* newMaster);
 
+	/// Removes the current master from this creature.
 	void removeMaster()
 	{
 		if (master) {
@@ -212,9 +219,55 @@ public:
 		}
 	}
 
-	bool isSummon() const { return master != nullptr; }
-	Creature* getMaster() const { return master; }
+	/// Checks if the creature is owned by a player, either directly or through its master.
+	bool hasPlayerOwned() const { return getPlayer() || (master && master->getPlayer()); }
+	/// Returns the player that owns this creature, either directly or through its master.
+	Player* getPlayerOwned() { return getPlayer() ? getPlayer() : (master ? master->getPlayer() : nullptr); }
+	/// Returns the player that owns this creature, either directly or through its master.
+	const Player* getPlayerOwned() const
+	{
+		return getPlayer() ? getPlayer() : (master ? master->getPlayer() : nullptr);
+	}
 
+	/// Checks if the creature is owned by an NPC, either directly or through its master.
+	bool hasNpcOwned() const { return getNpc() || (master && master->getNpc()); }
+	/// Returns the NPC that owns this creature, either directly or through its master.
+	Npc* getNpcOwned() { return getNpc() ? getNpc() : (master ? master->getNpc() : nullptr); }
+	/// Returns the NPC that owns this creature, either directly or through its master.
+	const Npc* getNpcOwned() const { return getNpc() ? getNpc() : (master ? master->getNpc() : nullptr); }
+
+	/// Checks if the creature is owned by a monster, either directly or through its master.
+	bool hasMonsterOwned() const { return getMonster() || (master && master->getMonster()); }
+	/// Returns the monster that owns this creature, either directly or through its master.
+	Monster* getMonsterOwned() { return getMonster() ? getMonster() : (master ? master->getMonster() : nullptr); }
+	/// Returns the monster that owns this creature, either directly or through its master.
+	const Monster* getMonsterOwned() const
+	{
+		return getMonster() ? getMonster() : (master ? master->getMonster() : nullptr);
+	}
+
+	/// Checks if the creature's master is a player.
+	bool isPlayerSummon() const { return master && master->getPlayer(); }
+	/// Returns the player who is the master of this creature.
+	Player* getPlayerMaster() { return master ? master->getPlayer() : nullptr; }
+	/// Returns the player who is the master of this creature.
+	const Player* getPlayerMaster() const { return master ? master->getPlayer() : nullptr; }
+
+	/// Checks if the creature's master is an NPC.
+	bool isNpcSummon() const { return master && master->getNpc(); }
+	/// Returns the NPC who is the master of this creature.
+	Npc* getNpcMaster() { return master ? master->getNpc() : nullptr; }
+	/// Returns the NPC who is the master of this creature.
+	const Npc* getNpcMaster() const { return master ? master->getNpc() : nullptr; }
+
+	/// Checks if the creature's master is a monster.
+	bool isMonsterSummon() const { return master && master->getMonster(); }
+	/// Returns the monster who is the master of this creature.
+	Monster* getMonsterMaster() { return master ? master->getMonster() : nullptr; }
+	/// Returns the monster who is the master of this creature.
+	const Monster* getMonsterMaster() const { return master ? master->getMonster() : nullptr; }
+
+	/// Retrieves the list of summoned creatures.
 	const std::list<Creature*>& getSummons() const { return summons; }
 
 	virtual int32_t getArmor() const { return 0; }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -571,8 +571,7 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 		spectator->onRemoveCreature(creature, isLogout);
 	}
 
-	Creature* master = creature->getMaster();
-	if (master && !master->isRemoved()) {
+	if (Creature* master = creature->getMaster(); !master->isRemoved()) {
 		creature->setMaster(nullptr);
 	}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2682,8 +2682,24 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "Creature", "getFollowCreature", LuaScriptInterface::luaCreatureGetFollowCreature);
 	registerMethod(L, "Creature", "setFollowCreature", LuaScriptInterface::luaCreatureSetFollowCreature);
 
+	registerMethod(L, "Creature", "isSummon", LuaScriptInterface::luaCreatureIsSummon);
 	registerMethod(L, "Creature", "getMaster", LuaScriptInterface::luaCreatureGetMaster);
 	registerMethod(L, "Creature", "setMaster", LuaScriptInterface::luaCreatureSetMaster);
+	registerMethod(L, "Creature", "removeMaster", LuaScriptInterface::luaCreatureRemoveMaster);
+
+	registerMethod(L, "Creature", "hasPlayerOwned", LuaScriptInterface::luaCreatureHasPlayerOwned);
+	registerMethod(L, "Creature", "getPlayerOwned", LuaScriptInterface::luaCreatureGetPlayerOwned);
+	registerMethod(L, "Creature", "hasNpcOwned", LuaScriptInterface::luaCreatureHasNpcOwned);
+	registerMethod(L, "Creature", "getNpcOwned", LuaScriptInterface::luaCreatureGetNpcOwned);
+	registerMethod(L, "Creature", "hasMonsterOwned", LuaScriptInterface::luaCreatureHasMonsterOwned);
+	registerMethod(L, "Creature", "getMonsterOwned", LuaScriptInterface::luaCreatureGetMonsterOwned);
+
+	registerMethod(L, "Creature", "isPlayerSummon", LuaScriptInterface::luaCreatureIsPlayerSummon);
+	registerMethod(L, "Creature", "getPlayerMaster", LuaScriptInterface::luaCreatureGetPlayerMaster);
+	registerMethod(L, "Creature", "isNpcSummon", LuaScriptInterface::luaCreatureIsNpcSummon);
+	registerMethod(L, "Creature", "getNpcMaster", LuaScriptInterface::luaCreatureGetNpcMaster);
+	registerMethod(L, "Creature", "isMonsterSummon", LuaScriptInterface::luaCreatureIsMonsterSummon);
+	registerMethod(L, "Creature", "getMonsterMaster", LuaScriptInterface::luaCreatureGetMonsterMaster);
 
 	registerMethod(L, "Creature", "getLight", LuaScriptInterface::luaCreatureGetLight);
 	registerMethod(L, "Creature", "setLight", LuaScriptInterface::luaCreatureSetLight);
@@ -8125,6 +8141,18 @@ int LuaScriptInterface::luaCreatureSetFollowCreature(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaCreatureIsSummon(lua_State* L)
+{
+	// creature:isSummon()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (creature) {
+		tfs::lua::pushBoolean(L, creature->isSummon());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int LuaScriptInterface::luaCreatureGetMaster(lua_State* L)
 {
 	// creature:getMaster()
@@ -8134,14 +8162,12 @@ int LuaScriptInterface::luaCreatureGetMaster(lua_State* L)
 		return 1;
 	}
 
-	Creature* master = creature->getMaster();
-	if (!master) {
+	if (Creature* master = creature->getMaster()) {
+		tfs::lua::pushUserdata(L, master);
+		tfs::lua::setCreatureMetatable(L, -1, master);
+	} else {
 		lua_pushnil(L);
-		return 1;
 	}
-
-	tfs::lua::pushUserdata(L, master);
-	tfs::lua::setCreatureMetatable(L, -1, master);
 	return 1;
 }
 
@@ -8158,6 +8184,192 @@ int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 
 	// update summon icon
 	g_game.updateKnownCreature(creature);
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureRemoveMaster(lua_State* L)
+{
+	// creature:removeMaster()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		creature->removeMaster();
+		tfs::lua::pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureHasPlayerOwned(lua_State* L)
+{
+	// creature:hasPlayerOwned()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		tfs::lua::pushBoolean(L, creature->hasPlayerOwned());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureGetPlayerOwned(lua_State* L)
+{
+	// creature:getPlayerOwned()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (Player* player = creature->getPlayerOwned()) {
+		tfs::lua::pushUserdata(L, player);
+		tfs::lua::setMetatable(L, -1, "Player");
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureHasNpcOwned(lua_State* L)
+{
+	// creature:hasNpcOwned()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		tfs::lua::pushBoolean(L, creature->hasNpcOwned());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureGetNpcOwned(lua_State* L)
+{
+	// creature:getNpcOwned()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (Npc* npc = creature->getNpcOwned()) {
+		tfs::lua::pushUserdata(L, npc);
+		tfs::lua::setMetatable(L, -1, "Npc");
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureHasMonsterOwned(lua_State* L)
+{
+	// creature:hasMonsterOwned()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		tfs::lua::pushBoolean(L, creature->hasMonsterOwned());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureGetMonsterOwned(lua_State* L)
+{
+	// creature:getMonsterOwned()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (Monster* monster = creature->getMonsterOwned()) {
+		tfs::lua::pushUserdata(L, monster);
+		tfs::lua::setMetatable(L, -1, "Monster");
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureIsPlayerSummon(lua_State* L)
+{
+	// creature:isPlayerSummon()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		tfs::lua::pushBoolean(L, creature->isPlayerSummon());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureGetPlayerMaster(lua_State* L)
+{
+	// creature:getPlayerMaster()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (Player* player = creature->getPlayerMaster()) {
+		tfs::lua::pushUserdata(L, player);
+		tfs::lua::setMetatable(L, -1, "Player");
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureIsNpcSummon(lua_State* L)
+{
+	// creature:isNpcSummon()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		tfs::lua::pushBoolean(L, creature->isNpcSummon());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureGetNpcMaster(lua_State* L)
+{
+	// creature:getNpcMaster()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (Npc* npc = creature->getNpcMaster()) {
+		tfs::lua::pushUserdata(L, npc);
+		tfs::lua::setMetatable(L, -1, "Npc");
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureIsMonsterSummon(lua_State* L)
+{
+	// creature:isMonsterSummon()
+	if (Creature* creature = tfs::lua::getUserdata<Creature>(L, 1)) {
+		tfs::lua::pushBoolean(L, creature->isMonsterSummon());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureGetMonsterMaster(lua_State* L)
+{
+	// creature:getMonsterMaster()
+	Creature* creature = tfs::lua::getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (Monster* monster = creature->getMonsterMaster()) {
+		tfs::lua::pushUserdata(L, monster);
+		tfs::lua::setMetatable(L, -1, "Monster");
+	} else {
+		lua_pushnil(L);
+	}
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -552,8 +552,24 @@ private:
 	static int luaCreatureGetFollowCreature(lua_State* L);
 	static int luaCreatureSetFollowCreature(lua_State* L);
 
+	static int luaCreatureIsSummon(lua_State* L);
 	static int luaCreatureGetMaster(lua_State* L);
 	static int luaCreatureSetMaster(lua_State* L);
+	static int luaCreatureRemoveMaster(lua_State* L);
+
+	static int luaCreatureHasPlayerOwned(lua_State* L);
+	static int luaCreatureGetPlayerOwned(lua_State* L);
+	static int luaCreatureHasNpcOwned(lua_State* L);
+	static int luaCreatureGetNpcOwned(lua_State* L);
+	static int luaCreatureHasMonsterOwned(lua_State* L);
+	static int luaCreatureGetMonsterOwned(lua_State* L);
+
+	static int luaCreatureIsPlayerSummon(lua_State* L);
+	static int luaCreatureGetPlayerMaster(lua_State* L);
+	static int luaCreatureIsNpcSummon(lua_State* L);
+	static int luaCreatureGetNpcMaster(lua_State* L);
+	static int luaCreatureIsMonsterSummon(lua_State* L);
+	static int luaCreatureGetMonsterMaster(lua_State* L);
 
 	static int luaCreatureGetLight(lua_State* L);
 	static int luaCreatureSetLight(lua_State* L);

--- a/src/player.h
+++ b/src/player.h
@@ -433,7 +433,6 @@ public:
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
 	bool isAttackable() const override;
-	static bool lastHitIsPlayer(Creature* lastHitCreature);
 
 	void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
 	void changeMana(int32_t manaChange);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3425,13 +3425,9 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bo
 	uint32_t masterId = 0;
 
 	if (creatureType == CREATURETYPE_MONSTER) {
-		const Creature* master = creature->getMaster();
-		if (master) {
-			masterPlayer = master->getPlayer();
-			if (masterPlayer) {
-				masterId = master->getID();
-				creatureType = CREATURETYPE_SUMMON_OWN;
-			}
+		if (const Player* masterPlayer = creature->getPlayerMaster()) {
+			masterId = masterPlayer->getID();
+			creatureType = CREATURETYPE_SUMMON_OWN;
 		}
 	}
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -501,25 +501,29 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 				return RETURNVALUE_NOTPOSSIBLE;
 			}
 
-			const CreatureVector* creatures = getCreatures();
-			if (monster->canPushCreatures() && !monster->isSummon()) {
-				if (creatures) {
-					for (Creature* tileCreature : *creatures) {
-						if (tileCreature->getPlayer() && tileCreature->getPlayer()->isInGhostMode()) {
-							continue;
-						}
+			if (const CreatureVector* creatures = getCreatures()) {
+				if (!creatures->empty()) {
+					if (monster->canPushCreatures() && !monster->isSummon()) {
+						for (Creature* tileCreature : *creatures) {
+							if (const Player* tilePlayer = tileCreature->getPlayer(); tilePlayer->isInGhostMode()) {
+								continue;
+							}
 
-						const Monster* creatureMonster = tileCreature->getMonster();
-						if (!creatureMonster || !tileCreature->isPushable() ||
-						    (creatureMonster->isSummon() && creatureMonster->getMaster()->getPlayer())) {
-							return RETURNVALUE_NOTPOSSIBLE;
+							if (!tileCreature->isPushable()) {
+								return RETURNVALUE_NOTPOSSIBLE;
+							}
+
+							const Monster* creatureMonster = tileCreature->getMonster();
+							if (!creatureMonster || creatureMonster->isPlayerSummon()) {
+								return RETURNVALUE_NOTPOSSIBLE;
+							}
 						}
-					}
-				}
-			} else if (creatures && !creatures->empty()) {
-				for (const Creature* tileCreature : *creatures) {
-					if (!tileCreature->isInGhostMode()) {
-						return RETURNVALUE_NOTENOUGHROOM;
+					} else {
+						for (const Creature* tileCreature : *creatures) {
+							if (!tileCreature->isInGhostMode()) {
+								return RETURNVALUE_NOTENOUGHROOM;
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Introduced methods to enhance the `Creature` class, allowing for better handling of creature ownership and master relationships.
- Removed the static methods `Combat::isPlayerCombat` and `Player::lastHitIsPlayer`.
- New getter methods for retrieving the respective owners: `getPlayerOwned()`, `getNpcOwned()` and `getMonsterOwned()`. Methods to determine if the creature is owned, either directly or through its master. 
- Methods like `isPlayerSummon()`, `isNpcSummon()` and `isMonsterSummon()` to check the type of creature master.
 
#### Usage
c++
```c++
// Check if the creature is a summon.
if (creature->isSummon()) {
    std::cout << "This creature is a summon." << std::endl;
}

// Retrieve the player that owns this creature.
if (Player* owner = creature->getPlayerOwned()) {
    std::cout << "This creature is owned by player: " << owner->getName() << std::endl;
}
```

lua
```lua
if creature:isSummon() then
    print("This creature is a summon.")
end

local owner = creature:getPlayerOwned()
if owner then
    print("This creature is owned by player: " .. owner:getName())
end
```

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
