### PR TITLE
Adding network msg to network msg

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2527,6 +2527,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "NetworkMessage", "addDouble", LuaScriptInterface::luaNetworkMessageAddDouble);
 	registerMethod(L, "NetworkMessage", "addItem", LuaScriptInterface::luaNetworkMessageAddItem);
 	registerMethod(L, "NetworkMessage", "addItemId", LuaScriptInterface::luaNetworkMessageAddItemId);
+	registerMethod(L, "NetworkMessage", "addNetworkMessage", LuaScriptInterface::luaNetworkMessageAddNetworkMessage);
 
 	registerMethod(L, "NetworkMessage", "reset", LuaScriptInterface::luaNetworkMessageReset);
 	registerMethod(L, "NetworkMessage", "seek", LuaScriptInterface::luaNetworkMessageSeek);
@@ -6289,6 +6290,26 @@ int LuaScriptInterface::luaNetworkMessageAddItemId(lua_State* L)
 	}
 
 	message->addItemId(itemId);
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaNetworkMessageAddNetworkMessage(lua_State* L)
+{
+	// networkMessage:addNetworkMessage(msg)
+	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	if (!message) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	NetworkMessage* msgToAdd = tfs::lua::getUserdata<NetworkMessage>(L, 2);
+	if (!msgToAdd) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	message->addNetworkMessage(msgToAdd);
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2527,7 +2527,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "NetworkMessage", "addDouble", LuaScriptInterface::luaNetworkMessageAddDouble);
 	registerMethod(L, "NetworkMessage", "addItem", LuaScriptInterface::luaNetworkMessageAddItem);
 	registerMethod(L, "NetworkMessage", "addItemId", LuaScriptInterface::luaNetworkMessageAddItemId);
-	registerMethod(L, "NetworkMessage", "addNetworkMessage", LuaScriptInterface::luaNetworkMessageAddNetworkMessage);
+	registerMethod(L, "NetworkMessage", "compose", LuaScriptInterface::luaNetworkMessageCompose);
 
 	registerMethod(L, "NetworkMessage", "reset", LuaScriptInterface::luaNetworkMessageReset);
 	registerMethod(L, "NetworkMessage", "seek", LuaScriptInterface::luaNetworkMessageSeek);
@@ -6294,9 +6294,9 @@ int LuaScriptInterface::luaNetworkMessageAddItemId(lua_State* L)
 	return 1;
 }
 
-int LuaScriptInterface::luaNetworkMessageAddNetworkMessage(lua_State* L)
+int LuaScriptInterface::luaNetworkMessageCompose(lua_State* L)
 {
-	// networkMessage:addNetworkMessage(msg)
+	// networkMessage:compose(otherMsg)
 	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
 	if (!message) {
 		lua_pushnil(L);
@@ -6309,7 +6309,7 @@ int LuaScriptInterface::luaNetworkMessageAddNetworkMessage(lua_State* L)
 		return 1;
 	}
 
-	message->addNetworkMessage(msgToAdd);
+	message->addNetworkMessage(*msgToAdd);
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -395,6 +395,7 @@ private:
 	static int luaNetworkMessageAddDouble(lua_State* L);
 	static int luaNetworkMessageAddItem(lua_State* L);
 	static int luaNetworkMessageAddItemId(lua_State* L);
+	static int luaNetworkMessageAddNetworkMessage(lua_State* L);
 
 	static int luaNetworkMessageReset(lua_State* L);
 	static int luaNetworkMessageSeek(lua_State* L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -395,7 +395,7 @@ private:
 	static int luaNetworkMessageAddDouble(lua_State* L);
 	static int luaNetworkMessageAddItem(lua_State* L);
 	static int luaNetworkMessageAddItemId(lua_State* L);
-	static int luaNetworkMessageAddNetworkMessage(lua_State* L);
+	static int luaNetworkMessageCompose(lua_State* L);
 
 	static int luaNetworkMessageReset(lua_State* L);
 	static int luaNetworkMessageSeek(lua_State* L);

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -191,3 +191,19 @@ void NetworkMessage::addItem(const Item* item)
 }
 
 void NetworkMessage::addItemId(uint16_t itemId) { add<uint16_t>(Item::items[itemId].clientId); }
+
+void NetworkMessage::addNetworkMessage(NetworkMessage* networkMsg)
+{
+	if (!networkMsg) {
+		return;
+	}
+
+	if (!canAdd(networkMsg->getLength())) {
+		return;
+	}
+
+	std::memcpy(buffer.data() + info.position, networkMsg->getBuffer() + INITIAL_BUFFER_POSITION,
+	            networkMsg->getLength());
+	info.position += networkMsg->getLength();
+	info.length += networkMsg->getLength();
+}

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -100,6 +100,7 @@ public:
 	}
 
 	void addBytes(const char* bytes, size_t size);
+	void addBytes(const uint8_t* bytes, size_t size);
 	void addPaddingBytes(size_t n);
 
 	void addString(std::string_view value);
@@ -111,7 +112,7 @@ public:
 	void addItem(uint16_t id, uint8_t count);
 	void addItem(const Item* item);
 	void addItemId(uint16_t itemId);
-	void addNetworkMessage(NetworkMessage* networkMsg);
+	void addNetworkMessage(const NetworkMessage& networkMsg);
 
 	MsgSize_t getLength() const { return info.length; }
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -54,12 +54,12 @@ public:
 	}
 
 	// Returns first element of body
-	uint8_t getPreviousByte() { 
-		if (info.position == INITIAL_BUFFER_POSITION)
-		{
+	uint8_t getPreviousByte()
+	{
+		if (info.position == INITIAL_BUFFER_POSITION) {
 			return buffer[INITIAL_BUFFER_POSITION];
 		}
-		return buffer[--info.position]; 
+		return buffer[--info.position];
 	}
 
 	template <typename T>

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -53,7 +53,14 @@ public:
 		return buffer[info.position++];
 	}
 
-	uint8_t getPreviousByte() { return buffer[--info.position]; }
+	// Returns first element of body
+	uint8_t getPreviousByte() { 
+		if (info.position == INITIAL_BUFFER_POSITION)
+		{
+			return buffer[INITIAL_BUFFER_POSITION];
+		}
+		return buffer[--info.position]; 
+	}
 
 	template <typename T>
 	std::enable_if_t<std::is_trivially_copyable_v<T>, T> get() noexcept

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -111,6 +111,7 @@ public:
 	void addItem(uint16_t id, uint8_t count);
 	void addItem(const Item* item);
 	void addItemId(uint16_t itemId);
+	void addNetworkMessage(NetworkMessage* networkMsg);
 
 	MsgSize_t getLength() const { return info.length; }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(tests_SRC
     ${CMAKE_CURRENT_LIST_DIR}/test_rsa.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_sha1.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_xtea.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_networkmessage.cpp
     )
 
 foreach(test_src ${tests_SRC})

--- a/src/tests/test_networkmessage.cpp
+++ b/src/tests/test_networkmessage.cpp
@@ -1,0 +1,123 @@
+#define BOOST_TEST_MODULE networkmessage
+
+#include "../otpch.h"
+
+#include "../networkmessage.h"
+#include "../position.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_reset)
+{
+	uint8_t expected = 12;
+	uint8_t actual = 0;
+	NetworkMessage msg{};
+	msg.addByte(expected);
+	msg.setBufferPosition(0);
+	actual = msg.getByte();
+	BOOST_TEST(msg.getLength() == 1);
+	BOOST_TEST(msg.getBufferPosition() == 1 + NetworkMessage::INITIAL_BUFFER_POSITION);
+	msg.reset();
+	BOOST_TEST(msg.getLength() == 0);
+	BOOST_TEST(actual == expected);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_getPreviousByte)
+{
+	NetworkMessage msg{};
+	msg.addByte(11);
+	msg.addByte(22);
+	msg.addByte(33);
+	msg.addByte(44);
+	BOOST_TEST(msg.getLength() == 4);
+	BOOST_TEST(msg.getPreviousByte() == 44);
+	BOOST_TEST(msg.getPreviousByte() == 33);
+	BOOST_TEST(msg.getPreviousByte() == 22);
+	BOOST_TEST(msg.getPreviousByte() == 11);
+	// overflow case
+	BOOST_TEST(msg.getPreviousByte() == 11);
+	BOOST_TEST(msg.getBufferPosition() == NetworkMessage::INITIAL_BUFFER_POSITION);
+
+}
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_add_get_template)
+{
+	NetworkMessage msg{};
+	msg.add<uint16_t>(std::numeric_limits<uint16_t>::max());
+	msg.add<uint32_t>(std::numeric_limits<uint32_t>::max());
+	msg.add<uint64_t>(std::numeric_limits<uint64_t>::max());
+	msg.setBufferPosition(0);
+	BOOST_TEST(msg.getLength() == 14);
+	BOOST_TEST(msg.get<uint16_t>() == std::numeric_limits<uint16_t>::max());
+	BOOST_TEST(msg.get<uint32_t>() == std::numeric_limits<uint32_t>::max());
+	BOOST_TEST(msg.get<uint64_t>() == std::numeric_limits<uint64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_string)
+{
+	NetworkMessage msg{};
+	msg.addString("test");
+	msg.addString("Msg");
+	msg.setBufferPosition(0);
+	BOOST_TEST(msg.getLength() == 11);
+	BOOST_TEST(msg.getString() == "test");
+	BOOST_TEST(msg.getString() == "Msg");
+}
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_position)
+{
+	Position position1(11, 22, 3);
+	Position position2(111, 222, 4);
+	NetworkMessage msg{};
+	msg.addPosition(position1);
+	msg.addPosition(position2);
+	msg.setBufferPosition(0);
+	BOOST_TEST(msg.getLength() == 10);
+	BOOST_TEST(msg.getPosition() == position1);
+	BOOST_TEST(msg.getPosition() == position2);
+}
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_skip)
+{
+	NetworkMessage msg{};
+	msg.addByte(1);
+	msg.addByte(2);
+	msg.addByte(5);
+	msg.setBufferPosition(0);
+	msg.skipBytes(2);
+	BOOST_TEST(msg.getLength() == 3);
+	BOOST_TEST(msg.getByte() == 5);
+}
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_byte)
+{
+	NetworkMessage msg{};
+	msg.addByte(12);
+	msg.addByte(34);
+	msg.setBufferPosition(0);
+	BOOST_TEST(msg.getLength() == 2);
+	BOOST_TEST(msg.getByte() == 12);
+	BOOST_TEST(msg.getByte() == 34);
+}
+
+BOOST_AUTO_TEST_CASE(test_networkmessage_bytes)
+{
+	uint8_t expected1[] = {1, 2, 3};
+	NetworkMessage msg1{};
+	msg1.addBytes(expected1, 3);
+	msg1.setBufferPosition(0);
+	BOOST_TEST(msg1.getLength() == 3);
+	BOOST_TEST(msg1.getByte() == expected1[0]);
+	BOOST_TEST(msg1.getByte() == expected1[1]);
+	BOOST_TEST(msg1.getByte() == expected1[2]);
+
+	const char* expected2 = {"abc"};
+	NetworkMessage msg2{};
+	msg2.addBytes(expected2, 3);
+	msg2.setBufferPosition(0);
+	BOOST_TEST(msg2.getLength() == 3);
+	BOOST_TEST(msg2.getByte() == expected2[0]);
+	BOOST_TEST(msg2.getByte() == expected2[1]);
+	BOOST_TEST(msg2.getByte() == expected2[2]);
+}

--- a/src/tests/test_networkmessage.cpp
+++ b/src/tests/test_networkmessage.cpp
@@ -22,7 +22,6 @@ BOOST_AUTO_TEST_CASE(test_networkmessage_reset)
 	BOOST_TEST(actual == expected);
 }
 
-
 BOOST_AUTO_TEST_CASE(test_networkmessage_getPreviousByte)
 {
 	NetworkMessage msg{};
@@ -38,7 +37,6 @@ BOOST_AUTO_TEST_CASE(test_networkmessage_getPreviousByte)
 	// overflow case
 	BOOST_TEST(msg.getPreviousByte() == 11);
 	BOOST_TEST(msg.getBufferPosition() == NetworkMessage::INITIAL_BUFFER_POSITION);
-
 }
 
 BOOST_AUTO_TEST_CASE(test_networkmessage_add_get_template)


### PR DESCRIPTION
### Pull Request Prelude

NetworkMessage functionality extension.

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Added ability to append a NetworkMessage  to another NetworkMessage, which allows caching of parts that are repeated in the message.

**Issues addressed:** <!-- Write here the issue number, if any. -->

[suggestion: caching NetworkMessage blocks #4450](https://github.com/otland/forgottenserver/issues/4450)

**How to test:** <!-- Write here how to test changes. -->

```LUA
local cacheMsg = NetworkMessage()
cacheMsg:addString("test")
cacheMsg:addByte(22)

local msg = NetworkMessage()
msg:addByte(5)
msg:addNetworkMessage(cacheMsg)
msg:addByte(66)

msg:seek(0)
print(msg:getByte())
print(msg:getString())
print(msg:getByte())
print(msg:getByte())
```
expected output
```
##### luajit
5
test
22
66
##### lua 5.3
5.0
test
22.0
66.0
```
