### PR TITLE
fix(creature): remove releaseFollowers call from destructor

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -37,8 +37,6 @@ Creature::~Creature()
 	for (auto condition : conditions) {
 		delete condition;
 	}
-
-	releaseFollowers();
 }
 
 bool Creature::canSee(const Position& myPos, const Position& pos, int32_t viewRangeX, int32_t viewRangeY)


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
I was testing and simply deleting this call here, everything works normally
all references are correctly removed

If enemies are killed while they still remain in the followers vector, they'll simply be removed when the player logs out/changes floor or anything that calls Game:removeCreature

**Issues addressed:** #5011