### PR TITLE
Fix lua memory leak on reload

### DIFF
--- a/src/baseevents.cpp
+++ b/src/baseevents.cpp
@@ -77,6 +77,7 @@ void BaseEvents::reInitState(bool fromLua)
 {
 	if (!fromLua) {
 		getScriptInterface().reInitState();
+		getScriptInterface().initState();
 	}
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5902,6 +5902,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			g_weapons->clear(true);
 			g_weapons->loadDefaults();
 			g_spells->clear(true);
+			g_scripts->clear(true);
 			g_scripts->loadScripts("scripts", false, true);
 			g_creatureEvents->removeInvalidEvents();
 			/*

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -13,6 +13,12 @@ Scripts::Scripts() : scriptInterface("Scripts Interface") { scriptInterface.init
 
 Scripts::~Scripts() { scriptInterface.reInitState(); }
 
+void Scripts::clear(bool fromLua)
+{
+	scriptInterface.reInitState();
+	scriptInterface.initState();
+}
+
 bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload)
 {
 	namespace fs = std::filesystem;

--- a/src/script.h
+++ b/src/script.h
@@ -12,6 +12,7 @@ public:
 	Scripts();
 	~Scripts();
 
+	void clear(bool fromLua);
 	bool loadScripts(std::string folderName, bool isLib, bool reload);
 	LuaScriptInterface& getScriptInterface() { return scriptInterface; }
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Dereference all lua memory on reload.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#4941

**How to test:** <!-- Write here how to test changes. -->
Create a global table in a lua script file, fill it with data. /reload scripts
Without this change the memory is not released.
<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
