### PR TITLE
CreatureEvents improvement: avoid registering with similar names, enforce lowercase in all cases

### DIFF
--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -62,7 +62,7 @@ bool CreatureEvents::registerEvent(Event_ptr event, const pugi::xml_node&)
 	}
 
 	// if not, register it normally
-	creatureEvents.emplace(creatureEvent->getName(), std::move(*creatureEvent));
+	creatureEvents.emplace(boost::algorithm::to_lower_copy(creatureEvent->getName()), std::move(*creatureEvent));
 	return true;
 }
 
@@ -85,13 +85,13 @@ bool CreatureEvents::registerLuaEvent(CreatureEvent* event)
 	}
 
 	// if not, register it normally
-	creatureEvents.emplace(creatureEvent->getName(), std::move(*creatureEvent));
+	creatureEvents.emplace(boost::algorithm::to_lower_copy(creatureEvent->getName()), std::move(*creatureEvent));
 	return true;
 }
 
 CreatureEvent* CreatureEvents::getEventByName(const std::string& name, bool forceLoaded /*= true*/)
 {
-	auto it = creatureEvents.find(name);
+	auto it = creatureEvents.find(boost::algorithm::to_lower_copy(name));
 	if (it != creatureEvents.end()) {
 		if (!forceLoaded || it->second.isLoaded()) {
 			return &it->second;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- CreatureEvents improvement: avoid registering with similar names, enforce lowercase in all cases. `PlayerLogin` and `playerlogin` are the same event, preventing issues with `creature:registerEvent("name")`.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
