### PR TITLE
fix onTickCondition missing nullcheck

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -931,8 +931,8 @@ void Creature::onEndCondition(ConditionType_t)
 
 void Creature::onTickCondition(ConditionType_t type, bool& bRemove)
 {
-	const auto &tile = getTile();
-	const auto &field = tile ? tile->getFieldItem() : nullptr;
+	const auto& tile = getTile();
+	const auto& field = tile ? tile->getFieldItem() : nullptr;
 	if (!field) {
 		return;
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -931,8 +931,12 @@ void Creature::onEndCondition(ConditionType_t)
 
 void Creature::onTickCondition(ConditionType_t type, bool& bRemove)
 {
-	const auto& tile = getTile();
-	const auto& field = tile ? tile->getFieldItem() : nullptr;
+	const Tile* tile = getTile();
+	if (!tile) {
+		return;
+	}
+
+	const MagicField* field = tile->getFieldItem();
 	if (!field) {
 		return;
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -931,7 +931,8 @@ void Creature::onEndCondition(ConditionType_t)
 
 void Creature::onTickCondition(ConditionType_t type, bool& bRemove)
 {
-	const MagicField* field = getTile()->getFieldItem();
+	const auto &tile = getTile();
+	const auto &field = tile ? tile->getFieldItem() : nullptr;
 	if (!field) {
 		return;
 	}


### PR DESCRIPTION
Check to ensure the creature has a valid tile before querying for field items, preventing potential null pointer dereferences.