### PR TITLE
 Properly escape IP in sessions table insert query

### DIFF
--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -122,10 +122,10 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 
 	if (!db.executeQuery(
 	        fmt::format("INSERT INTO `sessions` (`token`, `account_id`, `ip`) VALUES ({:s}, {:d}, INET6_ATON({:s}))",
-	                    db.escapeBlob(sessionKey.data(), sessionKey.size()), id,
-	                    db.escapeString(connection->getIP().to_string())))) {
-		disconnectClient("Failed to create session.\nPlease try again later.", version);
-		return;
+	            db.escapeBlob(sessionKey.data(), sessionKey.size()), id,
+	            "'" + db.escapeString(connection->getIP().to_string()) + "'"))) {
+	    disconnectClient("Failed to create session.\nPlease try again later.", version);
+	    return;
 	}
 
 	// Add char list


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR fixes a syntax error when inserting into the `sessions` table by correctly quoting and escaping the IP address passed to `INET6_ATON`. Previously, the IP string was concatenated directly, which could result in malformed SQL queries or potential security issues.

#### Changes:
- Wrapped `connection->getIP().to_string()` in single quotes.
- Escaped the IP using `db.escapeString()` before formatting into the SQL query.

### Why it matters:
Ensures correct SQL syntax and prevents connection errors when creating session entries, particularly with IPv6 addresses.

**Issues addressed:** From TFS Console "[Error - mysql_real_query] Query: INSERT INTO sessions (token, account_id, ip) VALUES ('1z�i���L����Lm&', 1, INET6_ATON(::ffff:127.0.0.1))
Message: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '::ffff:127.0.0.1))' at line 1"

**How to test:**
- Run the server.
- Connect with an IPv6 or IPv4 client.
- Ensure sessions are inserted correctly into the database without causing SQL errors.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide