### PR TITLE
fix(weapons): drop unneeded check in useWeapon

### DIFF
--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -772,8 +772,7 @@ bool WeaponDistance::useWeapon(Player* player, Item* item, Creature* target) con
 	}
 
 	if (item->getWeaponType() == WEAPON_AMMO) {
-		Item* bow = player->getWeapon(true);
-		if (bow && bow->getHitChance() != 0) {
+		if (Item* bow = player->getWeapon(true)) {
 			chance += bow->getHitChance();
 		}
 	}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Drops an unneeded check in WeaponDistance::useWeapon, if `bow->getHitChance()` is 0 it doesn't matter if it's added to `chance` or not.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
