### PR TITLE
Fix item description to respect reading distance limits

### DIFF
--- a/data/lib/core/item.lua
+++ b/data/lib/core/item.lua
@@ -740,9 +740,7 @@ do
 			end
 
 			if desc and desc:len() > 0 then
-				if not (isBed and desc == "Nobody is sleeping there.") then
-					response[#response + 1] = string.format("\n%s", desc)
-				end
+				response[#response + 1] = string.format("\n%s", desc)
 			end
 		else
 			if lookDistance <= 4 then


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This change ensures that item descriptions require the player to be within 4 SQMs to be read, matching the behavior of items with readable text. This keeps consistency between text and description reading logic. I've tested this behavior on wedding ring in RL tibia so it might be the same for other stuff with special description as well.

### This also fixes beds not showing "Nobody is sleeping there" at all.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
closes #4901

**How to test:** <!-- Write here how to test changes. -->
do the stuff on issue #4901 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
