### PR TITLE
fix: clean up customAttrMap when empty after erase

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -452,6 +452,12 @@ private:
 			auto lowercaseKey = boost::algorithm::to_lower_copy(std::string{key});
 			if (auto it = customAttrMap->find(lowercaseKey); it != customAttrMap->end()) {
 				customAttrMap->erase(it);
+
+				if (customAttrMap->empty()) {
+					delete customAttrMap;
+					getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = nullptr;
+					removeAttribute(ITEM_ATTRIBUTE_CUSTOM);
+				}
 				return true;
 			}
 		}


### PR DESCRIPTION
After removing custom attribute, if the map of custom attributes is empty, we should remove it and not keep it in the memory, as it prevents item::equals method from properly comparing items.

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ X] I have followed [proper The Forgotten Server code styling][code].
- [ X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Cleanup the custom attribute map and the ITEM_ATTRIBUTE_CUSTOM, if while removing the attribute, it turned out to be the only one in the map (making it empty).

**How to test:** <!-- Write here how to test changes. -->
Have 23 arrows.
Put custom attribute on 3 arrows
Pick 1 out of 3 arrows and remove the custom attribute from it.
Now that 1 arrow should stack with the 20 arrows, however that is not the case until relog.


https://github.com/user-attachments/assets/26dbf298-52df-43ea-ae60-08c43decc347

Tbh it's not the TFS 1.7 I am using (and can't use 1.7 either), so would be nice if another person confirmed. I just looked at the code and since it's basically 1:1 I guess the bug is also in here :)

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
