### PR TITLE
feat(net): add PROXY protocol v2 support for local proxies

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -21,6 +21,9 @@ expFromPlayersLevelRange = 75
 -- NOTE: allowWalkthrough is only applicable to players
 -- NOTE: two-factor auth requires token and timestamp in session key
 -- NOTE: statusCountMaxPlayersPerIp allows you to only count up to X players per IP in status response (0 = disabled)
+-- NOTE: connections from localhost may start with a PROXY protocol v2 header (e.g. HAProxy "send-proxy-v2"), the
+--       announced client address is then used instead of the socket address (bans, limits, session checks) and the
+--       status and login responses advertise 127.0.0.1 as the server address so that clients keep using the proxy
 ip = "127.0.0.1"
 bindOnlyGlobalAddress = false
 gameProtocolPort = 7172

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/protocol.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocolstatus.cpp
+	${CMAKE_CURRENT_LIST_DIR}/proxyprotocol.cpp
 	${CMAKE_CURRENT_LIST_DIR}/rsa.cpp
 	${CMAKE_CURRENT_LIST_DIR}/scheduler.cpp
 	${CMAKE_CURRENT_LIST_DIR}/script.cpp
@@ -136,6 +137,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.h
 	${CMAKE_CURRENT_LIST_DIR}/protocol.h
 	${CMAKE_CURRENT_LIST_DIR}/protocolstatus.h
+	${CMAKE_CURRENT_LIST_DIR}/proxyprotocol.h
 	${CMAKE_CURRENT_LIST_DIR}/pugicast.h
 	${CMAKE_CURRENT_LIST_DIR}/rsa.h
 	${CMAKE_CURRENT_LIST_DIR}/scheduler.h

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -126,11 +126,10 @@ void Connection::accept()
 		auto bufferLength = !receivedLastChar && receivedName && connectionState == CONNECTION_STATE_GAMEWORLD_AUTH
 		                        ? 1
 		                        : NetworkMessage::HEADER_LENGTH;
-		boost::asio::async_read(
-		    socket, boost::asio::buffer(msg.getBuffer(), bufferLength),
-		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
-			    thisPtr->parseHeader(error);
-		    });
+		asyncRead(msg.getBuffer(), bufferLength,
+		          [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
+			          thisPtr->parseHeader(error);
+		          });
 	} catch (boost::system::system_error& e) {
 		std::cout << "[Network error - Connection::accept] " << e.what() << std::endl;
 		close(FORCE_CLOSE);
@@ -152,7 +151,9 @@ void Connection::parseHeader(const boost::system::error_code& error)
 	if (!receivedFirstHeader) {
 		receivedFirstHeader = true;
 
-		// Only a proxy running on the same host is trusted to announce the original client address
+		// Only a proxy running on the same host is trusted to announce the original client address. Only the two
+		// bytes of a regular packet header have been read at this point, so this is a probe: the rest of the
+		// signature is checked once the full header is in, and a mismatch there hands the bytes back to this flow
 		if (proxy_protocol::isTrustedPeer(remoteAddress)) {
 			if (proxy_protocol::matchesSignature(msg.getBuffer(), NetworkMessage::HEADER_LENGTH)) {
 				readProxyHeader();
@@ -220,11 +221,10 @@ void Connection::parseHeader(const boost::system::error_code& error)
 
 		// Read packet content
 		msg.setLength(size + NetworkMessage::HEADER_LENGTH);
-		boost::asio::async_read(
-		    socket, boost::asio::buffer(msg.getBodyBuffer(), size),
-		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
-			    thisPtr->parsePacket(error);
-		    });
+		asyncRead(msg.getBodyBuffer(), size,
+		          [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
+			          thisPtr->parsePacket(error);
+		          });
 	} catch (boost::system::system_error& e) {
 		std::cout << "[Network error - Connection::parseHeader] " << e.what() << std::endl;
 		close(FORCE_CLOSE);
@@ -266,7 +266,23 @@ void Connection::parseProxyHeader(const boost::system::error_code& error)
 		return;
 	}
 
-	auto header = proxy_protocol::parseHeader(msg.getBuffer());
+	uint8_t* buffer = msg.getBuffer();
+	if (!proxy_protocol::matchesSignature(buffer, proxy_protocol::SIGNATURE.size())) {
+		// The first two bytes matched by coincidence: this is an ordinary packet that happens to start with 0x0D 0x0A.
+		// Hand everything read so far back to the regular flow, which consumes it before reading from the socket
+		pushback.assign(buffer, buffer + proxy_protocol::HEADER_LENGTH);
+
+		// Not relayed by a proxy, apply the connection limit that ServicePort defers for local peers
+		if (!acceptConnection(remoteAddress)) {
+			close(FORCE_CLOSE);
+			return;
+		}
+
+		accept();
+		return;
+	}
+
+	auto header = proxy_protocol::parseHeader(buffer);
 	if (!header || header->length > NETWORKMESSAGE_MAXSIZE - proxy_protocol::HEADER_LENGTH) {
 		std::cout << "[Warning - Connection::parseProxyHeader] Malformed PROXY protocol header from " << remoteAddress
 		          << std::endl;
@@ -384,11 +400,10 @@ void Connection::parsePacket(const boost::system::error_code& error)
 		    });
 
 		// Wait to the next packet
-		boost::asio::async_read(
-		    socket, boost::asio::buffer(msg.getBuffer(), NetworkMessage::HEADER_LENGTH),
-		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
-			    thisPtr->parseHeader(error);
-		    });
+		asyncRead(msg.getBuffer(), NetworkMessage::HEADER_LENGTH,
+		          [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
+			          thisPtr->parseHeader(error);
+		          });
 	} catch (boost::system::system_error& e) {
 		std::cout << "[Network error - Connection::parsePacket] " << e.what() << std::endl;
 		close(FORCE_CLOSE);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -11,6 +11,8 @@
 #include "server.h"
 #include "tasks.h"
 
+namespace proxy_protocol = tfs::net::proxy_protocol;
+
 Connection_ptr ConnectionManager::createConnection(boost::asio::io_context& io_context,
                                                    ConstServicePort_ptr servicePort)
 {
@@ -97,6 +99,14 @@ void Connection::accept(Protocol_ptr protocol)
 	accept();
 }
 
+void Connection::resolveRemoteAddress()
+{
+	boost::system::error_code error;
+	if (auto endpoint = socket.remote_endpoint(error); !error) {
+		remoteAddress = endpoint.address();
+	}
+}
+
 void Connection::accept()
 {
 	if (connectionState == CONNECTION_STATE_PENDING) {
@@ -104,11 +114,6 @@ void Connection::accept()
 	}
 
 	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-
-	boost::system::error_code error;
-	if (auto endpoint = socket.remote_endpoint(error); !error) {
-		remoteAddress = endpoint.address();
-	}
 
 	try {
 		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
@@ -142,6 +147,24 @@ void Connection::parseHeader(const boost::system::error_code& error)
 		return;
 	} else if (connectionState == CONNECTION_STATE_DISCONNECTED) {
 		return;
+	}
+
+	if (!receivedFirstHeader) {
+		receivedFirstHeader = true;
+
+		// Only a proxy running on the same host is trusted to announce the original client address
+		if (proxy_protocol::isTrustedPeer(remoteAddress)) {
+			if (proxy_protocol::matchesSignature(msg.getBuffer(), NetworkMessage::HEADER_LENGTH)) {
+				readProxyHeader();
+				return;
+			}
+
+			// Not relayed by a proxy, apply the connection limit that ServicePort defers for local peers
+			if (!acceptConnection(remoteAddress)) {
+				close(FORCE_CLOSE);
+				return;
+			}
+		}
 	}
 
 	uint32_t timePassed = std::max<uint32_t>(1, (time(nullptr) - timeConnected) + 1);
@@ -206,6 +229,111 @@ void Connection::parseHeader(const boost::system::error_code& error)
 		std::cout << "[Network error - Connection::parseHeader] " << e.what() << std::endl;
 		close(FORCE_CLOSE);
 	}
+}
+
+void Connection::readProxyHeader()
+{
+	try {
+		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.async_wait(
+		    [thisPtr = std::weak_ptr<Connection>(shared_from_this())](const boost::system::error_code& error) {
+			    Connection::handleTimeout(thisPtr, error);
+		    });
+
+		// Read the rest of the fixed-size header, the first NetworkMessage::HEADER_LENGTH bytes are already in
+		boost::asio::async_read(
+		    socket,
+		    boost::asio::buffer(msg.getBuffer() + NetworkMessage::HEADER_LENGTH,
+		                        proxy_protocol::HEADER_LENGTH - NetworkMessage::HEADER_LENGTH),
+		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
+			    thisPtr->parseProxyHeader(error);
+		    });
+	} catch (boost::system::system_error& e) {
+		std::cout << "[Network error - Connection::readProxyHeader] " << e.what() << std::endl;
+		close(FORCE_CLOSE);
+	}
+}
+
+void Connection::parseProxyHeader(const boost::system::error_code& error)
+{
+	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
+	readTimer.cancel();
+
+	if (error) {
+		close(FORCE_CLOSE);
+		return;
+	} else if (connectionState == CONNECTION_STATE_DISCONNECTED) {
+		return;
+	}
+
+	auto header = proxy_protocol::parseHeader(msg.getBuffer());
+	if (!header || header->length > NETWORKMESSAGE_MAXSIZE - proxy_protocol::HEADER_LENGTH) {
+		std::cout << "[Warning - Connection::parseProxyHeader] Malformed PROXY protocol header from " << remoteAddress
+		          << std::endl;
+		close(FORCE_CLOSE);
+		return;
+	}
+
+	proxyHeader = *header;
+	if (proxyHeader.length == 0) {
+		applyProxyHeader();
+		return;
+	}
+
+	try {
+		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.async_wait(
+		    [thisPtr = std::weak_ptr<Connection>(shared_from_this())](const boost::system::error_code& error) {
+			    Connection::handleTimeout(thisPtr, error);
+		    });
+
+		// Read the address block and any TLVs following it
+		boost::asio::async_read(
+		    socket, boost::asio::buffer(msg.getBuffer() + proxy_protocol::HEADER_LENGTH, proxyHeader.length),
+		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
+			    thisPtr->parseProxyAddress(error);
+		    });
+	} catch (boost::system::system_error& e) {
+		std::cout << "[Network error - Connection::parseProxyHeader] " << e.what() << std::endl;
+		close(FORCE_CLOSE);
+	}
+}
+
+void Connection::parseProxyAddress(const boost::system::error_code& error)
+{
+	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
+	readTimer.cancel();
+
+	if (error) {
+		close(FORCE_CLOSE);
+		return;
+	} else if (connectionState == CONNECTION_STATE_DISCONNECTED) {
+		return;
+	}
+
+	applyProxyHeader();
+}
+
+void Connection::applyProxyHeader()
+{
+	// A LOCAL command (e.g. a health check) is the proxy connecting on its own behalf, the real socket endpoints
+	// apply and the connection is not treated as relayed
+	if (proxyHeader.command == proxy_protocol::Command::PROXY) {
+		if (auto address =
+		        proxy_protocol::parseSourceAddress(proxyHeader, msg.getBuffer() + proxy_protocol::HEADER_LENGTH)) {
+			remoteAddress = *address;
+		}
+		proxied = true;
+	}
+
+	// The client address is known now, apply the connection limit that ServicePort defers for local peers
+	if (!acceptConnection(remoteAddress)) {
+		close(FORCE_CLOSE);
+		return;
+	}
+
+	// Continue with the regular protocol
+	accept();
 }
 
 void Connection::parsePacket(const boost::system::error_code& error)

--- a/src/connection.h
+++ b/src/connection.h
@@ -99,6 +99,10 @@ private:
 	void parseProxyAddress(const boost::system::error_code& error);
 	void applyProxyHeader();
 
+	// Reads `length` bytes into `buffer`, serving bytes handed back by the PROXY protocol detection before the socket
+	template <typename Handler>
+	void asyncRead(uint8_t* buffer, size_t length, Handler&& handler);
+
 	void onWriteOperation(const boost::system::error_code& error);
 
 	static void handleTimeout(ConnectionWeak_ptr connectionWeak, const boost::system::error_code& error);
@@ -127,6 +131,8 @@ private:
 	uint32_t packetsSent = 0;
 
 	tfs::net::proxy_protocol::Header proxyHeader{};
+	// Bytes read while probing for a PROXY protocol header that turned out to be ordinary client data
+	std::vector<uint8_t> pushback;
 
 	ConnectionState_t connectionState = CONNECTION_STATE_PENDING;
 	bool receivedFirst = false;
@@ -135,5 +141,27 @@ private:
 	bool receivedFirstHeader = false;
 	bool proxied = false;
 };
+
+template <typename Handler>
+void Connection::asyncRead(uint8_t* buffer, size_t length, Handler&& handler)
+{
+	if (!pushback.empty()) {
+		const size_t count = std::min(length, pushback.size());
+		std::copy_n(pushback.begin(), count, buffer);
+		pushback.erase(pushback.begin(), pushback.begin() + count);
+		buffer += count;
+		length -= count;
+
+		if (length == 0) {
+			// Complete through the executor like a socket read would, so the handler never runs inside the caller
+			boost::asio::post(socket.get_executor(), [handler = std::forward<Handler>(handler), count]() mutable {
+				handler(boost::system::error_code{}, count);
+			});
+			return;
+		}
+	}
+
+	boost::asio::async_read(socket, boost::asio::buffer(buffer, length), std::forward<Handler>(handler));
+}
 
 #endif // FS_CONNECTION_H

--- a/src/connection.h
+++ b/src/connection.h
@@ -5,6 +5,7 @@
 #define FS_CONNECTION_H
 
 #include "networkmessage.h"
+#include "proxyprotocol.h"
 
 enum ConnectionState_t
 {
@@ -84,10 +85,19 @@ public:
 	void send(const OutputMessage_ptr& msg);
 
 	const Address& getIP() const { return remoteAddress; };
+	// Whether the connection was relayed by a proxy that announced the original client address (PROXY protocol)
+	bool isProxied() const { return proxied; }
 
 private:
+	void resolveRemoteAddress();
+
 	void parseHeader(const boost::system::error_code& error);
 	void parsePacket(const boost::system::error_code& error);
+
+	void readProxyHeader();
+	void parseProxyHeader(const boost::system::error_code& error);
+	void parseProxyAddress(const boost::system::error_code& error);
+	void applyProxyHeader();
 
 	void onWriteOperation(const boost::system::error_code& error);
 
@@ -116,10 +126,14 @@ private:
 	time_t timeConnected;
 	uint32_t packetsSent = 0;
 
+	tfs::net::proxy_protocol::Header proxyHeader{};
+
 	ConnectionState_t connectionState = CONNECTION_STATE_PENDING;
 	bool receivedFirst = false;
 	bool receivedName = false;
 	bool receivedLastChar = false;
+	bool receivedFirstHeader = false;
+	bool proxied = false;
 };
 
 #endif // FS_CONNECTION_H

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -15,7 +15,9 @@ static constexpr auto CLIENT_VERSION_STR = "13.10";
 static constexpr auto AUTHENTICATOR_DIGITS = 6U;
 static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 
+#ifndef BOOST_ASIO_NO_DEPRECATED
 #define BOOST_ASIO_NO_DEPRECATED
+#endif
 #define OPENSSL_NO_DEPRECATED
 
 #ifndef __FUNCTION__

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -19,6 +19,9 @@ set(http_HDR
 	)
 
 add_library(http OBJECT ${http_SRC})
+# tfslib defines this in definitions.h; it changes the ABI of inline Boost.Asio functions (BOOST_ASIO_SYNC_OP_VOID),
+# so every translation unit linked into tfs must agree on it
+target_compile_definitions(http PRIVATE BOOST_ASIO_NO_DEPRECATED)
 target_link_libraries(http PRIVATE Boost::json)
 set_target_properties(http PROPERTIES UNITY_BUILD ${ENABLE_UNITY_BUILD})
 

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -1,5 +1,3 @@
-#define BOOST_ASIO_NO_DEPRECATED
-
 #include "http.h"
 
 #include "listener.h"

--- a/src/http/login.cpp
+++ b/src/http/login.cpp
@@ -33,7 +33,7 @@ int getPvpType()
 
 } // namespace
 
-std::pair<status, json::value> tfs::http::handle_login(const json::object& body, std::string_view ip)
+std::pair<status, json::value> tfs::http::handle_login(const json::object& body, std::string_view ip, bool proxied)
 {
 	using namespace std::chrono;
 
@@ -125,13 +125,15 @@ std::pair<status, json::value> tfs::http::handle_login(const json::object& body,
 		} while (result->next());
 	}
 
+	std::string serverIP = proxied ? "127.0.0.1" : getString(ConfigManager::IP);
+
 	json::array worlds{
 	    {
 	        {"id", 0}, // not implemented
 	        {"name", getString(ConfigManager::SERVER_NAME)},
-	        {"externaladdressprotected", getString(ConfigManager::IP)},
+	        {"externaladdressprotected", serverIP},
 	        {"externalportprotected", getNumber(ConfigManager::GAME_PORT)},
-	        {"externaladdressunprotected", getString(ConfigManager::IP)},
+	        {"externaladdressunprotected", serverIP},
 	        {"externalportunprotected", getNumber(ConfigManager::GAME_PORT)},
 	        {"previewstate", 0}, // not implemented
 	        {"location", getString(ConfigManager::LOCATION)},

--- a/src/http/login.h
+++ b/src/http/login.h
@@ -5,7 +5,9 @@
 
 namespace tfs::http {
 
+// `proxied` tells whether the client connected through a local proxy (PROXY protocol), in which case it is told to
+// keep going through it to reach the game server
 std::pair<boost::beast::http::status, boost::json::value> handle_login(const boost::json::object& body,
-                                                                       std::string_view ip);
+                                                                       std::string_view ip, bool proxied = false);
 
-}
+} // namespace tfs::http

--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -13,7 +13,7 @@ namespace json = boost::json;
 
 namespace {
 
-auto router(std::string_view type, const json::object& body, std::string_view ip)
+auto router(std::string_view type, const json::object& body, std::string_view ip, bool proxied)
 {
 	using namespace tfs::http;
 
@@ -21,7 +21,7 @@ auto router(std::string_view type, const json::object& body, std::string_view ip
 		return handle_cacheinfo(body, ip);
 	}
 	if (type == "login") {
-		return handle_login(body, ip);
+		return handle_login(body, ip, proxied);
 	}
 
 	return make_error_response();
@@ -32,9 +32,9 @@ thread_local json::monotonic_resource mr;
 } // namespace
 
 beast::http::message_generator tfs::http::handle_request(const beast::http::request<beast::http::string_body>& req,
-                                                         std::string_view ip)
+                                                         std::string_view ip, bool proxied)
 {
-	auto&& [status, responseBody] = [&req, ip]() {
+	auto&& [status, responseBody] = [&req, ip, proxied]() {
 		boost::system::error_code ec;
 		auto requestBody = json::parse(req.body(), ec, &mr);
 		if (ec || !requestBody.is_object()) {
@@ -47,7 +47,7 @@ beast::http::message_generator tfs::http::handle_request(const beast::http::requ
 			return make_error_response({.code = 2, .message = "Invalid request type."});
 		}
 
-		return router(typeField->get_string(), requestBodyObj, ip);
+		return router(typeField->get_string(), requestBodyObj, ip, proxied);
 	}();
 
 	beast::http::response<beast::http::string_body> res{status, req.version()};

--- a/src/http/router.h
+++ b/src/http/router.h
@@ -7,6 +7,6 @@
 namespace tfs::http {
 
 boost::beast::http::message_generator handle_request(
-    const boost::beast::http::request<boost::beast::http::string_body>& req, std::string_view ip);
+    const boost::beast::http::request<boost::beast::http::string_body>& req, std::string_view ip, bool proxied);
 
 } // namespace tfs::http

--- a/src/http/session.cpp
+++ b/src/http/session.cpp
@@ -3,12 +3,14 @@
 #include "router.h"
 
 #include <boost/asio/dispatch.hpp>
+#include <boost/asio/read.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
 #include <fmt/core.h>
 
 namespace asio = boost::asio;
 namespace beast = boost::beast;
+namespace proxy_protocol = tfs::net::proxy_protocol;
 
 namespace tfs::http {
 
@@ -57,7 +59,119 @@ void Session::run()
 	// on the I/O objects in this session. Although not strictly necessary
 	// for single-threaded contexts, this example code is written to be
 	// thread-safe by default.
-	dispatch(stream.get_executor(), [self = shared_from_this()] { self->read(); });
+	dispatch(stream.get_executor(), [self = shared_from_this()] { self->start(); });
+}
+
+void Session::start()
+{
+	beast::error_code ec;
+	auto endpoint = stream.socket().remote_endpoint(ec);
+	if (ec) {
+		fmt::print(stderr, "{}: {}\n", __FUNCTION__, ec.message());
+		return;
+	}
+
+	ip = endpoint.address().to_string();
+
+	// Only a proxy running on the same host is trusted to announce the original client address
+	if (proxy_protocol::isTrustedPeer(endpoint.address())) {
+		read_proxy_header();
+	} else {
+		read();
+	}
+}
+
+void Session::read_proxy_header()
+{
+	using namespace std::chrono_literals;
+
+	stream.expires_after(30s);
+
+	// Read a full fixed-size header before deciding: any HTTP request is longer than that, so a non-proxied client
+	// is not stalled by this read
+	asio::async_read(stream, buffer.prepare(proxy_protocol::HEADER_LENGTH),
+	                 [self = shared_from_this()](beast::error_code ec, size_t bytes_transferred) {
+		                 self->on_read_proxy_header(ec, bytes_transferred);
+	                 });
+}
+
+void Session::on_read_proxy_header(beast::error_code ec, size_t bytes_transferred)
+{
+	buffer.commit(bytes_transferred);
+
+	if (ec == asio::error::eof) {
+		close();
+		return;
+	}
+
+	if (ec) {
+		fmt::print(stderr, "{}: {}\n", __FUNCTION__, ec.message());
+		return;
+	}
+
+	auto data = static_cast<const uint8_t*>(buffer.data().data());
+	if (!proxy_protocol::matchesSignature(data, proxy_protocol::SIGNATURE.size())) {
+		// Not relayed by a proxy, what has been read is the start of the HTTP request
+		read();
+		return;
+	}
+
+	auto header = proxy_protocol::parseHeader(data);
+	if (!header) {
+		fmt::print(stderr, "{}: malformed PROXY protocol header from {}\n", __FUNCTION__, ip);
+		return;
+	}
+
+	proxyHeader = *header;
+	buffer.consume(proxy_protocol::HEADER_LENGTH);
+
+	if (proxyHeader.length == 0) {
+		apply_proxy_header();
+		return;
+	}
+
+	using namespace std::chrono_literals;
+
+	stream.expires_after(30s);
+
+	// Read the address block and any TLVs following it
+	asio::async_read(stream, buffer.prepare(proxyHeader.length),
+	                 [self = shared_from_this()](beast::error_code ec, size_t bytes_transferred) {
+		                 self->on_read_proxy_address(ec, bytes_transferred);
+	                 });
+}
+
+void Session::on_read_proxy_address(beast::error_code ec, size_t bytes_transferred)
+{
+	buffer.commit(bytes_transferred);
+
+	if (ec == asio::error::eof) {
+		close();
+		return;
+	}
+
+	if (ec) {
+		fmt::print(stderr, "{}: {}\n", __FUNCTION__, ec.message());
+		return;
+	}
+
+	apply_proxy_header();
+}
+
+void Session::apply_proxy_header()
+{
+	// A LOCAL command (e.g. a health check) is the proxy connecting on its own behalf, the real socket address
+	// applies and the connection is not treated as relayed
+	if (proxyHeader.command == proxy_protocol::Command::PROXY) {
+		auto data = static_cast<const uint8_t*>(buffer.data().data());
+		if (auto address = proxy_protocol::parseSourceAddress(proxyHeader, data)) {
+			ip = address->to_string();
+		}
+		proxied = true;
+	}
+
+	buffer.consume(proxyHeader.length);
+	read();
 }
 
 void Session::on_read(beast::error_code ec, size_t /*bytes_transferred*/)
@@ -72,8 +186,7 @@ void Session::on_read(beast::error_code ec, size_t /*bytes_transferred*/)
 		return;
 	};
 
-	auto ip = stream.socket().remote_endpoint().address().to_string();
-	write(handle_request(std::move(req), ip));
+	write(handle_request(std::move(req), ip, proxied));
 }
 
 void Session::on_write(beast::error_code ec, size_t /*bytes_transferred*/, bool keep_alive)

--- a/src/http/session.h
+++ b/src/http/session.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include "../proxyprotocol.h"
+
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/http/message_generator.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <memory>
+#include <string>
 
 namespace tfs::http {
 
@@ -20,12 +23,22 @@ public:
 	void run();
 
 private:
+	void start();
 	void on_read(boost::beast::error_code ec, size_t bytes_transferred);
 	void on_write(boost::beast::error_code ec, size_t bytes_transferred, bool keep_alive);
+
+	void read_proxy_header();
+	void on_read_proxy_header(boost::beast::error_code ec, size_t bytes_transferred);
+	void on_read_proxy_address(boost::beast::error_code ec, size_t bytes_transferred);
+	void apply_proxy_header();
 
 	boost::beast::tcp_stream stream;
 	boost::beast::flat_buffer buffer;
 	boost::beast::http::request<boost::beast::http::string_body> req;
+
+	std::string ip;
+	tfs::net::proxy_protocol::Header proxyHeader{};
+	bool proxied = false;
 };
 
 std::shared_ptr<Session> make_session(boost::asio::ip::tcp::socket&& socket);

--- a/src/http/tests/test_login.cpp
+++ b/src/http/tests/test_login.cpp
@@ -216,6 +216,24 @@ BOOST_FIXTURE_TEST_CASE(test_login_success_no_players, LoginFixture)
 	BOOST_TEST(characters.size() == 0);
 }
 
+BOOST_FIXTURE_TEST_CASE(test_login_success_proxied, LoginFixture)
+{
+	BOOST_TEST(db.executeQuery(
+	    "INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('klmn', 'klmn@example.com', SHA1('bar'))"));
+
+	auto&& [status, body] = tfs::http::handle_login(
+	    {{"type", "login"}, {"email", "klmn@example.com"}, {"password", "bar"}}, ip, /*proxied=*/true);
+
+	BOOST_TEST(status == status::ok);
+
+	// a client connecting through a local proxy is told to keep going through it
+	auto& worlds = body.at("playdata").at("worlds").as_array();
+	BOOST_TEST(worlds.size() == 1);
+	BOOST_TEST(worlds[0].at("externaladdressprotected").as_string() == "127.0.0.1");
+	BOOST_TEST(worlds[0].at("externaladdressunprotected").as_string() == "127.0.0.1");
+	BOOST_TEST(worlds[0].at("externalportprotected").as_int64() == 7171);
+}
+
 BOOST_FIXTURE_TEST_CASE(test_login_success, LoginFixture)
 {
 	auto premiumEndsAt = now + days(30);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -144,3 +144,12 @@ Connection::Address Protocol::getIP() const
 
 	return {};
 }
+
+bool Protocol::isProxied() const
+{
+	if (auto connection = getConnection()) {
+		return connection->isProxied();
+	}
+
+	return false;
+}

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -36,6 +36,7 @@ public:
 	Connection_ptr getConnection() const { return connection.lock(); }
 
 	Connection::Address getIP() const;
+	bool isProxied() const;
 
 	// Use this function for autosend messages only
 	OutputMessage_ptr getOutputBuffer(int32_t size);

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -13,6 +13,17 @@
 
 extern Game g_game;
 
+namespace {
+
+// Address clients on the given connection should use to reach the server: clients connecting through a local
+// proxy have to keep going through it
+std::string getServerIP(const Protocol& protocol)
+{
+	return protocol.isProxied() ? "127.0.0.1" : getString(ConfigManager::IP);
+}
+
+} // namespace
+
 std::map<Connection::Address, int64_t> ProtocolStatus::ipConnectMap;
 const uint64_t ProtocolStatus::start = OTSYS_TIME();
 
@@ -92,7 +103,7 @@ void ProtocolStatus::sendStatusString()
 	pugi::xml_node serverinfo = tsqp.append_child("serverinfo");
 	uint64_t uptime = (OTSYS_TIME() - ProtocolStatus::start) / 1000;
 	serverinfo.append_attribute("uptime") = std::to_string(uptime).c_str();
-	serverinfo.append_attribute("ip") = getString(ConfigManager::IP).c_str();
+	serverinfo.append_attribute("ip") = getServerIP(*this).c_str();
 	serverinfo.append_attribute("servername") = getString(ConfigManager::SERVER_NAME).c_str();
 	serverinfo.append_attribute("port") = std::to_string(getNumber(ConfigManager::HTTP_PORT)).c_str();
 	serverinfo.append_attribute("location") = getString(ConfigManager::LOCATION).c_str();
@@ -169,7 +180,7 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 	if (requestedInfo & REQUEST_BASIC_SERVER_INFO) {
 		output->addByte(0x10);
 		output->addString(getString(ConfigManager::SERVER_NAME));
-		output->addString(getString(ConfigManager::IP));
+		output->addString(getServerIP(*this));
 		output->addString(std::to_string(getNumber(ConfigManager::HTTP_PORT)));
 	}
 

--- a/src/proxyprotocol.cpp
+++ b/src/proxyprotocol.cpp
@@ -20,8 +20,6 @@ constexpr size_t addressBlockLength(AddressFamily family)
 			return 4 + 4 + 2 + 2;
 		case AddressFamily::INET6:
 			return 16 + 16 + 2 + 2;
-		case AddressFamily::UNIX:
-			return 108 + 108;
 		default:
 			return 0;
 	}
@@ -76,8 +74,17 @@ std::optional<Header> parseHeader(const uint8_t* data)
 	    .length = static_cast<uint16_t>((data[14] << 8) | data[15]),
 	};
 
-	if (header.command == Command::PROXY && header.length < addressBlockLength(header.family)) {
-		return std::nullopt;
+	if (header.command == Command::PROXY) {
+		// Only INET and INET6 carry a usable source address. The specification allows UNSPEC (falling back to the
+		// socket address) but a local proxy relaying a client it cannot identify is a misconfiguration, and accepting
+		// it would mark the connection as relayed while the loopback address stays in effect for bans and limits
+		if (header.family != AddressFamily::INET && header.family != AddressFamily::INET6) {
+			return std::nullopt;
+		}
+
+		if (header.length < addressBlockLength(header.family)) {
+			return std::nullopt;
+		}
 	}
 	return header;
 }

--- a/src/proxyprotocol.cpp
+++ b/src/proxyprotocol.cpp
@@ -1,0 +1,108 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "proxyprotocol.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace tfs::net::proxy_protocol {
+
+namespace {
+
+constexpr uint8_t VERSION = 0x2;
+
+// Size of the address block (addresses + ports) for each family
+constexpr size_t addressBlockLength(AddressFamily family)
+{
+	switch (family) {
+		case AddressFamily::INET:
+			return 4 + 4 + 2 + 2;
+		case AddressFamily::INET6:
+			return 16 + 16 + 2 + 2;
+		case AddressFamily::UNIX:
+			return 108 + 108;
+		default:
+			return 0;
+	}
+}
+
+} // namespace
+
+bool isTrustedPeer(const boost::asio::ip::address& peer)
+{
+	if (peer.is_v6()) {
+		const auto bytes = peer.to_v6().to_bytes();
+		const bool v4Mapped = std::all_of(bytes.begin(), bytes.begin() + 10, [](uint8_t byte) { return byte == 0; }) &&
+		                      bytes[10] == 0xFF && bytes[11] == 0xFF;
+		if (v4Mapped) {
+			return boost::asio::ip::address_v4{{bytes[12], bytes[13], bytes[14], bytes[15]}}.is_loopback();
+		}
+	}
+	return peer.is_loopback();
+}
+
+bool matchesSignature(const uint8_t* data, size_t size)
+{
+	size = std::min(size, SIGNATURE.size());
+	return std::equal(data, data + size, SIGNATURE.begin());
+}
+
+std::optional<Header> parseHeader(const uint8_t* data)
+{
+	if (!matchesSignature(data, SIGNATURE.size())) {
+		return std::nullopt;
+	}
+
+	const uint8_t versionCommand = data[12];
+	if ((versionCommand >> 4) != VERSION) {
+		return std::nullopt;
+	}
+
+	const uint8_t command = versionCommand & 0x0F;
+	if (command > static_cast<uint8_t>(Command::PROXY)) {
+		return std::nullopt;
+	}
+
+	// low nibble is the transport protocol, which is irrelevant here
+	const uint8_t family = data[13] >> 4;
+	if (family > static_cast<uint8_t>(AddressFamily::UNIX)) {
+		return std::nullopt;
+	}
+
+	Header header{
+	    .command = static_cast<Command>(command),
+	    .family = static_cast<AddressFamily>(family),
+	    .length = static_cast<uint16_t>((data[14] << 8) | data[15]),
+	};
+
+	if (header.command == Command::PROXY && header.length < addressBlockLength(header.family)) {
+		return std::nullopt;
+	}
+	return header;
+}
+
+std::optional<boost::asio::ip::address> parseSourceAddress(const Header& header, const uint8_t* data)
+{
+	if (header.command != Command::PROXY) {
+		return std::nullopt;
+	}
+
+	// The address block starts with the source address, in network byte order
+	switch (header.family) {
+		case AddressFamily::INET: {
+			boost::asio::ip::address_v4::bytes_type bytes;
+			std::memcpy(bytes.data(), data, bytes.size());
+			return boost::asio::ip::address_v4{bytes};
+		}
+		case AddressFamily::INET6: {
+			boost::asio::ip::address_v6::bytes_type bytes;
+			std::memcpy(bytes.data(), data, bytes.size());
+			return boost::asio::ip::address_v6{bytes};
+		}
+		default:
+			return std::nullopt;
+	}
+}
+
+} // namespace tfs::net::proxy_protocol

--- a/src/proxyprotocol.h
+++ b/src/proxyprotocol.h
@@ -1,0 +1,64 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_PROXYPROTOCOL_H
+#define FS_PROXYPROTOCOL_H
+
+#include <array>
+#include <boost/asio/ip/address.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+// Parser for the PROXY protocol, version 2 (binary), as sent by HAProxy's `send-proxy-v2` and compatible proxies:
+// https://www.haproxy.org/download/2.9/doc/proxy-protocol.txt
+//
+// A v2 header consists of a fixed 16-byte part (12-byte signature, version/command byte, address family/transport
+// byte, big-endian 16-bit length) followed by `length` bytes holding the address block and optional TLVs.
+namespace tfs::net::proxy_protocol {
+
+// Whether a PROXY protocol header from the given peer is trusted: only proxies running on the same host are, which
+// includes IPv4 loopback peers reported as IPv4-mapped IPv6 addresses (::ffff:127.0.0.1) by dual-stack listeners
+bool isTrustedPeer(const boost::asio::ip::address& peer);
+
+inline constexpr size_t HEADER_LENGTH = 16;
+
+inline constexpr std::array<uint8_t, 12> SIGNATURE = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
+                                                      0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
+
+enum class Command : uint8_t
+{
+	LOCAL = 0x0, // connection established by the proxy itself (e.g. health check); no address information
+	PROXY = 0x1, // connection relayed on behalf of a client whose address follows
+};
+
+enum class AddressFamily : uint8_t
+{
+	UNSPEC = 0x0,
+	INET = 0x1,
+	INET6 = 0x2,
+	UNIX = 0x3,
+};
+
+struct Header
+{
+	Command command;
+	AddressFamily family;
+	uint16_t length; // number of bytes following the fixed-size header (address block + TLVs)
+};
+
+// Returns whether the first `size` bytes of `data` are consistent with the start of a v2 header. Compares at most
+// SIGNATURE.size() bytes, so it can be used on a partial read to decide whether to keep reading a PROXY header.
+bool matchesSignature(const uint8_t* data, size_t size);
+
+// Parses the fixed-size header (HEADER_LENGTH bytes). Returns nullopt if the header is malformed, including when the
+// announced length is too short to hold the address block of the announced family.
+std::optional<Header> parseHeader(const uint8_t* data);
+
+// Returns the original client address from the address block following the header (`header.length` bytes), or
+// nullopt if the header carries no usable address (LOCAL command, UNSPEC or UNIX family).
+std::optional<boost::asio::ip::address> parseSourceAddress(const Header& header, const uint8_t* data);
+
+} // namespace tfs::net::proxy_protocol
+
+#endif // FS_PROXYPROTOCOL_H

--- a/src/proxyprotocol.h
+++ b/src/proxyprotocol.h
@@ -51,12 +51,12 @@ struct Header
 // SIGNATURE.size() bytes, so it can be used on a partial read to decide whether to keep reading a PROXY header.
 bool matchesSignature(const uint8_t* data, size_t size);
 
-// Parses the fixed-size header (HEADER_LENGTH bytes). Returns nullopt if the header is malformed, including when the
-// announced length is too short to hold the address block of the announced family.
+// Parses the fixed-size header (HEADER_LENGTH bytes). Returns nullopt if the header is malformed, including when a
+// PROXY command announces a family other than INET or INET6, or a length too short to hold its address block.
 std::optional<Header> parseHeader(const uint8_t* data);
 
 // Returns the original client address from the address block following the header (`header.length` bytes), or
-// nullopt if the header carries no usable address (LOCAL command, UNSPEC or UNIX family).
+// nullopt if the header carries no address (LOCAL command).
 std::optional<boost::asio::ip::address> parseSourceAddress(const Header& header, const uint8_t* data);
 
 } // namespace tfs::net::proxy_protocol

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -19,6 +19,23 @@ struct ConnectBlock
 	uint32_t count = 1;
 };
 
+boost::asio::ip::address getListenAddress()
+{
+	if (getBoolean(ConfigManager::BIND_ONLY_GLOBAL_ADDRESS)) {
+		return boost::asio::ip::make_address(getString(ConfigManager::IP));
+	}
+	return boost::asio::ip::address_v6::any();
+}
+
+void openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port)
+{
+	if (auto service = weak_service.lock()) {
+		service->open(port);
+	}
+}
+
+} // namespace
+
 bool acceptConnection(const Connection::Address& clientIP)
 {
 	static std::recursive_mutex mu;
@@ -54,23 +71,6 @@ bool acceptConnection(const Connection::Address& clientIP)
 	}
 	return true;
 }
-
-boost::asio::ip::address getListenAddress()
-{
-	if (getBoolean(ConfigManager::BIND_ONLY_GLOBAL_ADDRESS)) {
-		return boost::asio::ip::make_address(getString(ConfigManager::IP));
-	}
-	return boost::asio::ip::address_v6::any();
-}
-
-void openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port)
-{
-	if (auto service = weak_service.lock()) {
-		service->open(port);
-	}
-}
-
-} // namespace
 
 ServiceManager::~ServiceManager() { stop(); }
 
@@ -144,8 +144,12 @@ void ServicePort::onAccept(Connection_ptr connection, const boost::system::error
 			return;
 		}
 
+		connection->resolveRemoteAddress();
+
+		// A local peer may be a proxy announcing the real client address (PROXY protocol), so the connection limit
+		// for those is applied by Connection once the client address is known
 		const auto& remote_ip = connection->getIP();
-		if (acceptConnection(remote_ip)) {
+		if (tfs::net::proxy_protocol::isTrustedPeer(remote_ip) || acceptConnection(remote_ip)) {
 			Service_ptr service = services.front();
 			if (service->is_single_socket()) {
 				connection->accept(service->make_protocol(connection));

--- a/src/server.h
+++ b/src/server.h
@@ -7,6 +7,9 @@
 #include "connection.h"
 #include "signals.h"
 
+// Per-IP connection rate limit, returns whether a new connection from clientIP should be accepted
+bool acceptConnection(const Connection::Address& clientIP);
+
 class ServiceBase
 {
 public:

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(tests_SRC
     ${CMAKE_CURRENT_LIST_DIR}/test_base64.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_generate_token.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_matrixarea.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_proxyprotocol.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_rsa.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_sha1.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_xtea.cpp

--- a/src/tests/test_proxyprotocol.cpp
+++ b/src/tests/test_proxyprotocol.cpp
@@ -1,0 +1,148 @@
+#define BOOST_TEST_MODULE proxyprotocol
+
+#include "../otpch.h"
+
+#include "../proxyprotocol.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace proxy_protocol = tfs::net::proxy_protocol;
+
+namespace {
+
+constexpr uint8_t LOCAL = 0x0, PROXY = 0x1;
+constexpr uint8_t UNSPEC = 0x0, INET = 0x1, INET6 = 0x2, UNIX = 0x3;
+constexpr uint8_t STREAM = 0x1;
+
+// Builds the fixed-size part of a v2 header: signature, version and command, family and transport, big-endian length
+std::vector<uint8_t> makeHeader(uint8_t command, uint8_t family, uint16_t length)
+{
+	std::vector<uint8_t> header{proxy_protocol::SIGNATURE.begin(), proxy_protocol::SIGNATURE.end()};
+	header.push_back(0x20 | command);
+	header.push_back((family << 4) | STREAM);
+	header.push_back(length >> 8);
+	header.push_back(length & 0xFF);
+	return header;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(test_matches_signature_partial_and_full)
+{
+	const auto& signature = proxy_protocol::SIGNATURE;
+	BOOST_TEST(proxy_protocol::matchesSignature(signature.data(), 2));
+	BOOST_TEST(proxy_protocol::matchesSignature(signature.data(), signature.size()));
+	// extra bytes beyond the signature are not compared
+	BOOST_TEST(proxy_protocol::matchesSignature(makeHeader(PROXY, INET, 12).data(), proxy_protocol::HEADER_LENGTH));
+
+	// a regular packet whose length header happens to be 0x0D 0x0A passes the two-byte probe but not the full check
+	const std::array<uint8_t, proxy_protocol::HEADER_LENGTH> packet = {0x0D, 0x0A, 0x91, 0x6A, 0xC1, 0x0D, 0x0A, 0x00,
+	                                                                   0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+	BOOST_TEST(proxy_protocol::matchesSignature(packet.data(), 2));
+	BOOST_TEST(!proxy_protocol::matchesSignature(packet.data(), packet.size()));
+}
+
+BOOST_AUTO_TEST_CASE(test_parse_header_local)
+{
+	auto header = proxy_protocol::parseHeader(makeHeader(LOCAL, UNSPEC, 0).data());
+	BOOST_REQUIRE(header);
+	BOOST_TEST((header->command == proxy_protocol::Command::LOCAL));
+	BOOST_TEST(header->length == 0);
+
+	// a LOCAL header may still carry an address block, which is skipped
+	header = proxy_protocol::parseHeader(makeHeader(LOCAL, INET, 12).data());
+	BOOST_REQUIRE(header);
+	BOOST_TEST((header->command == proxy_protocol::Command::LOCAL));
+	BOOST_TEST(header->length == 12);
+}
+
+BOOST_AUTO_TEST_CASE(test_parse_header_proxy_inet)
+{
+	auto header = proxy_protocol::parseHeader(makeHeader(PROXY, INET, 12).data());
+	BOOST_REQUIRE(header);
+	BOOST_TEST((header->command == proxy_protocol::Command::PROXY));
+	BOOST_TEST((header->family == proxy_protocol::AddressFamily::INET));
+	BOOST_TEST(header->length == 12);
+
+	header = proxy_protocol::parseHeader(makeHeader(PROXY, INET6, 36).data());
+	BOOST_REQUIRE(header);
+	BOOST_TEST((header->family == proxy_protocol::AddressFamily::INET6));
+	BOOST_TEST(header->length == 36);
+
+	// TLVs may follow the address block
+	header = proxy_protocol::parseHeader(makeHeader(PROXY, INET, 12 + 7).data());
+	BOOST_REQUIRE(header);
+	BOOST_TEST(header->length == 19);
+}
+
+BOOST_AUTO_TEST_CASE(test_parse_header_rejects_families_without_address)
+{
+	// neither UNSPEC nor UNIX yields a client address, accepting them would mark the connection as relayed while
+	// keeping the proxy's own address
+	BOOST_TEST(!proxy_protocol::parseHeader(makeHeader(PROXY, UNSPEC, 0).data()));
+	BOOST_TEST(!proxy_protocol::parseHeader(makeHeader(PROXY, UNSPEC, 12).data()));
+	BOOST_TEST(!proxy_protocol::parseHeader(makeHeader(PROXY, UNIX, 216).data()));
+}
+
+BOOST_AUTO_TEST_CASE(test_parse_header_rejects_malformed)
+{
+	// address block shorter than the family requires
+	BOOST_TEST(!proxy_protocol::parseHeader(makeHeader(PROXY, INET, 11).data()));
+	BOOST_TEST(!proxy_protocol::parseHeader(makeHeader(PROXY, INET6, 35).data()));
+
+	// wrong version
+	auto header = makeHeader(PROXY, INET, 12);
+	header[12] = 0x11;
+	BOOST_TEST(!proxy_protocol::parseHeader(header.data()));
+
+	// unknown command
+	header = makeHeader(PROXY, INET, 12);
+	header[12] = 0x22;
+	BOOST_TEST(!proxy_protocol::parseHeader(header.data()));
+
+	// unknown family
+	header = makeHeader(PROXY, INET, 12);
+	header[13] = 0x41;
+	BOOST_TEST(!proxy_protocol::parseHeader(header.data()));
+
+	// corrupted signature
+	header = makeHeader(PROXY, INET, 12);
+	header[5] = 0x00;
+	BOOST_TEST(!proxy_protocol::parseHeader(header.data()));
+}
+
+BOOST_AUTO_TEST_CASE(test_parse_source_address)
+{
+	// source address, destination address, source port, destination port
+	const std::vector<uint8_t> inet = {192, 168, 1, 2, 10, 0, 0, 1, 0x1F, 0x90, 0x1C, 0x36};
+	auto header = proxy_protocol::parseHeader(makeHeader(PROXY, INET, inet.size()).data());
+	BOOST_REQUIRE(header);
+	auto address = proxy_protocol::parseSourceAddress(*header, inet.data());
+	BOOST_REQUIRE(address);
+	BOOST_TEST(address->to_string() == "192.168.1.2");
+
+	std::vector<uint8_t> inet6(36, 0);
+	inet6[0] = 0x20, inet6[1] = 0x01, inet6[2] = 0x0D, inet6[3] = 0xB8, inet6[15] = 0x01;
+	header = proxy_protocol::parseHeader(makeHeader(PROXY, INET6, inet6.size()).data());
+	BOOST_REQUIRE(header);
+	address = proxy_protocol::parseSourceAddress(*header, inet6.data());
+	BOOST_REQUIRE(address);
+	BOOST_TEST(address->to_string() == "2001:db8::1");
+
+	// a LOCAL command carries no client address even if an address block follows
+	header = proxy_protocol::parseHeader(makeHeader(LOCAL, INET, inet.size()).data());
+	BOOST_REQUIRE(header);
+	BOOST_TEST(!proxy_protocol::parseSourceAddress(*header, inet.data()));
+}
+
+BOOST_AUTO_TEST_CASE(test_is_trusted_peer)
+{
+	using boost::asio::ip::make_address;
+	BOOST_TEST(proxy_protocol::isTrustedPeer(make_address("127.0.0.1")));
+	BOOST_TEST(proxy_protocol::isTrustedPeer(make_address("127.0.0.53")));
+	BOOST_TEST(proxy_protocol::isTrustedPeer(make_address("::1")));
+	BOOST_TEST(proxy_protocol::isTrustedPeer(make_address("::ffff:127.0.0.1")));
+	BOOST_TEST(!proxy_protocol::isTrustedPeer(make_address("::ffff:10.0.0.1")));
+	BOOST_TEST(!proxy_protocol::isTrustedPeer(make_address("10.0.0.1")));
+	BOOST_TEST(!proxy_protocol::isTrustedPeer(make_address("2001:db8::1")));
+}


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add handling for the HAProxy PROXY protocol v2 (send-proxy-v2) binary header on all listening ports (game, login, status, and the HTTP login server). Only loopback/localhost peers are trusted to announce the original client address, so a remote client cannot spoof its in-game IP.

When a trusted local proxy relays a connection, the announced client address replaces the socket address everywhere it matters: IP bans, per-IP connection limits, status per-IP player counts, lastIP, and the HTTP-login/game session-IP lock. For proxied connections the advertised server address is overridden to 127.0.0.1 in the status and login responses so clients keep routing through the proxy.

A PROXY LOCAL header (e.g. health checks) is consumed but not treated as relayed. Malformed headers (wrong version, unknown command, a PROXY command with a family other than INET/INET6, short address block, oversized length) close the connection.

Detection on the game/login ports starts from the two-byte packet length header that is read first: if a loopback peer's first two bytes are `0D 0A`, the rest of the 16-byte header is read and the full signature checked. If it does not match, the bytes are handed back through a small push-back buffer that the regular reads drain before the socket, so a client whose first packet length happens to be 0x0A0D is handled exactly as if the probe had never happened (the HTTP session gets the same behaviour from Beast's buffer).

Also fix an ABI mismatch: BOOST_ASIO_NO_DEPRECATED was defined for tfslib (via definitions.h) but only one HTTP translation unit, changing the ABI of inline Boost.Asio functions (BOOST_ASIO_SYNC_OP_VOID) and causing a segfault in socket.shutdown() on disconnect. It is now set consistently for the http target.

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

Setup HAProxy with Proxy-v2 in front of TFS.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

