### PR TITLE
Fix issue in creature.cpp adding skull to master on summon AoE attacks

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -712,6 +712,10 @@ BlockType_t Creature::blockHit(Creature* attacker, CombatType_t combatType, int3
 		if (combatType != COMBAT_HEALING) {
 			attacker->onAttackedCreature(this);
 			attacker->onAttackedCreatureBlockHit(blockType);
+			if (attacker->getMaster() && attacker->getMaster()->getPlayer()) {
+				Player* masterPlayer = attacker->getMaster()->getPlayer();
+				masterPlayer->onAttackedCreature(this);
+			}
 		}
 	}
 


### PR DESCRIPTION
- [x] I have followed [[proper The Forgotten Server code styling](https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide)][code].
- [x] I have read and understood the [[contribution guidelines](https://github.com/otland/forgottenserver/wiki/Contributing)][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Added code to ensure that when a player's summon damages another player with an AoE attack, the master player is correctly assigned a skull.

**Code added:**
```cpp
if (attacker->getMaster() && attacker->getMaster()->getPlayer()) {
	Player* masterPlayer = attacker->getMaster()->getPlayer();
	masterPlayer->onAttackedCreature(this);
}
```

### Issues Addressed

Fixes the bug where a player's summon (e.g., fire devil or fire elemental) using AoE spells did not assign a skull to the master player when damaging other players.

### How to Test

1. Summon a creature (e.g., fire devil or fire elemental) as a player.
2. Have the summon cast an AoE spell near another player. You can summon 2 Fire Devils and make one attack the other.
3. Verify that the master player receives a skull when the AoE damages the other player.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing  
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide  
