### PR TITLE
Add missing requirement boost-json to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
   boost-iostreams \
   boost-locale \
   boost-system \
+  boost-json \
   fmt \
   luajit \
   mariadb-connector-c \


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This just add a missing dependency boost-json to Dockerfile
without it running the resulting docker container is going to throw the following error:
`Error loading shared library libboost_json.so.1.82.0: No such file or directory (needed by /bin/tfs)
Error relocating /bin/tfs: _ZN5boost4json5arrayC1ERKS1_NS0_11storage_ptrE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json6objectC1ERKS1_NS0_11storage_ptrE: symbol not found
Error relocating /bin/tfs: _ZNK5boost4json6object11if_containsENS_4core17basic_string_viewIcEE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json18monotonic_resourceC1EmNS0_11storage_ptrE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5arrayD1Ev: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5arrayC1ESt16initializer_listINS0_9value_refEENS0_11storage_ptrE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5parseENS_4core17basic_string_viewIcEERNS_6system10error_codeENS0_11storage_ptrERKNS0_13parse_optionsE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5valueaSENS_4core17basic_string_viewIcEE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5value7destroyEv: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5valueC1ERKS1_NS0_11storage_ptrE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json9serializeB5cxx11ERKNS0_5valueE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json6objectixENS_4core17basic_string_viewIcEE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5valueC1ESt16initializer_listINS0_9value_refEENS0_11storage_ptrE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5valueD1Ev: symbol not found
Error relocating /bin/tfs: _ZN5boost4json6objectD1Ev: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5array9push_backEONS0_5valueE: symbol not found
Error relocating /bin/tfs: _ZN5boost4json6objectC1EOS1_: symbol not found
Error relocating /bin/tfs: _ZN5boost4json18monotonic_resourceD1Ev: symbol not found
Error relocating /bin/tfs: _ZN5boost4json6object6empty_E: symbol not found
Error relocating /bin/tfs: _ZN5boost4json5array6empty_E: symbol not found
`

**Issues addressed:** There is not issue number<!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->
build the container
`docker build -t server .`

run the container
`docker run server`

- before changes it will shows the previously mentioned error trace
- after changes it should fail in an elegant way because the config.lua is not available

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
