### PR TITLE
feat: run TFS in docker using docker-compose.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=build /usr/src/forgottenserver/build/RelWithDebInfo/tfs /bin/tfs
 COPY data /srv/data/
 COPY LICENSE README.md *.dist *.sql key.pem /srv/
 
-EXPOSE 7171 7172
+EXPOSE 7171 7172 8080
 WORKDIR /srv
 VOLUME /srv
 ENTRYPOINT ["/bin/tfs"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,56 @@
+services:
+  ots:
+    build:
+      context: .
+    restart: on-failure
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 1s
+    volumes:
+      - .:/srv
+    environment:
+      MYSQL_HOST: mariadb
+      MYSQL_USER: root
+      MYSQL_PASSWORD: root
+      MYSQL_DATABASE: forgottenserver
+    ports:
+      - "7171:7171"
+      - "7172:7172"
+      - "8080:8080"
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+  mariadb:
+    image: mariadb:latest
+    container_name: mariadb-compose
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: forgottenserver
+    volumes:
+      - ./schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
+      - ./docker/data.sql:/docker-entrypoint-initdb.d/02-data.sql
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "mariadb", "-u", "root", "-proot", "forgottenserver", "-e", "SELECT 1;"]
+      interval: 1s
+      timeout: 1s
+      retries: 60
+      start_period: 3s
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    container_name: phpmyadmin-compose
+    environment:
+      PMA_HOST: mariadb
+      PMA_PORT: 3306
+      PMA_USER: root
+      PMA_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "8081:80"
+    depends_on:
+      mariadb:
+        condition: service_healthy

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,48 @@
+## Local docker dev
+
+If you have Docker installed, you can run a server in a container using:
+```
+docker-compose up
+```
+(first copy `config.lua.dist` into `config.lua`)
+
+It uses ports 7171, 7172, 8080, 8081 and 3307. These ports must be not used by another application. 
+
+Tibia Client should log in to URL `http://127.0.0.1:8080`.
+
+Account e-mail is `tfs@tfs`and password is `tfs`. There are characters `GOD` and one for each vocation on account.
+
+OTS files are in real-time synchronization. You can do changes in `data`/`config.lua` and run `/reload all` on GOD character to load changes. You don't have to restart OTS.
+
+Database data is not stored outside docker container. Every `docker-compose down`, it resets a database to state from `docker/data.sql`. If you want to add more accounts/characters, put them in that `.sql` file.
+
+#### Database management
+
+MariaDB database is running on port `3307`. You can connect to it using any database management tool with config:
+- host: `127.0.0.1`
+- port: `3307`
+- username: `root`
+- password: `root`
+- database name: `forgottenserver`
+
+There is also phpMyAdmin running in a container available on port `8081`. You can visit it: http://127.0.0.1:8081/index.php?route=/database/structure&db=forgottenserver
+
+#### Docker management
+
+To start server:
+```
+docker-compose up
+```
+
+To shut down server, press `CTRL+C`.
+
+To reset database:
+```
+docker-compose down
+```
+
+To compile TFS again:
+```
+docker-compose build
+```
+If you often compile and compilation is slow, you can try to replace `RelWithDebInfo` with `Debug` in 2 places in `Dockerfile`.

--- a/docker/data.sql
+++ b/docker/data.sql
@@ -1,0 +1,47 @@
+-- creates an account with e-mail: tfs@tfs password: tfs
+INSERT INTO `accounts` (`id`, `name`, `password`, `secret`, `type`, `premium_ends_at`, `email`, `creation`)
+VALUES ('1', 'tfs', 'e65018eee3ab1e3ecdfc67a91a2aa327434ab5b5', NULL, '6', '0', 'tfs@tfs', '0');
+
+-- creates character: GOD
+INSERT INTO `players` (`name`, `group_id`, `account_id`, `level`, `vocation`, `health`, `healthmax`, `experience`,
+                       `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `lookmount`,
+                       `lookmounthead`, `lookmountbody`, `lookmountlegs`, `lookmountfeet`, `currentmount`,
+                       `randomizemount`, `direction`, `maglevel`, `mana`, `manamax`, `manaspent`, `soul`, `town_id`,
+                       `posx`, `posy`, `posz`, `conditions`, `cap`, `sex`, `lastlogin`, `lastip`, `save`, `skull`,
+                       `skulltime`, `lastlogout`, `blessings`, `onlinetime`, `deletion`, `balance`,
+                       `offlinetraining_time`, `offlinetraining_skill`, `stamina`, `skill_fist`, `skill_fist_tries`,
+                       `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`,
+                       `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`,
+                       `skill_fishing`, `skill_fishing_tries`)
+VALUES ('GOD', '6', '1', '100', '0', '150', '150', '0', '0', '0', '0', '0', '136', '0', '0', '0', '0', '0', '0', '0',
+        '0', '2', '0', '0', '0', '0', '0', '1', '0', '0', '0', NULL, '400', '0', '0', 0x30, '1', '0', '0', '0', '0',
+        '0', '0', '0', '43200', '-1', '2520', '10', '0', '10', '0', '10', '0', '10', '0', '10', '0', '10', '0', '10',
+        '0');
+
+-- creates characters for each vocation
+INSERT INTO `players` (`name`, `group_id`, `account_id`, `level`, `vocation`, `health`, `healthmax`, `experience`,
+                       `lookbody`, `lookfeet`, `lookhead`, `looklegs`, `looktype`, `lookaddons`, `lookmount`,
+                       `lookmounthead`, `lookmountbody`, `lookmountlegs`, `lookmountfeet`, `currentmount`,
+                       `randomizemount`, `direction`, `maglevel`, `mana`, `manamax`, `manaspent`, `soul`, `town_id`,
+                       `posx`, `posy`, `posz`, `conditions`, `cap`, `sex`, `lastlogin`, `lastip`, `save`, `skull`,
+                       `skulltime`, `lastlogout`, `blessings`, `onlinetime`, `deletion`, `balance`,
+                       `offlinetraining_time`, `offlinetraining_skill`, `stamina`, `skill_fist`, `skill_fist_tries`,
+                       `skill_club`, `skill_club_tries`, `skill_sword`, `skill_sword_tries`, `skill_axe`,
+                       `skill_axe_tries`, `skill_dist`, `skill_dist_tries`, `skill_shielding`, `skill_shielding_tries`,
+                       `skill_fishing`, `skill_fishing_tries`)
+VALUES ('Sorcerer', '1', '1', '100', '1', '10000', '10000', '0', '0', '0', '0', '0', '136', '0', '0', '0', '0', '0', '0',
+        '0', '0', '2', '80', '30000', '30000', '0', '100', '1', '0', '0', '0', NULL, '10000', '0', '0', 0x30, '1', '0', '0',
+        '0', '0', '0', '0', '0', '43200', '-1', '2520', '10', '0', '10', '0', '10', '0', '10', '0', '10', '0', '10',
+        '0', '10', '0'),
+    ('Druid', '1', '1', '100', '2', '10000', '10000', '0', '0', '0', '0', '0', '136', '0', '0', '0', '0', '0', '0',
+        '0', '0', '2', '80', '30000', '30000', '0', '100', '1', '0', '0', '0', NULL, '10000', '0', '0', 0x30, '1', '0', '0',
+        '0', '0', '0', '0', '0', '43200', '-1', '2520', '10', '0', '10', '0', '10', '0', '10', '0', '10', '0', '10',
+        '0', '10', '0'),
+    ('Paladin', '1', '1', '100', '3', '20000', '20000', '0', '0', '0', '0', '0', '136', '0', '0', '0', '0', '0', '0',
+        '0', '0', '2', '15', '10000', '10000', '0', '100', '1', '0', '0', '0', NULL, '10000', '0', '0', 0x30, '1', '0', '0',
+        '0', '0', '0', '0', '0', '43200', '-1', '2520', '10', '0', '10', '0', '10', '0', '10', '0', '90', '0', '60',
+        '0', '10', '0'),
+    ('Knight', '1', '1', '100', '4', '30000', '30000', '0', '0', '0', '0', '0', '136', '0', '0', '0', '0', '0', '0',
+        '0', '0', '2', '9', '1000', '5000', '0', '100', '1', '0', '0', '0', NULL, '10000', '0', '0', 0x30, '1', '0', '0',
+        '0', '0', '0', '0', '0', '43200', '-1', '2520', '60', '0', '90', '0', '90', '0', '90', '0', '10', '0', '80',
+        '0', '10', '0');


### PR DESCRIPTION
All is described in `docker/README.md`.
It's docker configuration made using `docker-compose.yaml`.
It starts TFS, MariaDB and phpMyAdmin inside containers.

You can connect to it from Tibia Client using URL `http://127.0.0.1:8080`.

It creates account with e-mail `tfs@tfs` and password `tfs`.
On account are characters `GOD` and 1 for each vocation.

MariaDB runs on port `3307`, not `3306`, to do not require to shutdown local MySQL/MariaDB. You can access it using login `root` and password `root`.
phpMyAdmin runs on port 8081, you can access it using http://127.0.0.1:8081/
