### PR TITLE
fix: crash in ProtocolLogin (#4902)

### DIFF
--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -62,6 +62,11 @@ void ProtocolLogin::disconnectClient(const std::string& message, uint16_t versio
 void ProtocolLogin::getCharacterList(const std::string& accountName, const std::string& password,
                                      const std::string& token, uint16_t version)
 {
+	auto connection = getConnection();
+	if (!connection) {
+		return;
+	}
+
 	Database& db = Database::getInstance();
 
 	DBResult_ptr result = db.storeQuery(fmt::format(
@@ -118,7 +123,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	if (!db.executeQuery(
 	        fmt::format("INSERT INTO `sessions` (`token`, `account_id`, `ip`) VALUES ({:s}, {:d}, INET6_ATON({:s}))",
 	                    db.escapeBlob(sessionKey.data(), sessionKey.size()), id,
-	                    db.escapeString(getConnection()->getIP().to_string())))) {
+	                    db.escapeString(connection->getIP().to_string())))) {
 		disconnectClient("Failed to create session.\nPlease try again later.", version);
 		return;
 	}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`ProtocolLogin::getCharacterList` reads IP from `getConnection()` in dispatcher event, but does not check, if connection still exists.
Without connection, whole login process can be skipped, as there is no way to return list of characters to Tibia Client.

Fixes crash reported in https://github.com/otland/forgottenserver/issues/4902
