### PR TITLE
fix: load SQL config from config.lua (#4518)

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -75,6 +75,14 @@ premiumToCreateMarketOffer = true
 checkExpiredMarketOffersEachMinutes = 60
 maxMarketOffersAtATimePerPlayer = 100
 
+-- MySQL
+mysqlHost = "127.0.0.1"
+mysqlUser = "forgottenserver"
+mysqlPass = ""
+mysqlDatabase = "forgottenserver"
+mysqlPort = 3306
+mysqlSock = ""
+
 -- Misc.
 -- NOTE: classicAttackSpeed set to true makes players constantly attack at regular
 -- intervals regardless of other actions such as item (potion) use. This setting

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -34,11 +34,22 @@ ExperienceStages expStages;
 
 bool loaded = false;
 
-template <typename T>
-auto getEnv(const char* envVar, T&& defaultValue)
+std::string getEnv(const char* envVar, std::string defaultValue)
 {
 	if (auto value = std::getenv(envVar)) {
-		return pugi::cast<std::decay_t<T>>(value);
+		if (strlen(value)) {
+			return {value};
+		}
+	}
+	return defaultValue;
+}
+
+uint16_t getEnv(const char* envVar, uint16_t defaultValue)
+{
+	if (auto value = std::getenv(envVar)) {
+		if (strlen(value)) {
+			return pugi::cast<uint16_t>(value);
+		}
 	}
 	return defaultValue;
 }
@@ -185,13 +196,13 @@ bool ConfigManager::load()
 		string[MAP_NAME] = getGlobalString(L, "mapName", "forgotten");
 		string[MAP_AUTHOR] = getGlobalString(L, "mapAuthor", "Unknown");
 		string[HOUSE_RENT_PERIOD] = getGlobalString(L, "houseRentPeriod", "never");
-		string[MYSQL_HOST] = getGlobalString(L, "mysqlHost", getEnv("MYSQL_HOST", "127.0.0.1"));
-		string[MYSQL_USER] = getGlobalString(L, "mysqlUser", getEnv("MYSQL_USER", "forgottenserver"));
-		string[MYSQL_PASS] = getGlobalString(L, "mysqlPass", getEnv("MYSQL_PASSWORD", ""));
-		string[MYSQL_DB] = getGlobalString(L, "mysqlDatabase", getEnv("MYSQL_DATABASE", "forgottenserver"));
-		string[MYSQL_SOCK] = getGlobalString(L, "mysqlSock", getEnv("MYSQL_SOCK", ""));
+		string[MYSQL_HOST] = getEnv("MYSQL_HOST", getGlobalString(L, "mysqlHost", "127.0.0.1"));
+		string[MYSQL_USER] = getEnv("MYSQL_USER", getGlobalString(L, "mysqlUser", "forgottenserver"));
+		string[MYSQL_PASS] = getEnv("MYSQL_PASSWORD", getGlobalString(L, "mysqlPass", ""));
+		string[MYSQL_DB] = getEnv("MYSQL_DATABASE", getGlobalString(L, "mysqlDatabase", "forgottenserver"));
+		string[MYSQL_SOCK] = getEnv("MYSQL_SOCK", getGlobalString(L, "mysqlSock", ""));
 
-		integer[SQL_PORT] = getGlobalNumber(L, "mysqlPort", getEnv<uint16_t>("MYSQL_PORT", 3306));
+		integer[SQL_PORT] = getEnv("MYSQL_PORT", getGlobalNumber(L, "mysqlPort", 3306));
 
 		if (integer[GAME_PORT] == 0) {
 			integer[GAME_PORT] = getGlobalNumber(L, "gameProtocolPort", 7172);


### PR DESCRIPTION
### Changes Proposed

After changes, it loads `config.lua` config first, then loads env variables and if they are not empty, it overwrites `config.lua` values.

Right now TFS loads env first, so to do not overwrite it, we had to remove SQL config from `config.lua` in #4518 
There is no reason to remove SQL config from `config.lua`.
Env variables should be loaded last and overwrite any previous config (like it does in any other PHP/JS/Python/Java framework).

**Issues addressed:** #4518 #4931

**How to test:**
Scenario 1 - load config from `config.lua` and overwrite it with wrong env config value:
- set valid SQL config in `config.lua`
- before server start type `export SQL_PORT=12345` in terminal
- start TFS from terminal
- it will show error, that it cannot connect to database (because of wrong MySQL port)
- type `export SQL_PORT=3306` or `export SQL_PORT=` (empty values are skipped)
- start TFS from terminal
- it will start without error

Scenario 2 - load config from env, overwrite all `config.lua` variables:
- leave default SQL config in `config.lua`
- set valid config with env variables (export https://github.com/otland/forgottenserver/blob/e51b5b72b216501aafbb2e17245d6a8234a1a0a4/.env.example values), type in terminal:
```
export MYSQL_HOST=127.0.0.1
export MYSQL_USER=youruser
export MYSQL_PASSWORD=yourpassword
export MYSQL_DATABASE=dbname
export MYSQL_SOCK=
export MYSQL_PORT=3306
```
- run TFS from terminal
- it will start without error using env variables

@JoaozinhoBrasil 