### PR TITLE
refactor(creatures): move getKillers logic into Player::getCorpse

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -431,20 +431,6 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 	}
 }
 
-CreatureVector Creature::getKillers()
-{
-	CreatureVector killers;
-	const int64_t timeNow = OTSYS_TIME();
-	const uint32_t inFightTicks = getNumber(ConfigManager::PZ_LOCKED);
-	for (const auto& it : damageMap) {
-		Creature* attacker = g_game.getCreatureByID(it.first);
-		if (attacker && attacker != this && timeNow - it.second.ticks <= inFightTicks) {
-			killers.push_back(attacker);
-		}
-	}
-	return killers;
-}
-
 void Creature::onDeath()
 {
 	bool lastHitUnjustified = false;

--- a/src/creature.h
+++ b/src/creature.h
@@ -277,7 +277,6 @@ public:
 
 	virtual bool challengeCreature(Creature*, bool) { return false; }
 
-	CreatureVector getKillers();
 	void onDeath();
 	virtual uint64_t getGainedExperience(Creature* attacker) const;
 	void addDamagePoints(Creature* attacker, int32_t damagePoints);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2236,26 +2236,31 @@ Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
 {
 	Item* corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
 	if (corpse && corpse->getContainer()) {
-		size_t killersSize = getKillers().size();
+		auto killers = std::ranges::count_if(
+		    damageMap,
+		    [this, now = OTSYS_TIME(), inFightTicks = getNumber(ConfigManager::PZ_LOCKED)](const auto& pair) {
+			    const auto& attacker = g_game.getCreatureByID(pair.first);
+			    return attacker && attacker != this && (now - pair.second.ticks <= inFightTicks);
+		    });
 
 		if (lastHitCreature) {
 			if (!mostDamageCreature) {
 				corpse->setSpecialDescription(
 				    fmt::format("You recognize {:s}. {:s} was killed by {:s}{:s}", getNameDescription(),
 				                getSex() == PLAYERSEX_FEMALE ? "She" : "He", lastHitCreature->getNameDescription(),
-				                killersSize > 1 ? " and others." : "."));
+				                killers > 1 ? " and others." : "."));
 			} else if (lastHitCreature != mostDamageCreature) {
 				corpse->setSpecialDescription(
 				    fmt::format("You recognize {:s}. {:s} was killed by {:s}, {:s}{:s}", getNameDescription(),
 				                getSex() == PLAYERSEX_FEMALE ? "She" : "He", mostDamageCreature->getNameDescription(),
-				                lastHitCreature->getNameDescription(), killersSize > 2 ? " and others." : "."));
+				                lastHitCreature->getNameDescription(), killers > 2 ? " and others." : "."));
 			} else {
 				corpse->setSpecialDescription(
 				    fmt::format("You recognize {:s}. {:s} was killed by {:s} and others.", getNameDescription(),
 				                getSex() == PLAYERSEX_FEMALE ? "She" : "He", mostDamageCreature->getNameDescription()));
 			}
 		} else if (mostDamageCreature) {
-			if (killersSize > 1) {
+			if (killers > 1) {
 				corpse->setSpecialDescription(fmt::format(
 				    "You recognize {:s}. {:s} was killed by something evil, {:s}, and others", getNameDescription(),
 				    getSex() == PLAYERSEX_FEMALE ? "She" : "He", mostDamageCreature->getNameDescription()));
@@ -2267,7 +2272,7 @@ Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
 		} else {
 			corpse->setSpecialDescription(fmt::format("You recognize {:s}. {:s} was killed by something evil {:s}",
 			                                          getNameDescription(), getSex() == PLAYERSEX_FEMALE ? "She" : "He",
-			                                          killersSize ? " and others." : "."));
+			                                          killers ? " and others." : "."));
 		}
 	}
 	return corpse;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This pull request refactors how killer information is calculated for player death descriptions, removing `Creature::getKillers`, replacing it with `std::ranges::count_if` directly in `Player::getCorpse`. May improve performance by reducing unnecessary copying to an intermediate array.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
