### PR TITLE
Fix onNetworkMessage event memory leak

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1403,7 +1403,7 @@ void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr msg)
 
 	lua_pushnumber(L, recvByte);
 
-	tfs::lua::pushUserdata(L, msg.release()); 
+	tfs::lua::pushUserdata(L, msg.release());
 	tfs::lua::setMetatable(L, -1, "NetworkMessage");
 
 	scriptInterface.callVoidFunction(3);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1380,7 +1380,7 @@ void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip)
 	scriptInterface.callVoidFunction(4);
 }
 
-void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr msg)
+void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr& msg)
 {
 	// Player:onNetworkMessage(recvByte, msg)
 	if (playerHandlers.onNetworkMessage == -1) {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1380,7 +1380,7 @@ void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip)
 	scriptInterface.callVoidFunction(4);
 }
 
-void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage* msg)
+void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr msg)
 {
 	// Player:onNetworkMessage(recvByte, msg)
 	if (playerHandlers.onNetworkMessage == -1) {
@@ -1403,7 +1403,7 @@ void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage* msg)
 
 	lua_pushnumber(L, recvByte);
 
-	tfs::lua::pushUserdata(L, msg);
+	tfs::lua::pushUserdata(L, msg.release()); 
 	tfs::lua::setMetatable(L, -1, "NetworkMessage");
 
 	scriptInterface.callVoidFunction(3);

--- a/src/events.h
+++ b/src/events.h
@@ -7,9 +7,9 @@
 #include "const.h"
 #include "creature.h"
 #include "luascript.h"
+#include "networkmessage.h"
 
 class ItemType;
-class NetworkMessage;
 class Party;
 class Spell;
 class Tile;
@@ -83,7 +83,7 @@ void onLoseExperience(Player* player, uint64_t& exp);
 void onGainSkillTries(Player* player, skills_t skill, uint64_t& tries);
 void onWrapItem(Player* player, Item* item);
 void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
-void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage* msg);
+void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr msg);
 bool onSpellCheck(Player* player, const Spell* spell);
 
 } // namespace tfs::events::player

--- a/src/events.h
+++ b/src/events.h
@@ -83,7 +83,7 @@ void onLoseExperience(Player* player, uint64_t& exp);
 void onGainSkillTries(Player* player, skills_t skill, uint64_t& tries);
 void onWrapItem(Player* player, Item* item);
 void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
-void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr msg);
+void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr& msg);
 bool onSpellCheck(Player* player, const Spell* spell);
 
 } // namespace tfs::events::player

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5555,7 +5555,7 @@ void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, Networ
 		return;
 	}
 
-	tfs::events::player::onNetworkMessage(player, recvByte, std::move(msg));
+	tfs::events::player::onNetworkMessage(player, recvByte, msg);
 }
 
 std::vector<Item*> Game::getMarketItemList(uint16_t wareId, uint16_t sufficientCount, Player& player)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5548,14 +5548,14 @@ void Game::parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, const st
 	}
 }
 
-void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage* msg)
+void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr msg)
 {
 	Player* player = getPlayerByID(playerId);
 	if (!player) {
 		return;
 	}
 
-	tfs::events::player::onNetworkMessage(player, recvByte, msg);
+	tfs::events::player::onNetworkMessage(player, recvByte, std::move(msg));
 }
 
 std::vector<Item*> Game::getMarketItemList(uint16_t wareId, uint16_t sufficientCount, Player& player)

--- a/src/game.h
+++ b/src/game.h
@@ -392,7 +392,7 @@ public:
 	void playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16_t counter, uint16_t amount);
 
 	void parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, const std::string& buffer);
-	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage* msg);
+	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr msg);
 
 	std::vector<Item*> getMarketItemList(uint16_t wareId, uint16_t sufficientCount, Player& player);
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -9,6 +9,9 @@
 class Item;
 struct Position;
 
+class NetworkMessage;
+using NetworkMessage_ptr = std::unique_ptr<NetworkMessage>;
+
 class NetworkMessage
 {
 public:

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -793,8 +793,10 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 			// case 0xFE: break; // store window history 2
 
 		default:
+			// we cannot pass an unique_ptr as capture here because
+			// std::function requires the callable object to be *copyable*
 			g_dispatcher.addTask([=, playerID = player->getID(), msg = new NetworkMessage(msg)]() {
-				g_game.parsePlayerNetworkMessage(playerID, recvbyte, msg);
+				g_game.parsePlayerNetworkMessage(playerID, recvbyte, NetworkMessage_ptr(msg));
 			});
 			break;
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

**Issues addressed:**
Fix memory leak

**How to test:**
Disable **Player:onNetworkMessage** event and send packets with unknown opcode to server, such as from store.
