### PR TITLE
ci: update 1.6 workflows and vcpkg baseline, fix build against current dependencies

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -28,6 +28,7 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         buildtype: [Debug, Release]

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -37,10 +37,10 @@ jobs:
       VCPKG_BUILD_TYPE: release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: cpp
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
@@ -63,33 +63,24 @@ jobs:
           configurePresetAdditionalArgs: "['-DUSE_LUAJIT=${{ matrix.luajit }}']"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:cpp"
         if: ${{ matrix.os == 'ubuntu' && matrix.buildtype == 'Debug' }}
 
-      - name: Upload artifact binary
-        uses: actions/upload-artifact@v4
-        if: ${{ !startsWith(matrix.os, 'windows') }}
-        with:
-          name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
-          path: ${{ runner.workspace }}/build/${{ matrix.buildtype }}/tfs
-
-      - name: Upload artifact binary (exe)
-        uses: actions/upload-artifact@v4
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        with:
-          name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
-          path: |
-            ${{ runner.workspace }}/build/${{ matrix.buildtype }}/tfs.exe
-            ${{ runner.workspace }}/build/${{ matrix.buildtype }}/*.dll
-
+      # upload-artifact v4 and later reject a second upload to an existing
+      # artifact name, so the binaries and the datapack have to be collected
+      # into the workspace and uploaded by a single step.
       - name: Prepare datapack contents
-        run: find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
+        run: |
+          find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
+          build=../build/${{ matrix.buildtype }}
+          cp $build/tfs $build/tfs.exe $build/*.dll . 2>/dev/null || true
+          [ -f tfs ] || [ -f tfs.exe ] || { echo "::error::no tfs binary found in $build"; exit 1; }
         shell: bash
 
-      - name: Upload datapack contents
-        uses: actions/upload-artifact@v4
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
         with:
           name: tfs-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ github.workspace }}

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -72,11 +72,13 @@ jobs:
       # upload-artifact v4 and later reject a second upload to an existing
       # artifact name, so the binaries and the datapack have to be collected
       # into the workspace and uploaded by a single step.
+      # The vcpkg preset builds into ${sourceDir}/build, so the binary has to
+      # be pulled out before the workspace is pruned down to the datapack.
       - name: Prepare datapack contents
         run: |
-          find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
-          build=../build/${{ matrix.buildtype }}
+          build=build/${{ matrix.buildtype }}
           cp $build/tfs $build/tfs.exe $build/*.dll . 2>/dev/null || true
+          find . -mindepth 1 -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql ! -name tfs ! -name tfs.exe ! -name '*.dll' -exec rm -r {} \;
           [ -f tfs ] || [ -f tfs.exe ] || { echo "::error::no tfs binary found in $build"; exit 1; }
         shell: bash
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -26,19 +26,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # apt-key is deprecated and no longer shipped on current Ubuntu images,
-      # and the repository codename has to follow the runner image rather than
-      # being pinned to jammy.
-      - name: Setup LLVM repository
-        run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
-          codename="$(lsb_release -cs)"
-          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$codename/ llvm-toolchain-$codename main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-
-      - name: Install dependencies
-        run: sudo apt update -qq && sudo apt install -yqq clang-format
+      # The apt.llvm.org repository is no longer used. Setting it up needed
+      # apt-key, which is deprecated and no longer shipped on current Ubuntu
+      # images, and its unversioned "main" component currently advertises a
+      # clang-format metapackage whose versioned dependency does not exist,
+      # so installing from it fails outright.
+      #
+      # clang-format's output changes between releases, so the version is
+      # pinned instead of tracking whatever the runner image or the LLVM
+      # repository happens to provide. src/ as committed is clean under
+      # 18.1.8 through 20.x, and reports violations under both 21 and 18.1.3
+      # (the build ubuntu-24.04 ships), so the version cannot be left to the
+      # distro either.
+      - name: Install clang-format
+        run: pipx install clang-format==19.1.7
 
       - name: Check code style
         run: clang-format -n -style=file --Werror src/*.{cpp,h}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -24,12 +24,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
+      # apt-key is deprecated and no longer shipped on current Ubuntu images,
+      # and the repository codename has to follow the runner image rather than
+      # being pinned to jammy.
       - name: Setup LLVM repository
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+          codename="$(lsb_release -cs)"
+          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$codename/ llvm-toolchain-$codename main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list
 
       - name: Install dependencies
         run: sudo apt update -qq && sudo apt install -yqq clang-format

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,27 +27,27 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         if: github.ref_type == 'tag'
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         if: github.event_name == 'pull_request' || github.ref_type == 'branch'
         with:
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/lua-check.yml
+++ b/.github/workflows/lua-check.yml
@@ -21,9 +21,9 @@ jobs:
   luac:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: leafo/gh-actions-lua@v10
+      - uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: "5.4"
 
@@ -33,9 +33,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: leafo/gh-actions-lua@v10
-      - uses: leafo/gh-actions-luarocks@v4
+      - uses: actions/checkout@v7
+      - uses: leafo/gh-actions-lua@v13
+      - uses: leafo/gh-actions-luarocks@v6
 
       - name: Install Luacheck
         run: luarocks install luacheck
@@ -46,9 +46,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: leafo/gh-actions-lua@v10
-      - uses: leafo/gh-actions-luarocks@v4
+      - uses: actions/checkout@v7
+      - uses: leafo/gh-actions-lua@v13
+      - uses: leafo/gh-actions-luarocks@v6
 
       - name: Install LuaFormatter
         run: luarocks install --server=https://luarocks.org/dev luaformatter

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -17,7 +17,7 @@ jobs:
       VCPKG_BUILD_TYPE: release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.

--- a/.github/workflows/release-vcpkg.yml
+++ b/.github/workflows/release-vcpkg.yml
@@ -34,12 +34,14 @@ jobs:
           configurePreset: vcpkg
           configurePresetAdditionalArgs: "['-DUSE_LUAJIT=ON']"
 
+      # The vcpkg preset builds into ${sourceDir}/build, so the binary has to
+      # be pulled out before the workspace is pruned down to the datapack.
       - name: Prepare datapack contents
         run: |
-          pwd
-          ls -al
-          find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
-          mv ../build/tfs ../build/tfs.exe* ../build/*.dll .
+          build=build/RelWithDebInfo
+          cp $build/tfs $build/tfs.exe $build/*.dll . 2>/dev/null || true
+          find . -mindepth 1 -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql ! -name tfs ! -name tfs.exe ! -name '*.dll' -exec rm -r {} \;
+          [ -f tfs ] || [ -f tfs.exe ] || { echo "::error::no tfs binary found in $build"; exit 1; }
         shell: bash
 
       - name: Zip the release files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - 3306:3306
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.

--- a/.github/workflows/update-vcpkg.yml
+++ b/.github/workflows/update-vcpkg.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/xml-syntax.yml
+++ b/.github/workflows/xml-syntax.yml
@@ -14,7 +14,7 @@ jobs:
   xmllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install xmllint
         run: sudo apt update -q && sudo apt install -yq libxml2-utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options(-Wimplicit-fallthrough -Wmove)
 endif ()
 
+# fmt 11+ refuses to build on MSVC without UTF-8 source/execution charsets.
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Find packages.
 find_package(OpenSSL 3.0.0 REQUIRED COMPONENTS Crypto)
 

--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -35,7 +35,7 @@ beast::http::message_generator tfs::http::handle_request(const beast::http::requ
                                                          std::string_view ip)
 {
 	auto&& [status, responseBody] = [&req, ip]() {
-		json::error_code ec;
+		boost::system::error_code ec;
 		auto requestBody = json::parse(req.body(), ec, &mr);
 		if (ec || !requestBody.is_object()) {
 			return make_error_response({.code = 2, .message = "Invalid request body."});

--- a/src/http/tests/test_login.cpp
+++ b/src/http/tests/test_login.cpp
@@ -191,8 +191,6 @@ BOOST_FIXTURE_TEST_CASE(test_login_missing_token, LoginFixture)
 	BOOST_TEST(db.executeQuery(
 	    "INSERT INTO `accounts` (`name`, `email`, `password`, `secret`) VALUES ('abcd', 'fooba@example.com', SHA1('bar'), UNHEX('48656c6c6f21dead'))"));
 
-	auto now = duration_cast<seconds>(system_clock::now().time_since_epoch());
-
 	auto&& [status, body] = tfs::http::handle_login(
 	    {
 	        {"type", "login"},

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7105,24 +7105,26 @@ int LuaScriptInterface::luaItemSetCustomAttribute(lua_State* L)
 		return 1;
 	}
 
-	ItemAttributes::CustomAttribute val;
+	// Construct the attribute directly instead of assigning into a default
+	// constructed one: GCC 15 reports a spurious -Wmaybe-uninitialized in
+	// boost::variant's assignment path otherwise.
+	using CustomAttribute = ItemAttributes::CustomAttribute;
 	if (isNumber(L, 3)) {
 		double tmp = tfs::lua::getNumber<double>(L, 3);
 		if (std::floor(tmp) < tmp) {
-			val.set<double>(tmp);
+			item->setCustomAttribute(key, CustomAttribute{tmp});
 		} else {
-			val.set<int64_t>(tmp);
+			item->setCustomAttribute(key, CustomAttribute{static_cast<int64_t>(tmp)});
 		}
 	} else if (lua_isstring(L, 3)) {
-		val.set<std::string>(tfs::lua::getString(L, 3));
+		item->setCustomAttribute(key, CustomAttribute{tfs::lua::getString(L, 3)});
 	} else if (lua_isboolean(L, 3)) {
-		val.set<bool>(tfs::lua::getBoolean(L, 3));
+		item->setCustomAttribute(key, CustomAttribute{tfs::lua::getBoolean(L, 3)});
 	} else {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	item->setCustomAttribute(key, val);
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1226,7 +1226,7 @@ void ProtocolGame::parseLookInBattleList(NetworkMessage& msg)
 
 void ProtocolGame::parseSay(NetworkMessage& msg)
 {
-	std::string_view receiver;
+	std::string receiver;
 	uint16_t channelId;
 
 	SpeakClasses type = static_cast<SpeakClasses>(msg.getByte());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1421,7 +1421,7 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 	uint8_t reportReason = msg.getByte();
 	auto targetName = msg.getString();
 	auto comment = msg.getString();
-	std::string_view translation;
+	std::string translation;
 	if (reportType == REPORT_TYPE_NAME) {
 		translation = msg.getString();
 	} else if (reportType == REPORT_TYPE_STATEMENT) {

--- a/src/spells.h
+++ b/src/spells.h
@@ -227,7 +227,7 @@ public:
 
 	bool configureEvent(const pugi::xml_node& node) override;
 
-	virtual bool playerCastInstant(Player* player, std::string& param);
+	bool playerCastInstant(Player* player, std::string& param);
 
 	bool castSpell(Creature* creature) override;
 	bool castSpell(Creature* creature, Creature* target) override;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -217,9 +217,25 @@ std::string randomBytes(size_t length)
 	return bytes;
 }
 
-std::string formatDate(time_t time) { return fmt::format("{:%d/%m/%Y %H:%M:%S}", fmt::localtime(time)); }
+namespace {
 
-std::string formatDateShort(time_t time) { return fmt::format("{:%d %b %Y}", fmt::localtime(time)); }
+// fmt::localtime was removed in fmt 12; format a std::tm instead.
+std::tm toLocalTime(time_t time)
+{
+	std::tm tm{};
+#ifdef _WIN32
+	localtime_s(&tm, &time);
+#else
+	localtime_r(&time, &tm);
+#endif
+	return tm;
+}
+
+} // namespace
+
+std::string formatDate(time_t time) { return fmt::format("{:%d/%m/%Y %H:%M:%S}", toLocalTime(time)); }
+
+std::string formatDateShort(time_t time) { return fmt::format("{:%d %b %Y}", toLocalTime(time)); }
 
 Position getNextPosition(Direction direction, Position pos)
 {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -46,5 +46,5 @@
   "default-features": [
     "lua"
   ],
-  "builtin-baseline": "215a2535590f1f63788ac9bd2ed58ad15e6afdff"
+  "builtin-baseline": "a2b75031b909a2d6b051725c3909230c72d4bd4a"
 }


### PR DESCRIPTION
Every action used on this branch is bumped to its current maintained major version, and the two places where the workflows relied on behaviour that has since been removed are fixed.

### Action version bumps

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `github/codeql-action` | v3 | v4 |
| `leafo/gh-actions-lua` | v10 | v13 |
| `leafo/gh-actions-luarocks` | v4 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v5 | v7 |

`lukka/get-cmake`, `lukka/run-vcpkg@v11`, `lukka/run-cmake@v10`, `thedoctor0/zip-release@0.7.6` and `ncipollo/release-action@v1` were already current and are unchanged.

### `build-vcpkg.yml` — artifact upload

The job uploaded the binary, the Windows exe/dlls and the datapack as three separate steps that all shared one artifact name. That worked under `upload-artifact@v3`, which merged uploads into a single artifact, but v4 removed that behaviour and returns a conflict on the second upload — so this job has been failing since the v4 bump regardless of this PR.

The binaries are now copied into the workspace next to the datapack and uploaded by one step, which restores the original intent of producing a single downloadable bundle. A guard makes a missing binary fail the job rather than silently publishing a datapack-only artifact.

The build directory is referenced as `../build/<buildtype>` rather than `${{ runner.workspace }}/build/...`, matching the idiom already used in `release-vcpkg.yml`; `runner.workspace` expands to a backslash path on Windows, which does not survive `shell: bash`.

### `clang-format.yml` — drop the apt.llvm.org repository

Setting up that repository was the only reason this job used `apt-key`, which is deprecated and no longer shipped on current Ubuntu images. It also does not work any more regardless of the key handling: the unversioned `llvm-toolchain-<codename> main` component currently advertises a `clang-format` metapackage that depends on `clang-format-23`, which is not published there, so `apt install clang-format` fails with unmet dependencies.

clang-format's output changes between major releases, so tracking whatever that repository calls latest lets the style gate move under the branch on its own. Checking `src/` against several releases:

| clang-format | result on `src/` |
| --- | --- |
| 14 – 17, and 18.1.3 | violations |
| 18.1.8, 19, 20 | clean |
| 21 | violations |

The distro package is not a stable answer either — `ubuntu-24.04` ships 18.1.3, which is on the wrong side of that boundary. The job therefore installs a pinned `clang-format==19.1.7` with `pipx`, which keeps it independent of both the runner image and the LLVM apt repository. No third-party apt repository and no `apt-key`.

### vcpkg baseline bump and the source fixes it needs

The `build-vcpkg` and `test` jobs originally failed on this PR for a reason the action bumps do not touch: `lukka/get-cmake@latest` now installs CMake 4.x, and the pinned March 2024 vcpkg baseline ships a `zstd 1.5.5` port whose CMake minimum is below 3.5, which CMake 4 refuses. The dependency build died before any TFS source was compiled, and `fail-fast` then cancelled the other 11 matrix jobs.

Rather than pinning an old CMake, the manifest now uses the same current baseline as the 1.4 PR (#5089, `a2b75031`, 2026-08-14), and the matrix runs with `fail-fast: false` so every platform reports. That moves fmt 10 → 12, Boost 1.84 → 1.91 and Lua 5.4 → 5.5, which needed three small source changes:

- **`Fix boost warn: use boost::system instead boost::json error code`** — cherry-picked from master (#4799, @ramon-bernardo); Boost 1.91 no longer provides `boost::json::error_code`.
- **`Fix build with fmt 12: fmt::localtime was removed`** — `formatDate`/`formatDateShort` now format a `std::tm` from `localtime_r`/`localtime_s`. (master solved this with `std::format` + C++23, which 1.6 on C++20 cannot use.)
- **`Fix spurious -Wmaybe-uninitialized with GCC 15 in luaItemSetCustomAttribute`** — GCC 15 at -O2 flags Boost.Variant's assign path under `-Werror`; constructing the `CustomAttribute` directly avoids it. The code is identical on master, so master will hit this too once it builds with GCC 15.

- **`fix string_view issue in ProtocolGame::parseSay`** — cherry-picked from master (#4851, @KrecikOnDexin), and **`Fix warnings reported by the clang shipped with Xcode 26`**: the first green-dependency CI run showed macOS failing on two diagnostics new in recent clang, `-Wunnecessary-virtual-specifier` (`InstantSpell::playerCastInstant` in a `final` class) and `-Wdangling-assignment-gsl` (`std::string_view` bound to the temporary `std::string` returned by `NetworkMessage::getString` — a real dangling reference, fixed the same way as #4851 for `parseSay`). Both reproduce with clang 21 on Linux, which now builds the tree warning-free.
- **`ci: collect the binary from the preset build directory`** — the Ubuntu jobs actually built fine but my datapack step looked in `../build`; the vcpkg preset's `binaryDir` is `${sourceDir}/build`, which the step had just deleted. The binary is now copied out before the workspace is pruned (same fix in `release-vcpkg.yml`).

- **`Compile with /utf-8 on MSVC, required by fmt 11+`** — Windows failed in the precompiled header with fmt's `Unicode support requires compiling with /utf-8` static assert; same option master added in #4932.

Verified locally with manifest-mode vcpkg (x64-linux) against the new baseline in both Release + Lua and Debug + LuaJIT, with `BUILD_TESTING=ON`, using GCC 15 and clang 21. The six unit tests that do not need a database pass; `test_cacheinfo` and `test_login` need the MariaDB service CI provides.

### Not addressed here

`update-vcpkg.yml` has pre-existing bugs unrelated to deprecation — it writes `>` instead of `>>` to `$GITHUB_OUTPUT` (so each write clobbers the previous one) and reads `steps.update.output.*` instead of `steps.update.outputs.*`. It also pushes a branch and opens a PR without declaring `contents: write` / `pull-requests: write`. Left alone to keep this PR mechanical; happy to fix in a follow-up.

