### PR TITLE
Fix reload XML files from lua

### DIFF
--- a/data/scripts/xml/#quests.lua
+++ b/data/scripts/xml/#quests.lua
@@ -1,15 +1,13 @@
 -- If you don't intend to use quests.xml, you can delete this file.
-local xmlQuest = GlobalEvent("Load XML Quests")
 
-function xmlQuest.onStartup()
-	local questDoc = XMLDocument("data/XML/quests.xml")
-	if not questDoc then
-		io.write(
-			"[Warning - GlobalEvent::onStartup] Could not load quests.xml.\n")
+local function loadXMLQuests()
+	local doc = XMLDocument("data/XML/quests.xml")
+	if not doc then
+		io.write("[Warning - lib::xml::loadXMLQuests] Could not load quests.xml.\n")
 		return true
 	end
 
-	local quests = questDoc:child("quests")
+	local quests = doc:child("quests")
 	for questNode in quests:children() do
 		local missions = {}
 		for missionNode in questNode:children() do
@@ -41,7 +39,6 @@ function xmlQuest.onStartup()
 			missions = missions
 		}):register()
 	end
-	return true
 end
 
-xmlQuest:register()
+loadXMLQuests()

--- a/data/scripts/xml/#quests.lua
+++ b/data/scripts/xml/#quests.lua
@@ -3,7 +3,7 @@
 local function loadXMLQuests()
 	local doc = XMLDocument("data/XML/quests.xml")
 	if not doc then
-		io.write("[Warning - lib::xml::loadXMLQuests] Could not load quests.xml.\n")
+		io.write("[Warning - Scripts::XML::loadXMLQuests] Could not load quests.xml.\n")
 		return true
 	end
 

--- a/data/scripts/xml/#raids.lua
+++ b/data/scripts/xml/#raids.lua
@@ -219,7 +219,7 @@ end
 local function loadXMLRaids()
 	local doc = XMLDocument("data/raids/raids.xml")
 	if not doc then
-		io.write("[Warning - lib::xml::loadXMLRaids] Could not load raids.xml.\n")
+		io.write("[Warning - Scripts::XML::loadXMLRaids] Could not load raids.xml.\n")
 		return
 	end
 

--- a/data/scripts/xml/#raids.lua
+++ b/data/scripts/xml/#raids.lua
@@ -216,17 +216,17 @@ local function configureRaidEvent(node)
 	return raid
 end
 
-local event = GlobalEvent("load raids.xml")
-
-function event.onStartup()
+local function loadXMLRaids()
 	local doc = XMLDocument("data/raids/raids.xml")
 	if not doc then
-		return true
+		io.write("[Warning - lib::xml::loadXMLRaids] Could not load raids.xml.\n")
+		return
 	end
 
 	local raids = doc:child("raids")
 
 	io.write(">> Loading legacy XML raids from data/raids/raids.xml...\n")
+
 	local loaded, start = 0, os.mtime()
 	for node in raids:children() do
 		local enabled = node:attribute("enabled")
@@ -238,7 +238,8 @@ function event.onStartup()
 			end
 		end
 	end
+
 	io.write(">> Loaded " .. loaded .. " raids in " .. os.mtime() - start .. "ms.\n")
 end
 
-event:register()
+loadXMLRaids()

--- a/data/scripts/xml/actions.lua
+++ b/data/scripts/xml/actions.lua
@@ -92,18 +92,17 @@ local function configureActionEvent(node)
     return action
 end
 
-local event = GlobalEvent("load actions.xml")
-
-function event.onStartup()
+local function loadXMLActions()
     local doc = XMLDocument("data/actions/actions.xml")
     if not doc then
-        io.write("[Warning - GlobalEvent::onStartup] Could not load data/actions/actions.xml.\n")
-        return true
+        io.write("[Warning - lib::xml::loadXMLActions] Could not load actions.xml.\n")
+        return
     end
 
     local actions = doc:child("actions")
 
     io.write(">> Loading legacy XML actions from data/actions/actions.xml...\n")
+
     local loaded, start = 0, os.mtime()
     for node in actions:children() do
         local action = configureActionEvent(node)
@@ -112,7 +111,8 @@ function event.onStartup()
             loaded = loaded + 1
         end
     end
+
     io.write(">> Loaded " .. loaded .. " actions in " .. os.mtime() - start .. "ms.\n")
 end
 
-event:register()
+loadXMLActions()

--- a/data/scripts/xml/actions.lua
+++ b/data/scripts/xml/actions.lua
@@ -95,7 +95,7 @@ end
 local function loadXMLActions()
     local doc = XMLDocument("data/actions/actions.xml")
     if not doc then
-        io.write("[Warning - lib::xml::loadXMLActions] Could not load actions.xml.\n")
+        io.write("[Warning - Scripts::XML::loadXMLActions] Could not load actions.xml.\n")
         return
     end
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

Fix the problem with XML reloading via Lua; when a reload occurred, the Lua state was reset, but the XML file data was not reloaded correctly.

### Changes Proposed 
- It no longer loads during the start event but instead when the Lua files are loaded
- Move it to a separate folder in `data/scripts/xml`.

### On reload
![image](https://github.com/user-attachments/assets/ad688a36-c594-477f-a187-1b50537a7d8b)


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
