### PR TITLE
feat: use newer GCC version in runners

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: echo CXX=g++-14 >> $GITHUB_ENV
+        if: ${{ matrix.os == 'macos' || matrix.os == 'ubuntu' }}
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
         ports:
           - 3306:3306
 
+    env:
+      CXX: g++-14
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Updates the GitHub Actions workflows to explicitly set the C++ compiler version for both build and test jobs. GCC 14+ is required to use C++23 features, see [compiler support for C++23](https://en.cppreference.com/w/cpp/compiler_support/23.html).

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
