### PR TITLE
refactor(creature): remove unused onAddTileItem method

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -310,7 +310,6 @@ public:
 	virtual void onWalk();
 	virtual bool getNextStep(Direction& dir, uint32_t& flags);
 
-	virtual void onAddTileItem(const Tile*, const Position&) {}
 	virtual void onUpdateTileItem(const Tile*, const Position&, const Item*, const ItemType&, const Item*,
 	                              const ItemType&)
 	{}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -371,11 +371,6 @@ void Tile::onAddTileItem(Item* item)
 		}
 	}
 
-	// event methods
-	for (Creature* spectator : spectators) {
-		spectator->onAddTileItem(this, cylinderMapPos);
-	}
-
 	if ((!hasFlag(TILESTATE_PROTECTIONZONE) || getBoolean(ConfigManager::CLEAN_PROTECTION_ZONES)) &&
 	    item->isCleanable()) {
 		if (!dynamic_cast<HouseTile*>(this)) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Removed `Creature::onAddTileItem` method because it is not used anywhere in codebase

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
