### PR TITLE
Pathfinding Changes

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5730,12 +5730,12 @@ Guild_ptr Game::getGuild(uint32_t id) const
 	return it->second;
 }
 
-void Game::addGuild(Guild_ptr guild) 
+void Game::addGuild(Guild_ptr guild)
 {
-  if (!guild) {
-     return;
-   }
-   
+	if (!guild) {
+		return;
+	}
+
 	guilds[guild->getId()] = guild;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -653,7 +653,7 @@ uint16_t calculateHeuristic(const Position& p1, const Position& p2)
 {
 	uint16_t dx = std::abs(p1.getX() - p2.getX());
 	uint16_t dy = std::abs(p1.getY() - p2.getY());
-	return 10 * (dx + dy) - 6 * std::min(dx, dy); // Octile distance
+	return 10 * (dx + dy);
 }
 
 bool Map::getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,
@@ -690,7 +690,6 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
 
 	Position endPos;
-	bool sightClear = false;
 	AStarNodes nodes(pos.x , pos.y);
 
 	AStarNode* found = nullptr;
@@ -728,43 +727,6 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 
 			if (fpp.keepDistance && !pathCondition.isInRange(startPos, pos, fpp)) {
 				continue;
-			}
-
-			// If sight is clear we can ignore a lot of nodes.
-			if (sightClear) {
-				int32_t startX = startPos.getX();
-				int32_t startY = startPos.getY();
-				int32_t targetX = targetPos.getX();
-				int32_t targetY = targetPos.getY();
-
-				// We don't need nodes behind us.
-				// We also do not need nodes on a different x or y if target and start is same x/y.
-				if (startX > targetX && pos.x > startX) {
-					continue;
-				} else if (startX == targetX && pos.x != startX) {
-					continue;
-				} else if (startX < targetX && pos.x < startX) {
-					continue;
-				}
-				if (startY > targetY && pos.y > startY) {
-					continue;
-				} else if (startY == targetY && pos.y != startY) {
-					continue;
-				} else if (startY < targetY && pos.y < startY) {
-					continue;
-				}
-
-				// We don't need nodes past the targetPos
-				if (startX > targetX && pos.x < targetX) {
-					continue;
-				} else if (startX < targetX && pos.x > targetX) {
-					continue;
-				}
-				if (startY > targetY && pos.y < targetY) {
-					continue;
-				} else if (startY < targetY && pos.y > targetY) {
-					continue;
-				}
 			}
 
 			const Tile* tile;
@@ -849,7 +811,10 @@ AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
 {
 	// Needs to be large enough to never resize 250 should be plenty
 	// If you want paths larger than 20-30 sqm this must be increased.
-	nodes.reserve(250);
+	uint8_t reserveSize = 250;
+	nodes.reserve(reserveSize);
+	nodeMap.reserve(reserveSize);
+	visited.reserve(reserveSize);
 	createNode(nullptr, x, y, 0, 0);
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -691,6 +691,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
 
 	Position endPos;
+	bool sightClear = isSightClear(startPos, targetPos, true);
 	AStarNodes nodes(pos.x , pos.y);
 
 	AStarNode* found = nullptr;
@@ -728,6 +729,43 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 
 			if (fpp.keepDistance && !pathCondition.isInRange(startPos, pos, fpp)) {
 				continue;
+			}
+
+			// If sight is clear we can ignore a lot of nodes.
+			if (sightClear) {
+				int32_t startX = startPos.getX();
+				int32_t startY = startPos.getY();
+				int32_t targetX = targetPos.getX();
+				int32_t targetY = targetPos.getY();
+
+				// We don't need nodes behind us.
+				// We also do not need nodes on a different x or y if target and start is same x/y.
+				if (startX > targetX && pos.x > startX) {
+					continue;
+				} else if (startX == targetX && pos.x != startX) {
+					continue;
+				} else if (startX < targetX && pos.x < startX) {
+					continue;
+				}
+				if (startY > targetY && pos.y > startY) {
+					continue;
+				} else if (startY == targetY && pos.y != startY) {
+					continue;
+				} else if (startY < targetY && pos.y < startY) {
+					continue;
+				}
+
+				// We don't need nodes past the targetPos
+				if (startX > targetX && pos.x < targetX) {
+					continue;
+				} else if (startX < targetX && pos.x > targetX) {
+					continue;
+				}
+				if (startY > targetY && pos.y < targetY) {
+					continue;
+				} else if (startY < targetY && pos.y > targetY) {
+					continue;
+				}
 			}
 
 			const Tile* tile;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -668,7 +668,7 @@ static uint16_t calculateHeuristic(const Position& p1, const Position& p2)
 {
 	uint16_t dx = std::abs(p1.getX() - p2.getX());
 	uint16_t dy = std::abs(p1.getY() - p2.getY());
-	return 10 * (dx + dy);
+	return MAP_NORMALWALKCOST * (dx + dy);
 }
 
 bool Map::getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -664,11 +664,11 @@ const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 	return tile;
 }
 
-uint16_t calculateHeuristic(const Position& p1, const Position& p2)
+static uint16_t calculateHeuristic(const Position& p1, const Position& p2)
 {
 	uint16_t dx = std::abs(p1.getX() - p2.getX());
 	uint16_t dy = std::abs(p1.getY() - p2.getY());
-	return 10 * (dx + dy);
+	return MAP_NORMALWALKCOST * (dx + dy) + (MAP_DIAGONALWALKCOST - 2 * 10) * std::min(dx, dy);
 }
 
 bool Map::getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,
@@ -865,7 +865,7 @@ AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
 {
 	// Needs to be large enough to never resize 250 should be plenty
 	// If you want paths larger than 20-30 sqm this must be increased.
-	uint8_t reserveSize = 250;
+	uint8_t reserveSize = 150;
 	nodes.reserve(reserveSize);
 	nodeMap.reserve(reserveSize);
 	visited.reserve(reserveSize);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -707,7 +707,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	bool sightClear = isSightClear(startPos, targetPos, true, true);
 
 	Position endPos;
-	AStarNodes nodes(pos.x , pos.y);
+	AStarNodes nodes(pos.x, pos.y);
 
 	AStarNode* found = nullptr;
 	int32_t bestMatch = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -690,7 +690,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
 
 	Position endPos;
-	bool sightClear = isSightClear(startPos, targetPos, true);
+	bool sightClear = false;
 	AStarNodes nodes(pos.x , pos.y);
 
 	AStarNode* found = nullptr;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -661,7 +661,6 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
                           const FrozenPathingConditionCall& pathCondition, const FindPathParams& fpp) const
 {
 	Position pos = creature.getPosition();
-	Position endPos;
 	const Position startPos = pos;
 
 	// We can't walk, no need to create path.
@@ -674,24 +673,25 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 		return false;
 	}
 
+	uint16_t distanceX = startPos.getDistanceX(targetPos);
+	uint16_t distanceY = startPos.getDistanceY(targetPos);
 	// We are next to our target. Let dance step decide.
-	if (fpp.maxTargetDist <= 1 && startPos.getDistanceX(targetPos) <= 1 && startPos.getDistanceY(targetPos) <= 1) {
+	if (fpp.maxTargetDist <= 1 && distanceX <= 1 && distanceY <= 1) {
 		return true;
 	}
 
 	// Don't update path. The target is too far away.
 	int32_t maxDistanceX = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxClientViewportX + 1;
 	int32_t maxDistanceY = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxClientViewportY + 1;
-	if (startPos.getDistanceX(targetPos) > maxDistanceX || startPos.getDistanceY(targetPos) > maxDistanceY) {
+	if (distanceX > maxDistanceX || distanceY > maxDistanceY) {
 		return false;
 	}
 
 	static constexpr std::array<std::pair<int, int>, 8> allNeighbors = {
 	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
 
-	uint16_t width = startPos.getDistanceX(targetPos);
-	uint16_t height = startPos.getDistanceY(targetPos);
-	AStarNodes nodes(width, height);
+	Position endPos;
+	AStarNodes nodes(pos.x , pos.y);
 
 	AStarNode* found = nullptr;
 	int32_t bestMatch = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -651,10 +651,9 @@ const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 
 uint16_t calculateHeuristic(const Position& p1, const Position& p2)
 {
-	uint16_t dx = p1.getX() - p2.getX();
-	uint16_t dy = p1.getY() - p2.getY();
-
-	return dx * dx + dy * dy;
+	uint16_t dx = std::abs(p1.getX() - p2.getX());
+	uint16_t dy = std::abs(p1.getY() - p2.getY());
+	return 10 * (dx + dy) - 6 * std::min(dx, dy); // Octile distance
 }
 
 bool Map::getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -687,16 +687,16 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 		return false;
 	}
 
-	uint16_t distanceX = startPos.getDistanceX(targetPos);
-	uint16_t distanceY = startPos.getDistanceY(targetPos);
+	int32_t distanceX = startPos.getDistanceX(targetPos);
+	int32_t distanceY = startPos.getDistanceY(targetPos);
 	// We are next to our target. Let dance step decide.
 	if (fpp.maxTargetDist <= 1 && distanceX <= 1 && distanceY <= 1) {
 		return true;
 	}
 
 	// Don't update path. The target is too far away.
-	int32_t maxDistanceX = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxClientViewportX + 1;
-	int32_t maxDistanceY = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxClientViewportY + 1;
+	int32_t maxDistanceX = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxViewportX + 1;
+	int32_t maxDistanceY = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxViewportY + 1;
 	if (distanceX > maxDistanceX || distanceY > maxDistanceY) {
 		return false;
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -810,7 +810,9 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 // AStarNodes
 AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
 {
-	nodes.reserve(static_cast<size_t>(x * y));
+	// Needs to be large enough to never resize 250 should be plenty
+	// If you want paths larger than 20-30 sqm this must be increased.
+	nodes.reserve(250);
 	createNode(nullptr, x, y, 0, 0);
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -711,12 +711,12 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 
 	AStarNode* found = nullptr;
 	int32_t bestMatch = 0;
-	uint8_t iterations = 0;
+	uint16_t iterations = 0;
 	AStarNode* n = nodes.getBestNode();
 	while (n) {
 		iterations++;
 
-		if (iterations >= Map::nodeReserveSize) {
+		if (iterations >= Map::maxViewportX * Map::maxViewportY) {
 			return false;
 		}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -689,7 +689,9 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	static constexpr std::array<std::pair<int, int>, 8> allNeighbors = {
 	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
 
-	AStarNodes nodes(maxDistanceX, maxDistanceY);
+	uint16_t width = startPos.getDistanceX(targetPos);
+	uint16_t height = startPos.getDistanceY(targetPos);
+	AStarNodes nodes(width, height);
 
 	AStarNode* found = nullptr;
 	int32_t bestMatch = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -717,6 +717,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 		iterations++;
 
 		if (iterations >= Map::nodeReserveSize) {
+			nodes.clear();
 			return false;
 		}
 
@@ -819,6 +820,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	}
 
 	if (!found) {
+		nodes.clear();
 		return false;
 	}
 
@@ -856,6 +858,8 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 
 		found = found->parent;
 	}
+
+	nodes.clear();
 	return true;
 }
 
@@ -868,18 +872,21 @@ AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
 	createNode(nullptr, x, y, 0, 0);
 }
 
-AStarNodes::~AStarNodes()
+void AStarNodes::clear()
 {
-	for (auto* node : nodes) {
-		delete node;
+	nodes.clear();
+	visited.clear();
+	nodeMap.clear();
+	while (!openSet.empty()) {
+		openSet.pop();
 	}
 }
 
 AStarNode* AStarNodes::createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f)
 {
 	uint32_t key = hashCoord(x, y);
-	nodes.emplace_back(new AStarNode(parent, x, y, g, f));
-	AStarNode* node = nodes.back();
+	nodes.emplace_back(AStarNode{parent, x, y, g, f});
+	AStarNode* node = &nodes.back();
 	nodeMap[key] = node;
 	openSet.push(node);
 	return node;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -866,12 +866,9 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 // AStarNodes
 AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
 {
-	// Needs to be large enough to never resize 250 should be plenty
-	// If you want paths larger than 20-30 sqm this must be increased.
-	uint8_t reserveSize = 150;
-	nodes.reserve(reserveSize);
-	nodeMap.reserve(reserveSize);
-	visited.reserve(reserveSize);
+	nodes.reserve(Map::nodeReserveSize);
+	nodeMap.reserve(Map::nodeReserveSize);
+	visited.reserve(Map::nodeReserveSize);
 	createNode(nullptr, x, y, 0, 0);
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -716,7 +716,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	while (n) {
 		iterations++;
 
-		if (iterations >= 120) {
+		if (iterations >= Map::nodeReserveSize) {
 			nodes.clear();
 			return false;
 		}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -737,12 +737,11 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			pos.x = x + allNeighbors[i].first;
 			pos.y = y + allNeighbors[i].second;
 
-			if (fpp.maxSearchDist != 0 &&
-			    (startPos.getDistanceX(pos) > fpp.maxSearchDist || startPos.getDistanceY(pos) > fpp.maxSearchDist)) {
+			int32_t startDistanceToNode = startPos.getDistanceX(pos) + startPos.getDistanceY(pos);
+			if (fpp.maxSearchDist != 0 && startDistanceToNode > fpp.maxSearchDist) {
 				continue;
-			} else if ((startPos.getDistanceX(pos) + startPos.getDistanceY(pos) >
-			            Map::maxViewportX + Map::maxViewportY)) {
-				break;
+			} else if (fpp.maxSearchDist == 0 && (startDistanceToNode > (Map::maxViewportX + Map::maxViewportY))) {
+				continue;
 			}
 
 			if (fpp.keepDistance && !pathCondition.isInRange(startPos, pos, fpp)) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -668,7 +668,7 @@ static uint16_t calculateHeuristic(const Position& p1, const Position& p2)
 {
 	uint16_t dx = std::abs(p1.getX() - p2.getX());
 	uint16_t dy = std::abs(p1.getY() - p2.getY());
-	return MAP_NORMALWALKCOST * (dx + dy) + (MAP_DIAGONALWALKCOST - 2 * 10) * std::min(dx, dy);
+	return 10 * (dx + dy);
 }
 
 bool Map::getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,
@@ -740,6 +740,9 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 			if (fpp.maxSearchDist != 0 &&
 			    (startPos.getDistanceX(pos) > fpp.maxSearchDist || startPos.getDistanceY(pos) > fpp.maxSearchDist)) {
 				continue;
+			} else if ((startPos.getDistanceX(pos) + startPos.getDistanceY(pos) >
+			            Map::maxViewportX + Map::maxViewportY)) {
+				break;
 			}
 
 			if (fpp.keepDistance && !pathCondition.isInRange(startPos, pos, fpp)) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -689,7 +689,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 	static constexpr std::array<std::pair<int, int>, 8> allNeighbors = {
 	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
 
-	AStarNodes nodes(pos.x, pos.y);
+	AStarNodes nodes(maxDistanceX, maxDistanceY);
 
 	AStarNode* found = nullptr;
 	int32_t bestMatch = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -717,7 +717,6 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 		iterations++;
 
 		if (iterations >= Map::nodeReserveSize) {
-			nodes.clear();
 			return false;
 		}
 
@@ -819,8 +818,6 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 		n = nodes.getBestNode();
 	}
 
-	nodes.clear();
-
 	if (!found) {
 		return false;
 	}
@@ -871,19 +868,18 @@ AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
 	createNode(nullptr, x, y, 0, 0);
 }
 
-void AStarNodes::clear()
+AStarNodes::~AStarNodes()
 {
-	nodes.clear();
-	std::priority_queue<AStarNode*, std::vector<AStarNode*>, NodeCompare>().swap(openSet);
-	visited.clear();
-	nodeMap.clear();
+	for (auto* node : nodes) {
+		delete node;
+	}
 }
 
 AStarNode* AStarNodes::createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f)
 {
 	uint32_t key = hashCoord(x, y);
-	nodes.emplace_back(AStarNode{parent, x, y, g, f});
-	AStarNode* node = &nodes.back();
+	nodes.emplace_back(new AStarNode(parent, x, y, g, f));
+	AStarNode* node = nodes.back();
 	nodeMap[key] = node;
 	openSet.push(node);
 	return node;

--- a/src/map.h
+++ b/src/map.h
@@ -21,9 +21,9 @@ static constexpr uint16_t MAP_DIAGONALWALKCOST = 25;
 struct FindPathParams;
 struct AStarNode
 {
-	AStarNode* parent = nullptr;
-	uint16_t x, y = 0;
-	uint16_t g, f = 0;
+	AStarNode* parent;
+	uint16_t x, y;
+	uint16_t g, f;
 };
 
 inline uint32_t hashCoord(uint16_t x, uint16_t y) { return (static_cast<uint32_t>(x) << 16) | y; }

--- a/src/map.h
+++ b/src/map.h
@@ -31,7 +31,7 @@ inline uint32_t hashCoord(uint16_t x, uint16_t y) { return (static_cast<uint32_t
 class AStarNodes
 {
 public:
-	AStarNodes(uint16_t width, uint16_t height);
+	AStarNodes(uint16_t x, uint16_t y);
 	void clear();
 
 	AStarNode* createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f);

--- a/src/map.h
+++ b/src/map.h
@@ -161,7 +161,7 @@ public:
 	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 	static constexpr int32_t maxClientViewportX = 8;
 	static constexpr int32_t maxClientViewportY = 6;
-	static constexpr int16_t nodeReserveSize = (maxViewportX + maxViewportY) * 7;
+	static constexpr int16_t nodeReserveSize = (maxViewportX + maxViewportY) * 12;
 
 	uint32_t clean() const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -31,7 +31,7 @@ class AStarNodes
 {
 public:
 	AStarNodes(uint16_t x, uint16_t y);
-	void clear();
+	~AStarNodes();
 
 	AStarNode* createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f);
 	AStarNode* getBestNode();
@@ -41,7 +41,7 @@ public:
 	static uint16_t getTileWalkCost(const Creature& creature, const Tile* tile);
 
 private:
-	std::vector<AStarNode> nodes;
+	std::vector<AStarNode*> nodes;
 	std::unordered_map<uint32_t, AStarNode*> nodeMap;
 	std::unordered_set<uint32_t> visited;
 

--- a/src/map.h
+++ b/src/map.h
@@ -14,7 +14,6 @@ class Creature;
 
 static constexpr int32_t MAP_MAX_LAYERS = 16;
 
-
 static constexpr uint16_t MAP_NORMALWALKCOST = 10;
 static constexpr uint16_t MAP_DIAGONALWALKCOST = 25;
 
@@ -162,6 +161,7 @@ public:
 	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 	static constexpr int32_t maxClientViewportX = 8;
 	static constexpr int32_t maxClientViewportY = 6;
+	static constexpr int16_t nodeReserveSize = 150; // Increase if maxViewport is increased.
 
 	uint32_t clean() const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -160,7 +160,7 @@ public:
 	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 	static constexpr int32_t maxClientViewportX = 8;
 	static constexpr int32_t maxClientViewportY = 6;
-	static constexpr int16_t nodeReserveSize = (maxViewportX + maxViewportY) * 7;
+	static constexpr int16_t nodeReserveSize = static_cast<int16_t>((maxViewportX * maxViewportY * 3) / 2);
 
 	uint32_t clean() const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -235,7 +235,7 @@ public:
 	 *	\param blockFloor counts the ground tile as an obstacle
 	 *	\returns The result if there is an obstacle or not
 	 */
-	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false) const;
+	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false, bool pathfinding = false) const;
 
 	/**
 	 * Checks if path is clear from fromPos to toPos
@@ -244,8 +244,9 @@ public:
 	 *Destination point \param sameFloor checks if the destination is on same
 	 *floor \returns The result if there is no obstacles
 	 */
-	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false) const;
-	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z) const;
+	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false,
+	                  bool pathfinding = false) const;
+	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding = false) const;
 
 	const Tile* canWalkTo(const Creature& creature, const Position& pos) const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -31,7 +31,6 @@ class AStarNodes
 {
 public:
 	AStarNodes(uint16_t x, uint16_t y);
-	void clear();
 
 	AStarNode* createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f);
 	AStarNode* getBestNode();
@@ -161,7 +160,7 @@ public:
 	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 	static constexpr int32_t maxClientViewportX = 8;
 	static constexpr int32_t maxClientViewportY = 6;
-	static constexpr int16_t nodeReserveSize = (maxViewportX + maxViewportY) * 12;
+	static constexpr int16_t nodeReserveSize = (maxViewportX + maxViewportY) * 7;
 
 	uint32_t clean() const;
 

--- a/src/map.h
+++ b/src/map.h
@@ -31,7 +31,7 @@ class AStarNodes
 {
 public:
 	AStarNodes(uint16_t x, uint16_t y);
-	~AStarNodes();
+	void clear();
 
 	AStarNode* createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f);
 	AStarNode* getBestNode();
@@ -41,7 +41,7 @@ public:
 	static uint16_t getTileWalkCost(const Creature& creature, const Tile* tile);
 
 private:
-	std::vector<AStarNode*> nodes;
+	std::vector<AStarNode> nodes;
 	std::unordered_map<uint32_t, AStarNode*> nodeMap;
 	std::unordered_set<uint32_t> visited;
 

--- a/src/map.h
+++ b/src/map.h
@@ -161,7 +161,7 @@ public:
 	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 	static constexpr int32_t maxClientViewportX = 8;
 	static constexpr int32_t maxClientViewportY = 6;
-	static constexpr int16_t nodeReserveSize = 150; // Increase if maxViewport is increased.
+	static constexpr int16_t nodeReserveSize = (maxViewportX + maxViewportY) * 7;
 
 	uint32_t clean() const;
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1089,7 +1089,7 @@ void Monster::onWalk()
 {
 	Creature::onWalk();
 
-	if (attackedCreature || followCreature && isFleeing()) {
+	if ((attackedCreature || followCreature) && isFleeing()) {
 		if (lastPathUpdate - OTSYS_TIME() > 0) {
 			g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 			lastPathUpdate = OTSYS_TIME() + getNumber(ConfigManager::PATHFINDING_DELAY);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1085,7 +1085,14 @@ bool Monster::walkToSpawn()
 	return true;
 }
 
-void Monster::onWalk() { Creature::onWalk(); }
+void Monster::onWalk()
+{
+	Creature::onWalk();
+
+	if (isFleeing()) {
+		forceUpdatePath();
+	}
+}
 
 void Monster::onWalkComplete()
 {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1090,7 +1090,7 @@ void Monster::onWalk()
 	Creature::onWalk();
 
 	if ((attackedCreature || followCreature) && isFleeing()) {
-		if (lastPathUpdate - OTSYS_TIME() > 0) {
+		if (lastPathUpdate > OTSYS_TIME()) {
 			g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 			lastPathUpdate = OTSYS_TIME() + getNumber(ConfigManager::PATHFINDING_DELAY);
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1089,8 +1089,11 @@ void Monster::onWalk()
 {
 	Creature::onWalk();
 
-	if (isFleeing()) {
-		forceUpdatePath();
+	if (attackedCreature || followCreature && isFleeing()) {
+		if (lastPathUpdate - OTSYS_TIME() > 0) {
+			g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
+			lastPathUpdate = OTSYS_TIME() + getNumber(ConfigManager::PATHFINDING_DELAY);
+		}
 	}
 }
 

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -44,6 +44,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <queue>
 #include <utility>
 #include <valarray>
 #include <variant>

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -36,6 +36,7 @@
 #include <mysql/mysql.h>
 #include <optional>
 #include <pugixml.hpp>
+#include <queue>
 #include <random>
 #include <set>
 #include <sstream>
@@ -44,7 +45,6 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
-#include <queue>
 #include <utility>
 #include <valarray>
 #include <variant>


### PR DESCRIPTION
Performance enhancements to pathfinding algorithm. Remove new from node construction to help with memory problems.

1) Nodes are stored in each data structure using a hash of their x,y coordinates for quick look up.
2) Added a visited set so we do not repeat nodes.
3) Moved open nodes to a priority queue that stores them based on their f value for faster f value look up. (No more harsh sorting)
4) Added a sightline check to optimize clear paths performance.
5) Optimized heuristic calculation which increased performance on all paths.
6) Fixes #4884 