### PR TITLE
fix: VS2026 compilation error (#5076)

### DIFF
--- a/src/iomapserialize.h
+++ b/src/iomapserialize.h
@@ -10,6 +10,7 @@ class Item;
 class Map;
 class PropStream;
 class PropWriteStream;
+class Thing;
 class Tile;
 
 class IOMapSerialize


### PR DESCRIPTION
Compilation in VS2026 does not work.
Fixes https://github.com/otland/forgottenserver/issues/5076

**EDIT:**
OFFTOP / to verify (clean vcpkg compilation with VS2026 and 'master'):
~~Current vcpkg may not compile (some boost library) with VC2026 - if you clean all caches -, but 'master' does not compile, even if you have vcpkg compiled by VS2022.
I did not check vcpkg clean compilation with VS2026 and TFS 'master', only with my branch 'compilation' based on 1.4, so this problem may be only with my branch, not 'master'.~~

**EDIT 2:**
TFS master compiles with clean vcpkg in VS2026 with 1 line change from this PR.