### PR TITLE
fix(tile): ensure alwaysOnTop items are inserted above existing items with same order

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -906,7 +906,7 @@ void Tile::addThing(int32_t, Thing* thing)
 			if (items) {
 				for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 					// Note: this is different from internalAddThing
-					if (itemType.alwaysOnTopOrder <= Item::items[(*it)->getID()].alwaysOnTopOrder) {
+					if (itemType.alwaysOnTopOrder < Item::items[(*it)->getID()].alwaysOnTopOrder) {
 						items->insert(it, item);
 						isInserted = true;
 						break;
@@ -1460,7 +1460,7 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 		if (itemType.alwaysOnTop) {
 			bool isInserted = false;
 			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
-				if (Item::items[(*it)->getID()].alwaysOnTopOrder > itemType.alwaysOnTopOrder) {
+				if (Item::items[(*it)->getID()].alwaysOnTopOrder >= itemType.alwaysOnTopOrder) {
 					items->insert(it, item);
 					isInserted = true;
 					break;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
- Fixes the behavior of `alwaysOnTop` items in Tile class. Previously, when adding a new item with the same `alwaysOnTopOrder` as an existing item, it could be inserted below the existing item, causing visual and logical inconsistencies.
- It also works reloading the house tiles.

Before/After:
<img width="328" height="343" alt="image" src="https://github.com/user-attachments/assets/85534348-f29b-43be-8cba-e34f0f31a748" />
- Close #4278.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
