### PR TITLE
Fix: Unable to set spell group to 'NONE'

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -158,6 +158,8 @@ enum SpellGroup_t : uint8_t
 	SPELLGROUP_CRIPPLING = 6,
 	SPELLGROUP_FOCUS = 7,
 	SPELLGROUP_ULTIMATESTRIKES = 8,
+
+	SPELLGROUP_UNKNOWN = 255, // last, unspecified
 };
 
 enum SpellType_t : uint8_t

--- a/src/enums.h
+++ b/src/enums.h
@@ -159,7 +159,7 @@ enum SpellGroup_t : uint8_t
 	SPELLGROUP_FOCUS = 7,
 	SPELLGROUP_ULTIMATESTRIKES = 8,
 
-	SPELLGROUP_UNKNOWN = 255 // last, unspecified
+	SPELLGROUP_UNKNOWN = 255 // when no group set in revscript
 };
 
 enum SpellType_t : uint8_t

--- a/src/enums.h
+++ b/src/enums.h
@@ -159,7 +159,7 @@ enum SpellGroup_t : uint8_t
 	SPELLGROUP_FOCUS = 7,
 	SPELLGROUP_ULTIMATESTRIKES = 8,
 
-	SPELLGROUP_UNKNOWN = 255, // last, unspecified
+	SPELLGROUP_UNKNOWN = 255 // last, unspecified
 };
 
 enum SpellType_t : uint8_t

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16375,7 +16375,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				tfs::lua::pushBoolean(L, true);
 			} else if (lua_isstring(L, 2)) {
 				group = stringToSpellGroup(tfs::lua::getString(L, 2));
-				if (group != SPELLGROUP_NONE) {
+				if (group != SPELLGROUP_UNKNOWN) {
 					spell->setGroup(group);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown group: " << tfs::lua::getString(L, 2) << '\n';
@@ -16397,7 +16397,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				tfs::lua::pushBoolean(L, true);
 			} else if (lua_isstring(L, 2) && lua_isstring(L, 3)) {
 				primaryGroup = stringToSpellGroup(tfs::lua::getString(L, 2));
-				if (primaryGroup != SPELLGROUP_NONE) {
+				if (primaryGroup != SPELLGROUP_UNKNOWN) {
 					spell->setGroup(primaryGroup);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown primaryGroup: " << tfs::lua::getString(L, 2) << '\n';
@@ -16405,7 +16405,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 					return 1;
 				}
 				secondaryGroup = stringToSpellGroup(tfs::lua::getString(L, 3));
-				if (secondaryGroup != SPELLGROUP_NONE) {
+				if (secondaryGroup != SPELLGROUP_UNKNOWN) {
 					spell->setSecondaryGroup(secondaryGroup);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown secondaryGroup: " << tfs::lua::getString(L, 3)

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -385,6 +385,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		std::string tmpStr = boost::algorithm::to_lower_copy<std::string>(attr.as_string());
 		if (tmpStr == "none" || tmpStr == "0") {
 			group = SPELLGROUP_NONE;
+			groupCooldown = 0;
 		} else if (tmpStr == "attack" || tmpStr == "1") {
 			group = SPELLGROUP_ATTACK;
 		} else if (tmpStr == "healing" || tmpStr == "2") {
@@ -406,6 +407,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		std::string tmpStr = boost::algorithm::to_lower_copy<std::string>(attr.as_string());
 		if (tmpStr == "none" || tmpStr == "0") {
 			secondaryGroup = SPELLGROUP_NONE;
+			secondaryGroupCooldown = 0;
 		} else if (tmpStr == "attack" || tmpStr == "1") {
 			secondaryGroup = SPELLGROUP_ATTACK;
 		} else if (tmpStr == "healing" || tmpStr == "2") {
@@ -551,7 +553,7 @@ bool Spell::playerSpellCheck(Player* player) const
 		return false;
 	}
 
-	if (player->hasCondition(CONDITION_SPELLGROUPCOOLDOWN, group) ||
+	if ((group != SPELLGROUP_NONE && player->hasCondition(CONDITION_SPELLGROUPCOOLDOWN, group)) ||
 	    player->hasCondition(CONDITION_SPELLCOOLDOWN, spellId) ||
 	    (secondaryGroup != SPELLGROUP_NONE && player->hasCondition(CONDITION_SPELLGROUPCOOLDOWN, secondaryGroup))) {
 		player->sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
@@ -741,13 +743,13 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 				player->addCondition(condition);
 			}
 
-			if (groupCooldown > 0) {
+			if (group != SPELLGROUP_NONE && groupCooldown > 0) {
 				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
 				                                                  groupCooldown, 0, false, group);
 				player->addCondition(condition);
 			}
 
-			if (secondaryGroupCooldown > 0) {
+			if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
 				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
 				                                                  secondaryGroupCooldown, 0, false, secondaryGroup);
 				player->addCondition(condition);
@@ -857,13 +859,13 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 						player->addCondition(condition);
 					}
 
-					if (groupCooldown > 0) {
+					if (group != SPELLGROUP_NONE && groupCooldown > 0) {
 						Condition* condition = Condition::createCondition(
 						    CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
 						player->addCondition(condition);
 					}
 
-					if (secondaryGroupCooldown > 0) {
+					if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
 						Condition* condition =
 						    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
 						                               secondaryGroupCooldown, 0, false, secondaryGroup);
@@ -921,13 +923,13 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 					player->addCondition(condition);
 				}
 
-				if (groupCooldown > 0) {
+				if (group != SPELLGROUP_NONE && groupCooldown > 0) {
 					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
 					                                                  groupCooldown, 0, false, group);
 					player->addCondition(condition);
 				}
 
-				if (secondaryGroupCooldown > 0) {
+				if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
 					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
 					                                                  secondaryGroupCooldown, 0, false, secondaryGroup);
 					player->addCondition(condition);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -733,23 +733,20 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
-void Spell::addCooldowns(Player* player)
+void Spell::addCooldowns(Player* player) const
 {
 	if (cooldown > 0) {
-		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-															cooldown, 0, false, spellId);
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN, cooldown, 0, false, spellId);
 		player->addCondition(condition);
 	}
 
 	if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-															groupCooldown, 0, false, group);
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
 		player->addCondition(condition);
 	}
 
 	if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-															secondaryGroupCooldown, 0, false, secondaryGroup);
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
 		player->addCondition(condition);
 	}
 }

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -733,27 +733,31 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
+void Spell::setCooldowns(Player* player) {
+	if (cooldown > 0) {
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
+															cooldown, 0, false, spellId);
+		player->addCondition(condition);
+	}
+
+	if (group != SPELLGROUP_NONE && groupCooldown > 0) {
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
+															groupCooldown, 0, false, group);
+		player->addCondition(condition);
+	}
+
+	if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
+															secondaryGroupCooldown, 0, false, secondaryGroup);
+		player->addCondition(condition);
+	}
+}
+
 void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool payCost /*= true*/) const
 {
 	if (finishedCast) {
 		if (!player->hasFlag(PlayerFlag_HasNoExhaustion)) {
-			if (cooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-				                                                  cooldown, 0, false, spellId);
-				player->addCondition(condition);
-			}
-
-			if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-				                                                  groupCooldown, 0, false, group);
-				player->addCondition(condition);
-			}
-
-			if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-				                                                  secondaryGroupCooldown, 0, false, secondaryGroup);
-				player->addCondition(condition);
-			}
+			setCooldowns(player);
 		}
 
 		if (aggressive) {
@@ -853,24 +857,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			target = playerTarget;
 			if (!target || target->isRemoved() || target->isDead()) {
 				if (!casterTargetOrDirection) {
-					if (cooldown > 0) {
-						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-						                                                  cooldown, 0, false, spellId);
-						player->addCondition(condition);
-					}
-
-					if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-						Condition* condition = Condition::createCondition(
-						    CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
-						player->addCondition(condition);
-					}
-
-					if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-						Condition* condition =
-						    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-						                               secondaryGroupCooldown, 0, false, secondaryGroup);
-						player->addCondition(condition);
-					}
+					setCooldowns(player);
 
 					player->sendCancelMessage(ret);
 					g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -917,23 +904,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
 
 			if (ret != RETURNVALUE_NOERROR) {
-				if (cooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-					                                                  cooldown, 0, false, spellId);
-					player->addCondition(condition);
-				}
-
-				if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-					                                                  groupCooldown, 0, false, group);
-					player->addCondition(condition);
-				}
-
-				if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-					                                                  secondaryGroupCooldown, 0, false, secondaryGroup);
-					player->addCondition(condition);
-				}
+				setCooldowns(player);
 
 				player->sendCancelMessage(ret);
 				g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -373,6 +373,14 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		spellId = pugi::cast<uint16_t>(attr.value());
 	}
 
+	if ((attr = node.attribute("aggressive"))) {
+		aggressive = booleanString(attr.as_string());
+	}
+
+	if (group == SPELLGROUP_NONE) {
+		group = (aggressive ? SPELLGROUP_ATTACK : SPELLGROUP_HEALING);
+	}
+
 	if ((attr = node.attribute("group"))) {
 		std::string tmpStr = boost::algorithm::to_lower_copy<std::string>(attr.as_string());
 		if (tmpStr == "none" || tmpStr == "0") {
@@ -390,7 +398,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		}
 	}
 
-	if ((attr = node.attribute("groupcooldown"))) {
+	if (group != SPELLGROUP_NONE && (attr = node.attribute("groupcooldown"))) {
 		groupCooldown = pugi::cast<uint32_t>(attr.value());
 	}
 
@@ -411,7 +419,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		}
 	}
 
-	if ((attr = node.attribute("secondarygroupcooldown"))) {
+	if (secondaryGroup != SPELLGROUP_NONE && (attr = node.attribute("secondarygroupcooldown"))) {
 		secondaryGroupCooldown = pugi::cast<uint32_t>(attr.value());
 	}
 
@@ -489,14 +497,6 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 
 	if ((attr = node.attribute("pzlock"))) {
 		pzLock = booleanString(attr.as_string());
-	}
-
-	if ((attr = node.attribute("aggressive"))) {
-		aggressive = booleanString(attr.as_string());
-	}
-
-	if (group == SPELLGROUP_NONE) {
-		group = (aggressive ? SPELLGROUP_ATTACK : SPELLGROUP_HEALING);
 	}
 
 	for (auto vocationNode : node.children()) {

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -733,7 +733,8 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
-void Spell::setCooldowns(Player* player) {
+void Spell::addCooldowns(Player* player)
+{
 	if (cooldown > 0) {
 		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
 															cooldown, 0, false, spellId);
@@ -757,7 +758,7 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 {
 	if (finishedCast) {
 		if (!player->hasFlag(PlayerFlag_HasNoExhaustion)) {
-			setCooldowns(player);
+			addCooldowns(player);
 		}
 
 		if (aggressive) {
@@ -857,7 +858,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			target = playerTarget;
 			if (!target || target->isRemoved() || target->isDead()) {
 				if (!casterTargetOrDirection) {
-					setCooldowns(player);
+					addCooldowns(player);
 
 					player->sendCancelMessage(ret);
 					g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -904,7 +905,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
 
 			if (ret != RETURNVALUE_NOERROR) {
-				setCooldowns(player);
+				addCooldowns(player);
 
 				player->sendCancelMessage(ret);
 				g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);

--- a/src/spells.h
+++ b/src/spells.h
@@ -148,7 +148,8 @@ public:
 	}
 
 	SpellGroup_t getGroup() const { return group; }
-	void setGroup(SpellGroup_t g) {
+	void setGroup(SpellGroup_t g)
+	{
 		group = g;
 		if(group == SPELLGROUP_NONE) {
 			groupCooldown = 0;

--- a/src/spells.h
+++ b/src/spells.h
@@ -148,7 +148,12 @@ public:
 	}
 
 	SpellGroup_t getGroup() const { return group; }
-	void setGroup(SpellGroup_t g) { group = g; }
+	void setGroup(SpellGroup_t g) {
+		group = g;
+		if(group == SPELLGROUP_NONE) {
+			groupCooldown = 0;
+		}
+	}
 	SpellGroup_t getSecondaryGroup() const { return secondaryGroup; }
 	void setSecondaryGroup(SpellGroup_t g) { secondaryGroup = g; }
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -191,7 +191,7 @@ protected:
 	bool playerSpellCheck(Player* player) const;
 	bool playerInstantSpellCheck(Player* player, const Position& toPos);
 	bool playerRuneSpellCheck(Player* player, const Position& toPos);
-	void setCooldowns(Player* player);
+	void addCooldowns(Player* player);
 
 	std::map<uint16_t, bool> vocationSpellMap;
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -191,7 +191,7 @@ protected:
 	bool playerSpellCheck(Player* player) const;
 	bool playerInstantSpellCheck(Player* player, const Position& toPos);
 	bool playerRuneSpellCheck(Player* player, const Position& toPos);
-	void addCooldowns(Player* player);
+	void addCooldowns(Player* player) const;
 
 	std::map<uint16_t, bool> vocationSpellMap;
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -151,7 +151,7 @@ public:
 	void setGroup(SpellGroup_t g)
 	{
 		group = g;
-		if(group == SPELLGROUP_NONE) {
+		if (group == SPELLGROUP_NONE) {
 			groupCooldown = 0;
 		}
 	}

--- a/src/spells.h
+++ b/src/spells.h
@@ -191,6 +191,7 @@ protected:
 	bool playerSpellCheck(Player* player) const;
 	bool playerInstantSpellCheck(Player* player, const Position& toPos);
 	bool playerRuneSpellCheck(Player* player, const Position& toPos);
+	void setCooldowns(Player* player);
 
 	std::map<uint16_t, bool> vocationSpellMap;
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1115,7 +1115,9 @@ int64_t OTSYS_TIME()
 SpellGroup_t stringToSpellGroup(const std::string& value)
 {
 	std::string tmpStr = boost::algorithm::to_lower_copy(value);
-	if (tmpStr == "attack" || tmpStr == "1") {
+	if (tmpStr == "none" || tmpStr == "0") {
+		return SPELLGROUP_NONE;
+	} else if (tmpStr == "attack" || tmpStr == "1") {
 		return SPELLGROUP_ATTACK;
 	} else if (tmpStr == "healing" || tmpStr == "2") {
 		return SPELLGROUP_HEALING;
@@ -1125,7 +1127,7 @@ SpellGroup_t stringToSpellGroup(const std::string& value)
 		return SPELLGROUP_SPECIAL;
 	}
 
-	return SPELLGROUP_NONE;
+	return SPELLGROUP_UNKNOWN;
 }
 
 const std::vector<Direction>& getShuffleDirections()


### PR DESCRIPTION
### Pull Request Prelude
- [x ] I have followed [proper The Forgotten Server code styling][code].
- [x ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Using the spellgroup("none"), didn't work as below in the code, after it was already loaded, the code: if (group == SPELLGROUP_NONE) {, would have overriden it and set none to either attack or healing group.

This successfully fixes it.

If group is none, then we don't want to load/change group cooldowns, as other checks in the code for spell cooldown check only groupCooldown > 0, and not group != SPELLGROUP_NONE, so I think it will be more efficient to block it at loading.

**Issues addressed:** <!-- Write here the issue number, if any. -->
'none' spell tag not working.
**How to test:** <!-- Write here how to test changes. -->
Try to set spell's group to none, you will see using the spell will still put cd on attacking/healing group as this is what none is set to currently.
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
