### PR TITLE
Fix depot memory leak

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -692,6 +692,15 @@ void Container::postRemoveNotification(Thing* thing, const Cylinder* newParent, 
 	}
 }
 
+void Container::internalRemoveThing(Thing* thing)
+{
+	auto cit = std::find(itemlist.begin(), itemlist.end(), thing);
+	if (cit == itemlist.end()) {
+		return;
+	}
+	itemlist.erase(cit);
+}
+
 void Container::internalAddThing(Thing* thing) { internalAddThing(0, thing); }
 
 void Container::internalAddThing(uint32_t, Thing* thing)

--- a/src/container.h
+++ b/src/container.h
@@ -111,6 +111,7 @@ public:
 	void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index,
 	                            cylinderlink_t link = LINK_OWNER) override;
 
+	void internalRemoveThing(Thing* thing) override final;
 	void internalAddThing(Thing* thing) override final;
 	void internalAddThing(uint32_t index, Thing* thing) override final;
 	void startDecaying() override final;

--- a/src/cylinder.cpp
+++ b/src/cylinder.cpp
@@ -22,6 +22,11 @@ std::map<uint32_t, uint32_t>& Cylinder::getAllItemTypeCount(std::map<uint32_t, u
 
 Thing* Cylinder::getThing(size_t) const { return nullptr; }
 
+void Cylinder::internalRemoveThing(Thing*)
+{
+	//
+}
+
 void Cylinder::internalAddThing(Thing*)
 {
 	//

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -175,6 +175,12 @@ public:
 	virtual std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const;
 
 	/**
+	 * Removes an object from the cylinder without sending to the client(s)
+	 * \param thing is the object to add
+	 */
+	virtual void internalRemoveThing(Thing* thing);
+
+	/**
 	 * Adds an object to the cylinder without sending to the client(s)
 	 * \param thing is the object to add
 	 */

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -6,6 +6,9 @@
 
 #include "container.h"
 
+class DepotChest;
+using DepotChest_ptr = std::shared_ptr<DepotChest>;
+
 class DepotChest final : public Container
 {
 public:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5561,7 +5561,7 @@ std::vector<Item*> Game::getMarketItemList(uint16_t wareId, uint16_t sufficientC
 
 	for (const auto& chest : player.depotChests) {
 		if (!chest.second->empty()) {
-			containers.push_front(chest.second);
+			containers.push_front(chest.second.get());
 		}
 	}
 

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -410,8 +410,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 			int32_t pid = pair.second;
 			if (pid >= 0 && pid < 100) {
-				DepotChest* depotChest = player->getDepotChest(pid, true);
-				if (depotChest) {
+				if (const auto& depotChest = player->getDepotChest(pid, true)) {
 					depotChest->internalAddThing(item);
 				}
 			} else {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9087,10 +9087,10 @@ int LuaScriptInterface::luaPlayerGetDepotChest(lua_State* L)
 
 	uint32_t depotId = tfs::lua::getNumber<uint32_t>(L, 2);
 	bool autoCreate = tfs::lua::getBoolean(L, 3, false);
-	DepotChest* depotChest = player->getDepotChest(depotId, autoCreate);
+	const auto& depotChest = player->getDepotChest(depotId, autoCreate);
 	if (depotChest) {
-		tfs::lua::pushUserdata<Item>(L, depotChest);
-		tfs::lua::setItemMetatable(L, -1, depotChest);
+		pushSharedPtr(L, depotChest);
+		tfs::lua::setItemMetatable(L, -1, depotChest.get());
 	} else {
 		tfs::lua::pushBoolean(L, false);
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -6,6 +6,7 @@
 
 #include "creature.h"
 #include "cylinder.h"
+#include "depotchest.h"
 #include "depotlocker.h"
 #include "enums.h"
 #include "groups.h"
@@ -14,7 +15,6 @@
 #include "town.h"
 #include "vocation.h"
 
-class DepotChest;
 class House;
 struct Mount;
 class NetworkMessage;
@@ -356,7 +356,7 @@ public:
 	void addConditionSuppressions(uint32_t conditions);
 	void removeConditionSuppressions(uint32_t conditions);
 
-	DepotChest* getDepotChest(uint32_t depotId, bool autoCreate);
+	DepotChest_ptr getDepotChest(uint32_t depotId, bool autoCreate);
 	DepotLocker& getDepotLocker();
 	void onReceiveMail() const;
 	bool isNearDepotBox() const;
@@ -1167,7 +1167,7 @@ private:
 	std::unordered_set<uint32_t> VIPList;
 
 	std::map<uint8_t, OpenContainer> openContainers;
-	std::map<uint32_t, DepotChest*> depotChests;
+	std::map<uint32_t, DepotChest_ptr> depotChests;
 
 	std::map<uint16_t, uint8_t> outfits;
 	std::unordered_set<uint16_t> mounts;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2104,7 +2104,7 @@ void ProtocolGame::sendMarketEnter()
 
 	for (const auto& chest : player->depotChests) {
 		if (!chest.second->empty()) {
-			containerList.push_front(chest.second);
+			containerList.push_front(chest.second.get());
 		}
 	}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix #3346

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Removed memory leak

**How to test:** <!-- Write here how to test changes. -->
Add item to first slot of your depot, preferably backpack (can be nested).
Spam the code below lots of times. I've tested with 360 pages of full backpacks, which adds like 50mb to memory, after few relogs memory was not increased.
```
local chest = player:getDepotChest(0)
local item = chest:getItem(0)

for i = 1, 500 do
	chest:addItemEx(item:clone(), INDEX_WHEREEVER, FLAG_NOLIMIT)
end
```

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
