### PR TITLE
fix: door removal reference counting

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -267,8 +267,9 @@ void House::removeDoor(Door* door)
 {
 	auto it = doorSet.find(door);
 	if (it != doorSet.end()) {
-		door->decrementReferenceCounter();
+		Door* doorToRemove = *it;
 		doorSet.erase(it);
+		doorToRemove->decrementReferenceCounter();
 	}
 }
 


### PR DESCRIPTION
The set iterator was being dereferenced after erase, which seems risky.
Now I store the pointer before erasing the iterator from the set.

Is that the right  ?