### PR TITLE
Fix MySQL memory leaks

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -61,7 +61,7 @@ static bool executeQuery(tfs::detail::Mysql_ptr& handle, std::string_view query,
 	return true;
 }
 
-Database::~Database() { mysql_server_end(); }
+Database::~Database() { mysql_library_end(); }
 
 bool Database::connect()
 {

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -61,6 +61,8 @@ static bool executeQuery(tfs::detail::Mysql_ptr& handle, std::string_view query,
 	return true;
 }
 
+Database::~Database() { mysql_server_end(); }
+
 bool Database::connect()
 {
 	auto newHandle = connectToDatabase(false);

--- a/src/database.h
+++ b/src/database.h
@@ -37,6 +37,11 @@ public:
 	}
 
 	/**
+	 * Close MySQL client
+	 */
+	~Database();
+
+	/**
 	 * Connects to the database
 	 *
 	 * @return true on successful connection, false on error


### PR DESCRIPTION
### Pull Request Prelude

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fix MySQL memory leaks

**Issues addressed:** <!-- Write here the issue number, if any. -->

https://github.com/otland/forgottenserver/issues/4288

**How to test:** <!-- Write here how to test changes. -->

Requirements: Linux
1) Build project in debug mode
2) Check if Mysql server is not working
3) Run server using valgrind(valgrind --leak-check=full ./tfs)
4) Looks for logs like (They shouldn't be there)
```
==7227== 56 bytes in 1 blocks are possibly lost in loss record 3 of 3
==7227==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7227==    by 0x4FD4977: ??? (in /usr/lib/x86_64-linux-gnu/libmysqlclient.so.21.2.40)
==7227==    by 0x4F73EC4: mysql_server_init (in /usr/lib/x86_64-linux-gnu/libmysqlclient.so.21.2.40)
==7227==    by 0x4F83AF8: mysql_init (in /usr/lib/x86_64-linux-gnu/libmysqlclient.so.21.2.40)
==7227==    by 0x48B7CC: connectToDatabase(bool) (database.cpp:22)
==7227==    by 0x48BC34: Database::connect() (database.cpp:66)
==7227==    by 0x278F1E: (anonymous namespace)::mainLoader(ServiceManager*) (otserv.cpp:116)
==7227==    by 0x27A320: startServer()::{lambda()#1}::operator()() const (otserv.cpp:285)
==7227==    by 0x27BE4F: void std::__invoke_impl<void, startServer()::{lambda()#1}&>(std::__invoke_other, startServer()::{lambda()#1}&) (invoke.h:61)
==7227==    by 0x27BB7E: std::enable_if<is_invocable_r_v<void, startServer()::{lambda()#1}&>, void>::type std::__invoke_r<void, startServer()::{lambda()#1}&>(startServer()::{lambda()#1}&) (invoke.h:111)
==7227==    by 0x27B5BC: std::_Function_handler<void (), startServer()::{lambda()#1}>::_M_invoke(std::_Any_data const&) (std_function.h:290)
==7227==    by 0x168943: std::function<void ()>::operator()() const (std_function.h:591)
==7227== 
```