### PR TITLE
Use chrono time_point when formatting dates

### DIFF
--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -22,8 +22,8 @@ const std::optional<BanInfo> getAccountBanInfo(uint32_t accountId)
 		return std::nullopt;
 	}
 
-	int64_t expiresAt = result->getNumber<int64_t>("expires_at");
-	if (expiresAt != 0 && time(nullptr) > expiresAt) {
+	time_t expiresAt = result->getNumber<time_t>("expires_at");
+	if (expiresAt != 0 && std::chrono::system_clock::now() > std::chrono::system_clock::from_time_t(expiresAt)) {
 		// Move the ban to history if it has expired
 		g_databaseTasks.addTask(fmt::format(
 		    "INSERT INTO `account_ban_history` (`account_id`, `reason`, `banned_at`, `expired_at`, `banned_by`) VALUES ({:d}, {:s}, {:d}, {:d}, {:d})",
@@ -60,8 +60,8 @@ const std::optional<BanInfo> getIpBanInfo(const Connection::Address& clientIP)
 		return std::nullopt;
 	}
 
-	int64_t expiresAt = result->getNumber<int64_t>("expires_at");
-	if (expiresAt != 0 && time(nullptr) > expiresAt) {
+	time_t expiresAt = result->getNumber<time_t>("expires_at");
+	if (expiresAt != 0 && std::chrono::system_clock::now() > std::chrono::system_clock::from_time_t(expiresAt)) {
 		g_databaseTasks.addTask(
 		    fmt::format("DELETE FROM `ip_bans` WHERE `ip` = INET6_ATON('{:s}')", clientIP.to_string()));
 		return std::nullopt;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5132,7 +5132,8 @@ void Game::playerDebugAssert(uint32_t playerId, const std::string& assertLine, c
 	// TODO: move debug assertions to database
 	FILE* file = fopen("client_assertions.txt", "a");
 	if (file) {
-		fprintf(file, "----- %s - %s (%s) -----\n", formatDate(time(nullptr)).c_str(), player->getName().c_str(),
+		const auto& timestamp = std::format("{:%d/%m/%Y %T}", std::chrono::system_clock::now());
+		fprintf(file, "----- %s - %s (%s) -----\n", timestamp.c_str(), player->getName().c_str(),
 		        player->getIP().to_string().c_str());
 		fprintf(file, "%s\n%s\n%s\n%s\n", assertLine.c_str(), date.c_str(), description.c_str(), comment.c_str());
 		fclose(file);

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -8,7 +8,6 @@
 #include "configmanager.h"
 
 #include <chrono>
-#include <fmt/chrono.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
@@ -217,9 +216,10 @@ std::string randomBytes(size_t length)
 	return bytes;
 }
 
-std::string formatDate(time_t time) { return fmt::format("{:%d/%m/%Y %H:%M:%S}", fmt::localtime(time)); }
-
-std::string formatDateShort(time_t time) { return fmt::format("{:%d %b %Y}", fmt::localtime(time)); }
+std::string formatDateShort(time_t time)
+{
+	return std::format("{:%d %b %Y}", std::chrono::system_clock::from_time_t(time));
+}
 
 Position getNextPosition(Direction direction, Position pos)
 {

--- a/src/tools.h
+++ b/src/tools.h
@@ -39,7 +39,6 @@ Direction getDirectionTo(const Position& from, const Position& to);
 
 std::string getFirstLine(const std::string& str);
 
-std::string formatDate(time_t time);
 std::string formatDateShort(time_t time);
 
 uint16_t getDepotBoxId(uint16_t index);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This pull request updates the handling of time points to use `std::chrono::time_point` and `std::format` instead of the `fmt` library. Additionally, the unused `formatDate` function was removed.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
