### PR TITLE
refactor(cylinder): remove unused startDecaying method from interface

### DIFF
--- a/src/cylinder.cpp
+++ b/src/cylinder.cpp
@@ -36,8 +36,3 @@ void Cylinder::internalAddThing(uint32_t, Thing*)
 {
 	//
 }
-
-void Cylinder::startDecaying()
-{
-	//
-}

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -193,8 +193,6 @@ public:
 	 * position)
 	 */
 	virtual void internalAddThing(uint32_t index, Thing* thing);
-
-	virtual void startDecaying();
 };
 
 class VirtualCylinder final : public Cylinder


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Removes the unused `startDecaying` method from the `Cylinder` class.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
