### PR TITLE
Fix double libs loading

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -25,7 +25,6 @@ void load(bool reload /*= false*/)
 		return;
 	}
 
-	scriptInterface->loadFile("data/global.lua");
 	if (!scriptInterface->loadNpcLib("data/npc/lib/npc.lua")) {
 		std::cout << "[Warning - NpcLib::NpcLib] Can not load lib: data/npc/lib/npc.lua" << std::endl;
 		std::cout << scriptInterface->getLastLuaError() << std::endl;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed


**Issues addressed:** <!-- Write here the issue number, if any. -->
https://github.com/otland/forgottenserver/issues/4770

**How to test:** <!-- Write here how to test changes. -->
1. Run server
2. count "Using LuaJIT 2.1.0-beta3" or Lua 5.4 related string 
note:  global.lua is loading dofile('data/lib/lib.lua') that loads dofile('data/lib/debugging/lua_version.lua') that print lua version
