### PR TITLE
Use add_compile_definitions instead of add_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(HTTP "Enable HTTP support" ON)
 if (HTTP)
     list(APPEND VCPKG_MANIFEST_FEATURES "http")
     set(BOOST_REQUIRED_VERSION 1.75.0)
-    add_definitions(-DHTTP)
+    add_compile_definitions(HTTP)
 endif()
 
 option(BUILD_TESTING "Build unit tests" OFF)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

A quick check to [the documentation](https://cmake.org/cmake/help/latest/command/add_definitions.html):

> This command has been superseded by alternatives:
>     Use add_compile_definitions() to add preprocessor definitions.
>     Use include_directories() to add include directories.
>     Use add_compile_options() to add other options.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
