### PR TITLE
fix: Ubuntu 22.04 compilation (#4943)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(HTTP "Enable HTTP support" ON)
 if (HTTP)
     list(APPEND VCPKG_MANIFEST_FEATURES "http")
     set(BOOST_REQUIRED_VERSION 1.75.0)
+    add_definitions(-DHTTP_ENABLED)
 endif()
 
 option(BUILD_TESTING "Build unit tests" OFF)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -119,7 +119,9 @@ void Game::setGameState(GameState_t newState)
 			g_scheduler.stop();
 			g_databaseTasks.stop();
 			g_dispatcher.stop();
+#ifdef HTTP_ENABLED
 			tfs::http::stop();
+#endif
 			break;
 		}
 

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -225,8 +225,10 @@ void mainLoader(ServiceManager* services)
 	services->add<ProtocolOld>(static_cast<uint16_t>(getNumber(ConfigManager::LOGIN_PORT)));
 
 	// HTTP server
+#ifdef HTTP_ENABLED
 	tfs::http::start(getString(ConfigManager::IP), getNumber(ConfigManager::HTTP_PORT),
 	                 getNumber(ConfigManager::HTTP_WORKERS));
+#endif
 
 	RentPeriod_t rentPeriod;
 	std::string strRentPeriod = boost::algorithm::to_lower_copy(getString(ConfigManager::HOUSE_RENT_PERIOD));


### PR DESCRIPTION
### Changes Proposed

Fix Ubuntu 22.04 compilation with system libraries.

offtop: It's impossible to compile TFS without HTTP server. You can disable it by setting port to `0` in `config.lua`, but it's impossible to compile without HTTP.

**Issues addressed:**
https://github.com/otland/forgottenserver/issues/4943

**How to test:**
1. Install required libraries
2. Run `cmake --preset default -DHTTP=OFF -DUSE_LUAJIT=ON && cmake --build --config Release --preset default`

