### PR TITLE
Fix memory leak in spawns

### DIFF
--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -271,8 +271,6 @@ bool Spawn::findPlayer(const Position& pos)
 	return false;
 }
 
-bool Spawn::isInSpawnZone(const Position& pos) { return Spawns::isInZone(centerPos, radius, pos); }
-
 bool Spawn::spawnMonster(uint32_t spawnId, spawnBlock_t sb, bool startup /* = false*/)
 {
 	bool isBlocked = !startup && findPlayer(sb.pos);
@@ -391,9 +389,6 @@ void Spawn::cleanup()
 	while (it != spawnedMap.end()) {
 		Monster* monster = it->second;
 		if (monster->isRemoved()) {
-			monster->decrementReferenceCounter();
-			it = spawnedMap.erase(it);
-		} else if (!isInSpawnZone(monster->getPosition())) {
 			monster->decrementReferenceCounter();
 			it = spawnedMap.erase(it);
 		} else {

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -394,8 +394,8 @@ void Spawn::cleanup()
 		if (monster->isRemoved()) {
 			monster->decrementReferenceCounter();
 			it = spawnedMap.erase(it);
-		} else if (!isInSpawnZone(monster->getPosition()) && spawnId != 0) {
-			spawnedMap.insert({0, monster});
+		} else if (!isInSpawnZone(monster->getPosition())) {
+			monster->decrementReferenceCounter();
 			it = spawnedMap.erase(it);
 		} else {
 			++it;

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -389,7 +389,6 @@ void Spawn::cleanup()
 {
 	auto it = spawnedMap.begin();
 	while (it != spawnedMap.end()) {
-		uint32_t spawnId = it->first;
 		Monster* monster = it->second;
 		if (monster->isRemoved()) {
 			monster->decrementReferenceCounter();


### PR DESCRIPTION
When we spawn a monster, we increment the count on the monster object for the entry into the spawnedmap. When we remove the monster from the spawnedmap because of it being outside the zone, we don't decrement the ref count, which leads to a leak.

There is also extra logic in place for a spawn ID 0. Not sure why monsters were being removed from the spawned map and placed back into it with 0 as the id for when they leave the area, but I find no other interactions or checks for spawn id being 0, so there seems to be zero reason, and whatever was so special about spawn id 0 doesn't exist anymore, so I cleaned up that old code that has not been in use since apparently before TFS was TFS.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

remove dead code

**Issues addressed:** <!-- Write here the issue number, if any. -->

Memory leak
Overspawn
