### PR TITLE
fix(monster): reorder Monster::onCreatureAppear to run scripts before AI logic

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -112,16 +112,6 @@ void Monster::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
 {
 	if (creature == this) {
 		setLastPosition(getPosition());
-
-		// We just spawned lets look around to see who is there.
-		if (isSummon()) {
-			isMasterInRange = canSee(getMaster()->getPosition());
-		}
-
-		updateTargetList();
-		updateIdleStatus();
-	} else {
-		onCreatureEnter(creature);
 	}
 
 	if (mType->info.creatureAppearEvent != -1) {
@@ -147,6 +137,18 @@ void Monster::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
 		if (scriptInterface->callFunction(2)) {
 			return;
 		}
+	}
+
+	if (creature == this) {
+		// We just spawned lets look around to see who is there.
+		if (isSummon()) {
+			isMasterInRange = canSee(getMaster()->getPosition());
+		}
+
+		updateTargetList();
+		updateIdleStatus();
+	} else {
+		onCreatureEnter(creature);
 	}
 }
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Reordered the flow of `Monster::onCreatureAppear` so that the Lua creatureAppearEvent is executed before the internal AI logic. This aligns the function with other event handlers that evaluate Lua callbacks first and only execute internal behavior afterwards.

Introduced in #5030

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
