### PR TITLE
refactor: move static Combat methods out of header

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -97,70 +97,22 @@ CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
 	return damage;
 }
 
-CombatType_t Combat::ConditionToDamageType(ConditionType_t type)
+static bool isProtected(const Player* attacker, const Player* target)
 {
-	switch (type) {
-		case CONDITION_FIRE:
-			return COMBAT_FIREDAMAGE;
-
-		case CONDITION_ENERGY:
-			return COMBAT_ENERGYDAMAGE;
-
-		case CONDITION_BLEEDING:
-			return COMBAT_PHYSICALDAMAGE;
-
-		case CONDITION_DROWN:
-			return COMBAT_DROWNDAMAGE;
-
-		case CONDITION_POISON:
-			return COMBAT_EARTHDAMAGE;
-
-		case CONDITION_FREEZING:
-			return COMBAT_ICEDAMAGE;
-
-		case CONDITION_DAZZLED:
-			return COMBAT_HOLYDAMAGE;
-
-		case CONDITION_CURSED:
-			return COMBAT_DEATHDAMAGE;
-
-		default:
-			break;
+	uint32_t protectionLevel = getNumber(ConfigManager::PROTECTION_LEVEL);
+	if (target->getLevel() < protectionLevel || attacker->getLevel() < protectionLevel) {
+		return true;
 	}
 
-	return COMBAT_NONE;
-}
-
-ConditionType_t Combat::DamageToConditionType(CombatType_t type)
-{
-	switch (type) {
-		case COMBAT_FIREDAMAGE:
-			return CONDITION_FIRE;
-
-		case COMBAT_ENERGYDAMAGE:
-			return CONDITION_ENERGY;
-
-		case COMBAT_DROWNDAMAGE:
-			return CONDITION_DROWN;
-
-		case COMBAT_EARTHDAMAGE:
-			return CONDITION_POISON;
-
-		case COMBAT_ICEDAMAGE:
-			return CONDITION_FREEZING;
-
-		case COMBAT_HOLYDAMAGE:
-			return CONDITION_DAZZLED;
-
-		case COMBAT_DEATHDAMAGE:
-			return CONDITION_CURSED;
-
-		case COMBAT_PHYSICALDAMAGE:
-			return CONDITION_BLEEDING;
-
-		default:
-			return CONDITION_NONE;
+	if (!attacker->getVocation()->allowsPvp() || !target->getVocation()->allowsPvp()) {
+		return true;
 	}
+
+	if (attacker->getSkull() == SKULL_BLACK && attacker->getSkullClient(target) == SKULL_NONE) {
+		return true;
+	}
+
+	return false;
 }
 
 bool Combat::isPlayerCombat(const Creature* target)
@@ -266,24 +218,6 @@ ReturnValue Combat::canDoCombat(Creature* caster, Tile* tile, bool aggressive)
 bool Combat::isInPvpZone(const Creature* attacker, const Creature* target)
 {
 	return attacker->getZone() == ZONE_PVP && target->getZone() == ZONE_PVP;
-}
-
-bool Combat::isProtected(const Player* attacker, const Player* target)
-{
-	uint32_t protectionLevel = getNumber(ConfigManager::PROTECTION_LEVEL);
-	if (target->getLevel() < protectionLevel || attacker->getLevel() < protectionLevel) {
-		return true;
-	}
-
-	if (!attacker->getVocation()->allowsPvp() || !target->getVocation()->allowsPvp()) {
-		return true;
-	}
-
-	if (attacker->getSkull() == SKULL_BLACK && attacker->getSkullClient(target) == SKULL_NONE) {
-		return true;
-	}
-
-	return false;
 }
 
 ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
@@ -521,7 +455,7 @@ CallBack* Combat::getCallback(CallBackParam_t key)
 	return nullptr;
 }
 
-void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params)
+static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params)
 {
 	if (params.itemId != 0) {
 		uint16_t itemId = params.itemId;
@@ -1414,7 +1348,7 @@ void MagicField::onStepInField(Creature* creature)
 			if (!harmfulField && targetPlayer) {
 				Player* attackerPlayer = g_game.getPlayerByID(ownerId);
 				if (attackerPlayer) {
-					if (Combat::isProtected(attackerPlayer, targetPlayer)) {
+					if (isProtected(attackerPlayer, targetPlayer)) {
 						harmfulField = false;
 					}
 				}

--- a/src/combat.h
+++ b/src/combat.h
@@ -89,10 +89,7 @@ public:
 	Combat& operator=(const Combat&) = delete;
 
 	static bool isInPvpZone(const Creature* attacker, const Creature* target);
-	static bool isProtected(const Player* attacker, const Player* target);
 	static bool isPlayerCombat(const Creature* target);
-	static CombatType_t ConditionToDamageType(ConditionType_t type);
-	static ConditionType_t DamageToConditionType(CombatType_t type);
 	static ReturnValue canTargetCreature(Player* attacker, Creature* target);
 	static ReturnValue canDoCombat(Creature* caster, Tile* tile, bool aggressive);
 	static ReturnValue canDoCombat(Creature* attacker, Creature* target);
@@ -123,8 +120,6 @@ public:
 	void setOrigin(CombatOrigin origin) { params.origin = origin; }
 
 private:
-	static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile,
-	                              const CombatParams& params);
 	CombatDamage getCombatDamage(Creature* creature, Creature* target) const;
 
 	// configurable

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1368,6 +1368,40 @@ bool ConditionDamage::getNextDamage(int32_t& damage)
 	return false;
 }
 
+constexpr CombatType_t ConditionToDamageType(ConditionType_t type)
+{
+	switch (type) {
+		case CONDITION_FIRE:
+			return COMBAT_FIREDAMAGE;
+
+		case CONDITION_ENERGY:
+			return COMBAT_ENERGYDAMAGE;
+
+		case CONDITION_BLEEDING:
+			return COMBAT_PHYSICALDAMAGE;
+
+		case CONDITION_DROWN:
+			return COMBAT_DROWNDAMAGE;
+
+		case CONDITION_POISON:
+			return COMBAT_EARTHDAMAGE;
+
+		case CONDITION_FREEZING:
+			return COMBAT_ICEDAMAGE;
+
+		case CONDITION_DAZZLED:
+			return COMBAT_HOLYDAMAGE;
+
+		case CONDITION_CURSED:
+			return COMBAT_DEATHDAMAGE;
+
+		default:
+			break;
+	}
+
+	return COMBAT_NONE;
+}
+
 bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange)
 {
 	if (!creature) {
@@ -1381,7 +1415,7 @@ bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange)
 	CombatDamage damage;
 	damage.origin = ORIGIN_CONDITION;
 	damage.primary.value = healthChange;
-	damage.primary.type = Combat::ConditionToDamageType(conditionType);
+	damage.primary.type = ConditionToDamageType(conditionType);
 
 	Creature* attacker = g_game.getCreatureByID(owner);
 	if (field && creature->getPlayer() && attacker && attacker->getPlayer()) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -914,6 +914,38 @@ uint16_t AStarNodes::getMapWalkCost(AStarNode* node, const Position& neighborPos
 	return MAP_NORMALWALKCOST;
 }
 
+constexpr ConditionType_t DamageToConditionType(CombatType_t type)
+{
+	switch (type) {
+		case COMBAT_FIREDAMAGE:
+			return CONDITION_FIRE;
+
+		case COMBAT_ENERGYDAMAGE:
+			return CONDITION_ENERGY;
+
+		case COMBAT_DROWNDAMAGE:
+			return CONDITION_DROWN;
+
+		case COMBAT_EARTHDAMAGE:
+			return CONDITION_POISON;
+
+		case COMBAT_ICEDAMAGE:
+			return CONDITION_FREEZING;
+
+		case COMBAT_HOLYDAMAGE:
+			return CONDITION_DAZZLED;
+
+		case COMBAT_DEATHDAMAGE:
+			return CONDITION_CURSED;
+
+		case COMBAT_PHYSICALDAMAGE:
+			return CONDITION_BLEEDING;
+
+		default:
+			return CONDITION_NONE;
+	}
+}
+
 uint16_t AStarNodes::getTileWalkCost(const Creature& creature, const Tile* tile)
 {
 	uint16_t cost = 0;
@@ -925,7 +957,7 @@ uint16_t AStarNodes::getTileWalkCost(const Creature& creature, const Tile* tile)
 	if (const MagicField* field = tile->getFieldItem()) {
 		CombatType_t combatType = field->getCombatType();
 		const Monster* monster = creature.getMonster();
-		if (!creature.isImmune(combatType) && !creature.hasCondition(Combat::DamageToConditionType(combatType)) &&
+		if (!creature.isImmune(combatType) && !creature.hasCondition(DamageToConditionType(combatType)) &&
 		    (monster && !monster->canWalkOnFieldType(combatType))) {
 			cost += MAP_NORMALWALKCOST * 18;
 		}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Moves static methods that are only used once out of the header file to avoid bloating the class namespace.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
