### PR TITLE
Fix use-after-free in Browse Field handler

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -26,8 +26,7 @@ Container::Container(Tile* tile) : Container(ITEM_BROWSEFIELD, 30, false, true)
 	TileItemVector* itemVector = tile->getItemList();
 	if (itemVector) {
 		for (Item* item : *itemVector) {
-			if ((item->getContainer() || item->hasProperty(CONST_PROP_MOVEABLE)) &&
-			    !item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
+			if (item->shouldTriggerBrowseFieldUpdate() && !item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 				itemlist.push_front(item);
 				item->setParent(this);
 			}

--- a/src/item.h
+++ b/src/item.h
@@ -905,6 +905,8 @@ public:
 		return attributes;
 	}
 
+	bool shouldTriggerBrowseFieldUpdate() const { return getContainer() || hasProperty(CONST_PROP_MOVEABLE); }
+
 	void incrementReferenceCounter() { ++referenceCounter; }
 	void decrementReferenceCounter()
 	{

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -349,7 +349,7 @@ Thing* Tile::getTopVisibleThing(const Creature* creature)
 
 void Tile::onAddTileItem(Item* item)
 {
-	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
+	if (item->shouldTriggerBrowseFieldUpdate()) {
 		auto it = g_game.browseFields.find(this);
 		if (it != g_game.browseFields.end()) {
 			it->second->addItemBack(item);
@@ -386,7 +386,7 @@ void Tile::onAddTileItem(Item* item)
 
 void Tile::onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newItem, const ItemType& newType)
 {
-	if (newItem->hasProperty(CONST_PROP_MOVEABLE) || newItem->getContainer()) {
+	if (newItem->shouldTriggerBrowseFieldUpdate()) {
 		auto it = g_game.browseFields.find(this);
 		if (it != g_game.browseFields.end()) {
 			int32_t index = it->second->getThingIndex(oldItem);
@@ -395,7 +395,7 @@ void Tile::onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newIte
 				newItem->setParent(it->second);
 			}
 		}
-	} else if (oldItem->hasProperty(CONST_PROP_MOVEABLE) || oldItem->getContainer()) {
+	} else if (oldItem->shouldTriggerBrowseFieldUpdate()) {
 		auto it = g_game.browseFields.find(this);
 		if (it != g_game.browseFields.end()) {
 			Cylinder* oldParent = oldItem->getParent();
@@ -424,7 +424,7 @@ void Tile::onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newIte
 
 void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<int32_t>& oldStackPosVector, Item* item)
 {
-	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
+	if (item->shouldTriggerBrowseFieldUpdate()) {
 		auto it = g_game.browseFields.find(this);
 		if (it != g_game.browseFields.end()) {
 			it->second->removeThing(item, item->getItemCount());
@@ -967,13 +967,16 @@ void Tile::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
+	Item* realOldItem = item->clone();
+
 	const ItemType& oldType = Item::items[item->getID()];
 	const ItemType& newType = Item::items[itemId];
+
 	resetTileFlags(item);
 	item->setID(itemId);
 	item->setSubType(count);
 	setTileFlags(item);
-	onUpdateTileItem(item, oldType, item, newType);
+	onUpdateTileItem(realOldItem, oldType, item, newType);
 }
 
 void Tile::replaceThing(uint32_t index, Thing* thing)


### PR DESCRIPTION
Transforming an item placed on a `Tile` with Browse Field open on that tile will call `Tile::updateThing`, which will subsequently call `Tile::onUpdateTileItem`, which then ensures that the Browse Field's `Container` is in sync with the `Tile`, however, `Tile::updateThing` passes the same `Item` pointer as both the `oldItem` and `newItem` arguments to `Tile::onUpdateTileItem` which only coincidentally works for the majority of items whose flags do not happen to transition between being movable and not being movable. If you transform a movable item to a non-movable item, the second branch of the Browse Field handling in `Tile::onUpdateTileItem` will never execute, leaving the `Item` that has now been deleted in the Browse Field `Container`'s `itemlist` member, any further interaction with the item, or waiting for the Browse Field to expire will then result in use-after-free. This fixes the issue by passing a proper `oldItem` argument to detect such item state transitions. Unfortunately, this comes at the cost of `Item::clone` call, I'm not sure if there's a more efficient way to handle this.