### PR TITLE
fix(iomapserialize): add class Thing forward declaration

### DIFF
--- a/src/iomapserialize.h
+++ b/src/iomapserialize.h
@@ -10,6 +10,7 @@ class Item;
 class Map;
 class PropStream;
 class PropWriteStream;
+class Thing;
 class Tile;
 
 class IOMapSerialize


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This missing forward declaration causes a build error when unity build is disabled:

```
/home/rsa/Documents/forgottenserver/src/iomapserialize.h:30:54: error: ‘Thing’ has not been declared
   30 |         static bool loadItem(PropStream& propStream, Thing* parent);
      |                                                      ^~~~~
```

It used to be `Cylinder` but it was changed in #5058 and the forward declaration wasn't added accordingly.

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
