### PR TITLE
fix possible null at Creature::getZone type

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -170,7 +170,7 @@ public:
 	const Outfit_t getDefaultOutfit() const { return defaultOutfit; }
 	bool isInvisible() const;
 	ZoneType_t getZone() const
-    {
+	{
 		const Tile* tile = getTile();
 		if (!tile) {
 			return ZONE_NORMAL;


### PR DESCRIPTION
Avoided a potential segmentation fault by ensuring Creature::getZone returns ZONE_NORMAL when no tile is attached, preventing null pointer dereferences...