### PR TITLE
refactor(item): replace dynamic cast in getHoldingPlayer with explicit parent creature lookup

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -324,7 +324,18 @@ uint16_t Item::getSubType() const
 	return count;
 }
 
-const Player* Item::getHoldingPlayer() const { return dynamic_cast<const Player*>(getTopParent()); }
+const Player* Item::getHoldingPlayer() const
+{
+	const auto topParent = getTopParent();
+	if (!topParent) {
+		return nullptr;
+	}
+
+	if (const auto creature = topParent->getCreature()) {
+		return creature->getPlayer();
+	}
+	return nullptr;
+}
 
 void Item::setSubType(uint16_t n)
 {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Updates the `Item::getHoldingPlayer()` impl to remove the dynamic cast dependency and align the function with the Thing hierarchy.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
