### PR TITLE
Refactor OutputMessagePool: Extracted into tfs::net namespace

### DIFF
--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -62,29 +62,12 @@ private:
 	MsgSize_t outputBufferStart = INITIAL_BUFFER_POSITION;
 };
 
-class OutputMessagePool
-{
-public:
-	// non-copyable
-	OutputMessagePool(const OutputMessagePool&) = delete;
-	OutputMessagePool& operator=(const OutputMessagePool&) = delete;
+namespace tfs::net {
 
-	static OutputMessagePool& getInstance()
-	{
-		static OutputMessagePool instance;
-		return instance;
-	}
+OutputMessage_ptr make_output_message();
+void insert_protocol_to_autosend(const Protocol_ptr& protocol);
+void remove_protocol_from_autosend(const Protocol_ptr& protocol);
 
-	static OutputMessage_ptr getOutputMessage();
-
-	void addProtocolToAutosend(Protocol_ptr protocol);
-	void removeProtocolFromAutosend(const Protocol_ptr& protocol);
-
-private:
-	OutputMessagePool() = default;
-	// NOTE: A vector is used here because this container is mostly read and relatively rarely modified (only when a
-	// client connects/disconnects)
-	std::vector<Protocol_ptr> bufferedProtocols;
-};
+} // namespace tfs::net::protocol
 
 #endif // FS_OUTPUTMESSAGE_H

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -68,6 +68,6 @@ OutputMessage_ptr make_output_message();
 void insert_protocol_to_autosend(const Protocol_ptr& protocol);
 void remove_protocol_from_autosend(const Protocol_ptr& protocol);
 
-} // namespace tfs::net::protocol
+} // namespace tfs::net
 
 #endif // FS_OUTPUTMESSAGE_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -68,10 +68,10 @@ OutputMessage_ptr Protocol::getOutputBuffer(int32_t size)
 {
 	// dispatcher thread
 	if (!outputBuffer) {
-		outputBuffer = OutputMessagePool::getOutputMessage();
+		outputBuffer = tfs::net::make_output_message();
 	} else if ((outputBuffer->getLength() + size) > NetworkMessage::MAX_PROTOCOL_BODY_LENGTH) {
 		send(outputBuffer);
-		outputBuffer = OutputMessagePool::getOutputMessage();
+		outputBuffer = tfs::net::make_output_message();
 	}
 	return outputBuffer;
 }

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -146,7 +146,8 @@ void ProtocolGame::release()
 		player = nullptr;
 	}
 
-	OutputMessagePool::getInstance().removeProtocolFromAutosend(shared_from_this());
+	tfs::net::remove_protocol_from_autosend(shared_from_this());
+
 	Protocol::release();
 }
 
@@ -204,12 +205,13 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 
 		if (std::size_t currentSlot = clientLogin(*player)) {
 			uint8_t retryTime = getWaitTime(currentSlot);
-			auto output = OutputMessagePool::getOutputMessage();
+			auto output = tfs::net::make_output_message();
 			output->addByte(0x16);
 			output->addString(
 			    fmt::format("Too many players online.\nYou are at place {:d} on the waiting list.", currentSlot));
 			output->addByte(retryTime);
 			send(output);
+
 			disconnect();
 			return;
 		}
@@ -254,7 +256,8 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 			connect(foundPlayer->getID(), operatingSystem);
 		}
 	}
-	OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
+
+	tfs::net::insert_protocol_to_autosend(shared_from_this());
 }
 
 void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
@@ -452,7 +455,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 
 void ProtocolGame::onConnect()
 {
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 	static std::random_device rd;
 	static std::ranlux24 generator(rd());
 	static std::uniform_int_distribution<uint16_t> randNumber(0x00, 0xFF);
@@ -480,10 +483,11 @@ void ProtocolGame::onConnect()
 
 void ProtocolGame::disconnectClient(const std::string& message) const
 {
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 	output->addByte(0x14);
 	output->addString(message);
 	send(output);
+
 	disconnect();
 }
 
@@ -3410,7 +3414,7 @@ void ProtocolGame::sendModalWindow(const ModalWindow& modalWindow)
 
 void ProtocolGame::sendSessionEnd(SessionEndTypes_t reason)
 {
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 	output->addByte(0x18);
 	output->addByte(reason);
 	send(output);

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -51,8 +51,7 @@ std::string decodeSecret(std::string_view secret)
 
 void ProtocolLogin::disconnectClient(const std::string& message, uint16_t version)
 {
-	auto output = OutputMessagePool::getOutputMessage();
-
+	auto output = tfs::net::make_output_message();
 	output->addByte(version >= 1076 ? 0x0B : 0x0A);
 	output->addString(message);
 	send(output);
@@ -94,7 +93,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	uint32_t ticks = duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count() /
 	                 AUTHENTICATOR_PERIOD;
 
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 	if (!key.empty()) {
 		if (token.empty() || !(token == generateToken(key, ticks) || token == generateToken(key, ticks - 1) ||
 		                       token == generateToken(key, ticks + 1))) {

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -12,7 +12,7 @@ extern Game g_game;
 
 void ProtocolOld::disconnectClient(const std::string& message)
 {
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 	output->addByte(0x0A);
 	output->addString(message);
 	send(output);

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -75,7 +75,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 
 void ProtocolStatus::sendStatusString()
 {
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 
 	setRawMessages(true);
 
@@ -144,7 +144,7 @@ void ProtocolStatus::sendStatusString()
 
 void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& characterName)
 {
-	auto output = OutputMessagePool::getOutputMessage();
+	auto output = tfs::net::make_output_message();
 
 	if (requestedInfo & REQUEST_BASIC_SERVER_INFO) {
 		output->addByte(0x10);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Remove OutputMessagePool singleton, use namespace instead.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
