### PR TITLE
OTCv8 proxy + HAProxy

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -168,3 +168,18 @@ ownerName = ""
 ownerEmail = ""
 url = "https://otland.net/"
 location = "Sweden"
+
+-- Proxy settings
+-- NOTE:
+-- if you allow any proxy connections, you should configure your firewalls to not allow direct connections to OTS
+-- only your own HAProxy server IP addresses should be allowed to connect to OTS ports / OTCv8 proxy server ports,
+-- otherwise anyone can set up their own modified HAProxy server and spoof their in-game IP
+
+-- allow OTCv8 proxy connections
+allowOtcProxy = false
+-- allow HAProxy connections - for players or for server status protocol ex. otservlist
+allowHaProxy = false
+-- if you allow HAProxy connections and want to add the HAProxy VPS IP address as OTS IP address to otservlist etc.,
+-- here you can set IP address that will be returned in OTS status as the IP address of the server
+-- empty string = return actual IP address of the server
+statusIp = ""

--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -349,6 +349,8 @@ Creature = {}
 ---@field isPlayer fun(self: Player): boolean
 ---@field getGuid fun(self: Player): number
 ---@field getIp fun(self: Player): number
+---@field isOtcProxy fun(self: Player): boolean
+---@field isHaProxy fun(self: Player): boolean
 ---@field getAccountId fun(self: Player): number
 ---@field getLastLoginSaved fun(self: Player): number
 ---@field getLastLogout fun(self: Player): number
@@ -2202,6 +2204,8 @@ configKeys = {
 	MANASHIELD_BREAKABLE = 36,
 	CHECK_DUPLICATE_STORAGE_KEYS = 37,
 	MONSTER_OVERSPAWN = 38,
+	ALLOW_OTC_PROXY = 39,
+	ALLOW_HAPROXY = 40,
 
 	-- ConfigKeysString
 	MAP_NAME = 0,
@@ -2221,6 +2225,7 @@ configKeys = {
 	DEFAULT_PRIORITY = 14,
 	MAP_AUTHOR = 15,
 	CONFIG_FILE = 16,
+	STATUS_IP = 17,
 
 	-- ConfigKeysInteger
 	SQL_PORT = 0,

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -245,6 +245,8 @@ bool ConfigManager::load()
 	boolean[TWO_FACTOR_AUTH] = getGlobalBoolean(L, "enableTwoFactorAuth", true);
 	boolean[CHECK_DUPLICATE_STORAGE_KEYS] = getGlobalBoolean(L, "checkDuplicateStorageKeys", false);
 	boolean[MONSTER_OVERSPAWN] = getGlobalBoolean(L, "monsterOverspawn", false);
+	boolean[ALLOW_OTC_PROXY] = getGlobalBoolean(L, "allowOtcProxy", false);
+	boolean[ALLOW_HAPROXY] = getGlobalBoolean(L, "allowHaProxy", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");
@@ -253,6 +255,7 @@ bool ConfigManager::load()
 	string[URL] = getGlobalString(L, "url", "");
 	string[LOCATION] = getGlobalString(L, "location", "");
 	string[WORLD_TYPE] = getGlobalString(L, "worldType", "pvp");
+	string[STATUS_IP] = getGlobalString(L, "statusIp", "");
 
 	integer[MAX_PLAYERS] = getGlobalNumber(L, "maxPlayers");
 	integer[PZ_LOCKED] = getGlobalNumber(L, "pzLocked", 60000);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -47,6 +47,8 @@ enum boolean_config_t
 	MANASHIELD_BREAKABLE,
 	CHECK_DUPLICATE_STORAGE_KEYS,
 	MONSTER_OVERSPAWN,
+	ALLOW_OTC_PROXY,
+	ALLOW_HAPROXY,
 
 	LAST_BOOLEAN_CONFIG /* this must be the last one */
 };
@@ -70,6 +72,7 @@ enum string_config_t
 	DEFAULT_PRIORITY,
 	MAP_AUTHOR,
 	CONFIG_FILE,
+	STATUS_IP,
 
 	LAST_STRING_CONFIG /* this must be the last one */
 };

--- a/src/connection.h
+++ b/src/connection.h
@@ -83,9 +83,19 @@ public:
 
 	void send(const OutputMessage_ptr& msg);
 
-	const Address& getIP() const { return remoteAddress; };
+	const Address& getIP() const {
+		if (isOtcProxy() || isHaProxy()) {
+			return realIpAddress;
+		}
+		return remoteAddress;
+	};
+	bool isOtcProxy() const { return otcProxy; };
+	bool isHaProxy() const { return haProxy; };
 
 private:
+	void parseOtcProxyPacket(const boost::system::error_code& error);
+	void parseHaProxyPacket(const boost::system::error_code& error);
+	bool tryParseProxyPacket();
 	void parseHeader(const boost::system::error_code& error);
 	void parsePacket(const boost::system::error_code& error);
 
@@ -115,6 +125,11 @@ private:
 	Address remoteAddress;
 	time_t timeConnected;
 	uint32_t packetsSent = 0;
+
+	Address realIpAddress;
+	bool otcProxy = false;
+	bool haProxy = false;
+	bool receivedFirstHeader = false;
 
 	ConnectionState_t connectionState = CONNECTION_STATE_PENDING;
 	bool receivedFirst = false;

--- a/src/http/login.cpp
+++ b/src/http/login.cpp
@@ -125,13 +125,20 @@ std::pair<status, json::value> tfs::http::handle_login(const json::object& body,
 		} while (result->next());
 	}
 
+	std::string serverIp = getString(ConfigManager::IP);
+	if (getBoolean(ConfigManager::ALLOW_OTC_PROXY)) {
+		serverIp = std::string("127.0.0.1");
+	} else if (getBoolean(ConfigManager::ALLOW_HAPROXY)) {
+		serverIp = getString(ConfigManager::STATUS_IP);
+	}
+
 	json::array worlds{
 	    {
 	        {"id", 0}, // not implemented
 	        {"name", getString(ConfigManager::SERVER_NAME)},
-	        {"externaladdressprotected", getString(ConfigManager::IP)},
+	        {"externaladdressprotected", serverIp},
 	        {"externalportprotected", getNumber(ConfigManager::GAME_PORT)},
-	        {"externaladdressunprotected", getString(ConfigManager::IP)},
+	        {"externaladdressunprotected", serverIp},
 	        {"externalportunprotected", getNumber(ConfigManager::GAME_PORT)},
 	        {"previewstate", 0}, // not implemented
 	        {"location", getString(ConfigManager::LOCATION)},

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2312,6 +2312,8 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn(L, "configKeys", ConfigManager::SERVER_SAVE_SHUTDOWN);
 	registerEnumIn(L, "configKeys", ConfigManager::ONLINE_OFFLINE_CHARLIST);
 	registerEnumIn(L, "configKeys", ConfigManager::CHECK_DUPLICATE_STORAGE_KEYS);
+	registerEnumIn(L, "configKeys", ConfigManager::ALLOW_OTC_PROXY);
+	registerEnumIn(L, "configKeys", ConfigManager::ALLOW_HAPROXY);
 
 	registerEnumIn(L, "configKeys", ConfigManager::MAP_NAME);
 	registerEnumIn(L, "configKeys", ConfigManager::HOUSE_RENT_PERIOD);
@@ -2329,6 +2331,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn(L, "configKeys", ConfigManager::MYSQL_SOCK);
 	registerEnumIn(L, "configKeys", ConfigManager::DEFAULT_PRIORITY);
 	registerEnumIn(L, "configKeys", ConfigManager::MAP_AUTHOR);
+	registerEnumIn(L, "configKeys", ConfigManager::STATUS_IP);
 
 	registerEnumIn(L, "configKeys", ConfigManager::SQL_PORT);
 	registerEnumIn(L, "configKeys", ConfigManager::MAX_PLAYERS);
@@ -2763,6 +2766,8 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod(L, "Player", "getGuid", LuaScriptInterface::luaPlayerGetGuid);
 	registerMethod(L, "Player", "getIp", LuaScriptInterface::luaPlayerGetIp);
+	registerMethod(L, "Player", "isOtcProxy", LuaScriptInterface::luaPlayerIsOtcProxy);
+	registerMethod(L, "Player", "isHaProxy", LuaScriptInterface::luaPlayerIsHaProxy);
 	registerMethod(L, "Player", "getAccountId", LuaScriptInterface::luaPlayerGetAccountId);
 	registerMethod(L, "Player", "getLastLoginSaved", LuaScriptInterface::luaPlayerGetLastLoginSaved);
 	registerMethod(L, "Player", "getLastLogout", LuaScriptInterface::luaPlayerGetLastLogout);
@@ -9057,6 +9062,30 @@ int LuaScriptInterface::luaPlayerGetIp(lua_State* L)
 	Player* player = tfs::lua::getUserdata<Player>(L, 1);
 	if (player) {
 		tfs::lua::pushString(L, player->getIP().to_string());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerIsOtcProxy(lua_State* L)
+{
+	// player:isOtcProxy()
+	Player* player = tfs::lua::getUserdata<Player>(L, 1);
+	if (player) {
+		tfs::lua::pushBoolean(L, player->isOtcProxy());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerIsHaProxy(lua_State* L)
+{
+	// player:isHaProxy()
+	Player* player = tfs::lua::getUserdata<Player>(L, 1);
+	if (player) {
+		tfs::lua::pushBoolean(L, player->isHaProxy());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -621,6 +621,8 @@ private:
 
 	static int luaPlayerGetGuid(lua_State* L);
 	static int luaPlayerGetIp(lua_State* L);
+	static int luaPlayerIsOtcProxy(lua_State* L);
+	static int luaPlayerIsHaProxy(lua_State* L);
 	static int luaPlayerGetAccountId(lua_State* L);
 	static int luaPlayerGetLastLoginSaved(lua_State* L);
 	static int luaPlayerGetLastLogout(lua_State* L);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2046,6 +2046,24 @@ Connection::Address Player::getIP() const
 	return {};
 }
 
+bool Player::isOtcProxy() const
+{
+	if (client) {
+		return client->isOtcProxy();
+	}
+
+	return {};
+}
+
+bool Player::isHaProxy() const
+{
+	if (client) {
+		return client->isHaProxy();
+	}
+
+	return {};
+}
+
 void Player::death(Creature* lastHitCreature)
 {
 	loginPosition = town->templePosition;

--- a/src/player.h
+++ b/src/player.h
@@ -237,6 +237,8 @@ public:
 		}
 	}
 	Connection::Address getIP() const;
+	bool isOtcProxy() const;
+	bool isHaProxy() const;
 
 	void addContainer(uint8_t cid, Container* container);
 	void closeContainer(uint8_t cid);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -94,3 +94,21 @@ Connection::Address Protocol::getIP() const
 
 	return {};
 }
+
+bool Protocol::isOtcProxy() const
+{
+	if (auto connection = getConnection()) {
+		return connection->isOtcProxy();
+	}
+
+	return false;
+}
+
+bool Protocol::isHaProxy() const
+{
+	if (auto connection = getConnection()) {
+		return connection->isHaProxy();
+	}
+
+	return false;
+}

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -29,6 +29,8 @@ public:
 	Connection_ptr getConnection() const { return connection.lock(); }
 
 	Connection::Address getIP() const;
+	bool isOtcProxy() const;
+	bool isHaProxy() const;
 
 	// Use this function for autosend messages only
 	OutputMessage_ptr getOutputBuffer(int32_t size);

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -134,7 +134,13 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 		for (uint8_t i = 0; i < 2; i++) {
 			output->addByte(i); // world id
 			output->addString(i == 0 ? "Offline" : "Online");
-			output->addString(getString(ConfigManager::IP));
+			if (getConnection()->isOtcProxy()) {
+				output->addString("127.0.0.1");
+			} else if (getConnection()->isHaProxy()) {
+				output->addString(getString(ConfigManager::STATUS_IP));
+			} else {
+				output->addString(getString(ConfigManager::IP));
+			}
 			output->add<uint16_t>(getNumber(ConfigManager::GAME_PORT));
 			output->addByte(0);
 		}
@@ -142,7 +148,13 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 		output->addByte(1); // number of worlds
 		output->addByte(0); // world id
 		output->addString(getString(ConfigManager::SERVER_NAME));
-		output->addString(getString(ConfigManager::IP));
+		if (getConnection()->isOtcProxy()) {
+			output->addString("127.0.0.1");
+		} else if (getConnection()->isHaProxy()) {
+			output->addString(getString(ConfigManager::STATUS_IP));
+		} else {
+			output->addString(getString(ConfigManager::IP));
+		}
 		output->add<uint16_t>(getNumber(ConfigManager::GAME_PORT));
 		output->addByte(0);
 	}

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -90,7 +90,11 @@ void ProtocolStatus::sendStatusString()
 	pugi::xml_node serverinfo = tsqp.append_child("serverinfo");
 	uint64_t uptime = (OTSYS_TIME() - ProtocolStatus::start) / 1000;
 	serverinfo.append_attribute("uptime") = std::to_string(uptime).c_str();
-	serverinfo.append_attribute("ip") = getString(ConfigManager::IP).c_str();
+	if (!(getString(ConfigManager::STATUS_IP).empty())) {
+		serverinfo.append_attribute("ip") = getString(ConfigManager::STATUS_IP).c_str();
+	} else {
+		serverinfo.append_attribute("ip") = getString(ConfigManager::IP).c_str();
+	}
 	serverinfo.append_attribute("servername") = getString(ConfigManager::SERVER_NAME).c_str();
 	serverinfo.append_attribute("port") = std::to_string(getNumber(ConfigManager::LOGIN_PORT)).c_str();
 	serverinfo.append_attribute("location") = getString(ConfigManager::LOCATION).c_str();
@@ -149,7 +153,11 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 	if (requestedInfo & REQUEST_BASIC_SERVER_INFO) {
 		output->addByte(0x10);
 		output->addString(getString(ConfigManager::SERVER_NAME));
-		output->addString(getString(ConfigManager::IP));
+		if (!getString(ConfigManager::STATUS_IP).empty()) {
+			output->addString(getString(ConfigManager::STATUS_IP));
+		} else {
+			output->addString(getString(ConfigManager::IP));
+		}
 		output->addString(std::to_string(getNumber(ConfigManager::LOGIN_PORT)));
 	}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -21,6 +21,16 @@ struct ConnectBlock
 
 bool acceptConnection(const Connection::Address& clientIP)
 {
+	/*
+	 * With HAProxy, IP of client is known after establishing TCP connection.
+	 * In moment of connection (acceptConnection), each client has IP 127.0.0.1,
+	 * so we cannot limit number of connections per IP here.
+	 *
+	 * Anyway, use iptables (on HAProxy servers) to limit number of connections per IP, it's much more efficient.
+	 */
+	if (getBoolean(ConfigManager::ALLOW_OTC_PROXY) || getBoolean(ConfigManager::ALLOW_HAPROXY)) {
+		return true;
+	}
 	static std::recursive_mutex mu;
 	std::lock_guard lock{mu};
 


### PR DESCRIPTION
### Pull Request Prelude

Code to read real connection IP from OTCv8 proxy and HAProxy `send-proxy-v2` protocols.
Changes also allow owner to edit server IP showed in "server status protocol", so it's possible to add different VPS IP - with `haproxy` running on 7171 - as OTS IP to otservlist etc. = hide real server IP from DDoSers.

Goal is to hide IP on which is running OTS, so it can't be DDoSed.
With OTCv8 packets to/from server will go thru multiple proxy VPSes, so you can use multiple anti-DDoS services in same time and as long as any of them keep one proxy online, OTS will be online and does not lag.

### Changes Proposed

OTCv8 proxy is proxy system available in: OTCv8, OTCR (Mehah) and real Tibia Client (with extra .exe, more info: https://github.com/mehah/otclient/pull/978#issuecomment-2509871565 )

## How OTCv8 proxy works

OTC with Proxy System enabled will connect to multiple `haproxy` servers - each can be on other VPS behind other anti-DDoS system.
Each second it measures ping to OTS thru each `haproxy` - it measures real ping to OTS machine, not just ping to VPS hosting `haproxy`.
If there is any packet to send, OTC sends it thru 2 proxies with lowest ping (duplicates packet).

List of proxy server you must add in `init.lua` of OTC ex.:
```
g_proxy.addProxy('arm.skalski.pro', 6501, 0)
g_proxy.addProxy('arm.skalski.pro', 6502, 0)
g_proxy.addProxy('arm.skalski.pro', 6503, 0)
g_proxy.addProxy('arm.skalski.pro', 6504, 0)
```
Then every connection to `127.0.0.1` will be handled by Proxy System and send thru haproxy to OTS server machine.
On machine with OTS you must install "OTCv8 Proxy System server side app" (re-host: https://downloads-oracle.ots.me/?dir=data/otcv8-proxy-server).
This server side app will detect duplicated packets and send only first packet that comes with given ID to OTS.
Packets send by OTS will also go thru this app, it will duplicate them and send thru 2 `haproxy` servers to OTC.
Server side app is compatible with `send-proxy-v2` protocol and may send real IP of player to OTS - without that feature all players would have IP `127.0.0.1` on OTS, as connections to OTS come from server side proxy app.

How to configure server/OTCv8/haproxy by OTCv8 author:
http://web.archive.org/web/20201109120714/http://otclient.net/showthread.php?tid=438

More info about configuration and other apps required:
https://github.com/mehah/otclient/pull/978