### PR TITLE
refactor(thing): move description method to Creature and remove unused overrides

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -103,6 +103,7 @@ public:
 
 	virtual const std::string& getName() const = 0;
 	virtual const std::string& getNameDescription() const = 0;
+	virtual std::string getDescription(int32_t lookDistance) const = 0;
 
 	virtual CreatureType_t getType() const = 0;
 

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -227,7 +227,6 @@ public:
 
 	bool isPushable() const override { return false; }
 	int32_t getThrowRange() const override { return 1; }
-	std::string getDescription(int32_t) const override { return {}; }
 	bool isRemoved() const override { return false; }
 };
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -953,12 +953,6 @@ uint32_t Item::getWeight() const
 	return weight;
 }
 
-std::string Item::getDescription(int32_t) const
-{
-	// item descriptions moved to lua
-	return "";
-}
-
 std::string Item::getNameDescription(const ItemType& it, const Item* item /*= nullptr*/, int32_t subType /*= -1*/,
                                      bool addArticle /*= true*/)
 {

--- a/src/item.h
+++ b/src/item.h
@@ -725,7 +725,6 @@ public:
 	                                      bool addArticle = true);
 	static std::string getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count = 1);
 
-	std::string getDescription(int32_t lookDistance) const override final;
 	std::string getNameDescription() const;
 	std::string getWeightDescription() const;
 

--- a/src/thing.h
+++ b/src/thing.h
@@ -21,8 +21,6 @@ public:
 	Thing(const Thing&) = delete;
 	Thing& operator=(const Thing&) = delete;
 
-	virtual std::string getDescription(int32_t lookDistance) const = 0;
-
 	virtual bool hasParent() const { return false; }
 	virtual Cylinder* getParent() const { return nullptr; }
 	virtual Cylinder* getRealParent() const { return getParent(); }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -118,8 +118,6 @@ uint32_t Tile::getDownItemCount() const
 	return 0;
 }
 
-std::string Tile::getDescription(int32_t) const { return "You dont know why, but you cant see anything!"; }
-
 Teleport* Tile::getTeleportItem() const
 {
 	if (!hasFlag(TILESTATE_TELEPORT)) {

--- a/src/tile.h
+++ b/src/tile.h
@@ -190,8 +190,6 @@ public:
 
 	bool hasHeight(uint32_t n) const;
 
-	std::string getDescription(int32_t lookDistance) const override final;
-
 	int32_t getClientIndexOfCreature(const Player* player, const Creature* creature) const;
 	int32_t getStackposOfItem(const Player* player, const Item* item) const;
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Reorganizes the responsibility of the `getDescription` method within the object hierarchy. Previously, Thing defined a virtual method, which forced all subclasses including Item, Tile and Cylinder to impl it.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
