### PR TITLE
feat: add CMake option to enable address sanitizer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,6 @@ jobs:
           buildPreset: vcpkg
           buildPresetAdditionalArgs: "['--config', 'Debug']"
           configurePreset: vcpkg
-          configurePresetAdditionalArgs: "['-DBUILD_TESTING=ON']"
+          configurePresetAdditionalArgs: "['-DASAN=ON', '-DBUILD_TESTING=ON']"
           testPreset: vcpkg
           testPresetAdditionalArgs: "['--build-config', 'Debug', '--output-on-failure']"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,18 @@ else()
     list(APPEND VCPKG_MANIFEST_FEATURES "lua")
 endif()
 
+option(ASAN "Enable address sanitizer" OFF)
+if (ASAN)
+    if (MSVC)
+        message(WARNING "ASAN is experimental on Windows/MSVC")
+        add_compile_options(/fsanitize=address)
+        add_link_options(/fsanitize=address)
+    else ()
+        add_compile_options(-fsanitize=address)
+        add_link_options(-fsanitize=address)
+    endif ()
+endif ()
+
 project(tfs CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Introduces support for enabling [AddressSanitizer (ASAN)](https://github.com/google/sanitizers/wiki/addresssanitizer) in the build and test workflow, making it easier to catch memory errors during development and CI. The changes update both the CMake configuration and the GitHub Actions workflow to allow ASAN to be toggled and used during testing.

**How to test:** <!-- Write here how to test changes. -->

Generate the project with `-DASAN=ON` and build, it should report address sanitizer violations when the process exits.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
