### PR TITLE
Fix charged amulets never disappearing if decayto is 0

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1693,7 +1693,7 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 					newItemId = item->getDecayTo();
 				}
 
-				if (newItemId < 0) {
+				if (newItemId <= 0) {
 					internalRemoveItem(item);
 					return nullptr;
 				} else if (newItemId != newId) {


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
Charged amulet does not disappear, because the check explicitly checks for -1
this is a critical bug (infinite charged amulet) and setting decayto to 0 for charged amulets should not cause this bug (it's even quite logical to set it to 0 based on how duration ring works)

**How to test:** <!-- Write here how to test changes. -->
set decayto to 0 in items.xml for charged amulet
for example stone skin amulet

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
