### PR TITLE
Safe Handling of Null Function Pointer in fireAddRemItem

### DIFF
--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -993,7 +993,12 @@ uint32_t MoveEvent::fireAddRemItem(Item* item, Item* tileItem, const Position& p
 	if (scripted) {
 		return executeAddRemItem(item, tileItem, pos);
 	}
-	return moveFunction(item, tileItem, pos);
+
+	if (moveFunction) {
+		return moveFunction(item, tileItem, pos);
+	}
+
+	return 0;
 }
 
 bool MoveEvent::executeAddRemItem(Item* item, Item* tileItem, const Position& pos)


### PR DESCRIPTION
it's ensure they are valid before calling them. If moveFunction is not set (i.e., is nullptr), directly invoking it will cause undefined behavior, most likely resulting in a crash.