### PR TITLE
Prevent crash on onAttackedCreatureChangeZone

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1217,7 +1217,7 @@ void Player::onChangeZone(ZoneType_t zone)
 
 void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
 {
-	const auto& attackedCreature = getAttackedCreature();
+	const auto attackedCreature = getAttackedCreature();
 	if (!attackedCreature) {
 		return;
 	}


### PR DESCRIPTION
Avoids crashes when getAttackedCreature() ends up null — for example, if there’s no target or it gets removed while changing zones...

_**onCreatureDisappear ~ attackedCreature ~ removeAttackedCreature ~ setAttackedCreature ~ Creature::internalCreatureDisappear**_