### PR TITLE
remove seek from NetworkMessage

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -167,7 +167,6 @@ Tile = {}
 ---@field addItem fun(self: NetworkMessage, item: Item)
 ---@field addItemId fun(self: NetworkMessage, itemId: number)
 ---@field reset fun(self: NetworkMessage)
----@field seek fun(self: NetworkMessage, position: number)
 ---@field tell fun(self: NetworkMessage): number
 ---@field len fun(self: NetworkMessage): number
 ---@field skipBytes fun(self: NetworkMessage, count: number)

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2501,7 +2501,6 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "NetworkMessage", "addItemId", LuaScriptInterface::luaNetworkMessageAddItemId);
 
 	registerMethod(L, "NetworkMessage", "reset", LuaScriptInterface::luaNetworkMessageReset);
-	registerMethod(L, "NetworkMessage", "seek", LuaScriptInterface::luaNetworkMessageSeek);
 	registerMethod(L, "NetworkMessage", "tell", LuaScriptInterface::luaNetworkMessageTell);
 	registerMethod(L, "NetworkMessage", "len", LuaScriptInterface::luaNetworkMessageLength);
 	registerMethod(L, "NetworkMessage", "skipBytes", LuaScriptInterface::luaNetworkMessageSkipBytes);
@@ -6213,18 +6212,6 @@ int LuaScriptInterface::luaNetworkMessageReset(lua_State* L)
 	if (message) {
 		message->reset();
 		tfs::lua::pushBoolean(L, true);
-	} else {
-		lua_pushnil(L);
-	}
-	return 1;
-}
-
-int LuaScriptInterface::luaNetworkMessageSeek(lua_State* L)
-{
-	// networkMessage:seek(position)
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
-	if (message && isNumber(L, 2)) {
-		tfs::lua::pushBoolean(L, message->setBufferPosition(tfs::lua::getNumber<uint16_t>(L, 2)));
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -390,7 +390,6 @@ private:
 	static int luaNetworkMessageAddItemId(lua_State* L);
 
 	static int luaNetworkMessageReset(lua_State* L);
-	static int luaNetworkMessageSeek(lua_State* L);
 	static int luaNetworkMessageTell(lua_State* L);
 	static int luaNetworkMessageLength(lua_State* L);
 	static int luaNetworkMessageSkipBytes(lua_State* L);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

Remove seek functionality from NetworkMessage since it is not used anywhere in the codebase and can behave unexpectedly when used with addByte.

**Issues addressed:** <!-- Write here the issue number, if any. -->

#4877 

**How to test:** <!-- Write here how to test changes. -->

Compile and run the server.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
