### PR TITLE
Fix zlib context memory leak

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -43,6 +43,16 @@ bool XTEA_decrypt(NetworkMessage& msg, const xtea::round_keys& key)
 
 } // namespace
 
+Protocol::~Protocol()
+{
+	const auto zlibEndResult = deflateEnd(&zstream);
+	if (zlibEndResult == Z_DATA_ERROR) {
+		std::cout << "ZLIB discarded pending output or unprocessed input while cleaning up stream state" << std::endl;
+	} else if (zlibEndResult == Z_STREAM_ERROR) {
+		std::cout << "ZLIB encountered an error while cleaning up stream state" << std::endl;
+	}
+}
+
 void Protocol::onSendMessage(const OutputMessage_ptr& msg)
 {
 	if (!rawMessages) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,8 +18,7 @@ public:
 			std::cout << "ZLIB initialization error: " << (zstream.msg ? zstream.msg : "unknown") << std::endl;
 		}
 	}
-
-	virtual ~Protocol() { deflateEnd(&zstream); };
+	virtual ~Protocol();
 
 	// non-copyable
 	Protocol(const Protocol&) = delete;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,7 +18,8 @@ public:
 			std::cout << "ZLIB initialization error: " << (zstream.msg ? zstream.msg : "unknown") << std::endl;
 		}
 	}
-	virtual ~Protocol() = default;
+
+	virtual ~Protocol() { deflateEnd(&zstream); };
 
 	// non-copyable
 	Protocol(const Protocol&) = delete;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Leak of memory allocated by deflateInit2 for zstream

```
Direct leak of 166656 byte(s) in 28 object(s) allocated from:                                                                                                                                                                                                  
    #0 0x7e72d3163c77 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69                                                                                                                                                                     
    #1 0x7e72d298418a in deflateInit2_ (/lib/x86_64-linux-gnu/libz.so.1+0x918a) (BuildId: b6e5d9c258e911b2e478f8dedf22400e53225509)
```

**How to test:** <!-- Write here how to test changes. -->

build with asan and log in

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

@nekiro 
