### PR TITLE
fix(game): correct parent ref in transformItem postAddNotification

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1661,8 +1661,8 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 		}
 		parent->addThing(item);
 
-		if (auto parent = item->getParent()) {
-			parent->postAddNotification(item, parent, parent->getThingIndex(item));
+		if (auto itemParent = item->getParent()) {
+			itemParent->postAddNotification(item, parent, itemParent->getThingIndex(item));
 			return item;
 		}
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fix a bug in `Game::transformItem` where postAddNotification used the wrong parent pointer during alwaysOnTop transformations. The code now  uses itemParent instead of the shadowed parent variable, ensuring the notification is sent to the actual container the item ends up in.

Introduced in #5058

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
