### PR TITLE
Don't recreate stackables every move

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1232,6 +1232,8 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 				moveItem = item;
 			}
 		}
+	} else {
+		moveItem = item;
 	}
 
 	// add item

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1232,8 +1232,6 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 				moveItem = item;
 			}
 		}
-	} else {
-		fromCylinder->removeThing(item, moveCount);
 	}
 
 	// add item


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Follow up to #4761
Don't recreate stackables on every move, create new stackables only when really needed.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Stackable items are recreated even when they shouldn't, if you move a full stack of stackable item, why would you create a new item and delete the old one?
This seems pretty wasteful and unnecessary.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

**How to test:** <!-- Write here how to test changes. -->
Play with stackables

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
