### PR TITLE
Fix slow reaction speed on first pathmatch

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -740,6 +740,7 @@ void Creature::setAttackedCreature(Creature* creature)
 	creature->addFollower(this);
 	onAttackedCreature(attackedCreature);
 	attackedCreature->onAttacked();
+	forceUpdatePath();
 
 	for (Creature* summon : summons) {
 		summon->setAttackedCreature(creature);
@@ -788,6 +789,7 @@ void Creature::setFollowCreature(Creature* creature)
 	creature->addFollower(this);
 	hasFollowPath = false;
 	onFollowCreature(creature);
+	forceUpdatePath();
 }
 
 void Creature::removeFollowCreature()

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1089,11 +1089,8 @@ void Monster::onWalk()
 {
 	Creature::onWalk();
 
-	if ((attackedCreature || followCreature) && isFleeing()) {
-		if (lastPathUpdate > OTSYS_TIME()) {
-			g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
-			lastPathUpdate = OTSYS_TIME() + getNumber(ConfigManager::PATHFINDING_DELAY);
-		}
+	if (isFleeing() && lastPathUpdate > OTSYS_TIME()) {
+		forceUpdatePath();
 	}
 }
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Allow paths to be drawn as soon as a target/follower is set or removed.

**Issues addressed:** <!-- Write here the issue number, if any. -->
N/A

**How to test:** <!-- Write here how to test changes. -->
Check how long it takes for a monster to start moving when:
1) It is first spawned
2) When you go down stairs and the monster first targets you
3) When you set a target while you have summons
4) When you remove a target while you have summons
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
