### PR TITLE
refactor(player): remove onEquipInventory/onDeEquipInventory and inline inventory logic

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -791,9 +791,6 @@ public:
 	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
 	                    const Position& oldPos, bool teleport) override;
 
-	void onEquipInventory();
-	void onDeEquipInventory();
-
 	void onAttackedCreatureDisappear(bool isLogout) override;
 	void onFollowCreatureDisappear(bool isLogout) override;
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Their logic is now executed directly inside `Player::onCreatureAppear()` and `Player::onRemoveCreature()`. It's now executed at the end of cycle when data such as party, guild, regeneration... have already been applied.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
