### PR TITLE
Fix duplicate session tokens

### DIFF
--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -113,9 +113,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	}
 
 	// Generate and add session key
-	static std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned short> rbe;
-	std::string sessionKey(16, '\x00');
-	std::generate(sessionKey.begin(), sessionKey.end(), std::ref(rbe));
+	std::string sessionKey = randomBytes(16);
 
 	output->addByte(0x28);
 	output->addString(tfs::base64::encode({sessionKey.data(), sessionKey.size()}));


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix duplicate session tokens in protocollogin by using the same method that we are already using in http logins.

**Issues addressed:** <!-- Write here the issue number, if any. -->
#4960

The bug was cause by the  random algorithm not being seeded, using the default constructor means the same value every time you restart tfs.


