### PR TITLE
fix possible crash due to string conversion error

### DIFF
--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -41,14 +41,14 @@ Position NetworkMessage::getPosition()
 	return pos;
 }
 
-void NetworkMessage::addString(std::string_view value)
+void NetworkMessage::addString(const std::string_view& value)
 {
-	std::string latin1Str;
+	std::string latin1Str{};
 	try {
 		latin1Str = boost::locale::conv::from_utf<char>(value.data(), value.data() + value.size(), "ISO-8859-1",
 		                                                boost::locale::conv::skip);
-	} catch (const boost::locale::conv::conversion_error&) {
-		return;
+	} catch (const boost::locale::conv::conversion_error& e) {
+		std::clog << "Failed to convert string to ISO-8859-1: " << e.what() << ", will add an empty string as padding" << std::endl;
 	}
 
 	size_t stringLen = latin1Str.size();

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -41,7 +41,7 @@ Position NetworkMessage::getPosition()
 	return pos;
 }
 
-void NetworkMessage::addString(const std::string_view& value)
+void NetworkMessage::addString(std::string_view value)
 {
 	std::string latin1Str{};
 	try {

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -23,9 +23,13 @@ std::string NetworkMessage::getString(uint16_t stringLen /* = 0*/)
 	auto it = buffer.data() + info.position;
 	info.position += stringLen;
 
-	std::string_view latin1Str{reinterpret_cast<char*>(it), stringLen};
-	return boost::locale::conv::to_utf<char>(latin1Str.data(), latin1Str.data() + latin1Str.size(), "ISO-8859-1",
-	                                         boost::locale::conv::skip);
+	try {
+		std::string_view latin1Str{reinterpret_cast<char*>(it), stringLen};
+		return boost::locale::conv::to_utf<char>(latin1Str.data(), latin1Str.data() + latin1Str.size(), "ISO-8859-1",
+		                                         boost::locale::conv::skip);
+	} catch (const boost::locale::conv::conversion_error&) {
+		return {};
+	}
 }
 
 Position NetworkMessage::getPosition()
@@ -39,8 +43,14 @@ Position NetworkMessage::getPosition()
 
 void NetworkMessage::addString(std::string_view value)
 {
-	std::string latin1Str = boost::locale::conv::from_utf<char>(value.data(), value.data() + value.size(), "ISO-8859-1",
-	                                                            boost::locale::conv::skip);
+	std::string latin1Str;
+	try {
+		latin1Str = boost::locale::conv::from_utf<char>(value.data(), value.data() + value.size(), "ISO-8859-1",
+		                                               boost::locale::conv::skip);
+	} catch (const boost::locale::conv::conversion_error&) {
+		return;
+	}
+
 	size_t stringLen = latin1Str.size();
 	if (!canAdd(stringLen + 2) || stringLen > 8192) {
 		return;

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -48,7 +48,8 @@ void NetworkMessage::addString(const std::string_view& value)
 		latin1Str = boost::locale::conv::from_utf<char>(value.data(), value.data() + value.size(), "ISO-8859-1",
 		                                                boost::locale::conv::skip);
 	} catch (const boost::locale::conv::conversion_error& e) {
-		std::clog << "Failed to convert string to ISO-8859-1: " << e.what() << ", will add an empty string as padding" << std::endl;
+		std::cerr << "Failed to convert string to ISO-8859-1: " << e.what() << ", will add an empty string as padding"
+		          << std::endl;
 	}
 
 	size_t stringLen = latin1Str.size();

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -46,7 +46,7 @@ void NetworkMessage::addString(std::string_view value)
 	std::string latin1Str;
 	try {
 		latin1Str = boost::locale::conv::from_utf<char>(value.data(), value.data() + value.size(), "ISO-8859-1",
-		                                               boost::locale::conv::skip);
+		                                                boost::locale::conv::skip);
 	} catch (const boost::locale::conv::conversion_error&) {
 		return;
 	}

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -105,7 +105,7 @@ public:
 	void addBytes(const char* bytes, size_t size);
 	void addPaddingBytes(size_t n);
 
-	void addString(const std::string_view& value);
+	void addString(std::string_view value);
 
 	void addDouble(double value, uint8_t precision = 2);
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -105,7 +105,7 @@ public:
 	void addBytes(const char* bytes, size_t size);
 	void addPaddingBytes(size_t n);
 
-	void addString(std::string_view value);
+	void addString(const std::string_view& value);
 
 	void addDouble(double value, uint8_t precision = 2);
 


### PR DESCRIPTION
### Changes Proposed

It is possible that local::conv::to_utf/from_utf8 throw an exception if an invalid char is provided, as far as I am aware a network message can contain user[?] provided messages and thus can crash the server.

It is probably a good idea to use std::expected or std::optional for these error cases in such paths for better error handling, but this is for a different PR.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
