### PR TITLE
Disable item classification display until feature is implemented

### DIFF
--- a/data/lib/core/item.lua
+++ b/data/lib/core/item.lua
@@ -583,11 +583,15 @@ do
 			end
 		end
 
+		--[[
 		-- imbuements (to do)
 		-- \nImbuements: (Basic Strike 2:30h, Basic Void 2:30h, Empty Slot).
 
-		-- item class
+		
+		-- item class (placeholder)
 		-- Classification: x.
+		-- Disabled until classification system is implemented.
+
 		do
 			local classification = itemType:getClassification()
 			if classification == 0 then
@@ -595,6 +599,7 @@ do
 			end
 			response[#response + 1] = string.format("\nClassification: %s.", classification)
 		end
+		]]
 
 		-- item count (will be reused later)
 		local count = isVirtual and 1 or item:getCount()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The item classification system is not implemented and not in progress. However, the UI still shows "Classification: other" for every item, causing unnecessary clutter. This change comments out the code block responsible for that output, leaving a clear note for future reactivation when the feature is ready.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
