### PR TITLE
fix: always drop loot if stamina system is disabled

### DIFF
--- a/data/scripts/events/monster/default_onDropLoot.lua
+++ b/data/scripts/events/monster/default_onDropLoot.lua
@@ -9,7 +9,7 @@ event.onDropLoot = function(self, corpse)
 	local mType = self:getType()
 	local doCreateLoot = false
 
-	if not player or player:getStamina() > 840 then
+	if not player or player:getStamina() > 840 or not configManager.getBoolean(configKeys.STAMINA_SYSTEM) then
 		doCreateLoot = true
 	end
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** If stamina system is disabled, and a player has no stamina, loot will not be dropped when killing a monster

**How to test:** Set stamina system to false in config.lua, have 0 stamina, and kill monsters. With this fix, you will have loot dropping. If not, no loot will be generated.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
