### PR TITLE
Revert "Add Followers Reference Counter (#4968)"

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -37,8 +37,6 @@ Creature::~Creature()
 	for (auto condition : conditions) {
 		delete condition;
 	}
-
-	releaseFollowers();
 }
 
 bool Creature::canSee(const Position& myPos, const Position& pos, int32_t viewRangeX, int32_t viewRangeY)
@@ -818,7 +816,7 @@ void Creature::onFollowCreature(const Creature*)
 void Creature::onUnfollowCreature() { hasFollowPath = false; }
 
 // Pathfinding Events
-bool Creature::isFollower(const Creature* creature)
+bool Creature::isFollower(Creature* creature)
 {
 	auto it = std::find(followers.begin(), followers.end(), creature);
 	return it != followers.end();
@@ -828,16 +826,6 @@ void Creature::addFollower(Creature* creature)
 {
 	if (!isFollower(creature)) {
 		followers.push_back(creature);
-		creature->incrementReferenceCounter();
-	}
-}
-
-void Creature::removeFollower(Creature* creature)
-{
-	auto it = std::find(followers.begin(), followers.end(), creature);
-	if (it != followers.end()) {
-		creature->decrementReferenceCounter();
-		followers.erase(it);
 	}
 }
 
@@ -850,21 +838,10 @@ void Creature::removeFollowers()
 		                               const Position& followerPosition = creature->getPosition();
 		                               uint16_t distance = position.getDistanceX(followerPosition) +
 		                                                   position.getDistanceY(followerPosition);
-		                               bool isInRemoveRange = distance >= Map::maxViewportX + Map::maxViewportY ||
-		                                                      position.z != followerPosition.z;
-		                               if (isInRemoveRange) {
-			                               creature->decrementReferenceCounter();
-		                               }
-		                               return isInRemoveRange;
+		                               return distance >= Map::maxViewportX + Map::maxViewportY ||
+		                                      position.z != followerPosition.z;
 	                               }),
 	                followers.end());
-}
-
-void Creature::releaseFollowers()
-{
-	for (const auto& follower : followers) {
-		follower->decrementReferenceCounter();
-	}
 }
 
 void Creature::updateFollowersPaths()

--- a/src/creature.h
+++ b/src/creature.h
@@ -209,11 +209,9 @@ public:
 	virtual void onUnfollowCreature();
 
 	// Pathfinding functions
-	bool isFollower(const Creature* creature);
+	bool isFollower(Creature* creature);
 	void addFollower(Creature* creature);
-	void removeFollower(Creature* creature);
 	void removeFollowers();
-	void releaseFollowers();
 
 	// Pathfinding events
 	void updateFollowersPaths();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -547,8 +547,6 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 		return false;
 	}
 
-	creature->releaseFollowers();
-
 	Tile* tile = creature->getTile();
 
 	std::vector<int32_t> oldStackPosVector;


### PR DESCRIPTION
This reverts commit 30da1554b46b6b91694a3d0cc2b308408a36edd9.

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Currently, **TFS** is unusable; anyone who downloads it won't be able to use it because it crashes very quickly in almost all situations involving monsters.

It all started here: [30da1554b46b6b91694a3d0cc2b308408a36edd9] was a response to -> [https://github.com/otland/forgottenserver/issues/4961](https://github.com/otland/forgottenserver/issues/4961)

however: #4961 was never verified, it was a supposition of a random failure that is not known if it was tested on **TFS master** without changes.

I have already spent 1 hour juggling scripts and even deliberately manipulating the course of execution in debugging mode and I cannot reproduce said problem, at least not in the time I have been testing.