### PR TITLE
refactor(container): remove getParentContainer and inline parent weight update

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -67,20 +67,6 @@ Item* Container::clone() const
 	return clone;
 }
 
-Container* Container::getParentContainer()
-{
-	auto thing = getParent();
-	if (!thing) {
-		return nullptr;
-	}
-
-	auto item = thing->getItem();
-	if (!item) {
-		return nullptr;
-	}
-	return item->getContainer();
-}
-
 std::string Container::getName(bool addArticle /* = false*/) const
 {
 	const ItemType& it = items[id];
@@ -159,8 +145,13 @@ bool Container::unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, 
 void Container::updateItemWeight(int32_t diff)
 {
 	totalWeight += diff;
-	if (Container* parentContainer = getParentContainer()) {
-		parentContainer->updateItemWeight(diff);
+
+	if (const auto parent = getParent()) {
+		if (const auto item = parent->getItem()) {
+			if (const auto parentContainer = item->getContainer()) {
+				parentContainer->updateItemWeight(diff);
+			}
+		}
 	}
 }
 

--- a/src/container.h
+++ b/src/container.h
@@ -132,7 +132,6 @@ private:
 	void onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem);
 	void onRemoveContainerItem(uint32_t index, Item* item);
 
-	Container* getParentContainer();
 	void updateItemWeight(int32_t diff);
 
 	friend class ContainerIterator;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactors the Container class weight update logic, `getParentContainer` method has been removed and `updateItemWeight` now directly traverses the parent Thing to find the parent.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
