### PR TITLE
Fix lua globalevent:time(time)

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17860,7 +17860,7 @@ int LuaScriptInterface::luaGlobalEventTime(lua_State* L)
 
 		time_t difference = static_cast<time_t>(difftime(mktime(timeinfo), current_time));
 		if (difference < 0) {
-			difference += 86400;
+			difference += 86400000;
 		}
 
 		globalevent->setNextExecution(current_time + difference);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fix lua globalevent:time(time)

**Issues addressed:** <!-- Write here the issue number, if any. -->
https://github.com/otland/forgottenserver/issues/5004

**How to test:** <!-- Write here how to test changes. -->
1. Run server
2. Checks "Server Log" chat window

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
