### PR TITLE
fix(houses): clear ownerName after house sale

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -64,7 +64,7 @@ void House::setOwner(uint32_t guid, bool updateDatabase /* = true*/, Player* pla
 		// clean access lists
 		owner = 0;
 		ownerAccountId = 0;
-		ownerName.clear()
+		ownerName.clear();
 		setAccessList(SUBOWNER_LIST, "");
 		setAccessList(GUEST_LIST, "");
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This pull request fixes an issue where the previous owner's name remained visible on a house after it was sold.

The problem occurred because ownerName was not being cleared when resetting ownership data.
To resolve this, a call to ownerName.clear() was added right after resetting owner and ownerAccountId.

### Issues addressed:

Fixes incorrect display of previous owner name after house sale.
Prevents confusion when houses are transferred or sold to a new player.
