### PR TITLE
Fix build without HTTP module

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -117,7 +117,9 @@ void Game::setGameState(GameState_t newState)
 			g_scheduler.stop();
 			g_databaseTasks.stop();
 			g_dispatcher.stop();
+#ifdef HTTP
 			tfs::http::stop();
+#endif
 			break;
 		}
 

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -224,9 +224,11 @@ void mainLoader(ServiceManager* services)
 	// Legacy login protocol
 	services->add<ProtocolOld>(static_cast<uint16_t>(getNumber(ConfigManager::LOGIN_PORT)));
 
+#ifdef HTTP
 	// HTTP server
 	tfs::http::start(getString(ConfigManager::IP), getNumber(ConfigManager::HTTP_PORT),
 	                 getNumber(ConfigManager::HTTP_WORKERS));
+#endif
 
 	RentPeriod_t rentPeriod;
 	std::string strRentPeriod = boost::algorithm::to_lower_copy(getString(ConfigManager::HOUSE_RENT_PERIOD));


### PR DESCRIPTION
### Pull Request Prelude

Fix build without HTTP module

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
  
Adding missing #ifdef

**Issues addressed:** <!-- Write here the issue number, if any. -->

Cannot build project with HTTP flag disabled

**How to test:** <!-- Write here how to test changes. -->

2) Build with flag HTTP=OFF or add in src/CMakeLists.txt just before `if (HTTP)` add `SET(HTTP OFF)`