### PR TITLE
Remove redundant Game::cleanup()

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3826,7 +3826,6 @@ void Game::checkCreatureWalk(uint32_t creatureId)
 	Creature* creature = getCreatureByID(creatureId);
 	if (creature && !creature->isDead()) {
 		creature->onWalk();
-		cleanup();
 	}
 }
 


### PR DESCRIPTION
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

This PR proposes we reduce the calls to the Game::cleanup() method by eliminating it's call to creatures in the Game::checkCreatureWalk. The reason we can do this without concern, is also the reason it's worth so much to gain... we already call Game::cleanup() every 100 ms in the Game::checkCreatures method. 

It's my opinion, and from my own experience testing on my own project, not this one... That there is absolutely nothing to be lost by reducing these calls to only every cycle for Game::checkCreatures, and everything to gain.
