### PR TITLE
fix item destroy by doors

### DIFF
--- a/data/scripts/movements/closing_door.lua
+++ b/data/scripts/movements/closing_door.lua
@@ -22,7 +22,7 @@ function closingDoor.onStepOut(creature, item, position, fromPosition)
 	while tileItem and i < tileCount do
 		tileItem = tile:getThing(i)
 		if tileItem and tileItem:getUniqueId() ~= item.uid and tileItem:getType():isMovable() then
-			tileItem:remove()
+			doRelocate(position, creature:getPosition())
 		else
 			i = i + 1
 		end


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix items damaged by doors

**Issues addressed:**
https://github.com/otland/forgottenserver/issues/4839

**How to test:** <!-- Write here how to test changes. -->
Use doors in position 121, 83, 10
Create item 1787 like on image
![image](https://github.com/user-attachments/assets/21a3b7c4-c1f4-4d45-95e7-da7f691985d6)

Open doors
Put items under player
Move back from doors
