### PR TITLE
fix: build problems (#4955 #4956)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(HTTP "Enable HTTP support" ON)
 if (HTTP)
     list(APPEND VCPKG_MANIFEST_FEATURES "http")
     set(BOOST_REQUIRED_VERSION 1.75.0)
+    add_definitions(-DHTTP)
 endif()
 
 option(BUILD_TESTING "Build unit tests" OFF)

--- a/vc17/settings.props
+++ b/vc17/settings.props
@@ -15,6 +15,8 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>otpch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>HTTP;$(PREPROCESSOR_DEFS)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>

--- a/vc17/theforgottenserver.vcxproj
+++ b/vc17/theforgottenserver.vcxproj
@@ -157,7 +157,6 @@
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>$(VcpkgRoot)include\luajit;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This PR fixes build problems:
- TFS always builds with HTTP server disabled in C++ ( https://github.com/otland/forgottenserver/issues/4955 ), `-DHTTP=ON` and `-DHTTP=OFF` does not work, HTTP is always disabled
- builds other than Release x64 does not work in Visual Studio ( https://github.com/otland/forgottenserver/issues/4956 )
