### PR TITLE
Remove outdated set/getStorageValue warning message

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -592,16 +592,12 @@ function isPremium(cid) local p = Player(cid) return p and p:isPremium() or fals
 
 STORAGEVALUE_EMPTY = -1
 function Player:getStorageValue(key)
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking Creature:getStorageValue will return nil to indicate absence in the future. Please update your scripts accordingly.")
-
 	local v = Creature.getStorageValue(self, key)
 	return v or STORAGEVALUE_EMPTY
 end
 
 function Player:setStorageValue(key, value)
-
 	if value == STORAGEVALUE_EMPTY then
-		print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking Creature:setStorageValue with a value of -1 to remove it is deprecated. Please use Creature:removeStorageValue(key) instead.")
 		Creature.removeStorageValue(self, key)
 	else
 		Creature.setStorageValue(self, key, value)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
The deprecation warning printed by Player:get/setStorageValue has been removed.

It has been over two years since the change was introduced, providing enough time for users to adapt their scripts. The warning was being printed excessively, as the function is used in nearly all scripts, cluttering the server logs unnecessarily.

Anyone with questions or issues can refer to the forum or documentation.

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
