### PR TITLE
Avoid searching player inventory twice when accepting market offer

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5486,11 +5486,12 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 			buyerPlayer->onReceiveMail();
 		}
 	} else {
-		if (totalPrice > (player->getMoney() + player->bankBalance)) {
+		uint64_t playerMoney = player->getMoney();
+		if (totalPrice > (playerMoney + player->bankBalance)) {
 			return;
 		}
 
-		const auto debitCash = std::min(player->getMoney(), totalPrice);
+		const auto debitCash = std::min(playerMoney, totalPrice);
 		const auto debitBank = totalPrice - debitCash;
 		removeMoney(player, debitCash);
 		player->bankBalance -= debitBank;


### PR DESCRIPTION
getMoney loops through all containers held by the player, you really don't want do to this twice on a busy server

if someone is interested in reducing execution time of this even further (it won't be part of this PR, just giving you an idea):
- getMoney could stop searching the moment it finds predefined amount
- getMoney could stop searching earlier, or be skipped entirely if you subtract player's bank balance from the total amount of money to find in player's inventory