### PR TITLE
Revert "fix double libs loading (#4855)"

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -25,6 +25,7 @@ void load(bool reload /*= false*/)
 		return;
 	}
 
+	scriptInterface->loadFile("data/global.lua");
 	if (!scriptInterface->loadNpcLib("data/npc/lib/npc.lua")) {
 		std::cout << "[Warning - NpcLib::NpcLib] Can not load lib: data/npc/lib/npc.lua" << std::endl;
 		std::cout << scriptInterface->getLastLuaError() << std::endl;


### PR DESCRIPTION
This reverts commit 6f05ea840d77a39695d6f44b5dc0dd49fa6c0be3.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Revert comit related to double global.lua loading
Npc.h has own scriptInterface that require data from global.lua

https://github.com/otland/forgottenserver/blob/cf38586a291c59a1dd249dcb837d0c0c5fa2fdba/src/npc.h#L84

**How to test:** <!-- Write here how to test changes. -->
N/A
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
