### PR TITLE
refactor(thing): move container access logic to Item

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -69,11 +69,16 @@ Item* Container::clone() const
 
 Container* Container::getParentContainer()
 {
-	Thing* thing = getParent();
+	auto thing = getParent();
 	if (!thing) {
 		return nullptr;
 	}
-	return thing->getContainer();
+
+	auto item = thing->getItem();
+	if (!item) {
+		return nullptr;
+	}
+	return item->getContainer();
 }
 
 std::string Container::getName(bool addArticle /* = false*/) const

--- a/src/item.h
+++ b/src/item.h
@@ -512,6 +512,8 @@ public:
 
 	Item* getItem() override final { return this; }
 	const Item* getItem() const override final { return this; }
+	virtual Container* getContainer() { return nullptr; }
+	virtual const Container* getContainer() const { return nullptr; }
 	virtual Teleport* getTeleport() { return nullptr; }
 	virtual const Teleport* getTeleport() const { return nullptr; }
 	virtual TrashHolder* getTrashHolder() { return nullptr; }

--- a/src/thing.h
+++ b/src/thing.h
@@ -39,8 +39,6 @@ public:
 	virtual int32_t getThrowRange() const = 0;
 	virtual bool isPushable() const = 0;
 
-	virtual Container* getContainer() { return nullptr; }
-	virtual const Container* getContainer() const { return nullptr; }
 	virtual Item* getItem() { return nullptr; }
 	virtual const Item* getItem() const { return nullptr; }
 	virtual Creature* getCreature() { return nullptr; }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactors the ownership and access chain for containers, ensuring that only Item exposes container information. Previously, Thing exposed getContainer(), even though only Item-derived objects can validly represent containers. The new structure enforces correct type relationships and avoids incorrect assumptions.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
