### PR TITLE
Refactor: eliminate redundant getMountByID calls in tameMount and untameMount

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4381,12 +4381,8 @@ bool Player::toggleMount(bool mount)
 
 bool Player::tameMount(uint16_t mountId)
 {
-	if (!g_game.mounts.getMountByID(mountId)) {
-		return false;
-	}
-
 	Mount* mount = g_game.mounts.getMountByID(mountId);
-	if (hasMount(mount)) {
+	if (!mount || hasMount(mount)) {
 		return false;
 	}
 
@@ -4396,12 +4392,8 @@ bool Player::tameMount(uint16_t mountId)
 
 bool Player::untameMount(uint16_t mountId)
 {
-	if (!g_game.mounts.getMountByID(mountId)) {
-		return false;
-	}
-
 	Mount* mount = g_game.mounts.getMountByID(mountId);
-	if (!hasMount(mount)) {
+	if (!mount || !hasMount(mount)) {
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This pull request simplifies the logic in Player::tameMount and Player::untameMount by eliminating redundant calls to g_game.mounts.getMountByID(mountId).

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
