### PR TITLE
refactor(npc): remove generic creature speech bubble and restrict to NPCs only

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -250,8 +250,6 @@ public:
 	virtual float getAttackFactor() const { return 1.0f; }
 	virtual float getDefenseFactor() const { return 1.0f; }
 
-	virtual uint8_t getSpeechBubble() const { return SPEECHBUBBLE_NONE; }
-
 	bool addCondition(Condition* condition, bool force = false);
 	bool addCombatCondition(Condition* condition);
 	void removeCondition(ConditionType_t type, ConditionId_t conditionId, bool force = false);

--- a/src/npc.h
+++ b/src/npc.h
@@ -123,7 +123,7 @@ public:
 
 	CreatureType_t getType() const override { return CREATURETYPE_NPC; }
 
-	uint8_t getSpeechBubble() const override { return speechBubble; }
+	uint8_t getSpeechBubble() const { return speechBubble; }
 	void setSpeechBubble(const uint8_t bubble) { speechBubble = bubble; }
 
 	void doSay(const std::string& text);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3462,7 +3462,12 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bo
 		msg.addByte(otherPlayer ? otherPlayer->getVocation()->getClientId() : 0x00);
 	}
 
-	msg.addByte(creature->getSpeechBubble());
+	if (const auto npc = creature->getNpc()) {
+		msg.addByte(npc->getSpeechBubble());
+	} else {
+		msg.addByte(SPEECHBUBBLE_NONE);
+	}
+
 	msg.addByte(0xFF); // MARK_UNMARKED
 	msg.addByte(0x00); // inspection type (bool?)
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Removed the virtual getSpeechBubble method from Creature and made speech bubble handling NPC-specific. The game protocol now sends the NPC speech bubble only when the creature is an NPC, otherwise it explicitly falls back to `SPEECHBUBBLE_NONE`.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
