### PR TITLE
chore: vortex tamer achievement logic

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -33,7 +33,7 @@ PlayerStorageKeys = {
 	nailCaseUseCount = 30031,
 	swampDigging = 30032,
 	insectoidCell = 30033,
-	vortexTamer = 30034,
+	-- empty: 30034
 	mutatedPumpkin = 30035,
 
 	-- Achievements:

--- a/data/scripts/actions/others/usable_mount_items.lua
+++ b/data/scripts/actions/others/usable_mount_items.lua
@@ -42,11 +42,7 @@ function usableItemMounts.onUse(player, item, fromPosition, target, toPosition, 
 	end
 
 	if table.contains({26194, 26340, 26341}, item.itemid) then
-		local storage = player:getStorageValue(PlayerStorageKeys.vortexTamer)
-		player:setStorageValue(PlayerStorageKeys.vortexTamer, storage + 1)
-		if storage == 1 then
-			player:addAchievement("Vortex Tamer")
-		end
+		player:addAchievementProgress("Vortex Tamer", 3)
 	end
 
 	if useItem.achievement then

--- a/data/scripts/actions/others/usable_mount_items.lua
+++ b/data/scripts/actions/others/usable_mount_items.lua
@@ -2,17 +2,20 @@ local config = {
 	[26194] = { -- vibrant egg
 		name = "vortexion",
 		mountId = 94,
-		tameMessage = "You receive the permission to ride a sparkion."
+		tameMessage = "You receive the permission to ride a sparkion.",
+		achievementProgress = { name = "Vortex Tamer", progress = 3 }
 	},
 	[26340] = { -- crackling egg
 		name = "neon sparkid",
 		mountId = 98,
-		tameMessage = "You receive the permission to ride a neon sparkid."
+		tameMessage = "You receive the permission to ride a neon sparkid.",
+		achievementProgress = { name = "Vortex Tamer", progress = 3 }
 	},
 	[26341] = { -- menacing egg
 		name = "vortexion",
 		mountId = 99,
-		tameMessage = "You receive the permission to ride a vortexion."
+		tameMessage = "You receive the permission to ride a vortexion.",
+		achievementProgress = { name = "Vortex Tamer", progress = 3 }
 	},
 	[25521] = { -- mysterious scroll
 		name = "rift runner",
@@ -31,18 +34,22 @@ local config = {
 local usableItemMounts = Action()
 
 function usableItemMounts.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	local useItem = config[item.itemid]
+	if not useItem then
+		return true
+	end
+
 	if not player:isPremium() then
 		player:sendCancelMessage(RETURNVALUE_YOUNEEDPREMIUMACCOUNT)
 		return true
 	end
 
-	local useItem = config[item.itemid]
 	if player:hasMount(useItem.mountId) then
-		return false
+		return true
 	end
 
-	if table.contains({26194, 26340, 26341}, item.itemid) then
-		player:addAchievementProgress("Vortex Tamer", 3)
+	if useItem.achievementProgress then
+		player:addAchievementProgress(useItem.achievementProgress.name, useItem.achievementProgress.progress)
 	end
 
 	if useItem.achievement then
@@ -56,8 +63,8 @@ function usableItemMounts.onUse(player, item, fromPosition, target, toPosition, 
 	return true
 end
 
-for k, v in pairs(config) do
-	usableItemMounts:id(k)
+for itemId in pairs(config) do
+	usableItemMounts:id(itemId)
 end
 
 usableItemMounts:register()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x` inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
This pull request simplifies the logic for the "Vortex Tamer" achievement progression. Previously, the code used a storage to track progress and check if the player should receive the achievement. The new implementation uses the `addAchievementProgress` function to directly increment the achievement's progress.

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
