### PR TITLE
fix: null dereferencing on onAttackedCreatureDrainHealth

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -917,6 +917,10 @@ void Creature::onAttacked()
 
 void Creature::onAttackedCreatureDrainHealth(Creature* target, int32_t points)
 {
+	if (!target || points <= 0) {
+		return;
+	}
+
 	target->addDamagePoints(this, points);
 }
 


### PR DESCRIPTION
This prevents potential crashes due to null dereferencing and avoids processing invalid damage values.