### PR TITLE
Eliminate double randomizing directions in Monster::getDanceStep

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1352,7 +1352,6 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& direction, bo
 	}
 
 	if (!dirList.empty()) {
-		std::shuffle(dirList.begin(), dirList.end(), getRandomGenerator());
 		direction = dirList[uniform_random(0, dirList.size() - 1)];
 		return true;
 	}


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ x] I have followed [proper The Forgotten Server code styling][code].
- [x ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed & Issues Addressed

Before this change, the code shuffles the directions around, and then randomly picks a direction; Since we are already picking one of the directions at random, it serves no purpose to randomize their order.

The change is to eliminate the shuffle. 