### PR TITLE
Remove item tier on internalItemGetDescription

### DIFF
--- a/data/lib/core/item.lua
+++ b/data/lib/core/item.lua
@@ -587,30 +587,13 @@ do
 		-- \nImbuements: (Basic Strike 2:30h, Basic Void 2:30h, Empty Slot).
 
 		-- item class
-		-- Classification: x Tier: y (0.50% Onslaught).
+		-- Classification: x.
 		do
 			local classification = itemType:getClassification()
-			local tier = isVirtual and 0 or item:getTier() or 0
-
-			if classification > 0 or tier > 0 then
-				if classification == 0 then
-					classification = "other"
-				end
-
-				local tierString = tier
-				if tier > 0 then
-					local bonusType, bonusValue = itemType:getTierBonus(tier)
-					if bonusType ~= -1 then
-						if bonusType > 5 then
-							tierString = string.format("%d (%0.2f%% %s)", tier, bonusValue, getSpecialSkillName(bonusType))
-						else
-							tierString = string.format("%d (%d%% %s)", tier, bonusValue, getSpecialSkillName(bonusType))
-						end
-					end
-				end
-
-				response[#response + 1] = string.format("\nClassification: %s Tier: %s.", classification, tierString)
+			if classification == 0 then
+				classification = "other"
 			end
+			response[#response + 1] = string.format("\nClassification: %s.", classification)
 		end
 
 		-- item count (will be reused later)


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Remove item tier from script, fixing the `Item:getDescription`/`ItemType:getItemDescription` method.

Before
![image](https://github.com/user-attachments/assets/bd6e8fe8-e526-4b21-b52c-46909e26c85f)

After
![image](https://github.com/user-attachments/assets/67fcb6b2-c352-45cd-b285-a74202f29273)


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
